### PR TITLE
docs: multi-context layout + conventions agent skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ SFTP Enedis → ETL (DLT) → DuckDB → Query Builders → Core Pipelines → R
 - **Timezone**: All dates use `Europe/Paris` timezone
 - **Date convention**: R151 flux uses +1 day adjustment to harmonize with R64/R15/C15 (see [docs/conventions-dates-enedis.md](docs/conventions-dates-enedis.md))
 - **Column naming**: Follows `grandeur_cadran_unité` format
-- **Domain glossary**: see [CONTEXT.md](CONTEXT.md) — canonical definitions of PDL, FTA, TURPE, cadrans, flux, périmètre, abonnement, etc.
+- **Domain glossary**: see [CONTEXT-MAP.md](CONTEXT-MAP.md) — multi-context layout, business vocabulary in [`electricore/core/CONTEXT.md`](electricore/core/CONTEXT.md) (PDL, FTA, TURPE, cadrans, événements C15, périmètre, abonnement, Odoo); module-specific terms in `etl/api/bot/CONTEXT.md`.
 - **Architecture decisions**: see [docs/adr/](docs/adr/) — load-bearing past decisions (monorepo, Polars-only, R151 date adjustment, French language, DuckDB, DLT, query builders, AES rotation, API-centric architecture, Telegram bot, VPS Docker deployment)
 
 #### Column Naming Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,3 +321,17 @@ uv run --group test pytest --cov=electricore tests/
 - **DuckDB Integration**: [electricore/core/loaders/DUCKDB_INTEGRATION_GUIDE.md](electricore/core/loaders/DUCKDB_INTEGRATION_GUIDE.md)
 - **Odoo Query Builder**: [docs/odoo-query-builder.md](docs/odoo-query-builder.md)
 - **Date Conventions**: [docs/conventions-dates-enedis.md](docs/conventions-dates-enedis.md)
+
+## Agent skills
+
+### Issue tracker
+
+Issues live as GitHub issues on `Energie-De-Nantes/electricore` (via the `gh` CLI). See [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md).
+
+### Triage labels
+
+Canonical label names (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) used as-is on GitHub. See [docs/agents/triage-labels.md](docs/agents/triage-labels.md).
+
+### Domain docs
+
+Multi-context layout: [CONTEXT-MAP.md](CONTEXT-MAP.md) at root pointing to per-module `CONTEXT.md` (core/etl/api/bot); ADRs are repo-wide in [docs/adr/](docs/adr/). See [docs/agents/domain.md](docs/agents/domain.md).

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,19 @@
+# Context Map — ElectriCore
+
+ElectriCore est organisé en modules avec leur propre vocabulaire. Le glossaire métier de base vit dans `core` et est référencé par les autres modules ; chaque module ne définit que les termes qui lui sont propres.
+
+## Contextes
+
+- [**electricore/core/**](electricore/core/CONTEXT.md) — Vocabulaire métier (acteurs, PDL, FTA, cadrans, calendriers distributeur, tarification & taxes, événements C15, mesures & énergie, concepts pipeline, intégration Odoo).
+- [**electricore/etl/**](electricore/etl/CONTEXT.md) — Vocabulaire d'ingestion (flux Enedis, Mode ETL, Job ETL, Scheduler, transformers).
+- [**electricore/api/**](electricore/api/CONTEXT.md) — Vocabulaire du service REST (endpoints, services, `/health`).
+- [**electricore/bot/**](electricore/bot/CONTEXT.md) — Vocabulaire du bot Telegram (commandes, allowlist, client API).
+
+## Relations
+
+- `core` est la source unique du vocabulaire métier ; les autres modules le référencent plutôt que de redéfinir les mêmes termes.
+- `etl` ingère les flux Enedis dans DuckDB, consommés par `core`.
+- `api` expose `core` (calculs) et orchestre `etl` (déclenchements + jobs).
+- `bot` consomme `api` exclusivement (pas d'accès direct à `core` ni à `etl`).
+
+Les ADRs structurants sont au niveau racine dans [docs/adr/](docs/adr/) ; aucun ADR par contexte pour l'instant.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ La CI ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) exécute les troi
 - **Tout en français** : variables, fonctions, classes, colonnes, commentaires. Seules les APIs de bibliothèques tierces restent en anglais (`pl.col`, `.filter`…). Voir [ADR-0004](docs/adr/0004-langue-francaise.md).
 - **Pas d'accents dans les identifiants Python** (variables, fonctions, classes, colonnes). Préférer `energie_consommee` à `énergie_consommée`, `cout_total` à `coût_total`. Les accents restent autorisés dans les docstrings, messages et commentaires.
 - **Fonctions : `verbe_complement_complement`** — verbe à l'infinitif + compléments en snake_case (`calculer_consommation`, `valider_releve`, `recuperer_donnees`).
-- **Vocabulaire métier** : se référer à [CONTEXT.md](CONTEXT.md) pour les définitions canoniques et les synonymes à éviter.
+- **Vocabulaire métier** : se référer à [CONTEXT-MAP.md](CONTEXT-MAP.md) qui pointe vers les `CONTEXT.md` par module (le glossaire métier vit dans [`electricore/core/CONTEXT.md`](electricore/core/CONTEXT.md)).
 - **`notebooks/` et `scripts/`** sont exclus de ruff et mypy : conventions différentes (marimo, scripts ad-hoc).
 
 ## Process de release (mainteneurs)

--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ uv run --group test pytest --cov=electricore --cov-report=html
 - [Intégration DuckDB](electricore/core/loaders/DUCKDB_INTEGRATION_GUIDE.md) - Query Builder DuckDB
 - [Query Builder Odoo](docs/odoo-query-builder.md) - Intégration Odoo
 - [Conventions Dates](docs/conventions-dates-enedis.md) - Formats temporels Enedis
-- [CONTEXT.md](CONTEXT.md) — Glossaire métier canonique (PDL, FTA, TURPE, cadrans, flux…)
+- [CONTEXT-MAP.md](CONTEXT-MAP.md) — Carte des contextes multi-modules (vocabulaire métier dans `electricore/core/CONTEXT.md`, plus contextes etl/api/bot)
 - [docs/adr/](docs/adr/) — Décisions architecturales (monorepo, Polars, DuckDB, harmonisation R151…)
 
 ---

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,40 @@
+# Domain Docs
+
+Comment les engineering skills doivent consommer la documentation métier de ce dépôt.
+
+## Avant d'explorer, lire
+
+- [**`CONTEXT-MAP.md`**](../../CONTEXT-MAP.md) à la racine — pointe vers un `CONTEXT.md` par module. Lire celui (ou ceux) pertinents au sujet de la tâche.
+- [**`docs/adr/`**](../adr/) — lire les ADRs qui touchent la zone sur laquelle on s'apprête à travailler. Les ADRs sont au niveau racine (pas de `docs/adr/` par module pour l'instant).
+
+Si un de ces fichiers n'existe pas, **avancer en silence**. Ne pas signaler son absence ; ne pas proposer de le créer en amont. La skill productrice (`/grill-with-docs`) les crée paresseusement quand les termes ou décisions sont effectivement résolus.
+
+## Structure de fichiers
+
+Ce dépôt est multi-contextes :
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← décisions au niveau système
+└── electricore/
+    ├── core/CONTEXT.md               ← vocabulaire métier (canonique)
+    ├── etl/CONTEXT.md                ← vocabulaire ingestion
+    ├── api/CONTEXT.md                ← vocabulaire service REST
+    └── bot/CONTEXT.md                ← vocabulaire bot Telegram
+```
+
+Le glossaire métier vit dans `core` ; les autres modules ne redéfinissent pas les termes qu'ils consomment, ils s'y réfèrent.
+
+## Utiliser le vocabulaire du glossaire
+
+Quand votre sortie nomme un concept du domaine (titre d'issue, proposition de refactor, hypothèse de bug, nom de test), utiliser le terme tel que défini dans le `CONTEXT.md` pertinent. Ne pas dériver vers des synonymes explicitement marqués `_Éviter_`.
+
+Si le concept dont vous avez besoin n'est pas dans le glossaire, c'est un signal — soit vous inventez du vocabulaire que le projet n'utilise pas (à reconsidérer), soit il y a une vraie lacune (noter pour `/grill-with-docs`).
+
+## Signaler les conflits avec un ADR
+
+Si votre sortie contredit un ADR existant, le surfacer explicitement plutôt que de l'écraser en silence :
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,26 @@
+# Issue tracker: GitHub
+
+Issues et PRDs pour ce dépôt vivent comme issues GitHub sur `Energie-De-Nantes/electricore`. Utiliser la CLI `gh` pour toutes les opérations.
+
+## Conventions
+
+- **Créer une issue** : `gh issue create --title "..." --body "..."`. Utiliser un heredoc pour les corps multi-lignes.
+- **Lire une issue** : `gh issue view <number> --comments`, en filtrant les commentaires avec `jq` si besoin, et en récupérant aussi les labels.
+- **Lister les issues** : `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` avec les filtres `--label` / `--state` appropriés.
+- **Commenter** : `gh issue comment <number> --body "..."`
+- **Appliquer / retirer un label** : `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Fermer** : `gh issue close <number> --comment "..."`
+
+Le dépôt cible est inféré du `git remote -v` — `gh` le détecte automatiquement quand exécuté depuis le clone.
+
+## Quand une skill dit "publier sur le tracker"
+
+Créer une issue GitHub.
+
+## Quand une skill dit "récupérer le ticket pertinent"
+
+Exécuter `gh issue view <number> --comments`.
+
+## Conventions de titre
+
+Les commits suivent le Conventional Commits en français (voir CONTRIBUTING.md). Les titres d'issues n'ont pas de préfixe imposé mais doivent être clairs et orientés *résultat* plutôt que *implémentation*.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+Les skills parlent en termes de cinq rôles canoniques. Ce fichier mappe ces rôles aux labels effectivement utilisés dans le tracker (GitHub Issues du dépôt).
+
+| Rôle skill          | Label GitHub        | Signification                                       |
+| ------------------- | ------------------- | --------------------------------------------------- |
+| `needs-triage`      | `needs-triage`      | Le mainteneur doit évaluer l'issue                  |
+| `needs-info`        | `needs-info`        | En attente d'informations supplémentaires du reporter |
+| `ready-for-agent`   | `ready-for-agent`   | Spécifié de bout en bout, prêt pour un agent AFK    |
+| `ready-for-human`   | `ready-for-human`   | Nécessite une implémentation humaine                |
+| `wontfix`           | `wontfix`           | Ne sera pas traité                                  |
+
+Quand une skill mentionne un rôle (par ex. « apply the AFK-ready triage label »), utiliser la chaîne de la colonne *Label GitHub*.
+
+Modifier la colonne de droite pour refléter tout renommage futur côté GitHub.

--- a/docs/qualite-donnees-r151.md
+++ b/docs/qualite-donnees-r151.md
@@ -163,7 +163,7 @@ Liste des PDL à exclure de la validation :
 
 ## Références
 
-- Glossaire métier : [CONTEXT.md](../CONTEXT.md)
+- Glossaire métier : [CONTEXT-MAP.md](../CONTEXT-MAP.md) (vocabulaire ETL/flux dans [`electricore/etl/CONTEXT.md`](../electricore/etl/CONTEXT.md))
 - Conventions de dates : [docs/conventions-dates-enedis.md](conventions-dates-enedis.md)
 - Calendriers distributeur Enedis :
   - `DI000001` : Base (tarif simple)

--- a/docs/transmission.md
+++ b/docs/transmission.md
@@ -250,7 +250,7 @@ Les pipelines chargent ces règles via `load_turpe_rules()` / `load_accise_rules
 
 ## 9. Domaine : glossaire
 
-Le vocabulaire métier (PDL, FTA, C5/C4, HP/HC, TURPE, accise, flux C15/R151…) est défini dans [CONTEXT.md](../CONTEXT.md) à la racine du dépôt — c'est la source canonique.
+Le vocabulaire métier est éclaté par module : voir [CONTEXT-MAP.md](../CONTEXT-MAP.md) à la racine. L'essentiel (PDL, FTA, C5/C4, HP/HC, TURPE, accise, événements C15, périmètre, abonnement…) vit dans [`electricore/core/CONTEXT.md`](../electricore/core/CONTEXT.md).
 
 ---
 

--- a/electricore/api/CONTEXT.md
+++ b/electricore/api/CONTEXT.md
@@ -1,0 +1,17 @@
+# Contexte — api (service REST)
+
+Vocabulaire spécifique au service REST qui expose `core` et l'orchestration de l'`etl`. Hub central de l'architecture — voir [ADR-0009](../../docs/adr/0009-architecture-api-centrique.md).
+
+## API
+
+**API** :
+Service REST FastAPI ([electricore/api/](.)) exposant les flux Enedis (`/flux/*`), les déclenchements ETL (`/etl/*`), les calculs de taxes (`/taxes/*`), les exports de facturation (`/facturation/*`) et les vérifications pré-facturation (`/check/*`).
+
+**Endpoint sécurisé** :
+Endpoint nécessitant la clé `X-API-Key` (header) ou `?api_key=` (query). Tous les endpoints sont sécurisés sauf `/`, `/health`, `/docs`, `/redoc`.
+
+**`/health`** :
+Endpoint public qui retourne l'état de l'API, de la base DuckDB (accessible, dernière écriture, comptes par table) et du bot. Utilisé pour les checks de déploiement et le monitoring externe.
+
+**Service** :
+Module de [services/](services/) qui contient la logique d'un endpoint (ex : `duckdb_service.py` pour les requêtes flux, `facturation_service.py` pour la réconciliation Odoo↔Enedis). Permet de séparer la couche HTTP de la logique d'accès aux données.

--- a/electricore/bot/CONTEXT.md
+++ b/electricore/bot/CONTEXT.md
@@ -1,0 +1,17 @@
+# Contexte — bot (Telegram)
+
+Vocabulaire spécifique au bot Telegram, client conversationnel de l'`api`. Voir [ADR-0010](../../docs/adr/0010-bot-telegram-ui-operationnelle.md).
+
+## Bot
+
+**Bot** :
+Application [python-telegram-bot](https://docs.python-telegram-bot.org/) ([electricore/bot/](.)) qui expose des commandes Telegram appelant l'API ElectriCore. Pas de logique métier ; uniquement traduction commande Telegram → appel HTTP → formatage de la réponse.
+
+**Commande** :
+Handler Telegram déclenché par un message commençant par `/<nom>` (ex : `/etl`, `/taxes`, `/facturation`). Implémentée dans [bot.py](bot.py) comme une `async def cmd_<nom>(update, context)`.
+
+**Allowlist Telegram** :
+Liste d'identifiants numériques Telegram autorisés à utiliser le bot, configurée via `TELEGRAM_ALLOWED_USERS`. Tout autre utilisateur reçoit `⛔ Accès refusé`. Pas de rôles ni de granularité.
+
+**Client API** :
+Wrapper `httpx.AsyncClient` ([client.py](client.py)) qui factorise les appels HTTP vers l'API : injection automatique de la clé `X-API-Key`, gestion des timeouts (10 s pour les requêtes courtes, 300 s pour les exports lourds).

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -1,10 +1,10 @@
-# Contexte — ElectriCore
+# Contexte — core (métier)
 
-ElectriCore traite les flux de données du distributeur Enedis pour le marché français de l'électricité. Ce document est le glossaire canonique : tout terme métier utilisé dans le code, la documentation ou les commits doit avoir sa définition ici.
+Vocabulaire du domaine métier ElectriCore : acteurs, points de livraison, tarification, événements contractuels, calculs, intégration Odoo. C'est le contexte canonique référencé par les autres modules.
 
 ## Langue
 
-Voir [ADR-0004](docs/adr/0004-langue-francaise.md) — l'intégralité du code, des colonnes et de la documentation est en français.
+Voir [ADR-0004](../../docs/adr/0004-langue-francaise.md) — l'intégralité du code, des colonnes et de la documentation est en français.
 
 ---
 
@@ -100,34 +100,9 @@ Unité de déclaration des taxes (Accise, CTA), notée `YYYY-TN` (ex : `2025-T1`
 
 ---
 
-## Flux Enedis
-
-**Flux** :
-Fichier de données émis périodiquement par Enedis aux fournisseurs, au format XML ou CSV. Chaque type a un code (C15, R151…) et un contenu spécifique.
-
-**C15** :
-Flux d'événements contractuels (MES, RES, MCT…). Source de l'historique du périmètre.
-
-**R151** :
-Flux de relevés périodiques mensuels (index Linky par cadran). Source principale du calcul de consommation. Convention de date « fin de journée » — voir [ADR-0003](docs/adr/0003-r151-date-harmonisation.md).
-
-**R15** :
-Flux de relevés à la demande + événements ponctuels (déplacements, contestations).
-
-**R64** :
-Flux de relevés au format JSON, séries temporelles plus granulaires.
-
-**F12** :
-Synthèse mensuelle de facturation distributeur (volumes agrégés).
-
-**F15** :
-Facturation distributeur détaillée, utilisée pour valider les calculs TURPE.
-
----
-
 ## Événements contractuels (codes C15)
 
-Les *entrées* (le PDL devient actif chez nous) sont `PMES`, `MES`, `CFNE`. Les *sorties* (le PDL nous quitte) sont `RES`, `CFNS`. Les modifications en cours de vie utilisent `MCT`.
+Les *entrées* (le PDL devient actif chez nous) sont `PMES`, `MES`, `CFNE`. Les *sorties* (le PDL nous quitte) sont `RES`, `CFNS`. Les modifications en cours de vie utilisent `MCT`. Les flux C15 qui transportent ces événements sont décrits dans `electricore/etl/CONTEXT.md`.
 
 **PMES** (Première Mise En Service) :
 Variante de MES correspondant à une première activation du PDL. Distinction exacte avec MES à préciser (probablement liée à l'absence d'historique contractuel antérieur).
@@ -167,7 +142,7 @@ Limite contractuelle en kVA. Un seul champ en C5 (`puissance_souscrite_kva`), qu
 
 ---
 
-## Concepts pipeline (spécifiques ElectriCore)
+## Concepts pipeline
 
 **Périmètre** :
 Vue chronologique des événements contractuels d'un ou plusieurs PDL, enrichie pour la facturation. Produit par `pipeline_perimetre()` à partir du flux C15.
@@ -185,7 +160,7 @@ Intervalle entre deux relevés d'index, support du calcul de consommation et du 
 Agrégation d'abonnements + périodes d'énergie sur un mois calendaire, unité de la facturation client mensuelle.
 
 **Harmonisation des relevés** :
-Alignement des sources de relevés (R151, R15, R64) sur la convention de date « début de journée ». Implémenté dans `releves_harmonises()` — voir [ADR-0003](docs/adr/0003-r151-date-harmonisation.md).
+Alignement des sources de relevés (R151, R15, R64) sur la convention de date « début de journée ». Implémenté dans `releves_harmonises()` — voir [ADR-0003](../../docs/adr/0003-r151-date-harmonisation.md).
 
 **`date_ajustee`** (champ) :
 Booléen marquant les relevés dont la date a été décalée pendant l'harmonisation (R151 +1 jour).
@@ -201,27 +176,4 @@ Modalité de facturation où le client paie un montant mensuel constant basé su
 Identifiant Enedis d'une situation contractuelle d'un PDL — un PDL peut avoir plusieurs RSC successives. Côté Odoo, portée par `x_ref_situation_contractuelle` sur `sale.order`.
 
 **`x_invoicing_state`** :
-Champ Odoo qui matérialise l'avancement d'un `sale.order` dans le cycle de facturation mensuel. Les vérifications pré-facturation (`/check odoo`) reposent en partie sur sa répartition.
-
----
-
-## Plateforme et opérations
-
-**API** :
-Service REST FastAPI ([electricore/api/](electricore/api/)) qui expose les flux, les pipelines et l'orchestration ETL. Hub central de l'architecture — voir [ADR-0009](docs/adr/0009-architecture-api-centrique.md).
-
-**Bot** (Bot Telegram) :
-Client conversationnel de l'API ([electricore/bot/](electricore/bot/)) pour piloter l'ETL et générer des exports métier depuis Telegram. Voir [ADR-0010](docs/adr/0010-bot-telegram-ui-operationnelle.md).
-
-**Job ETL** :
-Exécution asynchrone du pipeline d'ingestion déclenchée par `POST /etl/run`. Identifié par un UUID, doté d'un statut (`running`, `completed`, `failed`) et d'une sortie (`output` ou `error`).
-
-**Mode ETL** :
-Paramètre du pipeline d'ingestion sélectionnant l'étendue de l'exécution :
-- `test` : 2 fichiers (validation rapide)
-- `r151` : flux R151 complet uniquement
-- `all` : tous les flux
-- `reset` : purge + ré-ingestion complète
-
-**Scheduler** :
-Conteneur Docker qui déclenche l'ETL via cron et appel HTTP à `/etl/run` (pas de logique métier embarquée). Voir [ADR-0011](docs/adr/0011-deploiement-vps-docker.md).
+Champ Odoo qui matérialise l'avancement d'un `sale.order` dans le cycle de facturation mensuel. Les vérifications pré-facturation (`/check odoo` côté bot) reposent en partie sur sa répartition.

--- a/electricore/etl/CONTEXT.md
+++ b/electricore/etl/CONTEXT.md
@@ -1,0 +1,46 @@
+# Contexte — etl (ingestion)
+
+Vocabulaire spécifique à l'ingestion des flux Enedis vers DuckDB. Les concepts métier portés par ces flux (PDL, événements contractuels, etc.) sont définis dans [`electricore/core/CONTEXT.md`](../core/CONTEXT.md).
+
+## Flux Enedis
+
+**Flux** :
+Fichier de données émis périodiquement par Enedis aux fournisseurs, au format XML ou CSV. Chaque type a un code (C15, R151…) et un contenu spécifique.
+
+**C15** :
+Flux d'événements contractuels (MES, RES, MCT…). Source de l'historique du périmètre.
+
+**R151** :
+Flux de relevés périodiques mensuels (index Linky par cadran). Source principale du calcul de consommation. Convention de date « fin de journée » — voir [ADR-0003](../../docs/adr/0003-r151-date-harmonisation.md).
+
+**R15** :
+Flux de relevés à la demande + événements ponctuels (déplacements, contestations).
+
+**R64** :
+Flux de relevés au format JSON, séries temporelles plus granulaires.
+
+**F12** :
+Synthèse mensuelle de facturation distributeur (volumes agrégés).
+
+**F15** :
+Facturation distributeur détaillée, utilisée pour valider les calculs TURPE.
+
+---
+
+## Pipeline d'ingestion
+
+**Mode ETL** :
+Paramètre du pipeline d'ingestion sélectionnant l'étendue de l'exécution :
+- `test` : 2 fichiers (validation rapide)
+- `r151` : flux R151 complet uniquement
+- `all` : tous les flux
+- `reset` : purge + ré-ingestion complète
+
+**Job ETL** :
+Exécution asynchrone du pipeline d'ingestion déclenchée via l'API (`POST /etl/run`). Identifié par un UUID, doté d'un statut (`running`, `completed`, `failed`) et d'une sortie (`output` ou `error`).
+
+**Scheduler** :
+Conteneur Docker qui déclenche périodiquement l'ETL via cron et un appel HTTP à `/etl/run` — pas de logique métier embarquée. Voir [ADR-0011](../../docs/adr/0011-deploiement-vps-docker.md).
+
+**Transformer** :
+Étape unitaire et composable de transformation d'un fichier (`crypto.py` déchiffrement AES, `archive.py` extraction ZIP, `parsers.py` parsing XML/CSV). Les transformers se chaînent via le `|` de DLT : `encrypted | decrypt | unzip | parse`.


### PR DESCRIPTION
## Résumé

Deux changements liés mais commités séparément :

**1. Multi-context layout** (`a529996`)
- Le glossaire racine `CONTEXT.md` devient `CONTEXT-MAP.md` qui pointe vers 4 contextes par module :
  - `electricore/core/CONTEXT.md` — métier (canonique, 80 % du vocabulaire)
  - `electricore/etl/CONTEXT.md` — flux Enedis + Mode/Job ETL + Scheduler
  - `electricore/api/CONTEXT.md` — service REST
  - `electricore/bot/CONTEXT.md` — bot Telegram
- Git détecte le rename `CONTEXT.md → electricore/core/CONTEXT.md` à 72 % (blame préservé).
- 5 fichiers de référence mis à jour : README, CLAUDE, CONTRIBUTING, `docs/transmission.md`, `docs/qualite-donnees-r151.md`.

**2. Setup conventions agent skills** (`6d7f78a`)

Posé par `/setup-matt-pocock-skills` pour que les skills `to-issues`, `triage`, `to-prd`, `qa`, `improve-codebase-architecture`, `diagnose`, `tdd` aient un point d'entrée canonique.

- `docs/agents/issue-tracker.md` — conventions `gh` CLI (GitHub Issues)
- `docs/agents/triage-labels.md` — mapping des 5 rôles canoniques (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`)
- `docs/agents/domain.md` — règles de lecture multi-contexte
- Section `## Agent skills` ajoutée à `CLAUDE.md`
- Labels GitHub créés : `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human` (`wontfix` existait déjà)

## Chiffres

- 2 commits, 14 fichiers, **+206 / −60 lignes**
- 4 nouveaux `CONTEXT.md` par module + 1 `CONTEXT-MAP.md` au lieu d'un seul fichier racine

## Impact technique

Aucun. Pas de code touché, pas de test. CI inchangée.

## Test plan

- [ ] CI verte (devrait être triviale, docs-only)
- [x] Links internes vérifiés (CONTEXT-MAP → 4 modules, refs → CONTEXT-MAP)
- [x] Labels GitHub créés et visibles via `gh label list`