### PR TITLE
refactor(core): renommage Périmètre → Historique (ADR-0013)

### DIFF
--- a/electricore/core/loaders/__init__.py
+++ b/electricore/core/loaders/__init__.py
@@ -14,7 +14,7 @@ from .duckdb import (
     # Utilitaires
     get_available_tables,
     # API legacy (compatibilité)
-    load_historique_perimetre,
+    load_historique,
     load_releves,
     r15,
     r64,
@@ -56,7 +56,7 @@ __all__ = [
     "releves_harmonises",
     "DuckDBQuery",
     # API legacy DuckDB (compatibilité)
-    "load_historique_perimetre",
+    "load_historique",
     "load_releves",
     # Utilitaires DuckDB
     "get_available_tables",

--- a/electricore/core/loaders/duckdb/__init__.py
+++ b/electricore/core/loaders/duckdb/__init__.py
@@ -18,7 +18,7 @@ API publique :
 - releves(), releves_harmonises() : Vues unifiées
 - DuckDBQuery : Builder immutable avec méthodes chainables
 - Utilitaires : get_available_tables(), execute_custom_query()
-- API legacy : load_historique_perimetre(), load_releves()
+- API legacy : load_historique(), load_releves()
 """
 
 # Imports internes
@@ -31,7 +31,7 @@ from .helpers import (
     # Utilitaires
     get_available_tables,
     # API legacy
-    load_historique_perimetre,
+    load_historique,
     load_releves,
     r15,
     r64,
@@ -60,7 +60,7 @@ __all__ = [
     "releves",
     "releves_harmonises",
     # API legacy (compatibilité)
-    "load_historique_perimetre",
+    "load_historique",
     "load_releves",
     # Utilitaires
     "get_available_tables",

--- a/electricore/core/loaders/duckdb/config.py
+++ b/electricore/core/loaders/duckdb/config.py
@@ -30,7 +30,7 @@ class DuckDBConfig:
 
         # Mapping des tables DuckDB vers schémas métier
         self.table_mappings = {
-            "historique_perimetre": {
+            "historique": {
                 "source_tables": ["flux_enedis.flux_c15"],
                 "description": "Historique des événements contractuels avec relevés avant/après",
             },

--- a/electricore/core/loaders/duckdb/helpers.py
+++ b/electricore/core/loaders/duckdb/helpers.py
@@ -189,14 +189,14 @@ def releves_harmonises(database_path: str | Path | None = None) -> DuckDBQuery:
 # =============================================================================
 
 
-def load_historique_perimetre(
+def load_historique(
     database_path: str | Path | None = None,
     filters: dict[str, Any] | None = None,
     limit: int | None = None,
     valider: bool = True,
 ) -> pl.LazyFrame:
     """
-    Charge l'historique de périmètre depuis DuckDB.
+    Charge l'historique des événements contractuels depuis DuckDB.
 
     .. deprecated::
         Utilisez `c15()` avec l'API fluide à la place.
@@ -211,7 +211,7 @@ def load_historique_perimetre(
         LazyFrame Polars contenant l'historique de périmètre
 
     Example:
-        >>> lf = load_historique_perimetre(
+        >>> lf = load_historique(
         ...     filters={"Date_Evenement": ">= '2024-01-01'"},
         ...     limit=1000
         ... )

--- a/electricore/core/loaders/duckdb/registry.py
+++ b/electricore/core/loaders/duckdb/registry.py
@@ -5,8 +5,6 @@ Ce module centralise toutes les configurations de flux Enedis
 avec leur schéma SQL, transformation Polars et validation Pandera.
 """
 
-from electricore.core.models.historique_perimetre import HistoriquePérimètre
-
 # Imports de validation
 from electricore.core.models.releve_index import RelevéIndex
 
@@ -14,7 +12,7 @@ from .query import QueryConfig
 from .sql import FLUX_SCHEMAS
 from .transforms import (
     transform_factures,
-    transform_historique_perimetre,
+    transform_historique,
     transform_r64,
     transform_releves,
 )
@@ -24,9 +22,7 @@ from .transforms import (
 # =============================================================================
 
 FLUX_CONFIGS: dict[str, QueryConfig] = {
-    "c15": QueryConfig(
-        schema=FLUX_SCHEMAS["c15"], transform=transform_historique_perimetre, validator=HistoriquePérimètre
-    ),
+    "c15": QueryConfig(schema=FLUX_SCHEMAS["c15"], transform=transform_historique, validator=None),
     "r151": QueryConfig(schema=FLUX_SCHEMAS["r151"], transform=transform_releves, validator=RelevéIndex),
     "r15": QueryConfig(schema=FLUX_SCHEMAS["r15"], transform=transform_releves, validator=RelevéIndex),
     "f15": QueryConfig(

--- a/electricore/core/loaders/duckdb/transforms.py
+++ b/electricore/core/loaders/duckdb/transforms.py
@@ -174,8 +174,8 @@ def compose(*transforms: Callable[[pl.LazyFrame], pl.LazyFrame]) -> Callable[[pl
 # PIPELINES PRÉDÉFINIS (Compositions pures)
 # =============================================================================
 
-# Pipeline pour historique périmètre (flux C15)
-transform_historique_perimetre = compose(
+# Pipeline pour historique (flux C15)
+transform_historique = compose(
     transform_dates(DATE_COLS_HISTORIQUE), transform_add_defaults(unite="kWh", precision="kWh")
 )
 

--- a/electricore/core/loaders/parquet.py
+++ b/electricore/core/loaders/parquet.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import polars as pl
 
-from electricore.core.models.historique_perimetre import HistoriquePérimètre
 from electricore.core.models.releve_index import RelevéIndex
 
 
@@ -54,35 +53,32 @@ def charger_releves(path: str | Path, valider: bool = True) -> pl.DataFrame:
     return df
 
 
-def charger_historique(path: str | Path, valider: bool = True) -> pl.DataFrame:
+def charger_historique(path: str | Path) -> pl.DataFrame:
     """
-    Charge et valide un fichier parquet d'historique de périmètre.
+    Charge un fichier parquet d'historique d'événements contractuels.
+
+    La validation Pandera n'est pas appliquée ici (cf. ADR-0013) : le modèle
+    `Historique` valide la sortie enrichie de `pipeline_historique`, pas le
+    brut potentiellement présent dans un parquet exporté.
 
     Args:
         path: Chemin vers le fichier parquet de l'historique
-        valider: Active la validation Pandera (défaut: True)
 
     Returns:
-        DataFrame Polars (validé si demandé)
+        DataFrame Polars
 
     Raises:
         FileNotFoundError: Si le fichier n'existe pas
-        pandera.errors.SchemaError: Si la validation échoue
     """
     path = Path(path)
     if not path.exists():
         raise FileNotFoundError(f"Le fichier parquet n'existe pas : {path}")
 
-    # Charger avec Polars
     df = pl.read_parquet(path)
 
     # Nettoyer les colonnes d'index pandas si présentes
     index_columns = [col for col in df.columns if col.startswith("__index_level_")]
     if index_columns:
         df = df.drop(index_columns)
-
-    # Validation avec Pandera si demandée
-    if valider:
-        df = HistoriquePérimètre.validate(df)
 
     return df

--- a/electricore/core/models/__init__.py
+++ b/electricore/core/models/__init__.py
@@ -5,7 +5,7 @@ Ces modèles sont adaptés pour fonctionner avec Polars et remplacent
 progressivement les modèles pandas existants.
 """
 
-from .historique_perimetre import HistoriquePérimètre
+from .historique import Historique
 from .releve_index import RelevéIndex
 
-__all__ = ["RelevéIndex", "HistoriquePérimètre"]
+__all__ = ["RelevéIndex", "Historique"]

--- a/electricore/core/models/historique.py
+++ b/electricore/core/models/historique.py
@@ -1,15 +1,20 @@
+"""Modèle Pandera pour `Historique`.
+
+Valide la sortie enrichie du pipeline `pipeline_historique` : événements
+contractuels C15 + détection des points de rupture (impacts abonnement et
+énergie, résumé des modifications) + événements FACTURATION artificiels insérés
+au 1er de chaque mois.
+
+Voir `electricore/core/CONTEXT.md` (entrée `Historique`) et ADR-0013.
+"""
+
 import pandera.polars as pa
 import polars as pl
 from pandera.engines.polars_engine import DateTime
 
 
-class HistoriquePérimètre(pa.DataFrameModel):
-    """
-    📌 Modèle Pandera pour l'historique des événements contractuels - Version Polars.
-
-    Contient toutes les modifications de périmètre au fil du temps.
-    Adapté pour fonctionner avec Polars pour des performances optimales.
-    """
+class Historique(pa.DataFrameModel):
+    """Séquence temporelle enrichie d'événements contractuels d'un PDL."""
 
     # Timestamp principal
     date_evenement: DateTime = pa.Field(nullable=False, dtype_kwargs={"time_unit": "us", "time_zone": "Europe/Paris"})
@@ -20,8 +25,8 @@ class HistoriquePérimètre(pa.DataFrameModel):
 
     # Informations Contractuelles
     segment_clientele: pl.Utf8 = pa.Field(nullable=False)
-    etat_contractuel: pl.Utf8 = pa.Field(nullable=False)  # "EN SERVICE", "RESILIE", etc.
-    evenement_declencheur: pl.Utf8 = pa.Field(nullable=False)  # Ex: "MCT", "MES", "RES"
+    etat_contractuel: pl.Utf8 = pa.Field(nullable=False)
+    evenement_declencheur: pl.Utf8 = pa.Field(nullable=False)
     type_evenement: pl.Utf8 = pa.Field(nullable=False)
     categorie: pl.Utf8 | None = pa.Field(nullable=True)
 
@@ -33,11 +38,11 @@ class HistoriquePérimètre(pa.DataFrameModel):
     type_compteur: pl.Utf8 = pa.Field(nullable=False)
     num_compteur: pl.Utf8 = pa.Field(nullable=False)
 
-    # Informations Demande (Optionnelles)
+    # Informations Demande (optionnelles)
     ref_demandeur: pl.Utf8 | None = pa.Field(nullable=True)
     id_affaire: pl.Utf8 | None = pa.Field(nullable=True)
 
-    # Colonnes supplémentaires fréquemment présentes dans les exports
+    # Colonnes supplémentaires fréquemment présentes
     source: pl.Utf8 | None = pa.Field(nullable=True)
     marque: pl.Utf8 | None = pa.Field(nullable=True)
     unite: pl.Utf8 | None = pa.Field(nullable=True)
@@ -45,7 +50,7 @@ class HistoriquePérimètre(pa.DataFrameModel):
     num_depannage: pl.Utf8 | None = pa.Field(nullable=True)
     date_derniere_modification_fta: pl.Utf8 | None = pa.Field(nullable=True)
 
-    # Colonnes de relevés "Avant" (index de compteurs)
+    # Colonnes de relevés "Avant"
     avant_date_releve: DateTime | None = pa.Field(
         nullable=True, dtype_kwargs={"time_unit": "us", "time_zone": "Europe/Paris"}
     )
@@ -60,7 +65,7 @@ class HistoriquePérimètre(pa.DataFrameModel):
     avant_index_hcb_kwh: pl.Float64 | None = pa.Field(nullable=True)
     avant_index_base_kwh: pl.Float64 | None = pa.Field(nullable=True)
 
-    # Colonnes de relevés "Après" (index de compteurs)
+    # Colonnes de relevés "Après"
     apres_date_releve: DateTime | None = pa.Field(
         nullable=True, dtype_kwargs={"time_unit": "us", "time_zone": "Europe/Paris"}
     )
@@ -75,54 +80,47 @@ class HistoriquePérimètre(pa.DataFrameModel):
     apres_index_hcb_kwh: pl.Float64 | None = pa.Field(nullable=True)
     apres_index_base_kwh: pl.Float64 | None = pa.Field(nullable=True)
 
+    # Colonnes ajoutées par l'enrichissement (detecter_points_de_rupture)
+    avant_puissance_souscrite: pl.Float64 | None = pa.Field(nullable=True)
+    avant_formule_tarifaire_acheminement: pl.Utf8 | None = pa.Field(nullable=True)
+    impacte_abonnement: pl.Boolean = pa.Field(nullable=False)
+    impacte_energie: pl.Boolean = pa.Field(nullable=False)
+    resume_modification: pl.Utf8 = pa.Field(nullable=False)
+
     @pa.dataframe_check
     def verifier_coherence_dates(cls, data) -> pl.LazyFrame:
-        """
-        Vérifie la cohérence des dates dans l'historique.
-        Les dates de relevés avant/après doivent être cohérentes avec la date d'événement.
-        """
+        """Les dates de relevés avant/après doivent être cohérentes avec date_evenement."""
         df_lazy = data.lazyframe
 
-        # Vérifier que les dates de relevés "Avant" sont <= date_evenement (quand définies)
         condition_avant = (
             pl.when(pl.col("avant_date_releve").is_not_null())
             .then(pl.col("avant_date_releve") <= pl.col("date_evenement"))
             .otherwise(pl.lit(True))
         )
 
-        # Vérifier que les dates de relevés "Après" sont >= date_evenement (quand définies)
         condition_apres = (
             pl.when(pl.col("apres_date_releve").is_not_null())
             .then(pl.col("apres_date_releve") >= pl.col("date_evenement"))
             .otherwise(pl.lit(True))
         )
 
-        # Combiner les conditions
-        coherence_dates = condition_avant & condition_apres
-
-        return df_lazy.select(coherence_dates.alias("dates_coherentes"))
+        return df_lazy.select((condition_avant & condition_apres).alias("dates_coherentes"))
 
     @pa.dataframe_check
     def verifier_presence_mesures_releves(cls, data) -> pl.LazyFrame:
-        """
-        Vérifie que si un calendrier distributeur est défini,
-        les mesures correspondantes sont présentes.
-        """
+        """Vérifie que les index présents correspondent au calendrier distributeur déclaré."""
         df_lazy = data.lazyframe
 
-        # Pour les relevés "Avant"
         cond_avant_d1 = (
             pl.when(pl.col("avant_id_calendrier_distributeur") == "DI000001")
             .then(pl.col("avant_index_base_kwh").is_not_null())
             .otherwise(pl.lit(True))
         )
-
         cond_avant_d2 = (
             pl.when(pl.col("avant_id_calendrier_distributeur") == "DI000002")
             .then(pl.col("avant_index_hp_kwh").is_not_null() & pl.col("avant_index_hc_kwh").is_not_null())
             .otherwise(pl.lit(True))
         )
-
         cond_avant_d3 = (
             pl.when(pl.col("avant_id_calendrier_distributeur") == "DI000003")
             .then(
@@ -133,20 +131,16 @@ class HistoriquePérimètre(pa.DataFrameModel):
             )
             .otherwise(pl.lit(True))
         )
-
-        # Pour les relevés "Après" (même logique)
         cond_apres_d1 = (
             pl.when(pl.col("apres_id_calendrier_distributeur") == "DI000001")
             .then(pl.col("apres_index_base_kwh").is_not_null())
             .otherwise(pl.lit(True))
         )
-
         cond_apres_d2 = (
             pl.when(pl.col("apres_id_calendrier_distributeur") == "DI000002")
             .then(pl.col("apres_index_hp_kwh").is_not_null() & pl.col("apres_index_hc_kwh").is_not_null())
             .otherwise(pl.lit(True))
         )
-
         cond_apres_d3 = (
             pl.when(pl.col("apres_id_calendrier_distributeur") == "DI000003")
             .then(
@@ -158,12 +152,8 @@ class HistoriquePérimètre(pa.DataFrameModel):
             .otherwise(pl.lit(True))
         )
 
-        # Combiner toutes les conditions
         mesures_valides = cond_avant_d1 & cond_avant_d2 & cond_avant_d3 & cond_apres_d1 & cond_apres_d2 & cond_apres_d3
-
         return df_lazy.select(mesures_valides.alias("mesures_releves_valides"))
 
     class Config:
-        """Configuration du modèle."""
-
-        strict = False  # Permet les colonnes supplémentaires durant la migration
+        strict = False  # tolère colonnes supplémentaires (date_entree, dates_facturation, etc.)

--- a/electricore/core/pipelines/energie.py
+++ b/electricore/core/pipelines/energie.py
@@ -600,7 +600,7 @@ def pipeline_energie(historique: pl.LazyFrame, releves: pl.LazyFrame) -> pl.Lazy
         >>> periodes_energie = pipeline_energie(historique_lf, releves_lf)
         >>> df = periodes_energie.collect()
     """
-    from .perimetre import detecter_points_de_rupture
+    from .historique import detecter_points_de_rupture
 
     schema_columns = historique.collect_schema().names()
 

--- a/electricore/core/pipelines/historique.py
+++ b/electricore/core/pipelines/historique.py
@@ -1,12 +1,20 @@
 """
-Expressions Polars pour le pipeline périmètre.
+Expressions Polars pour le pipeline historique.
 
 Ce module contient des expressions composables suivant la philosophie
 fonctionnelle de Polars. Les expressions sont des transformations pures
 qui peuvent être composées entre elles.
+
+Le pipeline `pipeline_historique` produit l'Historique enrichi au sens du
+glossaire (cf. `electricore/core/CONTEXT.md` et ADR-0013) : événements C15
++ détection des points de rupture + événements FACTURATION artificiels.
 """
 
+import pandera.polars as pa
 import polars as pl
+from pandera.typing.polars import LazyFrame
+
+from electricore.core.models.historique import Historique
 
 
 def expr_changement(col_name: str, over: str = "ref_situation_contractuelle") -> pl.Expr:
@@ -602,33 +610,34 @@ def inserer_evenements_facturation(lf: pl.LazyFrame) -> pl.LazyFrame:
     )
 
 
-def pipeline_perimetre(historique: pl.LazyFrame, date_limite: pl.Expr | None = None) -> pl.LazyFrame:
+@pa.check_types(lazy=True)
+def pipeline_historique(historique: pl.LazyFrame, date_limite: pl.Expr | None = None) -> LazyFrame[Historique]:
     """
-    Pipeline complet de traitement du périmètre - Version Polars.
+    Pipeline complet de production de l'Historique enrichi.
 
     Ce pipeline orchestre :
     1. La détection des points de rupture
-    2. L'insertion des événements de facturation
+    2. L'insertion des événements FACTURATION artificiels
     3. Le filtrage optionnel par date limite
 
     Args:
-        historique: LazyFrame contenant l'historique des événements contractuels
+        historique: LazyFrame contenant les événements contractuels bruts (sortie de `c15()`)
         date_limite: Expression Polars pour filtrer les événements après cette date
                     (défaut: 1er du mois courant si None)
 
     Returns:
-        LazyFrame enrichi avec détection des ruptures et événements de facturation
+        LazyFrame validé par le modèle `Historique`
 
     Example:
         >>> from datetime import datetime
         >>> import polars as pl
         >>>
         >>> # Pipeline complet
-        >>> enrichi = pipeline_perimetre(historique_lf)
+        >>> enrichi = pipeline_historique(historique_lf)
         >>>
         >>> # Avec date limite
         >>> date_limite = pl.lit(datetime(2024, 1, 1))
-        >>> enrichi = pipeline_perimetre(historique_lf, date_limite)
+        >>> enrichi = pipeline_historique(historique_lf, date_limite)
     """
     # Appliquer le filtrage par date si spécifié
     if date_limite is not None:

--- a/electricore/core/pipelines/orchestration.py
+++ b/electricore/core/pipelines/orchestration.py
@@ -5,7 +5,7 @@ Fournit des fonctions d'orchestration qui composent les pipelines purs Polars
 et retournent des ResultatFacturationPolars immutables.
 
 Ce module centralise l'orchestration de tous les pipelines Polars, garantissant
-que pipeline_perimetre n'est appelé qu'une seule fois et que les résultats
+que pipeline_historique n'est appelé qu'une seule fois et que les résultats
 intermédiaires sont accessibles via le container ResultatFacturationPolars.
 """
 
@@ -16,7 +16,7 @@ import polars as pl
 from electricore.core.pipelines.abonnements import pipeline_abonnements
 from electricore.core.pipelines.energie import pipeline_energie
 from electricore.core.pipelines.facturation import pipeline_facturation
-from electricore.core.pipelines.perimetre import pipeline_perimetre
+from electricore.core.pipelines.historique import pipeline_historique
 
 
 class ResultatFacturationPolars(NamedTuple):
@@ -69,7 +69,7 @@ def calculer_historique_enrichi(
     Returns:
         ResultatFacturationPolars avec historique_enrichi seulement
     """
-    historique_enrichi = pipeline_perimetre(historique, date_limite=date_limite)
+    historique_enrichi = pipeline_historique(historique, date_limite=date_limite)
     return ResultatFacturationPolars(historique_enrichi=historique_enrichi)
 
 
@@ -77,7 +77,7 @@ def calculer_abonnements(historique: pl.LazyFrame, date_limite: pl.Expr | None =
     """
     Calcule les abonnements avec leur contexte (historique enrichi) - Version Polars.
 
-    Orchestre pipeline_perimetre + pipeline_abonnements pour obtenir
+    Orchestre pipeline_historique + pipeline_abonnements pour obtenir
     les périodes d'abonnement avec TURPE fixe.
 
     Args:
@@ -88,7 +88,7 @@ def calculer_abonnements(historique: pl.LazyFrame, date_limite: pl.Expr | None =
     Returns:
         ResultatFacturationPolars avec historique_enrichi + abonnements
     """
-    historique_enrichi = pipeline_perimetre(historique, date_limite=date_limite)
+    historique_enrichi = pipeline_historique(historique, date_limite=date_limite)
     abonnements = pipeline_abonnements(historique_enrichi)
 
     return ResultatFacturationPolars(historique_enrichi=historique_enrichi, abonnements=abonnements)
@@ -100,7 +100,7 @@ def calculer_energie(
     """
     Calcule l'énergie avec son contexte (historique enrichi) - Version Polars.
 
-    Orchestre pipeline_perimetre + pipeline_energie pour obtenir
+    Orchestre pipeline_historique + pipeline_energie pour obtenir
     les périodes d'énergie avec TURPE variable.
 
     Args:
@@ -112,7 +112,7 @@ def calculer_energie(
     Returns:
         ResultatFacturationPolars avec historique_enrichi + energie
     """
-    historique_enrichi = pipeline_perimetre(historique, date_limite=date_limite)
+    historique_enrichi = pipeline_historique(historique, date_limite=date_limite)
     energie = pipeline_energie(historique_enrichi, releves)
 
     return ResultatFacturationPolars(historique_enrichi=historique_enrichi, energie=energie)
@@ -124,7 +124,7 @@ def facturation(
     """
     Pipeline complet de facturation avec méta-périodes mensuelles - Version Polars.
 
-    Orchestre toute la chaîne de traitement en appelant pipeline_perimetre
+    Orchestre toute la chaîne de traitement en appelant pipeline_historique
     une seule fois puis en composant tous les autres pipelines :
     1. Détection des points de rupture et événements de facturation
     2. Génération des périodes d'abonnement avec TURPE fixe
@@ -158,8 +158,8 @@ def facturation(
         # Unpacking
         hist, abo, ener, fact = result
     """
-    # Une seule fois pipeline_perimetre - évite la duplication
-    historique_enrichi = pipeline_perimetre(historique, date_limite=date_limite)
+    # Une seule fois pipeline_historique - évite la duplication
+    historique_enrichi = pipeline_historique(historique, date_limite=date_limite)
 
     # Calculs en parallèle possibles (même historique enrichi)
     abonnements = pipeline_abonnements(historique_enrichi)

--- a/notebooks/demos/demo_pipeline_abonnements.py
+++ b/notebooks/demos/demo_pipeline_abonnements.py
@@ -20,15 +20,15 @@ with app.setup:
     # Import des pipelines pandas
     from electricore.core.pipeline_abonnements import (
         pipeline_abonnement as pipeline_pandas,
-        generer_periodes_abonnement as genererperiodes_pandas
+        generer_periodes_abonnement as genererperiodes_pandas,
     )
 
     # Import des pipelines Polars
     from electricore.core.pipelines.abonnements import (
         pipeline_abonnements as pipeline,
-        generer_periodes_abonnement as generer_periodes
+        generer_periodes_abonnement as generer_periodes,
     )
-    from electricore.core.pipelines.perimetre import detecter_points_de_rupture, inserer_evenements_facturation
+    from electricore.core.pipelines.historique import detecter_points_de_rupture, inserer_evenements_facturation
 
     # Import des loaders DuckDB
     from electricore.core.loaders import c15
@@ -65,22 +65,22 @@ def load_data():
 
         # Mapping snake_case → majuscules pour pandas
         column_mapping = {
-            'ref_situation_contractuelle': 'Ref_Situation_Contractuelle',
-            'date_evenement': 'Date_Evenement',
-            'evenement_declencheur': 'Evenement_Declencheur',
-            'formule_tarifaire_acheminement': 'Formule_Tarifaire_Acheminement',
-            'puissance_souscrite_kva': 'Puissance_Souscrite',
-            'segment_clientele': 'Segment_Clientele',
-            'etat_contractuel': 'Etat_Contractuel',
-            'type_evenement': 'Type_Evenement',
-            'type_compteur': 'Type_Compteur',
-            'num_compteur': 'Num_Compteur',
-            'ref_demandeur': 'Ref_Demandeur',
-            'id_affaire': 'Id_Affaire',
-            'categorie': 'Categorie',
-            'impacte_abonnement': 'impacte_abonnement',
-            'impacte_energie': 'impacte_energie',
-            'resume_modification': 'resume_modification',
+            "ref_situation_contractuelle": "Ref_Situation_Contractuelle",
+            "date_evenement": "Date_Evenement",
+            "evenement_declencheur": "Evenement_Declencheur",
+            "formule_tarifaire_acheminement": "Formule_Tarifaire_Acheminement",
+            "puissance_souscrite_kva": "Puissance_Souscrite",
+            "segment_clientele": "Segment_Clientele",
+            "etat_contractuel": "Etat_Contractuel",
+            "type_evenement": "Type_Evenement",
+            "type_compteur": "Type_Compteur",
+            "num_compteur": "Num_Compteur",
+            "ref_demandeur": "Ref_Demandeur",
+            "id_affaire": "Id_Affaire",
+            "categorie": "Categorie",
+            "impacte_abonnement": "impacte_abonnement",
+            "impacte_energie": "impacte_energie",
+            "resume_modification": "resume_modification",
         }
 
         # Filtrer le mapping pour les colonnes qui existent
@@ -106,8 +106,13 @@ def _():
 @app.cell
 def _():
     colonnes_interessantes = [
-        "Ref_Situation_Contractuelle", "mois_annee", "debut_lisible", "fin_lisible",
-        "Formule_Tarifaire_Acheminement", "Puissance_Souscrite", "nb_jours"
+        "Ref_Situation_Contractuelle",
+        "mois_annee",
+        "debut_lisible",
+        "fin_lisible",
+        "Formule_Tarifaire_Acheminement",
+        "Puissance_Souscrite",
+        "nb_jours",
     ]
     return (colonnes_interessantes,)
 
@@ -181,18 +186,18 @@ def benchmark_performance(df_pandas, lf):
     # Résultats
     acceleration = temps_pandas / temps if temps > 0 else 0
 
-    print(f"🐼 Pandas  : {temps_pandas*1000:.1f}ms")
-    print(f"⚡ Polars  : {temps*1000:.1f}ms")
+    print(f"🐼 Pandas  : {temps_pandas * 1000:.1f}ms")
+    print(f"⚡ Polars  : {temps * 1000:.1f}ms")
     print(f"🚀 Accélération : {acceleration:.1f}x")
 
     if acceleration > 1:
         print(f"✅ Polars est {acceleration:.1f}x plus rapide !")
     elif acceleration < 1:
-        print(f"⚠️ Pandas est {1/acceleration:.1f}x plus rapide")
+        print(f"⚠️ Pandas est {1 / acceleration:.1f}x plus rapide")
     else:
         print("🟰 Performances équivalentes")
 
-    benchmark_results = {"pandas_ms": temps_pandas*1000, "polars_ms": temps*1000, "speedup": acceleration}
+    benchmark_results = {"pandas_ms": temps_pandas * 1000, "polars_ms": temps * 1000, "speedup": acceleration}
     return
 
 
@@ -221,11 +226,13 @@ def comparaison_periodes(periodes_pandas, periodes_lf):
 
     # Statistiques des périodes Polars
     if nb > 0:
-        stats = periodes.select([
-            pl.col("nb_jours").sum().alias("total_jours"),
-            pl.col("nb_jours").mean().alias("jours_moyen"),
-            pl.col("puissance_souscrite_kva").mean().alias("puissance_moyenne"),
-        ]).to_dicts()[0]
+        stats = periodes.select(
+            [
+                pl.col("nb_jours").sum().alias("total_jours"),
+                pl.col("nb_jours").mean().alias("jours_moyen"),
+                pl.col("puissance_souscrite_kva").mean().alias("puissance_moyenne"),
+            ]
+        ).to_dicts()[0]
 
         print(f"\n📈 Statistiques des périodes (Polars) :")
         print(f"- Total jours    : {stats['total_jours']}")
@@ -235,8 +242,7 @@ def comparaison_periodes(periodes_pandas, periodes_lf):
     # Répartition par FTA
     if nb > 0:
         fta_stats = (
-            periodes
-            .group_by("formule_tarifaire_acheminement")
+            periodes.group_by("formule_tarifaire_acheminement")
             .agg(pl.len().alias("count"))
             .sort("count", descending=True)
         )
@@ -261,7 +267,6 @@ def turpe_pandas(periodes_pandas):
 
     print("🐼 Calcul TURPE avec PANDAS...")
 
-
     # Appliquer le TURPE complet avec pandas
     from electricore.core.taxes.turpe import load_turpe_rules, ajouter_turpe_fixe as ajouter_turpe_fixe_pandas
 
@@ -273,8 +278,8 @@ def turpe_pandas(periodes_pandas):
         turpe_moyen_pandas = periodes_avec_turpe_pandas["turpe_fixe_eur"].mean()
 
         print(f"✅ TURPE calculé pour {len(periodes_avec_turpe_pandas)} périodes")
-        print(f"💰 Total TURPE : {total_turpe_pandas :.2f}€")
-        print(f"📊 TURPE moyen : {turpe_moyen_pandas :.2f}€")
+        print(f"💰 Total TURPE : {total_turpe_pandas:.2f}€")
+        print(f"📊 TURPE moyen : {turpe_moyen_pandas:.2f}€")
     else:
         print("⚠️ Colonne turpe_fixe_eur non trouvée")
         total_turpe_pandas = turpe_moyen_pandas = 0
@@ -295,14 +300,12 @@ def turpe(periodes_lf):
         periodes_avec_turpe = periodes_avec_turpe_lf.collect()
 
         if "turpe_fixe_eur" in periodes_avec_turpe.columns:
-            stats_turpe = (
-                periodes_avec_turpe
-                .select([
+            stats_turpe = periodes_avec_turpe.select(
+                [
                     pl.col("turpe_fixe_eur").sum().alias("total"),
                     pl.col("turpe_fixe_eur").mean().alias("moyen"),
-                ])
-                .to_dicts()[0]
-            )
+                ]
+            ).to_dicts()[0]
 
             total_turpe = stats_turpe["total"]
             turpe_moyen = stats_turpe["moyen"]

--- a/notebooks/demos/demo_pipeline_energie.py
+++ b/notebooks/demos/demo_pipeline_energie.py
@@ -20,19 +20,16 @@ with app.setup:
     # Import des pipelines pandas
     from electricore.core.pipeline_energie import (
         reconstituer_chronologie_relevés as reconstituer_pandas,
-        calculer_periodes_energie as calculer_energie_pandas
+        calculer_periodes_energie as calculer_energie_pandas,
     )
 
     # Import des pipelines Polars
     from electricore.core.pipelines.energie import (
         pipeline_energie,
         reconstituer_chronologie_releves,
-        calculer_periodes_energie
+        calculer_periodes_energie,
     )
-    from electricore.core.pipelines.perimetre import (
-        detecter_points_de_rupture,
-        inserer_evenements_facturation
-    )
+    from electricore.core.pipelines.historique import detecter_points_de_rupture, inserer_evenements_facturation
 
     # Import des loaders DuckDB
     from electricore.core.loaders import c15, r151, f15
@@ -59,9 +56,7 @@ def load_data():
 
     # Charger l'historique C15
     _lf_historique = c15().lazy()
-    lf_historique_enrichi = inserer_evenements_facturation(
-        detecter_points_de_rupture(_lf_historique)
-    )
+    lf_historique_enrichi = inserer_evenements_facturation(detecter_points_de_rupture(_lf_historique))
     df_historique = lf_historique_enrichi.collect()
 
     # Charger les relevés R151
@@ -73,40 +68,40 @@ def load_data():
 
     # Conversion pour pandas avec mapping colonnes complet
     _column_mapping = {
-        'ref_situation_contractuelle': 'Ref_Situation_Contractuelle',
-        'date_evenement': 'Date_Evenement',
-        'evenement_declencheur': 'Evenement_Declencheur',
-        'formule_tarifaire_acheminement': 'Formule_Tarifaire_Acheminement',
-        'puissance_souscrite_kva': 'Puissance_Souscrite',
-        'segment_clientele': 'Segment_Clientele',
-        'etat_contractuel': 'Etat_Contractuel',
-        'type_evenement': 'Type_Evenement',
-        'type_compteur': 'Type_Compteur',
-        'num_compteur': 'Num_Compteur',
-        'ref_demandeur': 'Ref_Demandeur',
-        'id_affaire': 'Id_Affaire',
-        'categorie': 'Categorie',
-        'impacte_energie': 'impacte_energie',
-        'impacte_abonnement': 'impacte_abonnement',
-        'resume_modification': 'resume_modification',
+        "ref_situation_contractuelle": "Ref_Situation_Contractuelle",
+        "date_evenement": "Date_Evenement",
+        "evenement_declencheur": "Evenement_Declencheur",
+        "formule_tarifaire_acheminement": "Formule_Tarifaire_Acheminement",
+        "puissance_souscrite_kva": "Puissance_Souscrite",
+        "segment_clientele": "Segment_Clientele",
+        "etat_contractuel": "Etat_Contractuel",
+        "type_evenement": "Type_Evenement",
+        "type_compteur": "Type_Compteur",
+        "num_compteur": "Num_Compteur",
+        "ref_demandeur": "Ref_Demandeur",
+        "id_affaire": "Id_Affaire",
+        "categorie": "Categorie",
+        "impacte_energie": "impacte_energie",
+        "impacte_abonnement": "impacte_abonnement",
+        "resume_modification": "resume_modification",
         # Index avant (noms exacts des colonnes)
-        'avant_base': 'Avant_BASE',
-        'avant_hp': 'Avant_HP',
-        'avant_hc': 'Avant_HC',
-        'avant_hch': 'Avant_HCH',
-        'avant_hph': 'Avant_HPH',
-        'avant_hpb': 'Avant_HPB',
-        'avant_hcb': 'Avant_HCB',
-        'avant_id_calendrier_distributeur': 'Avant_Id_Calendrier_Distributeur',
+        "avant_base": "Avant_BASE",
+        "avant_hp": "Avant_HP",
+        "avant_hc": "Avant_HC",
+        "avant_hch": "Avant_HCH",
+        "avant_hph": "Avant_HPH",
+        "avant_hpb": "Avant_HPB",
+        "avant_hcb": "Avant_HCB",
+        "avant_id_calendrier_distributeur": "Avant_Id_Calendrier_Distributeur",
         # Index après (noms exacts des colonnes avec accent)
-        'apres_base': 'Après_BASE',
-        'apres_hp': 'Après_HP',
-        'apres_hc': 'Après_HC',
-        'apres_hch': 'Après_HCH',
-        'apres_hph': 'Après_HPH',
-        'apres_hpb': 'Après_HPB',
-        'apres_hcb': 'Après_HCB',
-        'apres_id_calendrier_distributeur': 'Après_Id_Calendrier_Distributeur'
+        "apres_base": "Après_BASE",
+        "apres_hp": "Après_HP",
+        "apres_hc": "Après_HC",
+        "apres_hch": "Après_HCH",
+        "apres_hph": "Après_HPH",
+        "apres_hpb": "Après_HPB",
+        "apres_hcb": "Après_HCB",
+        "apres_id_calendrier_distributeur": "Après_Id_Calendrier_Distributeur",
     }
 
     # Filtrer le mapping pour les colonnes qui existent
@@ -115,33 +110,33 @@ def load_data():
 
     # Conversion relevés pour pandas (noms polars → noms pandas avec accents)
     _releves_mapping = {
-        'pdl': 'pdl',  # Garder pdl en minuscule comme attendu par pandas
-        'date_releve': 'Date_Releve',  # polars: date_releve → pandas: Date_Releve
-        'base': 'BASE',
-        'hp': 'HP',
-        'hc': 'HC',
-        'hch': 'HCH',
-        'hph': 'HPH',
-        'hpb': 'HPB',
-        'hcb': 'HCB',
-        'ref_situation_contractuelle': 'Ref_Situation_Contractuelle',
-        'formule_tarifaire_acheminement': 'Formule_Tarifaire_Acheminement',
-        'id_calendrier_distributeur': 'Id_Calendrier_Distributeur',
-        'source': 'Source',
-        'unite': 'Unité',  # polars: unite → pandas: Unité (avec accent)
-        'precision': 'Précision',  # polars: precision → pandas: Précision (avec accent)
-        'ordre_index': 'ordre_index',
-        'id_affaire': 'id_affaire',
-        'id_calendrier_fournisseur': 'id_calendrier_fournisseur'
+        "pdl": "pdl",  # Garder pdl en minuscule comme attendu par pandas
+        "date_releve": "Date_Releve",  # polars: date_releve → pandas: Date_Releve
+        "base": "BASE",
+        "hp": "HP",
+        "hc": "HC",
+        "hch": "HCH",
+        "hph": "HPH",
+        "hpb": "HPB",
+        "hcb": "HCB",
+        "ref_situation_contractuelle": "Ref_Situation_Contractuelle",
+        "formule_tarifaire_acheminement": "Formule_Tarifaire_Acheminement",
+        "id_calendrier_distributeur": "Id_Calendrier_Distributeur",
+        "source": "Source",
+        "unite": "Unité",  # polars: unite → pandas: Unité (avec accent)
+        "precision": "Précision",  # polars: precision → pandas: Précision (avec accent)
+        "ordre_index": "ordre_index",
+        "id_affaire": "id_affaire",
+        "id_calendrier_fournisseur": "id_calendrier_fournisseur",
     }
     _releves_mapping_filtered = {k: v for k, v in _releves_mapping.items() if k in df_releves.columns}
     df_releves_pandas = df_releves.to_pandas().rename(columns=_releves_mapping_filtered)
 
     # Filtrer les calendriers invalides pour le pipeline pandas
-    if 'Id_Calendrier_Distributeur' in df_releves_pandas.columns:
+    if "Id_Calendrier_Distributeur" in df_releves_pandas.columns:
         _before_filter = len(df_releves_pandas)
         df_releves_pandas = df_releves_pandas[
-            df_releves_pandas['Id_Calendrier_Distributeur'].isin(['DI000001', 'DI000002', 'DI000003'])
+            df_releves_pandas["Id_Calendrier_Distributeur"].isin(["DI000001", "DI000002", "DI000003"])
         ]
         _after_filter = len(df_releves_pandas)
         print(f"🔧 Filtrage calendriers: {_before_filter} → {_after_filter} relevés")
@@ -169,8 +164,13 @@ def _():
 @app.cell
 def _():
     colonnes_interessantes = [
-        "ref_situation_contractuelle", "debut_lisible", "fin_lisible",
-        "energie_base_kwh", "energie_hp_kwh", "energie_hc_kwh", "nb_jours"
+        "ref_situation_contractuelle",
+        "debut_lisible",
+        "fin_lisible",
+        "energie_base_kwh",
+        "energie_hp_kwh",
+        "energie_hc_kwh",
+        "nb_jours",
     ]
     return (colonnes_interessantes,)
 
@@ -191,8 +191,8 @@ def pipeline_pandas_energie(
         print(f"📋 Colonnes relevés: {sorted(df_releves_pandas.columns.tolist())}")
 
         # Filtrer les événements qui impactent l'énergie
-        if 'impacte_energie' in df_historique_pandas.columns:
-            _evt_energie = df_historique_pandas[df_historique_pandas['impacte_energie'] == True]
+        if "impacte_energie" in df_historique_pandas.columns:
+            _evt_energie = df_historique_pandas[df_historique_pandas["impacte_energie"] == True]
             print(f"📊 Événements énergie: {len(_evt_energie)}")
         else:
             print("⚠️ Colonne impacte_energie manquante, utilisation de tous les événements")
@@ -257,7 +257,7 @@ def _(periodes_collect):
 
 @app.cell
 def _(periodes_collect):
-    periodes_collect.filter(pl.col('pdl') == '14287988313383')
+    periodes_collect.filter(pl.col("pdl") == "14287988313383")
     return
 
 
@@ -277,7 +277,7 @@ def benchmark_performance(
     start = time.perf_counter()
     iterations = 5
     for _ in range(iterations):
-        _evt_energie = df_historique_pandas[df_historique_pandas['impacte_energie'] == True]
+        _evt_energie = df_historique_pandas[df_historique_pandas["impacte_energie"] == True]
         _chronologie = reconstituer_pandas(df_releves_pandas, _evt_energie)
         _ = calculer_energie_pandas(_chronologie)
     temps_pandas = (time.perf_counter() - start) / iterations
@@ -291,14 +291,14 @@ def benchmark_performance(
     # Résultats
     acceleration = temps_pandas / temps if temps > 0 else 0
 
-    print(f"🐼 Pandas  : {temps_pandas*1000:.1f}ms")
-    print(f"⚡ Polars  : {temps*1000:.1f}ms")
+    print(f"🐼 Pandas  : {temps_pandas * 1000:.1f}ms")
+    print(f"⚡ Polars  : {temps * 1000:.1f}ms")
     print(f"🚀 Accélération : {acceleration:.1f}x")
 
     if acceleration > 1:
         print(f"✅ Polars est {acceleration:.1f}x plus rapide !")
     elif acceleration < 1:
-        print(f"⚠️ Pandas est {1/acceleration:.1f}x plus rapide")
+        print(f"⚠️ Pandas est {1 / acceleration:.1f}x plus rapide")
     else:
         print("🟰 Performances équivalentes")
     return
@@ -349,8 +349,12 @@ def comparaison_periodes(periodes_pandas, periodes_lf):
                 polars_count = len(polars_non_null)
 
                 print(f"\n📈 {cadran.upper().replace('_', ' ')}:")
-                print(f"  🐼 Pandas  : {pandas_count:,} périodes, somme={pandas_sum:,.0f} kWh, moyenne={pandas_mean:.1f} kWh")
-                print(f"  ⚡ Polars  : {polars_count:,} périodes, somme={polars_sum:,.0f} kWh, moyenne={polars_mean:.1f} kWh")
+                print(
+                    f"  🐼 Pandas  : {pandas_count:,} périodes, somme={pandas_sum:,.0f} kWh, moyenne={pandas_mean:.1f} kWh"
+                )
+                print(
+                    f"  ⚡ Polars  : {polars_count:,} périodes, somme={polars_sum:,.0f} kWh, moyenne={polars_mean:.1f} kWh"
+                )
 
                 if pandas_sum > 0:
                     _diff_relative = abs(pandas_sum - polars_sum) / pandas_sum * 100
@@ -414,25 +418,25 @@ def calcul_turpe_pandas(periodes_pandas):
             _data = periodes_pandas.copy()
 
             # Mapping colonnes essentielles
-            if 'formule_tarifaire_acheminement' in _data.columns:
-                _data = _data.rename(columns={'formule_tarifaire_acheminement': 'Formule_Tarifaire_Acheminement'})
+            if "formule_tarifaire_acheminement" in _data.columns:
+                _data = _data.rename(columns={"formule_tarifaire_acheminement": "Formule_Tarifaire_Acheminement"})
 
             # Colonnes énergie
             for old, new in [
-                ('energie_base_kwh', 'BASE_energie'),
-                ('energie_hp_kwh', 'HP_energie'),
-                ('energie_hc_kwh', 'HC_energie'),
-                ('energie_hph_kwh', 'HPH_energie'),
-                ('energie_hpb_kwh', 'HPB_energie'),
-                ('energie_hch_kwh', 'HCH_energie'),
-                ('energie_hcb_kwh', 'HCB_energie')
+                ("energie_base_kwh", "BASE_energie"),
+                ("energie_hp_kwh", "HP_energie"),
+                ("energie_hc_kwh", "HC_energie"),
+                ("energie_hph_kwh", "HPH_energie"),
+                ("energie_hpb_kwh", "HPB_energie"),
+                ("energie_hch_kwh", "HCH_energie"),
+                ("energie_hcb_kwh", "HCB_energie"),
             ]:
                 if old in _data.columns:
                     _data = _data.rename(columns={old: new})
 
             # Créer colonne debut si manquante
-            if 'debut' not in _data.columns and 'debut_lisible' in _data.columns:
-                _data['debut'] = pd.to_datetime(_data['debut_lisible']).dt.tz_localize('Europe/Paris')
+            if "debut" not in _data.columns and "debut_lisible" in _data.columns:
+                _data["debut"] = pd.to_datetime(_data["debut_lisible"]).dt.tz_localize("Europe/Paris")
 
             # Calculer TURPE variable
             turpe_variable_pandas = calculer_turpe_variable(regles_turpe, _data)
@@ -455,14 +459,12 @@ def calcul_turpe(periodes_lf):
     periodes_avec_turpe = periodes_lf.collect()
 
     if "turpe_variable_eur" in periodes_avec_turpe.columns:
-        _stats_turpe = (
-            periodes_avec_turpe
-            .select([
+        _stats_turpe = periodes_avec_turpe.select(
+            [
                 pl.col("turpe_variable_eur").sum().alias("total"),
                 pl.col("turpe_variable_eur").mean().alias("moyen"),
-            ])
-            .to_dicts()[0]
-        )
+            ]
+        ).to_dicts()[0]
 
         total_turpe = _stats_turpe["total"]
         turpe_moyen = _stats_turpe["moyen"]

--- a/notebooks/demos/demo_pipeline_historique.py
+++ b/notebooks/demos/demo_pipeline_historique.py
@@ -17,12 +17,13 @@ with app.setup:
     # Import des pipelines
     from electricore.core.pipeline_perimetre import (
         detecter_points_de_rupture as detecter_pandas,
-        inserer_evenements_facturation as inserer_evenements_factu_pandas
+        inserer_evenements_facturation as inserer_evenements_factu_pandas,
     )
-    from electricore.core.pipelines.perimetre import (
+    from electricore.core.pipelines.historique import (
         detecter_points_de_rupture as detecter,
-        inserer_evenements_facturation as inserer_evenements_factu
+        inserer_evenements_facturation as inserer_evenements_factu,
     )
+
     # Import des loaders DuckDB
     from electricore.core.loaders import c15
 
@@ -40,13 +41,12 @@ def demo_data():
     # Données d'exemple pour un PDL avec plusieurs événements
     demo_data = {
         "Ref_Situation_Contractuelle": ["PDL001", "PDL001", "PDL001", "PDL001", "PDL001", "PDL001"],
-        "Date_Evenement": pd.to_datetime([
-            "2024-01-15", "2024-02-01", "2024-03-20", "2024-04-01", "2024-05-10", "2024-06-01"
-        ]),
+        "Date_Evenement": pd.to_datetime(
+            ["2024-01-15", "2024-02-01", "2024-03-20", "2024-04-01", "2024-05-10", "2024-06-01"]
+        ),
         "Evenement_Declencheur": ["MES", "FACTURATION", "MCT", "FACTURATION", "MCT", "RES"],
         "Puissance_Souscrite": [6.0, 6.0, 9.0, 9.0, 12.0, 12.0],
         "Formule_Tarifaire_Acheminement": ["BTINFCU4", "BTINFCU4", "BTINFMU4", "BTINFMU4", "BTINFMU4", "BTINFMU4"],
-
         # Colonnes obligatoires du schéma
         "pdl": ["PDL12345", "PDL12345", "PDL12345", "PDL12345", "PDL12345", "PDL12345"],
         "Segment_Clientele": ["C5", "C5", "C5", "C5", "C5", "C5"],
@@ -57,11 +57,23 @@ def demo_data():
         "Num_Compteur": ["12345678", "12345678", "12345678", "12345678", "12345678", "12345678"],
         "Ref_Demandeur": ["REF001", "REF001", "REF001", "REF001", "REF001", "REF001"],
         "Id_Affaire": ["AFF001", "AFF001", "AFF001", "AFF001", "AFF001", "AFF001"],
-
         # Colonnes Avant_/Après_ pour calendrier et index
-        "Avant_Id_Calendrier_Distributeur": ["CAL_HP_HC", "CAL_HP_HC", "CAL_HP_HC", "CAL_TEMPO", "CAL_TEMPO", "CAL_TEMPO"],
-        "Après_Id_Calendrier_Distributeur": ["CAL_HP_HC", "CAL_HP_HC", "CAL_TEMPO", "CAL_TEMPO", "CAL_TEMPO", "CAL_TEMPO"],
-
+        "Avant_Id_Calendrier_Distributeur": [
+            "CAL_HP_HC",
+            "CAL_HP_HC",
+            "CAL_HP_HC",
+            "CAL_TEMPO",
+            "CAL_TEMPO",
+            "CAL_TEMPO",
+        ],
+        "Après_Id_Calendrier_Distributeur": [
+            "CAL_HP_HC",
+            "CAL_HP_HC",
+            "CAL_TEMPO",
+            "CAL_TEMPO",
+            "CAL_TEMPO",
+            "CAL_TEMPO",
+        ],
         # Index avec quelques changements
         "Avant_BASE": [1000, 1250, 1600, 1950, 2400, 2800],
         "Après_BASE": [1000, 1250, 1650, 1950, 2400, 2800],  # Ajustement ligne 3
@@ -100,53 +112,53 @@ def load_data(demo_data):
 
         # Convertir les colonnes pour compatibilité avec le pipeline pandas (majuscules)
         column_mapping = {
-            'date_evenement': 'Date_Evenement',
-            'evenement_declencheur': 'Evenement_Declencheur',
-            'puissance_souscrite_kva': 'Puissance_Souscrite',
-            'formule_tarifaire_acheminement': 'Formule_Tarifaire_Acheminement',
-            'ref_situation_contractuelle': 'Ref_Situation_Contractuelle',
-            'segment_clientele': 'Segment_Clientele',
-            'etat_contractuel': 'Etat_Contractuel',
-            'type_evenement': 'Type_Evenement',
-            'type_compteur': 'Type_Compteur',
-            'num_compteur': 'Num_Compteur',
-            'ref_demandeur': 'Ref_Demandeur',
-            'id_affaire': 'Id_Affaire',
-            'avant_date_releve': 'Avant_Date_Releve',
-            'avant_nature_index': 'Avant_Nature_Index',
-            'avant_id_calendrier_fournisseur': 'Avant_Id_Calendrier_Fournisseur',
-            'avant_id_calendrier_distributeur': 'Avant_Id_Calendrier_Distributeur',
-            'apres_date_releve': 'Après_Date_Releve',
-            'apres_nature_index': 'Après_Nature_Index',
-            'apres_id_calendrier_fournisseur': 'Après_Id_Calendrier_Fournisseur',
-            'apres_id_calendrier_distributeur': 'Après_Id_Calendrier_Distributeur',
+            "date_evenement": "Date_Evenement",
+            "evenement_declencheur": "Evenement_Declencheur",
+            "puissance_souscrite_kva": "Puissance_Souscrite",
+            "formule_tarifaire_acheminement": "Formule_Tarifaire_Acheminement",
+            "ref_situation_contractuelle": "Ref_Situation_Contractuelle",
+            "segment_clientele": "Segment_Clientele",
+            "etat_contractuel": "Etat_Contractuel",
+            "type_evenement": "Type_Evenement",
+            "type_compteur": "Type_Compteur",
+            "num_compteur": "Num_Compteur",
+            "ref_demandeur": "Ref_Demandeur",
+            "id_affaire": "Id_Affaire",
+            "avant_date_releve": "Avant_Date_Releve",
+            "avant_nature_index": "Avant_Nature_Index",
+            "avant_id_calendrier_fournisseur": "Avant_Id_Calendrier_Fournisseur",
+            "avant_id_calendrier_distributeur": "Avant_Id_Calendrier_Distributeur",
+            "apres_date_releve": "Après_Date_Releve",
+            "apres_nature_index": "Après_Nature_Index",
+            "apres_id_calendrier_fournisseur": "Après_Id_Calendrier_Fournisseur",
+            "apres_id_calendrier_distributeur": "Après_Id_Calendrier_Distributeur",
             # Colonnes d'index
-            'avant_BASE': 'Avant_BASE',
-            'avant_HP': 'Avant_HP',
-            'avant_HC': 'Avant_HC',
-            'avant_HCH': 'Avant_HCH',
-            'avant_HPH': 'Avant_HPH',
-            'avant_HPB': 'Avant_HPB',
-            'avant_HCB': 'Avant_HCB',
-            'apres_BASE': 'Après_BASE',
-            'apres_HP': 'Après_HP',
-            'apres_HC': 'Après_HC',
-            'apres_HCH': 'Après_HCH',
-            'apres_HPH': 'Après_HPH',
-            'apres_HPB': 'Après_HPB',
-            'apres_HCB': 'Après_HCB',
+            "avant_BASE": "Avant_BASE",
+            "avant_HP": "Avant_HP",
+            "avant_HC": "Avant_HC",
+            "avant_HCH": "Avant_HCH",
+            "avant_HPH": "Avant_HPH",
+            "avant_HPB": "Avant_HPB",
+            "avant_HCB": "Avant_HCB",
+            "apres_BASE": "Après_BASE",
+            "apres_HP": "Après_HP",
+            "apres_HC": "Après_HC",
+            "apres_HCH": "Après_HCH",
+            "apres_HPH": "Après_HPH",
+            "apres_HPB": "Après_HPB",
+            "apres_HCB": "Après_HCB",
             # Autres
-            'categorie': 'Categorie',
-            'source': 'Source',
-            'unite': 'Unité',
-            'precision': 'Précision'
+            "categorie": "Categorie",
+            "source": "Source",
+            "unite": "Unité",
+            "precision": "Précision",
         }
 
         # Renommer les colonnes
         df_pandas = df_pandas.rename(columns=column_mapping)
 
         # Convertir les colonnes de dates
-        date_cols = ['Date_Evenement', 'Avant_Date_Releve', 'Après_Date_Releve']
+        date_cols = ["Date_Evenement", "Avant_Date_Releve", "Après_Date_Releve"]
         for _col in date_cols:
             if _col in df_pandas.columns:
                 df_pandas[_col] = pd.to_datetime(df_pandas[_col])
@@ -179,7 +191,7 @@ def pipeline_pandas(df_pandas):
     # # Afficher les colonnes clés
     # _colonnes_interessantes = [
     #     "Date_Evenement", "Evenement_Declencheur", "Puissance_Souscrite",
-    #     "Formule_Tarifaire_Acheminement", "impacte_abonnement", "impacte_energie", 
+    #     "Formule_Tarifaire_Acheminement", "impacte_abonnement", "impacte_energie",
     #     "resume_modification"
     # ]
 
@@ -201,7 +213,7 @@ def pipeline(lf):
     # Mêmes colonnes que pandas
     # _colonnes_interessantes = [
     #     "Date_Evenement", "Evenement_Declencheur", "Puissance_Souscrite",
-    #     "Formule_Tarifaire_Acheminement", "impacte_abonnement", "impacte_energie", 
+    #     "Formule_Tarifaire_Acheminement", "impacte_abonnement", "impacte_energie",
     #     "resume_modification"
     # ]
 
@@ -224,7 +236,7 @@ def benchmark_performance(df_pandas, lf):
         _ = detecter_pandas(df_pandas)
     temps_pandas = (time.perf_counter() - start) / 10
 
-    # Benchmark Polars 
+    # Benchmark Polars
     start = time.perf_counter()
     for _ in range(10):
         _ = detecter(lf).collect()
@@ -233,18 +245,18 @@ def benchmark_performance(df_pandas, lf):
     # Résultats
     acceleration = temps_pandas / temps if temps > 0 else 0
 
-    print(f"🐼 Pandas  : {temps_pandas*1000:.1f}ms")
-    print(f"⚡ Polars  : {temps*1000:.1f}ms") 
+    print(f"🐼 Pandas  : {temps_pandas * 1000:.1f}ms")
+    print(f"⚡ Polars  : {temps * 1000:.1f}ms")
     print(f"🚀 Accélération : {acceleration:.1f}x")
 
     if acceleration > 1:
         print(f"✅ Polars est {acceleration:.1f}x plus rapide !")
     elif acceleration < 1:
-        print(f"⚠️ Pandas est {1/acceleration:.1f}x plus rapide")
+        print(f"⚠️ Pandas est {1 / acceleration:.1f}x plus rapide")
     else:
         print("🟰 Performances équivalentes")
 
-    {"pandas_ms": temps_pandas*1000, "polars_ms": temps*1000, "speedup": acceleration}
+    {"pandas_ms": temps_pandas * 1000, "polars_ms": temps * 1000, "speedup": acceleration}
     return
 
 
@@ -323,7 +335,7 @@ def conclusion():
     print("=" * 30)
     print()
     print("Cette démonstration montre :")
-    print("• ✅ Équivalence fonctionnelle pandas ↔ Polars") 
+    print("• ✅ Équivalence fonctionnelle pandas ↔ Polars")
     print("• ⚡ Pipeline Polars avec LazyFrames optimisées")
     print("• 🧩 Expressions composables et réutilisables")
     print("• 📊 Détection d'impacts métier cohérente")
@@ -338,6 +350,7 @@ def conclusion():
 @app.cell
 def _():
     import marimo as mo
+
     return (mo,)
 
 

--- a/notebooks/validations/validation_turpe_f15.py
+++ b/notebooks/validations/validation_turpe_f15.py
@@ -22,23 +22,10 @@ with app.setup:
     from electricore.core.loaders import f15, c15, r151, execute_custom_query
 
     # Imports des pipelines Polars
-    from electricore.core.pipelines.energie import (
-        pipeline_energie,
-        calculer_periodes_energie
-    )
-    from electricore.core.pipelines.abonnements import (
-        pipeline_abonnements,
-        calculer_periodes_abonnement
-    )
-    from electricore.core.pipelines.turpe import (
-        load_turpe_rules,
-        ajouter_turpe_fixe,
-        ajouter_turpe_variable
-    )
-    from electricore.core.pipelines.perimetre import (
-        detecter_points_de_rupture,
-        inserer_evenements_facturation
-    )
+    from electricore.core.pipelines.energie import pipeline_energie, calculer_periodes_energie
+    from electricore.core.pipelines.abonnements import pipeline_abonnements, calculer_periodes_abonnement
+    from electricore.core.pipelines.turpe import load_turpe_rules, ajouter_turpe_fixe, ajouter_turpe_variable
+    from electricore.core.pipelines.historique import detecter_points_de_rupture, inserer_evenements_facturation
 
     # Import connecteur Odoo
     from electricore.core.loaders import OdooReader
@@ -53,7 +40,9 @@ def _():
     try:
         config = charger_config_odoo()
         _env = os.getenv("ODOO_ENV", "test")
-        _msg = mo.md(f"**Configuration Odoo chargée** (env: `{_env}`)\n\n- URL: `{config['url']}`\n- Base: `{config['db']}`\n- Utilisateur: `{config['username']}`\n- Mot de passe: `***`")
+        _msg = mo.md(
+            f"**Configuration Odoo chargée** (env: `{_env}`)\n\n- URL: `{config['url']}`\n- Base: `{config['db']}`\n- Utilisateur: `{config['username']}`\n- Mot de passe: `***`"
+        )
     except ValueError as e:
         config = {}
         _msg = mo.md(f"⚠️ **Configuration Odoo manquante**\n\n{e}\n\nDéfinissez les variables `ODOO_*` dans `.env`.")
@@ -167,41 +156,41 @@ def aggregations_f15(df_f15_turpe):
 
     # Agrégation par PDL
     df_f15_par_pdl = (
-        df_f15_turpe
-        .group_by("pdl")
-        .agg([
-            pl.col("montant_ht").sum().alias("montant_total_f15"),
-            pl.col("date_debut").min().alias("premiere_periode"),
-            pl.col("date_fin").max().alias("derniere_periode"),
-            pl.col("type_composante").n_unique().alias("nb_composantes")
-        ])
+        df_f15_turpe.group_by("pdl")
+        .agg(
+            [
+                pl.col("montant_ht").sum().alias("montant_total_f15"),
+                pl.col("date_debut").min().alias("premiere_periode"),
+                pl.col("date_fin").max().alias("derniere_periode"),
+                pl.col("type_composante").n_unique().alias("nb_composantes"),
+            ]
+        )
         .sort("montant_total_f15", descending=True)
     )
 
     # Agrégation par mois
     df_f15_par_mois = (
-        df_f15_turpe
-        .with_columns([
-            # Convertir en timezone naive pour éviter les conflits de join
-            pl.col("date_debut").str.to_datetime().dt.truncate("1mo").dt.replace_time_zone(None).alias("mois")
-        ])
+        df_f15_turpe.with_columns(
+            [
+                # Convertir en timezone naive pour éviter les conflits de join
+                pl.col("date_debut").str.to_datetime().dt.truncate("1mo").dt.replace_time_zone(None).alias("mois")
+            ]
+        )
         .group_by("mois")
-        .agg([
-            pl.col("montant_ht").sum().alias("montant_f15"),
-            pl.col("pdl").n_unique().alias("nb_pdl"),
-            pl.len().alias("nb_lignes")
-        ])
+        .agg(
+            [
+                pl.col("montant_ht").sum().alias("montant_f15"),
+                pl.col("pdl").n_unique().alias("nb_pdl"),
+                pl.len().alias("nb_lignes"),
+            ]
+        )
         .sort("mois")
     )
 
     # Agrégation par type de composante
     df_f15_par_composante = (
-        df_f15_turpe
-        .group_by(["type_composante", "part_turpe"])
-        .agg([
-            pl.col("montant_ht").sum().alias("montant_f15"),
-            pl.len().alias("nb_lignes")
-        ])
+        df_f15_turpe.group_by(["type_composante", "part_turpe"])
+        .agg([pl.col("montant_ht").sum().alias("montant_f15"), pl.len().alias("nb_lignes")])
         .sort("montant_f15", descending=True)
     )
     return df_f15_par_composante, df_f15_par_mois, df_f15_par_pdl
@@ -210,11 +199,13 @@ def aggregations_f15(df_f15_turpe):
 @app.cell(hide_code=True)
 def show_f15_summary(df_f15_par_composante, df_f15_par_mois, df_f15_par_pdl):
     """Affichage des résumés F15"""
-    mo.accordion(items={
-        'f15 par pdl':df_f15_par_pdl,
-        'f15 par mois':df_f15_par_mois,
-        'f15 par composante':df_f15_par_composante,
-    })
+    mo.accordion(
+        items={
+            "f15 par pdl": df_f15_par_pdl,
+            "f15 par mois": df_f15_par_mois,
+            "f15 par composante": df_f15_par_composante,
+        }
+    )
     return
 
 
@@ -228,8 +219,7 @@ def _():
 def _(df_f15_turpe):
     # Extraction du TURPE fixe depuis F15
     _df_f15_fixe = (
-        df_f15_turpe
-        .filter(pl.col("part_turpe") == "Fixe")
+        df_f15_turpe.filter(pl.col("part_turpe") == "Fixe")
         # .group_by("pdl")
         # .agg([
         #     pl.col("montant_ht").sum().alias("turpe_fixe_f15")
@@ -255,8 +245,7 @@ def _(df_f15_turpe):
 def _(df_f15_turpe):
     # Extraction du TURPE var depuis F15
     df_f15_variable = (
-        df_f15_turpe
-        .filter(pl.col("part_turpe") == "Variable")
+        df_f15_turpe.filter(pl.col("part_turpe") == "Variable")
         # .group_by("pdl")
         # .agg([
         #     pl.col("montant_ht").sum().alias("turpe_variable_f15")
@@ -295,16 +284,15 @@ def load_odoo_perimeter(config):
         with OdooReader(config=config) as odoo:
             # Récupération des PDL depuis les commandes Odoo, focus sur C5
             df_pdl_odoo = (
-                odoo.query('sale.order',
-                    domain=[('x_pdl', '!=', False)],  # Uniquement les commandes avec PDL
-                    fields=['name', 'x_pdl', 'partner_id'])
-                .filter(pl.col('x_pdl').is_not_null())
-                .select([
-                    pl.col('x_pdl').str.strip_chars().alias('pdl'),
-                    pl.col('name').alias('order_name')
-                ])
+                odoo.query(
+                    "sale.order",
+                    domain=[("x_pdl", "!=", False)],  # Uniquement les commandes avec PDL
+                    fields=["name", "x_pdl", "partner_id"],
+                )
+                .filter(pl.col("x_pdl").is_not_null())
+                .select([pl.col("x_pdl").str.strip_chars().alias("pdl"), pl.col("name").alias("order_name")])
                 .collect()
-                .unique('pdl')
+                .unique("pdl")
             )
 
         nb_pdl_odoo = len(df_pdl_odoo)
@@ -321,7 +309,7 @@ def load_odoo_perimeter(config):
         print("📄 Continuons sans filtre Odoo (tous les PDL F15 seront analysés)")
 
         # DataFrame vide si pas de connexion Odoo
-        df_pdl_odoo = pl.DataFrame({'pdl': [], 'order_name': []}, schema={'pdl': pl.Utf8, 'order_name': pl.Utf8})
+        df_pdl_odoo = pl.DataFrame({"pdl": [], "order_name": []}, schema={"pdl": pl.Utf8, "order_name": pl.Utf8})
     return
 
 
@@ -343,9 +331,7 @@ def load_pipeline_data():
     # Charger l'historique C15 enrichi
     print("📄 Chargement historique C15...")
     lf_historique = c15().lazy()
-    lf_historique_enrichi = inserer_evenements_facturation(
-        detecter_points_de_rupture(lf_historique)
-    )
+    lf_historique_enrichi = inserer_evenements_facturation(detecter_points_de_rupture(lf_historique))
     df_historique = lf_historique_enrichi.collect()
 
     # Charger les relevés R151
@@ -393,14 +379,12 @@ def calculate_turpe_fixe(df_historique):
     df_periodes_abonnement = lf_periodes_abonnement.collect()
 
     # Agrégation du TURPE fixe par PDL
-    df_turpe_fixe_pdl = (
-        df_periodes_abonnement
-        .group_by("pdl")
-        .agg([
+    df_turpe_fixe_pdl = df_periodes_abonnement.group_by("pdl").agg(
+        [
             pl.col("turpe_fixe_eur").sum().alias("turpe_fixe_total"),
             pl.col("debut").min().alias("date_debut_periode"),
-            pl.col("fin").max().alias("date_fin_periode")
-        ])
+            pl.col("fin").max().alias("date_fin_periode"),
+        ]
     )
 
     calc_time_fixe = time.time() - _start_time_fixe
@@ -429,41 +413,40 @@ def compare_turpe_fixe(df_f15_turpe, df_turpe_fixe_pdl):
 
     # Agrégation du TURPE fixe F15 par PDL
     df_f15_fixe_par_pdl = (
-        df_f15_turpe
-        .filter(pl.col("part_turpe") == "Fixe")
+        df_f15_turpe.filter(pl.col("part_turpe") == "Fixe")
         .group_by("pdl")
-        .agg([
-            pl.col("montant_ht").sum().alias("turpe_fixe_f15"),
-            pl.col("date_debut").min().alias("premiere_periode_f15"),
-            pl.col("date_fin").max().alias("derniere_periode_f15"),
-            pl.len().alias("nb_lignes_f15")
-        ])
+        .agg(
+            [
+                pl.col("montant_ht").sum().alias("turpe_fixe_f15"),
+                pl.col("date_debut").min().alias("premiere_periode_f15"),
+                pl.col("date_fin").max().alias("derniere_periode_f15"),
+                pl.len().alias("nb_lignes_f15"),
+            ]
+        )
     )
 
     # Jointure complète F15 vs Calculé
     df_comparison_fixe = (
-        df_f15_fixe_par_pdl
-        .join(df_turpe_fixe_pdl, on="pdl", how="full")
-        .with_columns([
-            pl.col("turpe_fixe_f15").fill_null(0.0),
-            pl.col("turpe_fixe_total").fill_null(0.0)
-        ])
-        .with_columns([
-            (pl.col("turpe_fixe_total") - pl.col("turpe_fixe_f15")).alias("ecart_absolu"),
-            pl.when(pl.col("turpe_fixe_f15") != 0.0)
-            .then(((pl.col("turpe_fixe_total") - pl.col("turpe_fixe_f15")) / pl.col("turpe_fixe_f15") * 100))
-            .otherwise(pl.lit(None))
-            .alias("ecart_relatif_pct"),
-            # Classification des PDL
-            pl.when((pl.col("turpe_fixe_f15") > 0) & (pl.col("turpe_fixe_total") > 0))
-            .then(pl.lit("Présent des 2 côtés"))
-            .when((pl.col("turpe_fixe_f15") > 0) & (pl.col("turpe_fixe_total") == 0))
-            .then(pl.lit("Manquant côté calcul"))
-            .when((pl.col("turpe_fixe_f15") == 0) & (pl.col("turpe_fixe_total") > 0))
-            .then(pl.lit("En trop côté calcul"))
-            .otherwise(pl.lit("Vide des 2 côtés"))
-            .alias("statut_pdl")
-        ])
+        df_f15_fixe_par_pdl.join(df_turpe_fixe_pdl, on="pdl", how="full")
+        .with_columns([pl.col("turpe_fixe_f15").fill_null(0.0), pl.col("turpe_fixe_total").fill_null(0.0)])
+        .with_columns(
+            [
+                (pl.col("turpe_fixe_total") - pl.col("turpe_fixe_f15")).alias("ecart_absolu"),
+                pl.when(pl.col("turpe_fixe_f15") != 0.0)
+                .then(((pl.col("turpe_fixe_total") - pl.col("turpe_fixe_f15")) / pl.col("turpe_fixe_f15") * 100))
+                .otherwise(pl.lit(None))
+                .alias("ecart_relatif_pct"),
+                # Classification des PDL
+                pl.when((pl.col("turpe_fixe_f15") > 0) & (pl.col("turpe_fixe_total") > 0))
+                .then(pl.lit("Présent des 2 côtés"))
+                .when((pl.col("turpe_fixe_f15") > 0) & (pl.col("turpe_fixe_total") == 0))
+                .then(pl.lit("Manquant côté calcul"))
+                .when((pl.col("turpe_fixe_f15") == 0) & (pl.col("turpe_fixe_total") > 0))
+                .then(pl.lit("En trop côté calcul"))
+                .otherwise(pl.lit("Vide des 2 côtés"))
+                .alias("statut_pdl"),
+            ]
+        )
         .sort(pl.col("ecart_absolu").abs(), descending=True)
     )
 
@@ -475,9 +458,11 @@ def compare_turpe_fixe(df_f15_turpe, df_turpe_fixe_pdl):
 
     nb_pdl_f15 = df_comparison_fixe.filter(pl.col("turpe_fixe_f15") > 0).select(pl.len()).item()
     nb_pdl_calcule = df_comparison_fixe.filter(pl.col("turpe_fixe_total") > 0).select(pl.len()).item()
-    nb_pdl_communs = df_comparison_fixe.filter(
-        (pl.col("turpe_fixe_f15") > 0) & (pl.col("turpe_fixe_total") > 0)
-    ).select(pl.len()).item()
+    nb_pdl_communs = (
+        df_comparison_fixe.filter((pl.col("turpe_fixe_f15") > 0) & (pl.col("turpe_fixe_total") > 0))
+        .select(pl.len())
+        .item()
+    )
 
     taux_couverture = (nb_pdl_calcule / nb_pdl_f15) * 100 if nb_pdl_f15 > 0 else 0
 
@@ -502,6 +487,7 @@ def calcul_prorata_temporel(df_f15_turpe):
     # Date de coupure = fin du mois dernier révolu
     from datetime import date
     import calendar
+
     _today = date.today()
     if _today.month == 1:
         _date_coupure = date(_today.year - 1, 12, 31)
@@ -518,46 +504,70 @@ def calcul_prorata_temporel(df_f15_turpe):
     df_f15_fixe = df_f15_turpe.filter(pl.col("part_turpe") == "Fixe")
 
     # Calcul du prorata pour chaque ligne
-    df_prorata = df_f15_fixe.with_columns([
-        # Conversion des dates
-        pl.col("date_debut").str.to_date().alias("debut_dt"),
-        pl.col("date_fin").str.to_date().alias("fin_dt"),
-        pl.date(_date_coupure.year, _date_coupure.month, _date_coupure.day).alias("date_coupure_dt")
-    ]).with_columns([
-        # Calcul des durées
-        (pl.col("fin_dt") - pl.col("debut_dt") + pl.duration(days=1)).dt.total_days().alias("duree_totale_jours"),
-        # Calcul de la fin effective (min entre fin période et date coupure)
-        pl.min_horizontal(pl.col("fin_dt"), pl.col("date_coupure_dt")).alias("fin_effective"),
-    ]).with_columns([
-        # Calcul des jours avant coupure
-        pl.max_horizontal(
-            pl.lit(0),
-            (pl.col("fin_effective") - pl.col("debut_dt") + pl.duration(days=1)).dt.total_days()
-        ).alias("jours_avant_coupure")
-    ]).with_columns([
-        # Calcul du ratio de prorata
-        (pl.col("jours_avant_coupure") / pl.col("duree_totale_jours")).alias("ratio_prorata"),
-        # Montant proratisé
-        (pl.col("montant_ht") * pl.col("jours_avant_coupure") / pl.col("duree_totale_jours")).alias("montant_proratise")
-    ])
+    df_prorata = (
+        df_f15_fixe.with_columns(
+            [
+                # Conversion des dates
+                pl.col("date_debut").str.to_date().alias("debut_dt"),
+                pl.col("date_fin").str.to_date().alias("fin_dt"),
+                pl.date(_date_coupure.year, _date_coupure.month, _date_coupure.day).alias("date_coupure_dt"),
+            ]
+        )
+        .with_columns(
+            [
+                # Calcul des durées
+                (pl.col("fin_dt") - pl.col("debut_dt") + pl.duration(days=1))
+                .dt.total_days()
+                .alias("duree_totale_jours"),
+                # Calcul de la fin effective (min entre fin période et date coupure)
+                pl.min_horizontal(pl.col("fin_dt"), pl.col("date_coupure_dt")).alias("fin_effective"),
+            ]
+        )
+        .with_columns(
+            [
+                # Calcul des jours avant coupure
+                pl.max_horizontal(
+                    pl.lit(0), (pl.col("fin_effective") - pl.col("debut_dt") + pl.duration(days=1)).dt.total_days()
+                ).alias("jours_avant_coupure")
+            ]
+        )
+        .with_columns(
+            [
+                # Calcul du ratio de prorata
+                (pl.col("jours_avant_coupure") / pl.col("duree_totale_jours")).alias("ratio_prorata"),
+                # Montant proratisé
+                (pl.col("montant_ht") * pl.col("jours_avant_coupure") / pl.col("duree_totale_jours")).alias(
+                    "montant_proratise"
+                ),
+            ]
+        )
+    )
 
     # Classification des périodes
-    df_classification = df_prorata.with_columns([
-        pl.when(pl.col("debut_dt") > pl.col("date_coupure_dt"))
-        .then(pl.lit("Entièrement après coupure"))
-        .when(pl.col("fin_dt") <= pl.col("date_coupure_dt"))
-        .then(pl.lit("Entièrement avant coupure"))
-        .otherwise(pl.lit("Partiellement après coupure"))
-        .alias("classification_temporelle")
-    ])
+    df_classification = df_prorata.with_columns(
+        [
+            pl.when(pl.col("debut_dt") > pl.col("date_coupure_dt"))
+            .then(pl.lit("Entièrement après coupure"))
+            .when(pl.col("fin_dt") <= pl.col("date_coupure_dt"))
+            .then(pl.lit("Entièrement avant coupure"))
+            .otherwise(pl.lit("Partiellement après coupure"))
+            .alias("classification_temporelle")
+        ]
+    )
 
     # Statistiques globales
-    stats = df_classification.group_by("classification_temporelle").agg([
-        pl.len().alias("nb_lignes"),
-        pl.col("montant_ht").sum().alias("montant_original"),
-        pl.col("montant_proratise").sum().alias("montant_proratise"),
-        pl.col("ratio_prorata").mean().alias("ratio_moyen")
-    ]).sort("montant_original", descending=True)
+    stats = (
+        df_classification.group_by("classification_temporelle")
+        .agg(
+            [
+                pl.len().alias("nb_lignes"),
+                pl.col("montant_ht").sum().alias("montant_original"),
+                pl.col("montant_proratise").sum().alias("montant_proratise"),
+                pl.col("ratio_prorata").mean().alias("ratio_moyen"),
+            ]
+        )
+        .sort("montant_original", descending=True)
+    )
 
     print(f"\n📊 STATISTIQUES DE PRORATA TEMPOREL:")
     print(stats.to_pandas().to_string(index=False, float_format="%.2f"))
@@ -570,16 +580,16 @@ def calcul_prorata_temporel(df_f15_turpe):
     print(f"\n💰 RÉSUMÉ FINANCIER:")
     print(f"   Montant original (F15 fixe): {total_original:,.2f} €")
     print(f"   Montant proratisé: {total_proratise:,.2f} €")
-    print(f"   Différence (à échoir): {difference:,.2f} € ({difference/total_original*100:.1f}%)")
+    print(f"   Différence (à échoir): {difference:,.2f} € ({difference / total_original * 100:.1f}%)")
     return (df_classification,)
 
 
 @app.cell
 def _(df_classification):
     # Agrégation des montants F15 proratisés par PDL
-    df_f15_prorata_pdl = df_classification.group_by("pdl").agg([
-        pl.col("montant_proratise").sum().alias("turpe_fixe_f15_prorata")
-    ])
+    df_f15_prorata_pdl = df_classification.group_by("pdl").agg(
+        [pl.col("montant_proratise").sum().alias("turpe_fixe_f15_prorata")]
+    )
     return (df_f15_prorata_pdl,)
 
 
@@ -589,18 +599,17 @@ def turpe_fixe_quality_metrics_prorata(df_f15_prorata_pdl, df_turpe_fixe_pdl):
 
     print(f"\n🎯 MÉTRIQUES DE QUALITÉ AVEC PRORATA TEMPOREL")
 
-
-
     # Jointure avec les montants calculés
-    df_comparison_prorata = df_f15_prorata_pdl.join(
-        df_turpe_fixe_pdl,
-        on="pdl",
-        how="inner"
-    ).with_columns([
-        # Calcul des écarts avec prorata
-        (pl.col("turpe_fixe_total") - pl.col("turpe_fixe_f15_prorata")).alias("ecart_absolu_prorata"),
-        (((pl.col("turpe_fixe_total") - pl.col("turpe_fixe_f15_prorata")) / pl.col("turpe_fixe_f15_prorata")) * 100).alias("ecart_relatif_pct_prorata")
-    ])
+    df_comparison_prorata = df_f15_prorata_pdl.join(df_turpe_fixe_pdl, on="pdl", how="inner").with_columns(
+        [
+            # Calcul des écarts avec prorata
+            (pl.col("turpe_fixe_total") - pl.col("turpe_fixe_f15_prorata")).alias("ecart_absolu_prorata"),
+            (
+                ((pl.col("turpe_fixe_total") - pl.col("turpe_fixe_f15_prorata")) / pl.col("turpe_fixe_f15_prorata"))
+                * 100
+            ).alias("ecart_relatif_pct_prorata"),
+        ]
+    )
 
     # Statistiques globales avec prorata
     total_calcule = df_comparison_prorata.select(pl.col("turpe_fixe_total").sum()).item()
@@ -611,12 +620,16 @@ def turpe_fixe_quality_metrics_prorata(df_f15_prorata_pdl, df_turpe_fixe_pdl):
     print(f"\n💰 COMPARAISON AVEC PRORATA:")
     print(f"   F15 proratisé: {total_f15_prorata:,.2f} € ({_nb_pdl_communs_prorata} PDL)")
     print(f"   Calculé: {total_calcule:,.2f} €")
-    print(f"   Écart global: {ecart_global_prorata:+,.2f} € ({ecart_global_prorata/total_f15_prorata*100:+.1f}%)")
+    print(f"   Écart global: {ecart_global_prorata:+,.2f} € ({ecart_global_prorata / total_f15_prorata * 100:+.1f}%)")
 
     # Métriques de précision avec prorata
     if _nb_pdl_communs_prorata > 0:
-        _nb_precise_1eur_prorata = df_comparison_prorata.filter(pl.col("ecart_absolu_prorata").abs() <= 1.0).select(pl.len()).item()
-        _nb_precise_5pct_prorata = df_comparison_prorata.filter(pl.col("ecart_relatif_pct_prorata").abs() <= 5.0).select(pl.len()).item()
+        _nb_precise_1eur_prorata = (
+            df_comparison_prorata.filter(pl.col("ecart_absolu_prorata").abs() <= 1.0).select(pl.len()).item()
+        )
+        _nb_precise_5pct_prorata = (
+            df_comparison_prorata.filter(pl.col("ecart_relatif_pct_prorata").abs() <= 5.0).select(pl.len()).item()
+        )
 
         _precision_1eur_prorata = (_nb_precise_1eur_prorata / _nb_pdl_communs_prorata) * 100
         _precision_5pct_prorata = (_nb_precise_5pct_prorata / _nb_pdl_communs_prorata) * 100
@@ -641,8 +654,12 @@ def turpe_fixe_quality_metrics_prorata(df_f15_prorata_pdl, df_turpe_fixe_pdl):
             _recommandation = "Problèmes majeurs dans le calcul"
 
         print(f"\n📊 MÉTRIQUES DE PRÉCISION (PRORATA):")
-        print(f"   Précision ±1€: {_precision_1eur_prorata:.1f}% ({_nb_precise_1eur_prorata}/{_nb_pdl_communs_prorata} PDL)")
-        print(f"   Précision ±5%: {_precision_5pct_prorata:.1f}% ({_nb_precise_5pct_prorata}/{_nb_pdl_communs_prorata} PDL)")
+        print(
+            f"   Précision ±1€: {_precision_1eur_prorata:.1f}% ({_nb_precise_1eur_prorata}/{_nb_pdl_communs_prorata} PDL)"
+        )
+        print(
+            f"   Précision ±5%: {_precision_5pct_prorata:.1f}% ({_nb_precise_5pct_prorata}/{_nb_pdl_communs_prorata} PDL)"
+        )
         print(f"   Écart moyen: {_ecart_moyen_prorata:+.2f} € | Écart médian: {_ecart_median_prorata:+.2f} €")
         print(f"   🎯 Évaluation: {_evaluation}")
         print(f"   💡 Recommandation: {_recommandation}")
@@ -667,81 +684,100 @@ def analyze_turpe_fixe_gaps_prorata(
     print("\n🔍 ANALYSE DES ÉCARTS PAR CATÉGORIE (PRORATA):")
 
     # Agrégation des montants F15 proratisés par PDL
-    df_f15_prorata_base = df_classification.group_by("pdl").agg([
-        pl.col("montant_proratise").sum().alias("turpe_fixe_f15_prorata"),
-        pl.col("date_debut").min().alias("date_arrivee_pdl")  # Première date de facturation
-    ])
+    df_f15_prorata_base = df_classification.group_by("pdl").agg(
+        [
+            pl.col("montant_proratise").sum().alias("turpe_fixe_f15_prorata"),
+            pl.col("date_debut").min().alias("date_arrivee_pdl"),  # Première date de facturation
+        ]
+    )
 
     # Récupération des métadonnées métier depuis les périodes d'abonnement
-    df_metadonnees_pdl = df_periodes_abonnement.group_by("pdl").agg([
-        pl.col("formule_tarifaire_acheminement").cast(pl.String).first(),  # FTA du PDL
-        pl.col("puissance_souscrite_kva").first()  # Puissance souscrite en kVA
-    ])
+    df_metadonnees_pdl = df_periodes_abonnement.group_by("pdl").agg(
+        [
+            pl.col("formule_tarifaire_acheminement").cast(pl.String).first(),  # FTA du PDL
+            pl.col("puissance_souscrite_kva").first(),  # Puissance souscrite en kVA
+        ]
+    )
 
     # Jointure des montants proratisés avec les métadonnées
     df_f15_prorata_avec_metadonnees = df_f15_prorata_base.join(
         df_metadonnees_pdl,
         on="pdl",
-        how="left"  # Garder tous les PDL même sans métadonnées
+        how="left",  # Garder tous les PDL même sans métadonnées
     )
 
     # Jointure complète pour analyser tous les PDL
-    df_comparison_prorata_full = df_f15_prorata_avec_metadonnees.join(
-        df_turpe_fixe_pdl,
-        on="pdl",
-        how="outer"
-    ).with_columns([
-        # Gestion des valeurs nulles et statut PDL
-        pl.col("turpe_fixe_f15_prorata").fill_null(0),
-        pl.col("turpe_fixe_total").fill_null(0),
-        pl.when(pl.col("turpe_fixe_f15_prorata").is_null())
-        .then(pl.lit("Seulement dans calculé"))
-        .when(pl.col("turpe_fixe_total").is_null())
-        .then(pl.lit("Seulement dans F15 prorata"))
-        .otherwise(pl.lit("Présent des 2 côtés"))
-        .alias("statut_pdl")
-    ]).with_columns([
-        # Calcul des écarts avec prorata
-        (pl.col("turpe_fixe_total") - pl.col("turpe_fixe_f15_prorata")).alias("ecart_absolu_prorata"),
-        (((pl.col("turpe_fixe_total") - pl.col("turpe_fixe_f15_prorata")) / pl.col("turpe_fixe_f15_prorata")) * 100).alias("ecart_relatif_pct_prorata")
-    ])
+    df_comparison_prorata_full = (
+        df_f15_prorata_avec_metadonnees.join(df_turpe_fixe_pdl, on="pdl", how="outer")
+        .with_columns(
+            [
+                # Gestion des valeurs nulles et statut PDL
+                pl.col("turpe_fixe_f15_prorata").fill_null(0),
+                pl.col("turpe_fixe_total").fill_null(0),
+                pl.when(pl.col("turpe_fixe_f15_prorata").is_null())
+                .then(pl.lit("Seulement dans calculé"))
+                .when(pl.col("turpe_fixe_total").is_null())
+                .then(pl.lit("Seulement dans F15 prorata"))
+                .otherwise(pl.lit("Présent des 2 côtés"))
+                .alias("statut_pdl"),
+            ]
+        )
+        .with_columns(
+            [
+                # Calcul des écarts avec prorata
+                (pl.col("turpe_fixe_total") - pl.col("turpe_fixe_f15_prorata")).alias("ecart_absolu_prorata"),
+                (
+                    ((pl.col("turpe_fixe_total") - pl.col("turpe_fixe_f15_prorata")) / pl.col("turpe_fixe_f15_prorata"))
+                    * 100
+                ).alias("ecart_relatif_pct_prorata"),
+            ]
+        )
+    )
 
     # Statistiques par statut PDL avec prorata
     _stats_par_statut_prorata = (
-        df_comparison_prorata_full
-        .group_by("statut_pdl")
-        .agg([
-            pl.len().alias("nb_pdl"),
-            pl.col("turpe_fixe_f15_prorata").sum().alias("montant_f15_prorata"),
-            pl.col("turpe_fixe_total").sum().alias("montant_calcule"),
-            pl.col("ecart_absolu_prorata").sum().alias("ecart_total_prorata")
-        ])
+        df_comparison_prorata_full.group_by("statut_pdl")
+        .agg(
+            [
+                pl.len().alias("nb_pdl"),
+                pl.col("turpe_fixe_f15_prorata").sum().alias("montant_f15_prorata"),
+                pl.col("turpe_fixe_total").sum().alias("montant_calcule"),
+                pl.col("ecart_absolu_prorata").sum().alias("ecart_total_prorata"),
+            ]
+        )
         .sort("ecart_total_prorata", descending=True)
     )
 
     for row in _stats_par_statut_prorata.iter_rows(named=True):
-        statut = row['statut_pdl']
-        nb_pdl = row['nb_pdl']
-        montant_f15_prorata = row['montant_f15_prorata']
-        montant_calcule = row['montant_calcule']
-        ecart = row['ecart_total_prorata']
+        statut = row["statut_pdl"]
+        nb_pdl = row["nb_pdl"]
+        montant_f15_prorata = row["montant_f15_prorata"]
+        montant_calcule = row["montant_calcule"]
+        ecart = row["ecart_total_prorata"]
 
         print(f"   📋 {statut}: {nb_pdl} PDL")
-        print(f"      F15 prorata: {montant_f15_prorata:,.2f} € | Calculé: {montant_calcule:,.2f} € | Écart: {ecart:+,.2f} €")
+        print(
+            f"      F15 prorata: {montant_f15_prorata:,.2f} € | Calculé: {montant_calcule:,.2f} € | Écart: {ecart:+,.2f} €"
+        )
 
     # Top 10 des écarts les plus importants avec prorata (PDL communs seulement)
     _top_ecarts_prorata = (
-        df_comparison_prorata_full
-        .filter(pl.col("statut_pdl") == "Présent des 2 côtés")
+        df_comparison_prorata_full.filter(pl.col("statut_pdl") == "Présent des 2 côtés")
         .filter(pl.col("ecart_relatif_pct_prorata").abs() > 0.1)  # Écarts > 0.1%
         .sort("ecart_absolu_prorata", descending=True)
-        .select([
-            "pdl", "date_arrivee_pdl", "formule_tarifaire_acheminement", "puissance_souscrite_kva",
-            "turpe_fixe_f15_prorata", "turpe_fixe_total",
-            "ecart_absolu_prorata", "ecart_relatif_pct_prorata"
-        ])
+        .select(
+            [
+                "pdl",
+                "date_arrivee_pdl",
+                "formule_tarifaire_acheminement",
+                "puissance_souscrite_kva",
+                "turpe_fixe_f15_prorata",
+                "turpe_fixe_total",
+                "ecart_absolu_prorata",
+                "ecart_relatif_pct_prorata",
+            ]
+        )
     )
-
 
     mo.vstack([mo.md(f"\n📈 ÉCARTS SIGNIFICATIFS (PDL communs - PRORATA):"), _top_ecarts_prorata])
     return

--- a/notebooks/validations/validation_turpe_variable.py
+++ b/notebooks/validations/validation_turpe_variable.py
@@ -23,23 +23,10 @@ with app.setup(hide_code=True):
     from electricore.core.loaders import f15, c15, r151, execute_custom_query
 
     # Imports des pipelines Polars
-    from electricore.core.pipelines.energie import (
-        pipeline_energie,
-        calculer_periodes_energie
-    )
-    from electricore.core.pipelines.abonnements import (
-        pipeline_abonnements,
-        calculer_periodes_abonnement
-    )
-    from electricore.core.pipelines.turpe import (
-        load_turpe_rules,
-        ajouter_turpe_fixe,
-        ajouter_turpe_variable
-    )
-    from electricore.core.pipelines.perimetre import (
-        detecter_points_de_rupture,
-        inserer_evenements_facturation
-    )
+    from electricore.core.pipelines.energie import pipeline_energie, calculer_periodes_energie
+    from electricore.core.pipelines.abonnements import pipeline_abonnements, calculer_periodes_abonnement
+    from electricore.core.pipelines.turpe import load_turpe_rules, ajouter_turpe_fixe, ajouter_turpe_variable
+    from electricore.core.pipelines.historique import detecter_points_de_rupture, inserer_evenements_facturation
 
     # Import connecteur Odoo
     from electricore.core.loaders import OdooReader, query
@@ -54,7 +41,9 @@ def _():
     try:
         config = charger_config_odoo()
         _env = os.getenv("ODOO_ENV", "test")
-        _msg = mo.md(f"**Configuration Odoo chargée** (env: `{_env}`)\n\n- URL: `{config['url']}`\n- Base: `{config['db']}`\n- Utilisateur: `{config['username']}`\n- Mot de passe: `***`")
+        _msg = mo.md(
+            f"**Configuration Odoo chargée** (env: `{_env}`)\n\n- URL: `{config['url']}`\n- Base: `{config['db']}`\n- Utilisateur: `{config['username']}`\n- Mot de passe: `***`"
+        )
     except ValueError as e:
         config = {}
         _msg = mo.md(f"⚠️ **Configuration Odoo manquante**\n\n{e}\n\nDéfinissez les variables `ODOO_*` dans `.env`.")
@@ -176,10 +165,7 @@ def _():
 @app.cell(hide_code=True)
 def _(df_f15_turpe):
     # Extraction du TURPE variable depuis F15
-    df_f15_variable = (
-        df_f15_turpe
-        .filter(pl.col("part_turpe") == "Variable")
-    )
+    df_f15_variable = df_f15_turpe.filter(pl.col("part_turpe") == "Variable")
 
     # Statistiques de base
     _total_montant = df_f15_variable.select(pl.col("montant_ht").sum()).item()
@@ -195,14 +181,15 @@ def _(df_f15_turpe):
 
     # Agrégation par PDL pour comparaison
     df_f15_variable_par_pdl = (
-        df_f15_variable
-        .group_by("pdl")
-        .agg([
-            pl.col("montant_ht").sum().alias("turpe_variable_f15"),
-            pl.col("date_debut").min().alias("premiere_periode_f15"),
-            pl.col("date_fin").max().alias("derniere_periode_f15"),
-            pl.len().alias("nb_lignes_f15")
-        ])
+        df_f15_variable.group_by("pdl")
+        .agg(
+            [
+                pl.col("montant_ht").sum().alias("turpe_variable_f15"),
+                pl.col("date_debut").min().alias("premiere_periode_f15"),
+                pl.col("date_fin").max().alias("derniere_periode_f15"),
+                pl.len().alias("nb_lignes_f15"),
+            ]
+        )
         .sort("turpe_variable_f15", descending=True)
     )
 
@@ -226,16 +213,11 @@ def load_odoo_perimeter(config):
         print("🔄 Connexion à Odoo...")
         with OdooReader(config=config) as odoo:
             df_pdl_odoo = (
-                query(odoo, 'sale.order',
-                    domain=[('x_pdl', '!=', False)],
-                    fields=['name', 'x_pdl', 'partner_id'])
-                .filter(pl.col('x_pdl').is_not_null())
-                .select([
-                    pl.col('x_pdl').str.strip_chars().alias('pdl'),
-                    pl.col('name').alias('order_name')
-                ])
+                query(odoo, "sale.order", domain=[("x_pdl", "!=", False)], fields=["name", "x_pdl", "partner_id"])
+                .filter(pl.col("x_pdl").is_not_null())
+                .select([pl.col("x_pdl").str.strip_chars().alias("pdl"), pl.col("name").alias("order_name")])
                 .collect()
-                .unique('pdl')
+                .unique("pdl")
             )
 
         nb_pdl_odoo = len(df_pdl_odoo)
@@ -247,7 +229,7 @@ def load_odoo_perimeter(config):
     except Exception as e:
         print(f"⚠️ Erreur connexion Odoo: {e}")
         print("📄 Continuons sans filtre Odoo (tous les PDL F15 seront analysés)")
-        df_pdl_odoo = pl.DataFrame({'pdl': [], 'order_name': []}, schema={'pdl': pl.Utf8, 'order_name': pl.Utf8})
+        df_pdl_odoo = pl.DataFrame({"pdl": [], "order_name": []}, schema={"pdl": pl.Utf8, "order_name": pl.Utf8})
     return
 
 
@@ -269,15 +251,14 @@ def load_pipeline_data():
     # Charger l'historique C15 enrichi
     print("📄 Chargement historique C15...")
     lf_historique = c15().lazy()
-    lf_historique_enrichi = inserer_evenements_facturation(
-        detecter_points_de_rupture(lf_historique)
-    )
+    lf_historique_enrichi = inserer_evenements_facturation(detecter_points_de_rupture(lf_historique))
     df_historique = lf_historique_enrichi.collect()
 
     # Charger les relevés R151
     # print("📄 Chargement relevés R151...")
     # lf_releves = r151().lazy()
     from electricore.core.loaders import releves_harmonises
+
     lf_releves = releves_harmonises().lazy()
     df_releves = lf_releves.collect()
 
@@ -294,7 +275,7 @@ def load_pipeline_data():
     _taux_couverture = len(_pdl_communs) / len(_pdl_historique) * 100 if _pdl_historique else 0
 
     print(f"🎯 Couverture R151: {len(_pdl_communs)}/{len(_pdl_historique)} PDL ({_taux_couverture:.1f}%)")
-    print(f"⚠️ PDL sans R151: {len(_pdl_historique) - len(_pdl_communs)} ({100-_taux_couverture:.1f}%)")
+    print(f"⚠️ PDL sans R151: {len(_pdl_historique) - len(_pdl_communs)} ({100 - _taux_couverture:.1f}%)")
     return df_historique, df_releves
 
 
@@ -314,22 +295,20 @@ def calculate_turpe_variable(df_historique, df_releves):
     _start_time_variable = time.time()
 
     # Pipeline énergie complet (inclut chronologie + calcul + TURPE variable)
-    lf_periodes_energie = pipeline_energie(
-        pl.LazyFrame(df_historique),
-        pl.LazyFrame(df_releves)
-    )
+    lf_periodes_energie = pipeline_energie(pl.LazyFrame(df_historique), pl.LazyFrame(df_releves))
     df_periodes_energie = lf_periodes_energie.collect()
 
     # Agrégation du TURPE variable par PDL
     df_turpe_variable_pdl = (
-        df_periodes_energie
-        .group_by("pdl")
-        .agg([
-            pl.col("turpe_variable_eur").sum().alias("turpe_variable_calcule"),
-            pl.col("debut").min().alias("date_debut_calcule"),
-            pl.col("fin").max().alias("date_fin_calcule"),
-            pl.len().alias("nb_periodes_calcule")
-        ])
+        df_periodes_energie.group_by("pdl")
+        .agg(
+            [
+                pl.col("turpe_variable_eur").sum().alias("turpe_variable_calcule"),
+                pl.col("debut").min().alias("date_debut_calcule"),
+                pl.col("fin").max().alias("date_fin_calcule"),
+                pl.len().alias("nb_periodes_calcule"),
+            ]
+        )
         .sort("turpe_variable_calcule", descending=True)
     )
 
@@ -359,52 +338,53 @@ def analyze_pdl_coverage(df_f15_variable_par_pdl, df_turpe_variable_pdl):
 
     # Jointure complète F15 vs Calculé
     df_coverage_analysis = (
-        df_f15_variable_par_pdl
-        .join(df_turpe_variable_pdl, on="pdl", how="outer")
-        .with_columns([
-            pl.col("turpe_variable_f15").fill_null(0.0),
-            pl.col("turpe_variable_calcule").fill_null(0.0)
-        ])
-        .with_columns([
-            # Classification des PDL selon leur présence
-            pl.when((pl.col("turpe_variable_f15") > 0) & (pl.col("turpe_variable_calcule") > 0))
-            .then(pl.lit("✅ Présent des 2 côtés"))
-            .when((pl.col("turpe_variable_f15") > 0) & (pl.col("turpe_variable_calcule") == 0))
-            .then(pl.lit("❌ Manquant côté calcul"))
-            .when((pl.col("turpe_variable_f15") == 0) & (pl.col("turpe_variable_calcule") > 0))
-            .then(pl.lit("⚠️ En trop côté calcul"))
-            .otherwise(pl.lit("⭕ Vide des 2 côtés"))
-            .alias("statut_couverture")
-        ])
+        df_f15_variable_par_pdl.join(df_turpe_variable_pdl, on="pdl", how="outer")
+        .with_columns([pl.col("turpe_variable_f15").fill_null(0.0), pl.col("turpe_variable_calcule").fill_null(0.0)])
+        .with_columns(
+            [
+                # Classification des PDL selon leur présence
+                pl.when((pl.col("turpe_variable_f15") > 0) & (pl.col("turpe_variable_calcule") > 0))
+                .then(pl.lit("✅ Présent des 2 côtés"))
+                .when((pl.col("turpe_variable_f15") > 0) & (pl.col("turpe_variable_calcule") == 0))
+                .then(pl.lit("❌ Manquant côté calcul"))
+                .when((pl.col("turpe_variable_f15") == 0) & (pl.col("turpe_variable_calcule") > 0))
+                .then(pl.lit("⚠️ En trop côté calcul"))
+                .otherwise(pl.lit("⭕ Vide des 2 côtés"))
+                .alias("statut_couverture")
+            ]
+        )
     )
 
     # Statistiques de couverture
     coverage_stats = (
-        df_coverage_analysis
-        .group_by("statut_couverture")
-        .agg([
-            pl.len().alias("nb_pdl"),
-            pl.col("turpe_variable_f15").sum().alias("montant_f15"),
-            pl.col("turpe_variable_calcule").sum().alias("montant_calcule")
-        ])
+        df_coverage_analysis.group_by("statut_couverture")
+        .agg(
+            [
+                pl.len().alias("nb_pdl"),
+                pl.col("turpe_variable_f15").sum().alias("montant_f15"),
+                pl.col("turpe_variable_calcule").sum().alias("montant_calcule"),
+            ]
+        )
         .sort("nb_pdl", descending=True)
     )
 
     print("\n📊 STATISTIQUES DE COUVERTURE PDL:")
     for _row_cov in coverage_stats.iter_rows(named=True):
-        _statut = _row_cov['statut_couverture']
-        _nb_pdl_cov = _row_cov['nb_pdl']
-        _montant_f15 = _row_cov['montant_f15']
-        _montant_calcule = _row_cov['montant_calcule']
+        _statut = _row_cov["statut_couverture"]
+        _nb_pdl_cov = _row_cov["nb_pdl"]
+        _montant_f15 = _row_cov["montant_f15"]
+        _montant_calcule = _row_cov["montant_calcule"]
         print(f"   {_statut}: {_nb_pdl_cov} PDL")
         print(f"      F15: {_montant_f15:,.2f} € | Calculé: {_montant_calcule:,.2f} €")
 
     # Taux de couverture principal
     _nb_f15_total_cov = df_coverage_analysis.filter(pl.col("turpe_variable_f15") > 0).select(pl.len()).item()
     _nb_calcule_total_cov = df_coverage_analysis.filter(pl.col("turpe_variable_calcule") > 0).select(pl.len()).item()
-    _nb_communs_cov = df_coverage_analysis.filter(
-        (pl.col("turpe_variable_f15") > 0) & (pl.col("turpe_variable_calcule") > 0)
-    ).select(pl.len()).item()
+    _nb_communs_cov = (
+        df_coverage_analysis.filter((pl.col("turpe_variable_f15") > 0) & (pl.col("turpe_variable_calcule") > 0))
+        .select(pl.len())
+        .item()
+    )
 
     _taux_couverture = (_nb_communs_cov / _nb_f15_total_cov) * 100 if _nb_f15_total_cov > 0 else 0
 
@@ -445,43 +425,67 @@ def temporal_transformation_variable(df_f15_variable):
     print(f"📅 Date de coupure pour transformation temporelle: {_date_coupure}")
 
     # Calcul du prorata temporel pour chaque ligne F15 Variable
-    df_f15_variable_prorata = df_f15_variable.with_columns([
-        # Conversion des dates
-        pl.date(_date_coupure.year, _date_coupure.month, _date_coupure.day).alias("date_coupure_dt")
-    ]).with_columns([
-        # Calcul des durées
-        (pl.col("date_fin") - pl.col("date_debut") + pl.duration(days=1)).dt.total_days().alias("duree_totale_jours"),
-        # Fin effective (min entre fin période et date coupure)
-        pl.min_horizontal(pl.col("date_fin"), pl.col("date_coupure_dt")).alias("fin_effective"),
-    ]).with_columns([
-        # Jours avant coupure
-        pl.max_horizontal(
-            pl.lit(0),
-            (pl.col("fin_effective") - pl.col("date_debut") + pl.duration(days=1)).dt.total_days()
-        ).alias("jours_avant_coupure")
-    ]).with_columns([
-        # Ratio et montant proratisé
-        (pl.col("jours_avant_coupure") / pl.col("duree_totale_jours")).alias("ratio_prorata"),
-        (pl.col("montant_ht") * pl.col("jours_avant_coupure") / pl.col("duree_totale_jours")).alias("montant_proratise")
-    ])
+    df_f15_variable_prorata = (
+        df_f15_variable.with_columns(
+            [
+                # Conversion des dates
+                pl.date(_date_coupure.year, _date_coupure.month, _date_coupure.day).alias("date_coupure_dt")
+            ]
+        )
+        .with_columns(
+            [
+                # Calcul des durées
+                (pl.col("date_fin") - pl.col("date_debut") + pl.duration(days=1))
+                .dt.total_days()
+                .alias("duree_totale_jours"),
+                # Fin effective (min entre fin période et date coupure)
+                pl.min_horizontal(pl.col("date_fin"), pl.col("date_coupure_dt")).alias("fin_effective"),
+            ]
+        )
+        .with_columns(
+            [
+                # Jours avant coupure
+                pl.max_horizontal(
+                    pl.lit(0), (pl.col("fin_effective") - pl.col("date_debut") + pl.duration(days=1)).dt.total_days()
+                ).alias("jours_avant_coupure")
+            ]
+        )
+        .with_columns(
+            [
+                # Ratio et montant proratisé
+                (pl.col("jours_avant_coupure") / pl.col("duree_totale_jours")).alias("ratio_prorata"),
+                (pl.col("montant_ht") * pl.col("jours_avant_coupure") / pl.col("duree_totale_jours")).alias(
+                    "montant_proratise"
+                ),
+            ]
+        )
+    )
 
     # Classification temporelle
-    df_temporal_analysis = df_f15_variable_prorata.with_columns([
-        pl.when(pl.col("date_debut") > pl.col("date_coupure_dt"))
-        .then(pl.lit("Entièrement après coupure"))
-        .when(pl.col("date_fin") <= pl.col("date_coupure_dt"))
-        .then(pl.lit("Entièrement avant coupure"))
-        .otherwise(pl.lit("Partiellement après coupure"))
-        .alias("classification_temporelle")
-    ])
+    df_temporal_analysis = df_f15_variable_prorata.with_columns(
+        [
+            pl.when(pl.col("date_debut") > pl.col("date_coupure_dt"))
+            .then(pl.lit("Entièrement après coupure"))
+            .when(pl.col("date_fin") <= pl.col("date_coupure_dt"))
+            .then(pl.lit("Entièrement avant coupure"))
+            .otherwise(pl.lit("Partiellement après coupure"))
+            .alias("classification_temporelle")
+        ]
+    )
 
     # Statistiques de transformation temporelle
-    temporal_stats = df_temporal_analysis.group_by("classification_temporelle").agg([
-        pl.len().alias("nb_lignes"),
-        pl.col("montant_ht").sum().alias("montant_original"),
-        pl.col("montant_proratise").sum().alias("montant_proratise"),
-        pl.col("ratio_prorata").mean().alias("ratio_moyen")
-    ]).sort("montant_original", descending=True)
+    temporal_stats = (
+        df_temporal_analysis.group_by("classification_temporelle")
+        .agg(
+            [
+                pl.len().alias("nb_lignes"),
+                pl.col("montant_ht").sum().alias("montant_original"),
+                pl.col("montant_proratise").sum().alias("montant_proratise"),
+                pl.col("ratio_prorata").mean().alias("ratio_moyen"),
+            ]
+        )
+        .sort("montant_original", descending=True)
+    )
 
     print(f"\n📊 STATISTIQUES TRANSFORMATION TEMPORELLE:")
     print(temporal_stats.to_pandas().to_string(index=False, float_format="%.2f"))
@@ -494,12 +498,12 @@ def temporal_transformation_variable(df_f15_variable):
     print(f"\n💰 IMPACT TRANSFORMATION TEMPORELLE:")
     print(f"   Montant original F15: {total_original:,.2f} €")
     print(f"   Montant après prorata: {total_proratise:,.2f} €")
-    print(f"   Différence (à échoir): {difference:,.2f} € ({difference/total_original*100:.1f}%)")
+    print(f"   Différence (à échoir): {difference:,.2f} € ({difference / total_original * 100:.1f}%)")
 
     # Agrégation par PDL des montants proratisés
-    df_f15_variable_prorata_pdl = df_temporal_analysis.group_by("pdl").agg([
-        pl.col("montant_proratise").sum().alias("turpe_variable_f15_prorata")
-    ])
+    df_f15_variable_prorata_pdl = df_temporal_analysis.group_by("pdl").agg(
+        [pl.col("montant_proratise").sum().alias("turpe_variable_f15_prorata")]
+    )
     return df_f15_variable_prorata_pdl, temporal_stats
 
 
@@ -520,14 +524,21 @@ def compare_with_transformations(
 
     # Jointure des PDL communs avec calculs réels uniquement
     df_comparison = (
-        df_f15_variable_prorata_pdl
-        .join(df_turpe_variable_pdl, on="pdl", how="inner")
+        df_f15_variable_prorata_pdl.join(df_turpe_variable_pdl, on="pdl", how="inner")
         .filter(pl.col("turpe_variable_calcule") > 0)  # Garder uniquement les PDL avec calcul réel
-        .with_columns([
-            # Calcul des écarts
-            (pl.col("turpe_variable_calcule") - pl.col("turpe_variable_f15_prorata")).alias("ecart_absolu"),
-            (((pl.col("turpe_variable_calcule") - pl.col("turpe_variable_f15_prorata")) / pl.col("turpe_variable_f15_prorata")) * 100).alias("ecart_relatif_pct")
-        ])
+        .with_columns(
+            [
+                # Calcul des écarts
+                (pl.col("turpe_variable_calcule") - pl.col("turpe_variable_f15_prorata")).alias("ecart_absolu"),
+                (
+                    (
+                        (pl.col("turpe_variable_calcule") - pl.col("turpe_variable_f15_prorata"))
+                        / pl.col("turpe_variable_f15_prorata")
+                    )
+                    * 100
+                ).alias("ecart_relatif_pct"),
+            ]
+        )
         .sort(pl.col("ecart_absolu").abs(), descending=True)
     )
 
@@ -540,7 +551,7 @@ def compare_with_transformations(
     print(f"\n💰 COMPARAISON APRÈS TRANSFORMATIONS:")
     print(f"   F15 (prorata): {total_f15_prorata:,.2f} € ({nb_pdl_communs} PDL)")
     print(f"   Calculé: {_total_calcule_comp:,.2f} €")
-    print(f"   Écart global: {_ecart_global:+,.2f} € ({_ecart_global/total_f15_prorata*100:+.1f}%)")
+    print(f"   Écart global: {_ecart_global:+,.2f} € ({_ecart_global / total_f15_prorata * 100:+.1f}%)")
 
     # Métriques de précision
     if nb_pdl_communs > 0:
@@ -586,16 +597,13 @@ def attribution_funnel_simple(
     print(f"📊 NIVEAU 0 - Comparaison brute (avant correction):")
     print(f"   F15 total (tous PDL): {_total_f15_brut:,.2f} €")
     print(f"   Calculé total: {_total_calcule_funnel:,.2f} €")
-    print(f"   Écart brut: {_ecart_brut:+,.2f} € ({_ecart_brut/_total_f15_brut*100:+.1f}%)")
+    print(f"   Écart brut: {_ecart_brut:+,.2f} € ({_ecart_brut / _total_f15_brut * 100:+.1f}%)")
 
     # 1. CORRECTION : Exclure les PDL sans R151 du F15
     _pdl_avec_r151 = df_releves.select("pdl").unique().to_series().to_list()
 
     # F15 filtré sur les PDL ayant des données R151 uniquement
-    df_f15_variable_filtre = (
-        df_f15_variable_par_pdl
-        .filter(pl.col("pdl").is_in(_pdl_avec_r151))
-    )
+    df_f15_variable_filtre = df_f15_variable_par_pdl.filter(pl.col("pdl").is_in(_pdl_avec_r151))
 
     _total_f15_filtre = df_f15_variable_filtre.select(pl.col("turpe_variable_f15").sum()).item()
     _nb_pdl_f15_total = len(df_f15_variable_par_pdl)
@@ -606,7 +614,7 @@ def attribution_funnel_simple(
     print(f"\n📊 NIVEAU 1 - Exclusion PDL sans R151:")
     print(f"   PDL F15 total: {_nb_pdl_f15_total}")
     print(f"   PDL F15 avec données R151: {_nb_pdl_f15_filtre}")
-    print(f"   PDL exclus (sans R151): {_nb_pdl_exclus} ({_nb_pdl_exclus/_nb_pdl_f15_total*100:.1f}%)")
+    print(f"   PDL exclus (sans R151): {_nb_pdl_exclus} ({_nb_pdl_exclus / _nb_pdl_f15_total * 100:.1f}%)")
     print(f"   F15 filtré (PDL avec R151): {_total_f15_filtre:,.2f} €")
     print(f"   Montant PDL exclus: {_montant_pdl_exclus:,.2f} € (compteurs non-communicants)")
 
@@ -616,15 +624,16 @@ def attribution_funnel_simple(
     print(f"\n📊 NIVEAU 2 - Comparaison sur périmètre commun:")
     print(f"   F15 filtré (PDL avec R151): {_total_f15_filtre:,.2f} €")
     print(f"   Calculé (PDL avec R151): {_total_calcule_funnel:,.2f} €")
-    print(f"   Écart après exclusion: {_ecart_apres_exclusion:+,.2f} € ({_ecart_apres_exclusion/_total_f15_filtre*100:+.1f}%)")
+    print(
+        f"   Écart après exclusion: {_ecart_apres_exclusion:+,.2f} € ({_ecart_apres_exclusion / _total_f15_filtre * 100:+.1f}%)"
+    )
 
     # 3. Impact des transformations temporelles (prorata)
     # Recalculer les montants F15 filtrés mais uniquement sur les PDL avec calculs réels
     _pdl_avec_calculs = set(df_comparison.select("pdl").to_series().to_list())
 
     _montant_f15_filtre_calculs_reels = (
-        df_f15_variable_filtre
-        .filter(pl.col("pdl").is_in(list(_pdl_avec_calculs)))
+        df_f15_variable_filtre.filter(pl.col("pdl").is_in(list(_pdl_avec_calculs)))
         .select(pl.col("turpe_variable_f15").sum())
         .item()
     )
@@ -639,7 +648,7 @@ def attribution_funnel_simple(
     print(f"   F15 filtré après prorata: {_montant_f15_prorata:,.2f} €")
     print(f"   Impact prorata temporel: {-_impact_prorata:+,.2f} €")
     print(f"   Calculé (PDL avec calculs): {_montant_calcule_communs:,.2f} €")
-    print(f"   Écart final: {_ecart_final:+,.2f} € ({_ecart_final/_montant_f15_prorata*100:+.1f}%)")
+    print(f"   Écart final: {_ecart_final:+,.2f} € ({_ecart_final / _montant_f15_prorata * 100:+.1f}%)")
 
     # 4. Synthèse finale simplifiée avec cohérence des montants
     _ecart_calculs_reels = _montant_calcule_communs - _montant_f15_filtre_calculs_reels
@@ -674,36 +683,35 @@ def _():
 def _(coverage_stats, df_comparison, temporal_stats):
     """Affichage des résultats principaux"""
 
-    mo.vstack([
-        mo.md("## 📊 Statistiques de couverture PDL"),
-        coverage_stats,
-
-        mo.md("## ⏰ Impact transformation temporelle"),
-        temporal_stats,
-
-        mo.md("## 🔝 Top 10 écarts après transformations"),
-        df_comparison.head(10).select([
-            "pdl", "turpe_variable_f15_prorata", "turpe_variable_calcule",
-            "ecart_absolu", "ecart_relatif_pct"
-        ]),
-
-        mo.md("## 📈 Distribution des écarts"),
-        df_comparison.select([
-            pl.col("ecart_absolu").abs().alias("ecart_abs")
-        ]).with_columns([
-            pl.when(pl.col("ecart_abs") <= 1.0)
-            .then(pl.lit("≤ 1€"))
-            .when(pl.col("ecart_abs") <= 5.0)
-            .then(pl.lit("1-5€"))
-            .when(pl.col("ecart_abs") <= 10.0)
-            .then(pl.lit("5-10€"))
-            .otherwise(pl.lit("> 10€"))
-            .alias("tranche_ecart")
-        ]).group_by("tranche_ecart").agg([
-            pl.len().alias("nb_pdl"),
-            (pl.len() / len(df_comparison) * 100).alias("pourcentage")
-        ]).sort("nb_pdl", descending=True)
-    ])
+    mo.vstack(
+        [
+            mo.md("## 📊 Statistiques de couverture PDL"),
+            coverage_stats,
+            mo.md("## ⏰ Impact transformation temporelle"),
+            temporal_stats,
+            mo.md("## 🔝 Top 10 écarts après transformations"),
+            df_comparison.head(10).select(
+                ["pdl", "turpe_variable_f15_prorata", "turpe_variable_calcule", "ecart_absolu", "ecart_relatif_pct"]
+            ),
+            mo.md("## 📈 Distribution des écarts"),
+            df_comparison.select([pl.col("ecart_absolu").abs().alias("ecart_abs")])
+            .with_columns(
+                [
+                    pl.when(pl.col("ecart_abs") <= 1.0)
+                    .then(pl.lit("≤ 1€"))
+                    .when(pl.col("ecart_abs") <= 5.0)
+                    .then(pl.lit("1-5€"))
+                    .when(pl.col("ecart_abs") <= 10.0)
+                    .then(pl.lit("5-10€"))
+                    .otherwise(pl.lit("> 10€"))
+                    .alias("tranche_ecart")
+                ]
+            )
+            .group_by("tranche_ecart")
+            .agg([pl.len().alias("nb_pdl"), (pl.len() / len(df_comparison) * 100).alias("pourcentage")])
+            .sort("nb_pdl", descending=True),
+        ]
+    )
     return
 
 
@@ -732,89 +740,93 @@ def analyser_periodes_manquantes(df_f15_variable, df_periodes_energie):
     print("🔍 Analyse des périodes manquantes par PDL...")
 
     # 1. Calculer les statistiques par PDL pour les périodes calculées
-    stats_calcules = (
-        df_periodes_energie
-        .group_by("pdl")
-        .agg([
+    stats_calcules = df_periodes_energie.group_by("pdl").agg(
+        [
             pl.col("debut").min().alias("premiere_periode_calculee"),
             pl.col("fin").max().alias("derniere_periode_calculee"),
             pl.len().alias("nb_periodes_calculees"),
             pl.col("nb_jours").filter(pl.col("data_complete")).sum().alias("total_jours"),
-            pl.col("turpe_variable_eur").sum().alias("turpe_variable_total")
-        ])
+            pl.col("turpe_variable_eur").sum().alias("turpe_variable_total"),
+        ]
     )
 
     # 2. Calculer les statistiques par PDL pour les périodes F15
-    stats_f15 = (
-        df_f15_variable
-        .group_by("pdl")
-        .agg([
+    stats_f15 = df_f15_variable.group_by("pdl").agg(
+        [
             pl.col("date_debut").min().alias("premiere_periode_f15"),
             pl.col("date_fin").max().alias("derniere_periode_f15"),
             pl.len().alias("nb_periodes_f15"),
-            (pl.col("date_fin").max()- pl.col("date_debut").min()).dt.total_days().cast(pl.Int32).alias("total_jours_f15"),
-            pl.col("montant_ht").sum().alias("turpe_f15_total")
-        ])
+            (pl.col("date_fin").max() - pl.col("date_debut").min())
+            .dt.total_days()
+            .cast(pl.Int32)
+            .alias("total_jours_f15"),
+            pl.col("montant_ht").sum().alias("turpe_f15_total"),
+        ]
     )
 
     # 3. Jointure pour comparer les deux sources
     comparaison_periodes = (
-        stats_f15
-        .join(stats_calcules, on="pdl", how="inner")
-        .with_columns([
-            # Calcul des jours de décalage en début/fin
-            (pl.col("premiere_periode_calculee") - pl.col("premiere_periode_f15")).dt.total_days().alias("decalage_debut_jours"),
-            (pl.col("derniere_periode_f15") - pl.col("derniere_periode_calculee")).dt.total_days().alias("decalage_fin_jours"),
-            # Ratio de périodes
-            (pl.col("total_jours") / pl.col("total_jours_f15")).alias("taux_couverture")
-        ])
-        .with_columns([
-            # Classification des PDL par taux de couverture
-            pl.when(pl.col("taux_couverture") >= .95)
-            .then(pl.lit("Couverture complète (≥95%)"))
-            .when(pl.col("taux_couverture") >= .80)
-            .then(pl.lit("Couverture élevée (80-94%)"))
-            .when(pl.col("taux_couverture") >= .50)
-            .then(pl.lit("Couverture partielle (50-79%)"))
-            .otherwise(pl.lit("Couverture faible (<50%)"))
-            .alias("categorie_couverture"),
-
-            (pl.col("turpe_f15_total") * pl.col("taux_couverture")).alias("f15_proratise_couverture")
-        ])
-        .with_columns([
-            (pl.col("turpe_variable_total") - pl.col("f15_proratise_couverture")).alias("erreur_prorata")
-        ])
+        stats_f15.join(stats_calcules, on="pdl", how="inner")
+        .with_columns(
+            [
+                # Calcul des jours de décalage en début/fin
+                (pl.col("premiere_periode_calculee") - pl.col("premiere_periode_f15"))
+                .dt.total_days()
+                .alias("decalage_debut_jours"),
+                (pl.col("derniere_periode_f15") - pl.col("derniere_periode_calculee"))
+                .dt.total_days()
+                .alias("decalage_fin_jours"),
+                # Ratio de périodes
+                (pl.col("total_jours") / pl.col("total_jours_f15")).alias("taux_couverture"),
+            ]
+        )
+        .with_columns(
+            [
+                # Classification des PDL par taux de couverture
+                pl.when(pl.col("taux_couverture") >= 0.95)
+                .then(pl.lit("Couverture complète (≥95%)"))
+                .when(pl.col("taux_couverture") >= 0.80)
+                .then(pl.lit("Couverture élevée (80-94%)"))
+                .when(pl.col("taux_couverture") >= 0.50)
+                .then(pl.lit("Couverture partielle (50-79%)"))
+                .otherwise(pl.lit("Couverture faible (<50%)"))
+                .alias("categorie_couverture"),
+                (pl.col("turpe_f15_total") * pl.col("taux_couverture")).alias("f15_proratise_couverture"),
+            ]
+        )
+        .with_columns([(pl.col("turpe_variable_total") - pl.col("f15_proratise_couverture")).alias("erreur_prorata")])
     )
 
     # FILTRE TEMPORAIRE : Exclure PDL avec données aberrantes
     # TODO: Implémenter détection automatique de qualité (voir docs/qualite-donnees-r151.md)
     PDL_ABERRANTS = ["14290738060355"]  # Index aberrants sept 2025 (962 MWh/mois)
-    comparaison_periodes = comparaison_periodes.filter(
-        ~pl.col("pdl").is_in(PDL_ABERRANTS)
-    )
+    comparaison_periodes = comparaison_periodes.filter(~pl.col("pdl").is_in(PDL_ABERRANTS))
 
     print(f"⚠️  PDL exclus de la validation : {len(PDL_ABERRANTS)} (données aberrantes)")
 
     # 4. Statistiques globales
     nb_pdl_total = len(comparaison_periodes)
     stats_par_categorie = (
-        comparaison_periodes
-        .group_by("categorie_couverture")
-        .agg([
-            pl.len().alias("nb_pdl"),
-            pl.col("taux_couverture").mean().alias("taux_moyen"),
-            pl.col("nb_periodes_calculees").sum().alias("periodes_calculees"),
-            pl.col("nb_periodes_f15").sum().alias("periodes_f15"),
-            pl.col("turpe_variable_total").sum().alias("montant_calcule"),
-            pl.col("turpe_f15_total").sum().alias("montant_f15"),
-            pl.col("f15_proratise_couverture").sum().alias("montant_f15_proratise")
-        ])
-        .with_columns([
-            (pl.col("nb_pdl") / nb_pdl_total * 100).alias("proportion_pdl_pct"),
-            (pl.col("montant_calcule") - pl.col("montant_f15")).alias("ecart_montant"),
-            ((pl.col("montant_calcule") - pl.col("montant_f15")) / pl.col("montant_f15") * 100).alias("ecart_pct"),
-            (pl.col("montant_calcule") - pl.col("montant_f15_proratise")).alias("ecart_montant_prorata"),
-        ])
+        comparaison_periodes.group_by("categorie_couverture")
+        .agg(
+            [
+                pl.len().alias("nb_pdl"),
+                pl.col("taux_couverture").mean().alias("taux_moyen"),
+                pl.col("nb_periodes_calculees").sum().alias("periodes_calculees"),
+                pl.col("nb_periodes_f15").sum().alias("periodes_f15"),
+                pl.col("turpe_variable_total").sum().alias("montant_calcule"),
+                pl.col("turpe_f15_total").sum().alias("montant_f15"),
+                pl.col("f15_proratise_couverture").sum().alias("montant_f15_proratise"),
+            ]
+        )
+        .with_columns(
+            [
+                (pl.col("nb_pdl") / nb_pdl_total * 100).alias("proportion_pdl_pct"),
+                (pl.col("montant_calcule") - pl.col("montant_f15")).alias("ecart_montant"),
+                ((pl.col("montant_calcule") - pl.col("montant_f15")) / pl.col("montant_f15") * 100).alias("ecart_pct"),
+                (pl.col("montant_calcule") - pl.col("montant_f15_proratise")).alias("ecart_montant_prorata"),
+            ]
+        )
         .sort("taux_moyen", descending=True)
     )
 
@@ -822,11 +834,11 @@ def analyser_periodes_manquantes(df_f15_variable, df_periodes_energie):
     print(f"   Total PDL analysés: {nb_pdl_total}")
 
     for _row in stats_par_categorie.iter_rows(named=True):
-        _cat = _row['categorie_couverture']
-        _nb_pdl = _row['nb_pdl']
-        _prop_pct = _row['proportion_pdl_pct']
-        _taux_moyen = _row['taux_moyen']
-        _ecart_pct = _row['ecart_pct']
+        _cat = _row["categorie_couverture"]
+        _nb_pdl = _row["nb_pdl"]
+        _prop_pct = _row["proportion_pdl_pct"]
+        _taux_moyen = _row["taux_moyen"]
+        _ecart_pct = _row["ecart_pct"]
 
         print(f"   📋 {_cat}:")
         print(f"      {_nb_pdl} PDL ({_prop_pct:.1f}%) - Couverture moyenne: {_taux_moyen:.1f}%")
@@ -864,61 +876,55 @@ def analyse_erreurs_prorata(comparaison_periodes, stats_par_categorie):
     print(f"   Calculé total: {_total_calcule:,.2f} €")
     print(f"   F15 brut: {_total_f15_brut:,.2f} €")
     print(f"   F15 proratisé: {_total_f15_prorata:,.2f} €")
-    print(f"   Erreur brute: {_erreur_brute:+,.2f} € ({_erreur_brute/_total_f15_brut*100:+.2f}%)")
-    print(f"   Erreur proratisée: {_erreur_prorata:+,.2f} € ({_erreur_prorata/_total_f15_prorata*100:+.2f}%)")
+    print(f"   Erreur brute: {_erreur_brute:+,.2f} € ({_erreur_brute / _total_f15_brut * 100:+.2f}%)")
+    print(f"   Erreur proratisée: {_erreur_prorata:+,.2f} € ({_erreur_prorata / _total_f15_prorata * 100:+.2f}%)")
 
     # 2. Impact du prorata par catégorie de couverture
     print(f"\n📈 IMPACT DU PRORATA PAR CATÉGORIE:")
 
-    stats_erreurs = (
-        stats_par_categorie
-        .with_columns([
+    stats_erreurs = stats_par_categorie.with_columns(
+        [
             (pl.col("montant_calcule") - pl.col("montant_f15_proratise")).alias("erreur_prorata_categorie"),
-            ((pl.col("montant_calcule") - pl.col("montant_f15_proratise")) / pl.col("montant_f15_proratise") * 100).alias("erreur_prorata_pct")
-        ])
-        .select([
-            "categorie_couverture",
-            "nb_pdl",
-            "taux_moyen",
-            "ecart_pct",
-            "erreur_prorata_pct"
-        ])
-    )
+            (
+                (pl.col("montant_calcule") - pl.col("montant_f15_proratise")) / pl.col("montant_f15_proratise") * 100
+            ).alias("erreur_prorata_pct"),
+        ]
+    ).select(["categorie_couverture", "nb_pdl", "taux_moyen", "ecart_pct", "erreur_prorata_pct"])
 
     for _row in stats_erreurs.iter_rows(named=True):
-        _cat = _row['categorie_couverture']
-        _nb_pdl = _row['nb_pdl']
-        _taux = _row['taux_moyen']
-        _erreur_brute = _row['ecart_pct']
-        _erreur_prorata = _row['erreur_prorata_pct']
+        _cat = _row["categorie_couverture"]
+        _nb_pdl = _row["nb_pdl"]
+        _taux = _row["taux_moyen"]
+        _erreur_brute = _row["ecart_pct"]
+        _erreur_prorata = _row["erreur_prorata_pct"]
 
         print(f"   📋 {_cat}:")
-        print(f"      {_nb_pdl} PDL - Couverture: {_taux*100:.1f}%")
+        print(f"      {_nb_pdl} PDL - Couverture: {_taux * 100:.1f}%")
         print(f"      Erreur brute: {_erreur_brute:+.2f}% → Erreur proratisée: {_erreur_prorata:+.2f}%")
 
     # 3. Distribution des erreurs individuelles
     print(f"\n🎯 DISTRIBUTION DES ERREURS INDIVIDUELLES:")
 
     # Analyse des erreurs par PDL
-    erreurs_stats = (
-        comparaison_periodes
-        .with_columns([
+    erreurs_stats = comparaison_periodes.with_columns(
+        [
             (pl.col("erreur_prorata").abs()).alias("erreur_abs"),
-            (pl.col("erreur_prorata") / pl.col("f15_proratise_couverture") * 100).alias("erreur_pct")
-        ])
-        .select([
+            (pl.col("erreur_prorata") / pl.col("f15_proratise_couverture") * 100).alias("erreur_pct"),
+        ]
+    ).select(
+        [
             pl.col("erreur_abs").mean().alias("erreur_moyenne"),
             pl.col("erreur_abs").median().alias("erreur_mediane"),
             pl.col("erreur_abs").std().alias("erreur_ecart_type"),
             pl.col("erreur_pct").abs().lt(5.0).sum().alias("nb_pdl_erreur_5pct"),
             pl.col("erreur_pct").abs().lt(10.0).sum().alias("nb_pdl_erreur_10pct"),
-            pl.len().alias("nb_pdl_total")
-        ])
+            pl.len().alias("nb_pdl_total"),
+        ]
     )
 
     _stats = erreurs_stats.row(0, named=True)
-    _precision_5pct = (_stats['nb_pdl_erreur_5pct'] / _stats['nb_pdl_total']) * 100
-    _precision_10pct = (_stats['nb_pdl_erreur_10pct'] / _stats['nb_pdl_total']) * 100
+    _precision_5pct = (_stats["nb_pdl_erreur_5pct"] / _stats["nb_pdl_total"]) * 100
+    _precision_10pct = (_stats["nb_pdl_erreur_10pct"] / _stats["nb_pdl_total"]) * 100
 
     print(f"   Erreur moyenne: {_stats['erreur_moyenne']:.2f} €")
     print(f"   Erreur médiane: {_stats['erreur_mediane']:.2f} €")
@@ -930,21 +936,22 @@ def analyse_erreurs_prorata(comparaison_periodes, stats_par_categorie):
     print(f"\n🔍 TOP 10 ÉCARTS APRÈS PRORATA:")
 
     top_ecarts = (
-        comparaison_periodes
-        .with_columns([
-            (pl.col("erreur_prorata") / pl.col("f15_proratise_couverture") * 100).alias("erreur_pct")
-        ])
+        comparaison_periodes.with_columns(
+            [(pl.col("erreur_prorata") / pl.col("f15_proratise_couverture") * 100).alias("erreur_pct")]
+        )
         .filter(pl.col("erreur_pct").abs() > 0.1)
         .sort("erreur_prorata", descending=True)
-        .select([
-            "pdl",
-            "taux_couverture",
-            "categorie_couverture",
-            "turpe_variable_total",
-            "f15_proratise_couverture",
-            "erreur_prorata",
-            "erreur_pct"
-        ])
+        .select(
+            [
+                "pdl",
+                "taux_couverture",
+                "categorie_couverture",
+                "turpe_variable_total",
+                "f15_proratise_couverture",
+                "erreur_prorata",
+                "erreur_pct",
+            ]
+        )
         .head(10)
     )
     return (top_ecarts,)
@@ -990,7 +997,9 @@ def validation_hypothese_final(comparaison_periodes):
         _explication = "L'ajustement par couverture ramène l'erreur à <1%. Les périodes manquantes expliquent bien l'écart initial."
     elif abs(_erreur_prorata_pct) < 2.0 and _amelioration > 1.0:
         _resultat = "⚠️ HYPOTHÈSE PARTIELLEMENT VALIDÉE"
-        _explication = "L'ajustement améliore significativement la précision. Les périodes manquantes sont un facteur important."
+        _explication = (
+            "L'ajustement améliore significativement la précision. Les périodes manquantes sont un facteur important."
+        )
     elif _amelioration > 0.5:
         _resultat = "🟡 HYPOTHÈSE PARTIELLEMENT SUPPORTÉE"
         _explication = "L'ajustement améliore la précision mais des écarts résiduels subsistent."

--- a/tests/core/loaders/test_duckdb_loader.py
+++ b/tests/core/loaders/test_duckdb_loader.py
@@ -19,14 +19,14 @@ from electricore.core.loaders.duckdb import (
     duckdb_connection,
     execute_custom_query,
     get_available_tables,
-    load_historique_perimetre,
+    load_historique,
     load_releves,
     releves,
 )
 
 # Import des transformations depuis le module interne
 from electricore.core.loaders.duckdb.transforms import (
-    transform_historique_perimetre as _transform_historique_perimetre,
+    transform_historique as _transform_historique,
 )
 from electricore.core.loaders.duckdb.transforms import (
     transform_releves as _transform_releves,
@@ -52,11 +52,11 @@ class TestDuckDBConfig:
         config = DuckDBConfig()
 
         # Vérifier que les mappings essentiels existent
-        assert "historique_perimetre" in config.table_mappings
+        assert "historique" in config.table_mappings
         assert "releves" in config.table_mappings
 
         # Vérifier la structure des mappings
-        hist_mapping = config.table_mappings["historique_perimetre"]
+        hist_mapping = config.table_mappings["historique"]
         assert "source_tables" in hist_mapping
         assert "description" in hist_mapping
 
@@ -95,7 +95,7 @@ class TestDuckDBConnection:
 class TestTransformationFunctions:
     """Tests pour les fonctions de transformation."""
 
-    def test_transform_historique_perimetre(self):
+    def test_transform_historique(self):
         """Test de transformation des données d'historique."""
         from datetime import datetime
 
@@ -110,7 +110,7 @@ class TestTransformationFunctions:
         ).lazy()
 
         # Appliquer la transformation
-        result = _transform_historique_perimetre(test_data)
+        result = _transform_historique(test_data)
 
         # Vérifier que c'est toujours un LazyFrame
         assert isinstance(result, pl.LazyFrame)
@@ -274,7 +274,7 @@ class TestTransformationFunctions:
 class TestLoadFunctions:
     """Tests pour les fonctions de chargement de données."""
 
-    def test_load_historique_perimetre_basic(self):
+    def test_load_historique_basic(self):
         """Test de base du chargement d'historique."""
         # Test simplifié : vérifier que la fonction retourne un LazyFrame
         # lorsque la base existe
@@ -287,14 +287,14 @@ class TestLoadFunctions:
         query_filtered = query.filter({"pdl": ["PDL123"]}).limit(100)
         assert isinstance(query_filtered, DuckDBQuery)
 
-        # Vérifier load_historique_perimetre avec base inexistante échoue correctement
+        # Vérifier load_historique avec base inexistante échoue correctement
         with pytest.raises(FileNotFoundError):
-            load_historique_perimetre(database_path="nonexistent_test.duckdb").collect()
+            load_historique(database_path="nonexistent_test.duckdb").collect()
 
-    def test_load_historique_perimetre_database_not_found(self):
+    def test_load_historique_database_not_found(self):
         """Test avec base de données inexistante."""
         with pytest.raises(FileNotFoundError):
-            load_historique_perimetre(database_path="nonexistent.duckdb")
+            load_historique(database_path="nonexistent.duckdb")
 
     def test_load_releves_basic(self):
         """Test de base du chargement de relevés."""
@@ -389,7 +389,7 @@ class TestIntegrationWithRealData:
         """Test avec la vraie base DuckDB si disponible."""
         try:
             # Charger un petit échantillon
-            result = load_historique_perimetre(
+            result = load_historique(
                 database_path="electricore/etl/flux_enedis_pipeline.duckdb", limit=5, valider=False
             )
 

--- a/tests/integration/test_pipelines_snapshot.py
+++ b/tests/integration/test_pipelines_snapshot.py
@@ -16,7 +16,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from electricore.core.pipelines.abonnements import pipeline_abonnements
 from electricore.core.pipelines.energie import pipeline_energie
-from electricore.core.pipelines.perimetre import pipeline_perimetre
+from electricore.core.pipelines.historique import pipeline_historique
 
 # =========================================================================
 # FIXTURES SNAPSHOT - DONNÉES DE TEST
@@ -158,14 +158,14 @@ def releves_snapshot_test() -> pl.LazyFrame:
 @pytest.mark.skip(reason="Needs snapshot generation")
 @pytest.mark.integration
 @pytest.mark.smoke
-def test_pipeline_perimetre_snapshot(historique_snapshot_test: pl.LazyFrame, snapshot: SnapshotAssertion):
+def test_pipeline_historique_snapshot(historique_snapshot_test: pl.LazyFrame, snapshot: SnapshotAssertion):
     """
     Test snapshot du pipeline périmètre.
 
     Ce test capture le résultat complet du pipeline. Toute modification
     de la logique métier déclenchera une alerte nécessitant review.
     """
-    result = pipeline_perimetre(historique_snapshot_test).collect()
+    result = pipeline_historique(historique_snapshot_test).collect()
 
     # Convertir en dict pour snapshot
     result_dict = result.to_dicts()
@@ -176,13 +176,13 @@ def test_pipeline_perimetre_snapshot(historique_snapshot_test: pl.LazyFrame, sna
 
 @pytest.mark.skip(reason="Needs snapshot generation")
 @pytest.mark.integration
-def test_pipeline_perimetre_structure_snapshot(historique_snapshot_test: pl.LazyFrame, snapshot: SnapshotAssertion):
+def test_pipeline_historique_structure_snapshot(historique_snapshot_test: pl.LazyFrame, snapshot: SnapshotAssertion):
     """
     Test snapshot de la structure de sortie du pipeline périmètre.
 
     Capture uniquement les colonnes et types, pas les valeurs.
     """
-    result = pipeline_perimetre(historique_snapshot_test).collect()
+    result = pipeline_historique(historique_snapshot_test).collect()
 
     structure = {
         "columns": result.columns,
@@ -308,7 +308,7 @@ def test_pipeline_energie_aggrege_snapshot(
 
 @pytest.mark.skip(reason="Needs snapshot generation")
 @pytest.mark.integration
-def test_pipeline_perimetre_pdl_unique_snapshot(snapshot: SnapshotAssertion):
+def test_pipeline_historique_pdl_unique_snapshot(snapshot: SnapshotAssertion):
     """Test snapshot avec un seul PDL et événement."""
     historique_minimal = pl.LazyFrame(
         {
@@ -323,7 +323,7 @@ def test_pipeline_perimetre_pdl_unique_snapshot(snapshot: SnapshotAssertion):
         }
     )
 
-    result = pipeline_perimetre(historique_minimal).collect()
+    result = pipeline_historique(historique_minimal).collect()
 
     assert result.to_dicts() == snapshot
 

--- a/tests/unit/test_expressions_historique.py
+++ b/tests/unit/test_expressions_historique.py
@@ -1,8 +1,8 @@
-"""Tests unitaires pour les expressions Polars du pipeline périmètre."""
+"""Tests unitaires pour les expressions Polars du pipeline historique."""
 
 import polars as pl
 
-from electricore.core.pipelines.perimetre import (
+from electricore.core.pipelines.historique import (
     colonnes_evenement_facturation,
     detecter_points_de_rupture,
     expr_changement,

--- a/tests/unit/test_expressions_historique_parametrized.py
+++ b/tests/unit/test_expressions_historique_parametrized.py
@@ -1,5 +1,5 @@
 """
-Tests unitaires paramétrés pour les expressions Polars du pipeline périmètre.
+Tests unitaires paramétrés pour les expressions Polars du pipeline historique.
 
 Ce module démontre l'usage de @pytest.mark.parametrize pour réduire
 la duplication de code et améliorer la couverture des edge cases.
@@ -8,7 +8,7 @@ la duplication de code et améliorer la couverture des edge cases.
 import polars as pl
 import pytest
 
-from electricore.core.pipelines.perimetre import (
+from electricore.core.pipelines.historique import (
     expr_changement,
     expr_evenement_structurant,
     expr_impacte_abonnement,


### PR DESCRIPTION
## Summary

- Renomme `pipelines/perimetre.py` → `historique.py` et `pipeline_perimetre` → `pipeline_historique` (décoré `@pa.check_types`).
- Supprime `HistoriquePérimètre` (validait le brut sans nom métier autonome) ; crée `Historique` validant la sortie enrichie.
- Cascade : registry (`validator=None` pour C15), loaders, transforms, table_mappings, tests, notebooks.

Implémente [ADR-0013](https://github.com/Energie-De-Nantes/electricore/blob/main/docs/adr/0013-renommage-perimetre-historique.md) et débloque #13.

## Test plan

- [x] `uv run --group test pytest -q` : 254 passed, 35 skipped (légitimes — identique au baseline pré-refactor)
- [x] `uvx ruff format` : propre
- [x] `uvx ruff check` : All checks passed
- [x] Pre-commit hook : Passed (ruff check + format)
- [x] Aucune référence résiduelle à `pipeline_perimetre`, `HistoriquePérimètre`, `transform_historique_perimetre`, `load_historique_perimetre` dans le code applicatif ou les tests

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)