### PR TITLE
feat(facturation): extension LignesFactureRapprochees + lignes_factures_du_mois (v1.6)

### DIFF
--- a/docs/adr/0014-lignes-factures-du-mois-avec-flags.md
+++ b/docs/adr/0014-lignes-factures-du-mois-avec-flags.md
@@ -1,0 +1,27 @@
+# Lignes de factures du mois exposées avec flags d'état
+
+## Contexte
+
+L'ancien helper Odoo `lignes_a_facturer` filtrait côté XML-RPC sur `sale.order.x_invoicing_state == 'draft'` ET `account.move.state == 'draft'`. Hors période de facturation (toutes factures validées), il retournait systématiquement zéro ligne, rendant impossibles : le test du notebook de facturation, l'audit du mois précédent, ou toute consultation rétrospective. Symétriquement, `lignes_quantite_zero` souffrait du même problème.
+
+## Décision
+
+Remplacer ces deux helpers par une fonction unique `lignes_factures_du_mois(odoo, mois)` qui :
+
+- Filtre côté Odoo uniquement par `sale.order.state == 'sale'` et `invoice_date` dans le mois cible (volume maîtrisé).
+- N'applique aucun filtre sur `x_invoicing_state`, `account.move.state`, ni `quantity`.
+- Ajoute deux colonnes booléennes mutuellement exclusives sur le sous-ensemble draft :
+  - `a_facturer` = `(x_invoicing_state == 'draft') AND (account.move.state == 'draft') AND (quantity > 0)` — réplique le contrat de l'ex-`lignes_a_facturer`.
+  - `a_supprimer` = même triplet avec `quantity == 0` — réplique l'ex-`lignes_quantite_zero`.
+
+Le filtre métier devient explicite côté consommateur : `df.filter(pl.col("a_facturer"))` en prod, pas de filtre en test/audit. `rapprocher_facturation_mensuelle` ne filtre plus en interne et propage les deux flags au modèle `LignesFactureRapprochees`.
+
+## Raison
+
+Cette forme résout simultanément trois usages (facturation active, test hors période, audit a posteriori) avec une seule fonction et un seul endpoint. Les alternatives écartées :
+
+- **Env var serveur (`ELECTRICORE_INCLUDE_ALL_INVOICING_STATES`)** : état caché invisible des consommateurs, source de surprises en debug.
+- **Paramètre query API (`?inclure_validees=true`)** : surface publique, risque d'usage involontaire en prod.
+- **Mock côté client (fixture)** : décorelle le test de la chaîne API réelle, défaite le but de la migration #13.
+
+Le coût assumé : volume légèrement supérieur côté Odoo (toutes les lignes du mois, pas seulement les draft), borné par le filtre `invoice_date` qui limite à un mois calendaire.

--- a/electricore/api/services/facturation_service.py
+++ b/electricore/api/services/facturation_service.py
@@ -25,9 +25,11 @@ def calculer_lignes_facture_rapprochees(mois: str | None = None) -> pl.DataFrame
     with OdooReader(config=settings.get_odoo_config()) as odoo:
         lignes_df = lignes_a_facturer(odoo).collect()
 
-    _, _, _, fact = facturation(historique=c15().lazy(), releves=releves_harmonises().lazy())
+    hist_enrichi, _, _, fact = facturation(historique=c15().lazy(), releves=releves_harmonises().lazy())
 
-    return rapprocher_facturation_mensuelle(lignes_odoo=lignes_df, fact_mensuelle=fact.lazy(), mois=mois)
+    return rapprocher_facturation_mensuelle(
+        lignes_odoo=lignes_df, fact_mensuelle=fact.lazy(), historique=hist_enrichi, mois=mois
+    )
 
 
 def generer_facturation_xlsx(mois: str | None = None) -> bytes:
@@ -83,7 +85,7 @@ def generer_documents_facturation(mois: str | None = None) -> tuple[bytes, str]:
     # 2. Pipeline facturation Enedis (un seul calcul, partagé pour le rapprochement + le filtre F15/C15)
     lf_historique = c15().lazy()
     lf_releves = releves_harmonises().lazy()
-    _, _, _, fact = facturation(historique=lf_historique, releves=lf_releves)
+    hist_enrichi, _, _, fact = facturation(historique=lf_historique, releves=lf_releves)
 
     # 3. Résoudre le mois cible (None → dernier mois disponible)
     debut_mois_expr = pl.col("debut").dt.truncate("1mo").dt.date()
@@ -93,7 +95,9 @@ def generer_documents_facturation(mois: str | None = None) -> tuple[bytes, str]:
     mois_date = pl.lit(mois).str.to_date()
 
     # 4. Rapprochement Odoo ↔ Enedis (même fonction core que XLSX / Arrow)
-    reconciliation = rapprocher_facturation_mensuelle(lignes_odoo=lignes_df, fact_mensuelle=fact.lazy(), mois=mois)
+    reconciliation = rapprocher_facturation_mensuelle(
+        lignes_odoo=lignes_df, fact_mensuelle=fact.lazy(), historique=hist_enrichi, mois=mois
+    )
     changements_puissance = reconciliation.filter(pl.col("memo_puissance") != "")
 
     # 5. F15 du mois

--- a/electricore/api/services/facturation_service.py
+++ b/electricore/api/services/facturation_service.py
@@ -11,7 +11,8 @@ import polars as pl
 import xlsxwriter
 
 from electricore.api.config import settings
-from electricore.core.loaders import OdooReader, c15, f15, lignes_a_facturer, releves_harmonises
+from electricore.core.loaders import OdooReader, c15, f15, releves_harmonises
+from electricore.core.loaders.odoo import lignes_factures_du_mois
 from electricore.core.pipelines.facturation import rapprocher_facturation_mensuelle
 from electricore.core.pipelines.orchestration import facturation
 
@@ -22,10 +23,15 @@ def calculer_lignes_facture_rapprochees(mois: str | None = None) -> pl.DataFrame
     Args:
         mois: format "YYYY-MM-DD" (premier jour du mois). None = dernier mois des données.
     """
-    with OdooReader(config=settings.get_odoo_config()) as odoo:
-        lignes_df = lignes_a_facturer(odoo).collect()
-
     hist_enrichi, _, _, fact = facturation(historique=c15().lazy(), releves=releves_harmonises().lazy())
+
+    # Résoudre le mois si non fourni avant d'interroger Odoo (cf. ADR-0014).
+    if mois is None:
+        debut_mois_expr = pl.col("debut").dt.truncate("1mo").dt.date()
+        mois = str(fact.select(debut_mois_expr.alias("m"))["m"].max())
+
+    with OdooReader(config=settings.get_odoo_config()) as odoo:
+        lignes_df = lignes_factures_du_mois(odoo, mois).collect()
 
     return rapprocher_facturation_mensuelle(
         lignes_odoo=lignes_df, fact_mensuelle=fact.lazy(), historique=hist_enrichi, mois=mois
@@ -78,21 +84,21 @@ def generer_documents_facturation(mois: str | None = None) -> tuple[bytes, str]:
     - reconciliation.csv
     - changements_puissance.csv
     """
-    # 1. Lignes Odoo en brouillon
-    with OdooReader(config=settings.get_odoo_config()) as odoo:
-        lignes_df = lignes_a_facturer(odoo).collect()
-
-    # 2. Pipeline facturation Enedis (un seul calcul, partagé pour le rapprochement + le filtre F15/C15)
+    # 1. Pipeline facturation Enedis (un seul calcul, partagé pour le rapprochement + le filtre F15/C15)
     lf_historique = c15().lazy()
     lf_releves = releves_harmonises().lazy()
     hist_enrichi, _, _, fact = facturation(historique=lf_historique, releves=lf_releves)
 
-    # 3. Résoudre le mois cible (None → dernier mois disponible)
+    # 2. Résoudre le mois cible (None → dernier mois disponible) AVANT d'interroger Odoo (ADR-0014)
     debut_mois_expr = pl.col("debut").dt.truncate("1mo").dt.date()
     if mois is None:
         mois = str(fact.select(debut_mois_expr.alias("m"))["m"].max())
     suffix = mois[:7]
     mois_date = pl.lit(mois).str.to_date()
+
+    # 3. Lignes Odoo du mois cible (toutes, avec flags a_facturer / a_supprimer)
+    with OdooReader(config=settings.get_odoo_config()) as odoo:
+        lignes_df = lignes_factures_du_mois(odoo, mois).collect()
 
     # 4. Rapprochement Odoo ↔ Enedis (même fonction core que XLSX / Arrow)
     reconciliation = rapprocher_facturation_mensuelle(

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -193,7 +193,7 @@ Opération **aval** qui relie les lignes de facture Odoo (déjà tagguées avec 
 _Éviter_ : réconciliation (anglicisme), jointure facturation, `updates_rsc` (ancien nom de variable).
 
 **`lignes_facture_rapprochees`** :
-DataFrame résultat du *Rapprochement facturation mensuelle*. Une ligne par ligne de facture Odoo en brouillon, enrichie de la quantité calculée à partir des flux Enedis (`quantite_enedis`). Sert de proposition de mise à jour : la décision d'écriture dans Odoo est prise par l'opérateur depuis un notebook (cf. [ADR-0012](../../docs/adr/0012-api-read-only-odoo.md)).
+DataFrame résultat du *Rapprochement facturation mensuelle*. Une ligne par ligne de facture Odoo du mois cible (tous états confondus), enrichie de la quantité calculée à partir des flux Enedis (`quantite_enedis`) et de deux flags : `a_facturer` (ligne en attente d'injection de quantité) et `a_supprimer` (ligne brouillon à quantité nulle, candidate à `unlink`). Sert de proposition de mise à jour : la décision d'écriture dans Odoo est prise par l'opérateur depuis un notebook (cf. [ADR-0012](../../docs/adr/0012-api-read-only-odoo.md)).
 
 **`x_invoicing_state`** :
 Champ Odoo qui matérialise l'avancement d'un `sale.order` dans le cycle de facturation mensuel. Les vérifications pré-facturation (`/check odoo` côté bot) reposent en partie sur sa répartition.

--- a/electricore/core/loaders/__init__.py
+++ b/electricore/core/loaders/__init__.py
@@ -34,8 +34,9 @@ from .odoo import (
     # Expressions Polars utilitaires
     expr_calculer_trimestre_facturation,
     factures,
-    lignes_a_facturer,
+    flags_etat_facturation,
     lignes_factures,
+    lignes_factures_du_mois,
     partenaires,
     # API fonctionnelle - Helpers simples
     query,
@@ -76,7 +77,8 @@ __all__ = [
     "commandes_factures",
     "commandes_lignes",
     "consommations_mensuelles",
-    "lignes_a_facturer",
+    "lignes_factures_du_mois",
+    "flags_etat_facturation",
     # Expressions Polars utilitaires Odoo
     "expr_calculer_trimestre_facturation",
 ]

--- a/electricore/core/loaders/odoo/__init__.py
+++ b/electricore/core/loaders/odoo/__init__.py
@@ -26,9 +26,9 @@ from .helpers import (
     commandes_lignes,
     consommations_mensuelles,
     factures,
-    lignes_a_facturer,
+    flags_etat_facturation,
     lignes_factures,
-    lignes_quantite_zero,
+    lignes_factures_du_mois,
     partenaires,
     query,
 )
@@ -65,8 +65,8 @@ __all__ = [
     "commandes_factures",
     "commandes_lignes",
     "consommations_mensuelles",
-    "lignes_a_facturer",
-    "lignes_quantite_zero",
+    "lignes_factures_du_mois",
+    "flags_etat_facturation",
     # Transformations
     "normalize_many2one_fields",
     "convert_odoo_dates",

--- a/electricore/core/loaders/odoo/helpers.py
+++ b/electricore/core/loaders/odoo/helpers.py
@@ -319,6 +319,7 @@ def lignes_factures_du_mois(odoo: OdooReader, mois: str, domain: list | None = N
             domain=base_domain,
             fields=[
                 "name",
+                "state",  # nécessaire pour forcer le rename de account.move.state → state_account_move
                 "x_pdl",
                 "x_ref_situation_contractuelle",
                 "x_lisse",

--- a/electricore/core/loaders/odoo/helpers.py
+++ b/electricore/core/loaders/odoo/helpers.py
@@ -8,6 +8,10 @@ Toutes les fonctions sont pures : elles prennent un OdooReader en paramètre
 et retournent un OdooQuery chainable.
 """
 
+from datetime import date
+
+import polars as pl
+
 from .query import OdooQuery
 from .reader import OdooReader
 
@@ -262,84 +266,73 @@ def consommations_mensuelles(odoo: OdooReader, domain: list | None = None) -> Od
     return commandes_lignes(odoo, domain=domain)
 
 
-def lignes_a_facturer(odoo: OdooReader, domain: list | None = None) -> OdooQuery:
-    """
-    Query builder pour les lignes de factures brouillon à facturer.
+def flags_etat_facturation(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """Ajoute les colonnes booléennes `a_facturer` et `a_supprimer` (cf. ADR-0014).
 
-    Navigation : sale.order (state=sale) → account.move (state=draft)
-                 → account.move.line (qty > 0) → product.product → product.category
+    Les deux flags sont mutuellement exclusifs sur le sous-ensemble draft :
 
-    Filtre côté Odoo (XML-RPC) :
-    - sale.order : state = 'sale' ET au moins une facture draft
-    - account.move : state = 'draft' uniquement
-    - account.move.line : quantity > 0 (exclut lignes vides/notes)
-
-    Les sale.order sans facture draft sont exclus dès la requête initiale.
+    - `a_facturer` : ligne en attente d'injection de quantité Enedis
+      (x_invoicing_state == 'draft' AND state_account_move == 'draft' AND quantity > 0).
+    - `a_supprimer` : ligne brouillon à quantité nulle, candidate à `unlink`
+      (mêmes conditions avec quantity == 0).
 
     Args:
-        odoo: Instance OdooReader connectée
-        domain: Filtres additionnels sur sale.order (ex: [('x_pdl', '!=', False)])
+        lf: LazyFrame contenant les colonnes `x_invoicing_state`, `state_account_move`,
+            `quantity`.
 
     Returns:
-        OdooQuery chainable retournant les lignes à facturer
-
-    Example:
-        >>> with OdooReader(config) as odoo:
-        ...     df = (lignes_a_facturer(odoo)
-        ...         .filter(pl.col('name_product_category').is_in(['Abonnements', 'HP', 'HC', 'Base']))
-        ...         .select(['name', 'x_pdl', 'invoice_date', 'quantity', 'price_total',
-        ...                  'name_product_product', 'name_product_category'])
-        ...         .collect())
+        LazyFrame enrichi des deux colonnes booléennes.
     """
-    base_domain = [("state", "=", "sale"), ("x_invoicing_state", "=", "draft")] + (domain or [])
-    return (
+    drafts = (pl.col("x_invoicing_state") == "draft") & (pl.col("state_account_move") == "draft")
+    return lf.with_columns(
+        [
+            (drafts & (pl.col("quantity") > 0)).alias("a_facturer"),
+            (drafts & (pl.col("quantity") == 0)).alias("a_supprimer"),
+        ]
+    )
+
+
+def lignes_factures_du_mois(odoo: OdooReader, mois: str, domain: list | None = None) -> pl.LazyFrame:
+    """Toutes les lignes de factures Odoo dont `invoice_date` tombe dans le mois cible.
+
+    Aucun filtre sur `x_invoicing_state` ni `account.move.state` côté Odoo : les
+    distinctions métier sont matérialisées par les flags `a_facturer` et `a_supprimer`
+    ajoutés en sortie (cf. ADR-0014). Remplace `lignes_a_facturer` et `lignes_quantite_zero`.
+
+    Args:
+        odoo: Instance OdooReader connectée.
+        mois: Premier jour du mois cible au format "YYYY-MM-DD".
+        domain: Filtres additionnels sur `sale.order`.
+
+    Returns:
+        LazyFrame Polars avec une ligne par `account.move.line` du mois cible
+        et les colonnes `a_facturer`, `a_supprimer`.
+    """
+    d = date.fromisoformat(mois)
+    mois_suivant = (date(d.year + 1, 1, 1) if d.month == 12 else date(d.year, d.month + 1, 1)).isoformat()
+    base_domain = [("state", "=", "sale")] + (domain or [])
+
+    return flags_etat_facturation(
         query(
             odoo,
             "sale.order",
             domain=base_domain,
-            fields=["name", "x_pdl", "x_ref_situation_contractuelle", "x_lisse", "invoice_ids"],
+            fields=[
+                "name",
+                "x_pdl",
+                "x_ref_situation_contractuelle",
+                "x_lisse",
+                "x_invoicing_state",
+                "invoice_ids",
+            ],
         )
-        .follow("invoice_ids", domain=[("state", "=", "draft")], fields=["name", "invoice_date", "invoice_line_ids"])
-        .follow("invoice_line_ids", domain=[("quantity", ">", 0)], fields=["name", "product_id", "quantity"])
+        .follow(
+            "invoice_ids",
+            domain=[("invoice_date", ">=", mois), ("invoice_date", "<", mois_suivant)],
+            fields=["name", "invoice_date", "state", "invoice_line_ids"],
+        )
+        .follow("invoice_line_ids", fields=["name", "product_id", "quantity"])
         .follow("product_id", fields=["name", "categ_id"])
         .enrich("categ_id", fields=["name"])
-    )
-
-
-def lignes_quantite_zero(odoo: OdooReader, domain: list | None = None) -> OdooQuery:
-    """
-    Query builder pour les lignes de factures brouillon avec quantité nulle.
-
-    Identifie les account.move.line avec quantity = 0 dans les factures draft,
-    candidates à la suppression avant validation (via OdooWriter.unlink).
-
-    Navigation : sale.order (state=sale) → account.move (state=draft)
-                 → account.move.line (quantity = 0) → product.product
-
-    Filtre côté Odoo (XML-RPC) :
-    - sale.order : state = 'sale' ET au moins une facture draft
-    - account.move : state = 'draft' uniquement
-    - account.move.line : quantity = 0
-
-    Args:
-        odoo: Instance OdooReader connectée
-        domain: Filtres additionnels sur sale.order (ex: [('x_pdl', '!=', False)])
-
-    Returns:
-        OdooQuery chainable — colonne `invoice_line_ids` contient les IDs
-        des account.move.line à supprimer
-
-    Example:
-        >>> with OdooReader(config) as odoo:
-        ...     df = lignes_quantite_zero(odoo).collect()
-        ...     ids_a_supprimer = df['invoice_line_ids'].drop_nulls().to_list()
-    """
-    base_domain = [("state", "=", "sale"), ("x_invoicing_state", "=", "draft")] + (domain or [])
-    return (
-        query(odoo, "sale.order", domain=base_domain, fields=["name", "state", "x_pdl", "x_lisse", "invoice_ids"])
-        .follow("invoice_ids", domain=[("state", "=", "draft")], fields=["name", "invoice_date", "invoice_line_ids"])
-        .follow(
-            "invoice_line_ids", domain=[("quantity", "=", 0)], fields=["name", "product_id", "quantity", "price_unit"]
-        )
-        .follow("product_id", fields=["name"])
+        .lazy()
     )

--- a/electricore/core/models/lignes_facture_rapprochees.py
+++ b/electricore/core/models/lignes_facture_rapprochees.py
@@ -14,11 +14,11 @@ class LignesFactureRapprochees(pa.DataFrameModel):
 
     # Identifiants Odoo
     invoice_line_ids: pl.Int64 = pa.Field(nullable=False)
-    x_pdl: pl.Utf8 = pa.Field(nullable=False)
-    x_lisse: pl.Boolean = pa.Field(nullable=False)
+    x_pdl: pl.Utf8 | None = pa.Field(nullable=True)
+    x_lisse: pl.Boolean | None = pa.Field(nullable=True)  # défaut Odoo = null, à fill_null(False) côté consommateur
     name_account_move: pl.Utf8 = pa.Field(nullable=False)
-    name_product_category: pl.Utf8 = pa.Field(nullable=False)
-    name_product_product: pl.Utf8 = pa.Field(nullable=False)
+    name_product_category: pl.Utf8 | None = pa.Field(nullable=True)
+    name_product_product: pl.Utf8 | None = pa.Field(nullable=True)
     quantity: pl.Float64 = pa.Field(nullable=False)
 
     # Quantité Enedis + mémo

--- a/electricore/core/models/lignes_facture_rapprochees.py
+++ b/electricore/core/models/lignes_facture_rapprochees.py
@@ -38,6 +38,10 @@ class LignesFactureRapprochees(pa.DataFrameModel):
     num_compteur: pl.Utf8 | None = pa.Field(nullable=True)
     type_compteur: pl.Utf8 | None = pa.Field(nullable=True)
 
+    # Flags d'état de facturation (cf. ADR-0014, mutuellement exclusifs sur sous-ensemble draft)
+    a_facturer: pl.Boolean | None = pa.Field(nullable=True)
+    a_supprimer: pl.Boolean | None = pa.Field(nullable=True)
+
     class Config:
         strict = True
         coerce = True

--- a/electricore/core/models/lignes_facture_rapprochees.py
+++ b/electricore/core/models/lignes_facture_rapprochees.py
@@ -6,11 +6,13 @@ Résultat du *Rapprochement facturation mensuelle*. Voir
 
 import pandera.polars as pa
 import polars as pl
+from pandera.engines.polars_engine import DateTime
 
 
 class LignesFactureRapprochees(pa.DataFrameModel):
-    """Lignes de facture Odoo en brouillon enrichies de `quantite_enedis`."""
+    """Lignes de facture Odoo enrichies des données Enedis du mois (quantité, méta-période, compteur)."""
 
+    # Identifiants Odoo
     invoice_line_ids: pl.Int64 = pa.Field(nullable=False)
     x_pdl: pl.Utf8 = pa.Field(nullable=False)
     x_lisse: pl.Boolean = pa.Field(nullable=False)
@@ -18,8 +20,23 @@ class LignesFactureRapprochees(pa.DataFrameModel):
     name_product_category: pl.Utf8 = pa.Field(nullable=False)
     name_product_product: pl.Utf8 = pa.Field(nullable=False)
     quantity: pl.Float64 = pa.Field(nullable=False)
+
+    # Quantité Enedis + mémo
     quantite_enedis: pl.Float64 | None = pa.Field(nullable=True)
     memo_puissance: pl.Utf8 | None = pa.Field(nullable=True)
+
+    # Méta-période Enedis du mois (nullable si pas de match RSC)
+    ref_situation_contractuelle: pl.Utf8 | None = pa.Field(nullable=True)
+    pdl: pl.Utf8 | None = pa.Field(nullable=True)
+    debut: DateTime | None = pa.Field(nullable=True, dtype_kwargs={"time_unit": "us", "time_zone": "Europe/Paris"})
+    fin: DateTime | None = pa.Field(nullable=True, dtype_kwargs={"time_unit": "us", "time_zone": "Europe/Paris"})
+    data_complete: pl.Boolean | None = pa.Field(nullable=True)
+    turpe_fixe_eur: pl.Float64 | None = pa.Field(nullable=True)
+    turpe_variable_eur: pl.Float64 | None = pa.Field(nullable=True)
+
+    # Identifiants compteur (issus de l'Historique)
+    num_compteur: pl.Utf8 | None = pa.Field(nullable=True)
+    type_compteur: pl.Utf8 | None = pa.Field(nullable=True)
 
     class Config:
         strict = True

--- a/electricore/core/pipelines/facturation.py
+++ b/electricore/core/pipelines/facturation.py
@@ -436,16 +436,24 @@ MAPPING_CATEGORIE_COLONNE: dict[str, str] = {
 def rapprocher_facturation_mensuelle(
     lignes_odoo: pl.DataFrame,
     fact_mensuelle: pl.LazyFrame,
+    historique: pl.LazyFrame,
     mois: str | None = None,
 ) -> DataFrame[LignesFactureRapprochees]:
     """Joint les lignes de facture Odoo (taggées RSC) à la facturation Enedis du mois.
 
-    Calcule `quantite_enedis` selon `name_product_category`. Voir l'entrée
+    Calcule `quantite_enedis` selon `name_product_category` et préserve les méta-données
+    Enedis (debut, fin, turpe_*, data_complete) ainsi que les identifiants compteur
+    (num_compteur, type_compteur) joints depuis l'Historique. Voir l'entrée
     *Rapprochement facturation mensuelle* dans `core/CONTEXT.md`.
     """
     debut_mois = pl.col("debut").dt.truncate("1mo").dt.date()
     mois_cible = pl.lit(mois).str.to_date() if mois is not None else debut_mois.max()
     fact_mois = fact_mensuelle.filter(debut_mois == mois_cible)
+
+    # Identifiants compteur projetés par RSC (dernier connu si plusieurs événements)
+    compteur_par_rsc = historique.select(["ref_situation_contractuelle", "num_compteur", "type_compteur"]).unique(
+        subset=["ref_situation_contractuelle"], keep="last"
+    )
 
     quantite_enedis_expr = pl.coalesce(
         [
@@ -462,9 +470,14 @@ def rapprocher_facturation_mensuelle(
             right_on="ref_situation_contractuelle",
             how="left",
         )
+        # Le join consomme `ref_situation_contractuelle` côté droit ; on le ré-expose
+        # depuis la clé Odoo (valeur identique par construction).
+        .with_columns(pl.col("x_ref_situation_contractuelle").alias("ref_situation_contractuelle"))
+        .join(compteur_par_rsc, on="ref_situation_contractuelle", how="left")
         .with_columns(quantite_enedis_expr)
         .select(
             [
+                # Identifiants Odoo + quantité
                 "invoice_line_ids",
                 "x_pdl",
                 "x_lisse",
@@ -474,6 +487,17 @@ def rapprocher_facturation_mensuelle(
                 "quantity",
                 "quantite_enedis",
                 "memo_puissance",
+                # Méta-période Enedis
+                "ref_situation_contractuelle",
+                "pdl",
+                "debut",
+                "fin",
+                "data_complete",
+                "turpe_fixe_eur",
+                "turpe_variable_eur",
+                # Identifiants compteur
+                "num_compteur",
+                "type_compteur",
             ]
         )
         .collect()

--- a/electricore/core/pipelines/facturation.py
+++ b/electricore/core/pipelines/facturation.py
@@ -498,6 +498,9 @@ def rapprocher_facturation_mensuelle(
                 # Identifiants compteur
                 "num_compteur",
                 "type_compteur",
+                # Flags d'état de facturation (ADR-0014)
+                "a_facturer",
+                "a_supprimer",
             ]
         )
         .collect()

--- a/notebooks/facturation.py
+++ b/notebooks/facturation.py
@@ -126,10 +126,10 @@ def _(mois_input):
                 f"**{len(lignes_a_facturer_df)}** à facturer · "
                 f"**{len(lignes_a_supprimer)}** à supprimer"
             ),
-            mo.ui.table(lignes_a_facturer_df),
+            mo.ui.table(lignes_odoo_df),
         ]
     )
-    return lignes_a_facturer_df, lignes_a_supprimer
+    return (lignes_a_facturer_df,)
 
 
 @app.cell(hide_code=True)
@@ -345,7 +345,9 @@ def _(fact_mois, lignes_a_facturer_df, taux_verification):
         .to_dicts()
     )
 
-    _preview = pl.DataFrame(orders_records)
+    # Schéma explicite : préserve les colonnes même si la liste est vide
+    # (cas légitime hors période de facturation, cf. ADR-0014).
+    _preview = pl.DataFrame(orders_records, schema={"id": pl.Int64, "x_invoicing_state": pl.Utf8})
     mo.vstack(
         [
             mo.md(

--- a/notebooks/facturation.py
+++ b/notebooks/facturation.py
@@ -45,7 +45,8 @@ with app.setup:
 
     # Client API electricore (cf. ADR-0009 + ADR-0012)
     _api_url = os.getenv("ELECTRICORE_API_URL", "https://electricore.localhost")
-    _api_key = os.getenv("ELECTRICORE_API_KEY", "")
+    # Fallback : 1re clé de la liste API_KEYS (format serveur : "key1,key2,...")
+    _api_key = os.getenv("ELECTRICORE_API_KEY") or os.getenv("API_KEYS", "").split(",")[0].strip()
     # verify=False : Caddy local TLS auto-signé (cf. docs/deploiement.md)
     _http_client = httpx.Client(verify=False, timeout=httpx.Timeout(30.0, read=120.0))
     client = ElectricoreClient(url=_api_url, api_key=_api_key, http_client=_http_client)

--- a/notebooks/facturation.py
+++ b/notebooks/facturation.py
@@ -18,9 +18,11 @@ with app.setup:
     if str(project_root) not in sys.path:
         sys.path.append(str(project_root))
 
+    from datetime import date
+
     from electricore.client import ElectricoreClient
     from electricore.core.loaders import OdooReader
-    from electricore.core.loaders.odoo import lignes_a_facturer, lignes_quantite_zero
+    from electricore.core.loaders.odoo import lignes_factures_du_mois
 
     # Configuration du logging
     logging.basicConfig(level=logging.INFO)
@@ -61,20 +63,40 @@ def _():
 @app.cell(hide_code=True)
 def _():
     mo.md(r"""
-    # Récupération des données Odoo
+    # Mois cible
 
-    `OdooReader` reste utilisé en notebook pour la lecture des lignes Odoo et
-    la persistance via `OdooWriter` (cf. ADR-0012). Les flux Enedis et le
-    rapprochement passent par l'API.
+    Toutes les requêtes (Odoo + Enedis) portent sur ce mois (cf. ADR-0014 :
+    `lignes_factures_du_mois` retourne toutes les lignes du mois avec les flags
+    `a_facturer` / `a_supprimer`, sans dépendre de l'état de facturation actuel).
     """)
     return
 
 
 @app.cell
 def _():
+    _today = date.today().replace(day=1)
+    mois_input = mo.ui.text(label="Mois (YYYY-MM-DD)", value=_today.isoformat())
+    mois_input
+    return (mois_input,)
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    # Récupération des données Odoo
+
+    `OdooReader` reste utilisé en notebook pour les colonnes non exposées par
+    l'API (sale_order_id, invoice_ids) et la persistance via `OdooWriter`
+    (cf. ADR-0012).
+    """)
+    return
+
+
+@app.cell
+def _(mois_input):
     with OdooReader(config=config) as _odoo:
-        lignes_a_facturer_df = (
-            lignes_a_facturer(_odoo)
+        lignes_odoo_df = (
+            lignes_factures_du_mois(_odoo, mois=mois_input.value)
             .filter(pl.col("name_product_category").is_in(["Abonnements", "HP", "HC", "Base"]))
             .collect()
             .select(
@@ -90,19 +112,24 @@ def _():
                     "name_product_product",
                     "name_account_move",
                     "name_product_category",
+                    "a_facturer",
+                    "a_supprimer",
                 ]
             )
         )
-    lignes_a_facturer_df
-    return (lignes_a_facturer_df,)
-
-
-@app.cell
-def _():
-    with OdooReader(config=config) as _odoo:
-        lignes_a_supprimer = lignes_quantite_zero(_odoo).collect()
-    lignes_a_supprimer
-    return
+    lignes_a_facturer_df = lignes_odoo_df.filter(pl.col("a_facturer"))
+    lignes_a_supprimer = lignes_odoo_df.filter(pl.col("a_supprimer"))
+    mo.vstack(
+        [
+            mo.md(
+                f"**{len(lignes_odoo_df)}** lignes du mois · "
+                f"**{len(lignes_a_facturer_df)}** à facturer · "
+                f"**{len(lignes_a_supprimer)}** à supprimer"
+            ),
+            mo.ui.table(lignes_a_facturer_df),
+        ]
+    )
+    return lignes_a_facturer_df, lignes_a_supprimer
 
 
 @app.cell(hide_code=True)
@@ -110,26 +137,21 @@ def _():
     mo.md(r"""
     # Récupération des données Enedis
 
-    Un seul appel à `client.facturation(mois)` qui retourne déjà
-    `lignes_facture_rapprochees` (Odoo × Enedis × compteur) calculé côté serveur.
-
-    Sélectionne le mois (laisser vide → dernier mois disponible côté serveur).
+    `client.facturation(mois)` retourne `lignes_facture_rapprochees` (Odoo × Enedis × compteur)
+    calculé côté serveur, incluant les flags `a_facturer` / `a_supprimer`. Le notebook filtre
+    côté client en prod via `.filter(pl.col("a_facturer"))`.
     """)
     return
 
 
 @app.cell
-def _():
-    mois_input = mo.ui.text(label="Mois (YYYY-MM-DD)", placeholder="vide = dernier mois disponible")
-    mois_input
-    return (mois_input,)
-
-
-@app.cell
 def _(mois_input):
-    _mois = mois_input.value or None
-    fact_mois = client.facturation(mois=_mois)
-    mo.md(f"**{len(fact_mois)}** lignes récupérées · mois demandé: `{_mois or 'dernier disponible'}`")
+    fact_mois_brut = client.facturation(mois=mois_input.value)
+    fact_mois = fact_mois_brut.filter(pl.col("a_facturer"))
+    mo.md(
+        f"**{len(fact_mois_brut)}** lignes du mois côté serveur · "
+        f"**{len(fact_mois)}** à facturer (a_facturer=True)"
+    )
     return (fact_mois,)
 
 

--- a/notebooks/facturation.py
+++ b/notebooks/facturation.py
@@ -4,36 +4,51 @@ __generated_with = "0.21.1"
 app = marimo.App(width="medium")
 
 with app.setup:
+    import logging
+    import os
+    import sys
+    from pathlib import Path
+
+    import httpx
     import marimo as mo
     import polars as pl
-    import logging
-    from pathlib import Path
-    import sys
 
     # Ajouter le chemin vers electricore
     project_root = Path.cwd()
     if str(project_root) not in sys.path:
         sys.path.append(str(project_root))
 
+    from electricore.client import ElectricoreClient
     from electricore.core.loaders import OdooReader
-    from electricore.core.loaders.odoo import query, lignes_a_facturer, lignes_quantite_zero
-    from electricore.core.loaders import c15, releves_harmonises
-    from electricore.core.pipelines.orchestration import facturation
+    from electricore.core.loaders.odoo import lignes_a_facturer, lignes_quantite_zero
+
     # Configuration du logging
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
 
-    """Configuration Odoo depuis .env"""
-    import os
+    """Configuration Odoo + ElectricoreClient depuis .env"""
     from electricore.config import charger_config_odoo
 
     try:
         config = charger_config_odoo()
         _env = os.getenv("ODOO_ENV", "test")
-        config_msg = mo.md(f"**Configuration Odoo chargée** (env: `{_env}`)\n\n- URL: `{config['url']}`\n- Base: `{config['db']}`\n- Utilisateur: `{config['username']}`\n- Mot de passe: `***`")
+        config_msg = mo.md(
+            f"**Configuration Odoo chargée** (env: `{_env}`)\n\n"
+            f"- URL: `{config['url']}`\n- Base: `{config['db']}`\n"
+            f"- Utilisateur: `{config['username']}`\n- Mot de passe: `***`"
+        )
     except ValueError as e:
         config = {}
-        config_msg = mo.md(f"⚠️ **Configuration Odoo manquante**\n\n{e}\n\nDéfinissez les variables `ODOO_*` dans `.env`.")
+        config_msg = mo.md(
+            f"⚠️ **Configuration Odoo manquante**\n\n{e}\n\nDéfinissez les variables `ODOO_*` dans `.env`."
+        )
+
+    # Client API electricore (cf. ADR-0009 + ADR-0012)
+    _api_url = os.getenv("ELECTRICORE_API_URL", "https://electricore.localhost")
+    _api_key = os.getenv("ELECTRICORE_API_KEY", "")
+    # verify=False : Caddy local TLS auto-signé (cf. docs/deploiement.md)
+    _http_client = httpx.Client(verify=False, timeout=httpx.Timeout(30.0, read=120.0))
+    client = ElectricoreClient(url=_api_url, api_key=_api_key, http_client=_http_client)
 
 
 @app.cell
@@ -46,6 +61,10 @@ def _():
 def _():
     mo.md(r"""
     # Récupération des données Odoo
+
+    `OdooReader` reste utilisé en notebook pour la lecture des lignes Odoo et
+    la persistance via `OdooWriter` (cf. ADR-0012). Les flux Enedis et le
+    rapprochement passent par l'API.
     """)
     return
 
@@ -55,19 +74,23 @@ def _():
     with OdooReader(config=config) as _odoo:
         lignes_a_facturer_df = (
             lignes_a_facturer(_odoo)
-            .filter(pl.col('name_product_category').is_in(['Abonnements', 'HP', 'HC', 'Base']))
+            .filter(pl.col("name_product_category").is_in(["Abonnements", "HP", "HC", "Base"]))
             .collect()
-            .select(['sale_order_id',
-                     'name',
-                     'x_pdl',
-                     'x_lisse',
-                     'x_ref_situation_contractuelle', 
-                     'invoice_ids',
-                     'invoice_line_ids', 
-                     'quantity',
-                     'name_product_product',
-                     'name_account_move',
-                     'name_product_category'])
+            .select(
+                [
+                    "sale_order_id",
+                    "name",
+                    "x_pdl",
+                    "x_lisse",
+                    "x_ref_situation_contractuelle",
+                    "invoice_ids",
+                    "invoice_line_ids",
+                    "quantity",
+                    "name_product_product",
+                    "name_account_move",
+                    "name_product_category",
+                ]
+            )
         )
     lignes_a_facturer_df
     return (lignes_a_facturer_df,)
@@ -85,38 +108,34 @@ def _():
 def _():
     mo.md(r"""
     # Récupération des données Enedis
+
+    Un seul appel à `client.facturation(mois)` qui retourne déjà
+    `lignes_facture_rapprochees` (Odoo × Enedis × compteur) calculé côté serveur.
+
+    Sélectionne le mois (laisser vide → dernier mois disponible côté serveur).
     """)
     return
 
 
 @app.cell
 def _():
-    lf_historique = c15().lazy()
-    lf_releves = releves_harmonises().lazy() # releves_harmonises = R151 et R64 fusionnés
-    return lf_historique, lf_releves
+    mois_input = mo.ui.text(label="Mois (YYYY-MM-DD)", placeholder="vide = dernier mois disponible")
+    mois_input
+    return (mois_input,)
 
 
 @app.cell
-def _(lf_historique, lf_releves):
-    hist, abo, energie, fact = facturation(
-        historique=lf_historique,
-        releves=lf_releves,
-    )
-    return (fact,)
-
-
-@app.cell
-def _(fact):
-    mois_en_cours = fact["mois_annee"][fact["debut"].arg_max()]
-    mo.md(f"**Mois en cours** : {mois_en_cours}")
-    return (mois_en_cours,)
-
-
-@app.cell
-def _(fact, mois_en_cours):
-    fact_mois = fact.filter(pl.col("mois_annee") == mois_en_cours)
-    fact_mois
+def _(mois_input):
+    _mois = mois_input.value or None
+    fact_mois = client.facturation(mois=_mois)
+    mo.md(f"**{len(fact_mois)}** lignes récupérées · mois demandé: `{_mois or 'dernier disponible'}`")
     return (fact_mois,)
+
+
+@app.cell
+def _(fact_mois):
+    fact_mois
+    return
 
 
 @app.cell(hide_code=True)
@@ -124,18 +143,21 @@ def _():
     mo.md(r"""
     ## Déménagements
 
-    On détecte ici les déménagements du mois, en regardant les pdls qui ont deux ref_contractuelles. Les factures associées sont normalement correctement peuplées, mais il faut potentiellement vérifier.
+    PDLs avec plusieurs `ref_situation_contractuelle` distinctes dans le mois.
+    Dédoublonnage sur `(pdl, ref_situation_contractuelle)` requis (la table
+    `fact_mois` a une ligne par invoice_line, pas par RSC).
     """)
     return
 
 
 @app.cell
 def _(fact_mois):
-    _pdl_counts = fact_mois.group_by("pdl").agg(pl.len().alias("n"))
+    _pdl_rsc = fact_mois.select(["pdl", "ref_situation_contractuelle"]).unique()
+    _pdl_counts = _pdl_rsc.group_by("pdl").agg(pl.len().alias("n"))
     pdls_doublons = _pdl_counts.filter(pl.col("n") > 1)["pdl"].to_list()
 
     fact_déménagements = fact_mois.filter(pl.col("pdl").is_in(pdls_doublons))
-    mo.ui.table(fact_déménagements) if pdls_doublons else mo.md("")
+    mo.ui.table(fact_déménagements) if pdls_doublons else mo.md("✅ Aucun déménagement détecté")
     return
 
 
@@ -143,19 +165,13 @@ def _(fact_mois):
 def _():
     mo.md(r"""
     # Réconciliation Enedis → Odoo
+
+    `fact_mois` (= `lignes_facture_rapprochees`) contient déjà le rapprochement
+    par `invoice_line_ids`. Plus besoin de joindre côté client : on enrichit
+    juste avec les colonnes Odoo non exposées par l'API (`sale_order_id`,
+    `invoice_ids`).
     """)
     return
-
-
-@app.cell
-def _():
-    MAPPING_CATEGORIE = {
-        "HP":          "energie_hp_kwh",
-        "HC":          "energie_hc_kwh",
-        "Base":        "energie_base_kwh",
-        "Abonnements": "nb_jours",
-    }
-    return (MAPPING_CATEGORIE,)
 
 
 @app.cell(hide_code=True)
@@ -171,57 +187,17 @@ def _():
 
 
 @app.cell
-def _(updates_rsc):
-    updates_rsc.filter(pl.col('memo_puissance') != '')
-    return
-
-
-@app.cell(hide_code=True)
-def _():
-    mo.md(r"""
-    ## Version RSC (cible — une fois `x_ref_situation_contractuelle` peuplé dans Odoo)
-
-    Join direct sur `ref_situation_contractuelle` : gère nativement les déménagements
-    (deux contrats sur le même PDL en cours de mois) sans exclusion manuelle.
-
-    **Prérequis** : champ `x_ref_situation_contractuelle` créé et peuplé sur `sale.order`
-    via le notebook `injection_rsc.py`.
-    """)
+def _(fact_mois):
+    fact_mois.filter(pl.col("memo_puissance") != "")
     return
 
 
 @app.cell
-def _(MAPPING_CATEGORIE, fact_mois, lignes_a_facturer_df):
-    _quantite_enedis_rsc = pl.coalesce([
-        pl.when(pl.col("name_product_category") == cat).then(pl.col(col).cast(pl.Float64))
-        for cat, col in MAPPING_CATEGORIE.items()
-    ]).alias("quantite_enedis")
-
-    updates_rsc = (
-        lignes_a_facturer_df
-        .join(
-            fact_mois,
-            left_on="x_ref_situation_contractuelle",
-            right_on="ref_situation_contractuelle",
-            how="left",
-        )
-        .with_columns(_quantite_enedis_rsc)
-        .select([
-            "invoice_line_ids", "x_pdl", "x_lisse", "name_account_move",
-            "name_product_category", "name_product_product",
-            "quantity", "quantite_enedis", "memo_puissance",
-        ])
-    )
-    mo.ui.table(updates_rsc)
-    return (updates_rsc,)
-
-
-@app.cell
-def _(updates_rsc):
-    _sans_match_rsc = updates_rsc.filter(pl.col("quantite_enedis").is_null())
-    mo.md(f"❌ **{_sans_match_rsc['x_pdl'].n_unique()} PDL(s) sans correspondance Enedis**") \
-        if not _sans_match_rsc.is_empty() \
-        else mo.md("✅ Tous les PDLs ont une correspondance Enedis")
+def _(fact_mois):
+    _sans_match = fact_mois.filter(pl.col("quantite_enedis").is_null())
+    mo.md(
+        f"❌ **{_sans_match['x_pdl'].n_unique()} PDL(s) sans correspondance Enedis**"
+    ) if not _sans_match.is_empty() else mo.md("✅ Tous les PDLs ont une correspondance Enedis")
     return
 
 
@@ -235,45 +211,56 @@ def _():
 
 @app.cell
 def _():
-    filtre_a_injecter = (
-        pl.col("quantite_enedis").is_not_null()
-        & ~pl.col("x_lisse").fill_null(False)
-    )
+    filtre_a_injecter = pl.col("quantite_enedis").is_not_null() & ~pl.col("x_lisse").fill_null(False)
     return (filtre_a_injecter,)
 
 
 @app.cell
-def _(filtre_a_injecter, updates_rsc):
+def _(fact_mois, filtre_a_injecter):
     from electricore.core.writers import OdooWriter
 
-    _a_injecter = updates_rsc.filter(filtre_a_injecter)
-    _sans_match  = updates_rsc.filter(pl.col("quantite_enedis").is_null())
+    _a_injecter = fact_mois.filter(filtre_a_injecter)
+    _sans_match = fact_mois.filter(pl.col("quantite_enedis").is_null())
 
-    sim_mode   = mo.ui.checkbox(label="Mode simulation (aucune écriture réelle)", value=True)
+    sim_mode = mo.ui.checkbox(label="Mode simulation (aucune écriture réelle)", value=True)
     run_button = mo.ui.run_button(label="Injecter dans Odoo")
 
-    mo.vstack([
-        mo.md(f"**{len(_a_injecter)}** lignes à mettre à jour "
-              f"· **{len(_sans_match)}** sans correspondance Enedis (ignorées)"),
-        mo.ui.table(_a_injecter.select([
-            "name_account_move", "x_pdl", "name_product_category",
-            "name_product_product", "quantity", "quantite_enedis", "memo_puissance",
-        ])),
-        sim_mode,
-        run_button,
-    ])
+    mo.vstack(
+        [
+            mo.md(
+                f"**{len(_a_injecter)}** lignes à mettre à jour "
+                f"· **{len(_sans_match)}** sans correspondance Enedis (ignorées)"
+            ),
+            mo.ui.table(
+                _a_injecter.select(
+                    [
+                        "name_account_move",
+                        "x_pdl",
+                        "name_product_category",
+                        "name_product_product",
+                        "quantity",
+                        "quantite_enedis",
+                        "memo_puissance",
+                    ]
+                )
+            ),
+            sim_mode,
+            run_button,
+        ]
+    )
     return OdooWriter, run_button, sim_mode
 
 
 @app.cell
-def _(filtre_a_injecter, updates_rsc):
+def _(fact_mois, filtre_a_injecter):
     lines_records = (
-        updates_rsc
-        .filter(filtre_a_injecter)
-        .select([
-            pl.col("invoice_line_ids").cast(pl.Int64).alias("id"),
-            pl.col("quantite_enedis").alias("quantity"),
-        ])
+        fact_mois.filter(filtre_a_injecter)
+        .select(
+            [
+                pl.col("invoice_line_ids").cast(pl.Int64).alias("id"),
+                pl.col("quantite_enedis").alias("quantity"),
+            ]
+        )
         .to_dicts()
     )
     return (lines_records,)
@@ -290,7 +277,10 @@ def _():
 @app.cell
 def _():
     taux_verification = mo.ui.slider(
-        0, 20, value=5, step=1,
+        0,
+        20,
+        value=5,
+        step=1,
         label="% d'orders à vérifier (→ populated)",
         show_value=True,
     )
@@ -302,43 +292,47 @@ def _():
 def _(fact_mois, lignes_a_facturer_df, taux_verification):
     import numpy as np
 
-    _odoo_df = (
-        lignes_a_facturer_df
-        .select(['sale_order_id', 'x_lisse', 'x_ref_situation_contractuelle'])
-        .unique()
-    )
-    _enedis_df = fact_mois.select(['data_complete', 'ref_situation_contractuelle'])
+    # Côté Odoo : sale_order_id + x_lisse, unique par RSC
+    _odoo_df = lignes_a_facturer_df.select(["sale_order_id", "x_lisse", "x_ref_situation_contractuelle"]).unique()
+    # Côté Enedis : data_complete par RSC (déduplication car fact_mois a 1 ligne / invoice_line)
+    _enedis_df = fact_mois.select(["data_complete", "ref_situation_contractuelle"]).unique()
 
     _df = (
-        _odoo_df
-        .join(_enedis_df, left_on="x_ref_situation_contractuelle",
-              right_on="ref_situation_contractuelle", how="left")
+        _odoo_df.join(
+            _enedis_df,
+            left_on="x_ref_situation_contractuelle",
+            right_on="ref_situation_contractuelle",
+            how="left",
+        )
         .with_columns((pl.col("data_complete") | pl.col("x_lisse")).alias("a_jour"))
         .with_columns(pl.Series("rand", np.random.rand(len(_odoo_df))))
     )
 
     orders_records = (
-        _df
-        .with_columns(
+        _df.with_columns(
             pl.when(~pl.col("a_jour"))
-              .then(pl.lit("draft"))
-              .when(pl.col("rand") < taux_verification.value / 100)
-              .then(pl.lit("populated"))
-              .otherwise(pl.lit("checked"))
-              .alias("x_invoicing_state")
+            .then(pl.lit("draft"))
+            .when(pl.col("rand") < taux_verification.value / 100)
+            .then(pl.lit("populated"))
+            .otherwise(pl.lit("checked"))
+            .alias("x_invoicing_state")
         )
-        .select(['sale_order_id', 'x_invoicing_state'])
+        .select(["sale_order_id", "x_invoicing_state"])
         .rename({"sale_order_id": "id"})
         .to_dicts()
     )
 
     _preview = pl.DataFrame(orders_records)
-    mo.vstack([
-        mo.md(f"**{_preview.filter(pl.col('x_invoicing_state') == 'draft')['id'].len()}** draft · "
-              f"**{_preview.filter(pl.col('x_invoicing_state') == 'populated')['id'].len()}** populated · "
-              f"**{_preview.filter(pl.col('x_invoicing_state') == 'checked')['id'].len()}** checked"),
-        mo.ui.table(_preview),
-    ])
+    mo.vstack(
+        [
+            mo.md(
+                f"**{_preview.filter(pl.col('x_invoicing_state') == 'draft')['id'].len()}** draft · "
+                f"**{_preview.filter(pl.col('x_invoicing_state') == 'populated')['id'].len()}** populated · "
+                f"**{_preview.filter(pl.col('x_invoicing_state') == 'checked')['id'].len()}** checked"
+            ),
+            mo.ui.table(_preview),
+        ]
+    )
     return (orders_records,)
 
 
@@ -351,49 +345,47 @@ def _():
 
 
 @app.cell
-def _(fact_mois, lf_historique, lignes_a_facturer_df):
-    _histo_df = (
-        lf_historique
-        .collect()
-        .select(['ref_situation_contractuelle', 'num_compteur', "type_compteur"])
-    )
+def _(fact_mois, lignes_a_facturer_df):
+    # Côté Odoo : invoice_ids unique par RSC
+    _odoo_df = lignes_a_facturer_df.select(["invoice_ids", "x_ref_situation_contractuelle"]).unique()
 
-    _odoo_df = (
-        lignes_a_facturer_df
-        .select(['invoice_ids', 'x_ref_situation_contractuelle'])
-        .unique()
-    )
-
+    # Côté Enedis : 1 ligne par RSC avec debut/fin/turpe/compteur (dédoublonnage : fact_mois a 1 ligne / invoice_line)
     _enedis_df = fact_mois.select(
-        ['ref_situation_contractuelle', 
-         'debut', 'fin', 
-         'turpe_fixe_eur', 'turpe_variable_eur'])
+        [
+            "ref_situation_contractuelle",
+            "debut",
+            "fin",
+            "turpe_fixe_eur",
+            "turpe_variable_eur",
+            "num_compteur",
+            "type_compteur",
+        ]
+    ).unique()
 
     _to_rename = {
-        'invoice_ids':'id',
-        'turpe':'x_turpe',
-        'debut':'x_start_invoice_period',
-        'fin':'x_end_invoice_period',
-        'type_compteur':'x_type_compteur',
-        'num_compteur':'x_num_serie_compteur',
+        "invoice_ids": "id",
+        "turpe": "x_turpe",
+        "debut": "x_start_invoice_period",
+        "fin": "x_end_invoice_period",
+        "type_compteur": "x_type_compteur",
+        "num_compteur": "x_num_serie_compteur",
     }
 
     _df = (
-        _odoo_df
-        .join(_enedis_df, 
-              left_on="x_ref_situation_contractuelle",
-              right_on="ref_situation_contractuelle", 
-              how="left")
-        .join(_histo_df, 
-              left_on="x_ref_situation_contractuelle",
-              right_on="ref_situation_contractuelle",
-              how="left")
-        .with_columns([
-            (pl.col('turpe_fixe_eur') + pl.col('turpe_variable_eur')).alias('turpe'),
-            pl.col('debut').dt.strftime("%Y-%m-%d"),
-            pl.col('fin').dt.strftime("%Y-%m-%d"),
-        ])
-        .drop(['turpe_fixe_eur', 'turpe_variable_eur', 'x_ref_situation_contractuelle'])
+        _odoo_df.join(
+            _enedis_df,
+            left_on="x_ref_situation_contractuelle",
+            right_on="ref_situation_contractuelle",
+            how="left",
+        )
+        .with_columns(
+            [
+                (pl.col("turpe_fixe_eur") + pl.col("turpe_variable_eur")).alias("turpe"),
+                pl.col("debut").dt.strftime("%Y-%m-%d"),
+                pl.col("fin").dt.strftime("%Y-%m-%d"),
+            ]
+        )
+        .drop(["turpe_fixe_eur", "turpe_variable_eur", "x_ref_situation_contractuelle"])
         .rename(mapping=_to_rename)
     )
     invoices_records = _df.to_dicts()

--- a/tests/integration/test_facturation_service_smoke.py
+++ b/tests/integration/test_facturation_service_smoke.py
@@ -36,14 +36,34 @@ def lf_fact_mensuelle_minimal() -> pl.LazyFrame:
     return pl.LazyFrame(
         {
             "ref_situation_contractuelle": ["RSC001"],
+            "pdl": ["12345678901234"],
             "debut": [datetime(2025, 1, 1)],
+            "fin": [datetime(2025, 2, 1)],
             "energie_hp_kwh": [123.45],
             "energie_hc_kwh": [0.0],
             "energie_base_kwh": [0.0],
             "nb_jours": [31],
+            "turpe_fixe_eur": [12.34],
+            "turpe_variable_eur": [56.78],
+            "data_complete": [True],
             "memo_puissance": [""],
         }
-    ).with_columns(pl.col("debut").dt.replace_time_zone("Europe/Paris"))
+    ).with_columns(
+        pl.col("debut").dt.replace_time_zone("Europe/Paris"),
+        pl.col("fin").dt.replace_time_zone("Europe/Paris"),
+    )
+
+
+@pytest.fixture
+def lf_historique_minimal() -> pl.LazyFrame:
+    """Historique mock minimal pour rapprocher_facturation_mensuelle."""
+    return pl.LazyFrame(
+        {
+            "ref_situation_contractuelle": ["RSC001"],
+            "num_compteur": ["12345678"],
+            "type_compteur": ["LINKY"],
+        }
+    )
 
 
 @pytest.fixture
@@ -61,7 +81,9 @@ def df_flux_vide() -> pl.DataFrame:
 
 
 @pytest.fixture
-def service_loaders_mockes(monkeypatch, df_lignes_odoo_minimal, lf_fact_mensuelle_minimal, df_flux_vide):
+def service_loaders_mockes(
+    monkeypatch, df_lignes_odoo_minimal, lf_fact_mensuelle_minimal, lf_historique_minimal, df_flux_vide
+):
     """Patch tous les loaders et l'orchestration utilisés par le service.
 
     `generer_facturation_xlsx` et `generer_documents_facturation` chargent
@@ -100,7 +122,7 @@ def service_loaders_mockes(monkeypatch, df_lignes_odoo_minimal, lf_fact_mensuell
     monkeypatch.setattr(facturation_service, "releves_harmonises", lambda: _QueryMock(df_flux_vide))
 
     def _fake_facturation(historique, releves):
-        return (None, None, None, lf_fact_mensuelle_minimal.collect())
+        return (lf_historique_minimal, None, None, lf_fact_mensuelle_minimal.collect())
 
     monkeypatch.setattr(facturation_service, "facturation", _fake_facturation)
 

--- a/tests/integration/test_facturation_service_smoke.py
+++ b/tests/integration/test_facturation_service_smoke.py
@@ -27,6 +27,8 @@ def df_lignes_odoo_minimal() -> pl.DataFrame:
             "name_product_category": ["HP"],
             "name_product_product": ["Énergie HP"],
             "quantity": [100.0],
+            "a_facturer": [True],
+            "a_supprimer": [False],
         }
     )
 
@@ -116,7 +118,9 @@ def service_loaders_mockes(
             return _QueryMock(self.lazy().filter(*args, **kwargs))
 
     monkeypatch.setattr(facturation_service, "OdooReader", _OdooReaderMock)
-    monkeypatch.setattr(facturation_service, "lignes_a_facturer", lambda odoo: _QueryMock(df_lignes_odoo_minimal))
+    monkeypatch.setattr(
+        facturation_service, "lignes_factures_du_mois", lambda odoo, mois: _QueryMock(df_lignes_odoo_minimal)
+    )
     monkeypatch.setattr(facturation_service, "c15", lambda: _QueryMock(df_flux_vide))
     monkeypatch.setattr(facturation_service, "f15", lambda: _QueryMock(df_flux_vide))
     monkeypatch.setattr(facturation_service, "releves_harmonises", lambda: _QueryMock(df_flux_vide))

--- a/tests/unit/test_lignes_factures_du_mois.py
+++ b/tests/unit/test_lignes_factures_du_mois.py
@@ -1,0 +1,71 @@
+"""Tests pour `lignes_factures_du_mois` et l'utilitaire `flags_etat_facturation`.
+
+Cf. ADR-0014 — la fonction expose toutes les lignes de factures du mois
+(quel que soit l'état) avec des flags `a_facturer` et `a_supprimer` calculés.
+"""
+
+import polars as pl
+
+from electricore.core.loaders.odoo.helpers import flags_etat_facturation
+
+
+class TestFlagsEtatFacturation:
+    """`a_facturer` et `a_supprimer` dérivent de (x_invoicing_state, state_account_move, quantity)."""
+
+    def test_draft_qty_positive_donne_a_facturer(self):
+        lf = pl.LazyFrame(
+            {
+                "x_invoicing_state": ["draft"],
+                "state_account_move": ["draft"],
+                "quantity": [100.0],
+            }
+        )
+
+        resultat = flags_etat_facturation(lf).collect()
+
+        assert resultat["a_facturer"].item() is True
+        assert resultat["a_supprimer"].item() is False
+
+    def test_draft_qty_nulle_donne_a_supprimer(self):
+        lf = pl.LazyFrame(
+            {
+                "x_invoicing_state": ["draft"],
+                "state_account_move": ["draft"],
+                "quantity": [0.0],
+            }
+        )
+
+        resultat = flags_etat_facturation(lf).collect()
+
+        assert resultat["a_facturer"].item() is False
+        assert resultat["a_supprimer"].item() is True
+
+    def test_sale_non_draft_n_est_ni_a_facturer_ni_a_supprimer(self):
+        """Une commande déjà validée (x_invoicing_state != 'draft') reste hors scope, peu importe la qty."""
+        lf = pl.LazyFrame(
+            {
+                "x_invoicing_state": ["checked", "populated", "checked"],
+                "state_account_move": ["draft", "draft", "posted"],
+                "quantity": [100.0, 0.0, 50.0],
+            }
+        )
+
+        resultat = flags_etat_facturation(lf).collect()
+
+        assert resultat["a_facturer"].to_list() == [False, False, False]
+        assert resultat["a_supprimer"].to_list() == [False, False, False]
+
+    def test_move_non_draft_n_est_pas_a_facturer(self):
+        """Une facture validée (state_account_move != 'draft') reste hors scope."""
+        lf = pl.LazyFrame(
+            {
+                "x_invoicing_state": ["draft", "draft"],
+                "state_account_move": ["posted", "cancel"],
+                "quantity": [100.0, 0.0],
+            }
+        )
+
+        resultat = flags_etat_facturation(lf).collect()
+
+        assert resultat["a_facturer"].to_list() == [False, False]
+        assert resultat["a_supprimer"].to_list() == [False, False]

--- a/tests/unit/test_rapprochement_facturation.py
+++ b/tests/unit/test_rapprochement_facturation.py
@@ -6,10 +6,12 @@ du mois ciblé, et calcule `quantite_enedis` selon la catégorie de produit.
 """
 
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import polars as pl
 import pytest
 
+from electricore.core.models.lignes_facture_rapprochees import LignesFactureRapprochees
 from electricore.core.pipelines.facturation import rapprocher_facturation_mensuelle
 
 
@@ -39,24 +41,53 @@ def _ligne_odoo(
 def _fact_mensuelle(
     *,
     rsc: str = "RSC001",
+    pdl: str = "12345678901234",
     mois: datetime = datetime(2025, 1, 1),
+    fin: datetime = datetime(2025, 2, 1),
     energie_hp_kwh: float = 0.0,
     energie_hc_kwh: float = 0.0,
     energie_base_kwh: float = 0.0,
     nb_jours: int = 31,
+    turpe_fixe_eur: float = 0.0,
+    turpe_variable_eur: float = 0.0,
+    data_complete: bool = True,
     memo_puissance: str = "",
 ) -> pl.LazyFrame:
     return pl.LazyFrame(
         {
             "ref_situation_contractuelle": [rsc],
+            "pdl": [pdl],
             "debut": [mois],
+            "fin": [fin],
             "energie_hp_kwh": [energie_hp_kwh],
             "energie_hc_kwh": [energie_hc_kwh],
             "energie_base_kwh": [energie_base_kwh],
             "nb_jours": [nb_jours],
+            "turpe_fixe_eur": [turpe_fixe_eur],
+            "turpe_variable_eur": [turpe_variable_eur],
+            "data_complete": [data_complete],
             "memo_puissance": [memo_puissance],
         }
-    ).with_columns(pl.col("debut").dt.replace_time_zone("Europe/Paris"))
+    ).with_columns(
+        pl.col("debut").dt.replace_time_zone("Europe/Paris"),
+        pl.col("fin").dt.replace_time_zone("Europe/Paris"),
+    )
+
+
+def _historique(
+    *,
+    rsc: str = "RSC001",
+    num_compteur: str = "12345678",
+    type_compteur: str = "LINKY",
+) -> pl.LazyFrame:
+    """Petit historique : 1 ligne par RSC avec identifiants compteur."""
+    return pl.LazyFrame(
+        {
+            "ref_situation_contractuelle": [rsc],
+            "num_compteur": [num_compteur],
+            "type_compteur": [type_compteur],
+        }
+    )
 
 
 class TestMappingCategories:
@@ -66,7 +97,9 @@ class TestMappingCategories:
         lignes = _ligne_odoo(categorie="HP")
         fact = _fact_mensuelle(energie_hp_kwh=123.45)
 
-        resultat = rapprocher_facturation_mensuelle(lignes_odoo=lignes, fact_mensuelle=fact, mois="2025-01-01")
+        resultat = rapprocher_facturation_mensuelle(
+            lignes_odoo=lignes, fact_mensuelle=fact, historique=_historique(), mois="2025-01-01"
+        )
 
         assert resultat["quantite_enedis"].item() == 123.45
 
@@ -82,7 +115,9 @@ class TestMappingCategories:
         lignes = _ligne_odoo(categorie=categorie)
         fact = _fact_mensuelle(**kwargs_fact)
 
-        resultat = rapprocher_facturation_mensuelle(lignes_odoo=lignes, fact_mensuelle=fact, mois="2025-01-01")
+        resultat = rapprocher_facturation_mensuelle(
+            lignes_odoo=lignes, fact_mensuelle=fact, historique=_historique(), mois="2025-01-01"
+        )
 
         assert resultat["quantite_enedis"].item() == attendu
 
@@ -91,7 +126,9 @@ class TestMappingCategories:
         lignes = _ligne_odoo(categorie="CategorieDouteuse")
         fact = _fact_mensuelle(energie_hp_kwh=999.0, energie_hc_kwh=999.0)
 
-        resultat = rapprocher_facturation_mensuelle(lignes_odoo=lignes, fact_mensuelle=fact, mois="2025-01-01")
+        resultat = rapprocher_facturation_mensuelle(
+            lignes_odoo=lignes, fact_mensuelle=fact, historique=_historique(), mois="2025-01-01"
+        )
 
         assert resultat["quantite_enedis"].item() is None
 
@@ -102,19 +139,16 @@ class TestFiltreMois:
     def test_mois_none_selectionne_dernier_mois_disponible(self):
         """Sans mois explicite, on retient le dernier mois présent dans fact_mensuelle."""
         lignes = _ligne_odoo(categorie="HP")
-        fact = pl.LazyFrame(
-            {
-                "ref_situation_contractuelle": ["RSC001", "RSC001"],
-                "debut": [datetime(2025, 1, 1), datetime(2025, 2, 1)],
-                "energie_hp_kwh": [100.0, 200.0],
-                "energie_hc_kwh": [0.0, 0.0],
-                "energie_base_kwh": [0.0, 0.0],
-                "nb_jours": [31, 28],
-                "memo_puissance": ["", ""],
-            }
-        ).with_columns(pl.col("debut").dt.replace_time_zone("Europe/Paris"))
+        fact = pl.concat(
+            [
+                _fact_mensuelle(mois=datetime(2025, 1, 1), fin=datetime(2025, 2, 1), energie_hp_kwh=100.0),
+                _fact_mensuelle(mois=datetime(2025, 2, 1), fin=datetime(2025, 3, 1), energie_hp_kwh=200.0),
+            ]
+        )
 
-        resultat = rapprocher_facturation_mensuelle(lignes_odoo=lignes, fact_mensuelle=fact, mois=None)
+        resultat = rapprocher_facturation_mensuelle(
+            lignes_odoo=lignes, fact_mensuelle=fact, historique=_historique(), mois=None
+        )
 
         assert resultat["quantite_enedis"].item() == 200.0
 
@@ -124,6 +158,7 @@ class TestColonnesSortie:
 
     COLONNES_ATTENDUES = frozenset(
         [
+            # Identifiants Odoo + quantité
             "invoice_line_ids",
             "x_pdl",
             "x_lisse",
@@ -133,16 +168,127 @@ class TestColonnesSortie:
             "quantity",
             "quantite_enedis",
             "memo_puissance",
+            # Méta-période Enedis
+            "ref_situation_contractuelle",
+            "pdl",
+            "debut",
+            "fin",
+            "data_complete",
+            "turpe_fixe_eur",
+            "turpe_variable_eur",
+            # Identifiants compteur
+            "num_compteur",
+            "type_compteur",
         ]
     )
 
-    def test_sortie_ne_contient_que_les_colonnes_attendues(self):
+    def test_sortie_contient_les_colonnes_attendues(self):
         lignes = _ligne_odoo(categorie="HP")
         fact = _fact_mensuelle(energie_hp_kwh=10.0)
+        hist = _historique()
 
-        resultat = rapprocher_facturation_mensuelle(lignes_odoo=lignes, fact_mensuelle=fact, mois="2025-01-01")
+        resultat = rapprocher_facturation_mensuelle(
+            lignes_odoo=lignes, fact_mensuelle=fact, historique=hist, mois="2025-01-01"
+        )
 
         assert frozenset(resultat.columns) == self.COLONNES_ATTENDUES
+
+
+class TestJoinHistorique:
+    """num_compteur et type_compteur sont projetés depuis l'Historique."""
+
+    def test_compteur_provient_de_historique(self):
+        lignes = _ligne_odoo(rsc="RSC001", categorie="HP")
+        fact = _fact_mensuelle(rsc="RSC001", energie_hp_kwh=10.0)
+        hist = _historique(rsc="RSC001", num_compteur="87654321", type_compteur="CBE")
+
+        resultat = rapprocher_facturation_mensuelle(
+            lignes_odoo=lignes, fact_mensuelle=fact, historique=hist, mois="2025-01-01"
+        )
+
+        assert resultat["num_compteur"].item() == "87654321"
+        assert resultat["type_compteur"].item() == "CBE"
+
+    def test_compteur_null_si_rsc_absent_de_historique(self):
+        lignes = _ligne_odoo(rsc="RSC001", categorie="HP")
+        fact = _fact_mensuelle(rsc="RSC001", energie_hp_kwh=10.0)
+        hist = _historique(rsc="AUTRE_RSC", num_compteur="ZZZ", type_compteur="ZZZ")
+
+        resultat = rapprocher_facturation_mensuelle(
+            lignes_odoo=lignes, fact_mensuelle=fact, historique=hist, mois="2025-01-01"
+        )
+
+        assert resultat["num_compteur"].item() is None
+        assert resultat["type_compteur"].item() is None
+
+
+class TestSchemaLignesFactureRapprochees:
+    """Le modèle Pandera transporte aussi les méta-données Enedis et compteur."""
+
+    def test_modele_accepte_les_colonnes_etendues(self):
+        """Le modèle accepte les 9 colonnes Odoo originales + 9 colonnes Enedis/compteur."""
+        df = pl.DataFrame(
+            {
+                # 9 colonnes existantes (Odoo + quantité Enedis)
+                "invoice_line_ids": [101],
+                "x_pdl": ["12345678901234"],
+                "x_lisse": [False],
+                "name_account_move": ["INV/2025/0001"],
+                "name_product_category": ["HP"],
+                "name_product_product": ["Énergie HP"],
+                "quantity": [100.0],
+                "quantite_enedis": [123.45],
+                "memo_puissance": [""],
+                # 9 colonnes nouvelles (méta Enedis + identifiants compteur)
+                "ref_situation_contractuelle": ["RSC001"],
+                "pdl": ["12345678901234"],
+                "data_complete": [True],
+                "debut": [datetime(2025, 1, 1, tzinfo=ZoneInfo("Europe/Paris"))],
+                "fin": [datetime(2025, 1, 31, tzinfo=ZoneInfo("Europe/Paris"))],
+                "turpe_fixe_eur": [12.34],
+                "turpe_variable_eur": [56.78],
+                "num_compteur": ["12345678"],
+                "type_compteur": ["LINKY"],
+            }
+        )
+
+        # Ne doit pas lever
+        LignesFactureRapprochees.validate(df)
+
+    def test_modele_tolere_nulls_sur_les_colonnes_etendues(self):
+        """Les colonnes étendues sont nullable (ligne Odoo sans match Enedis)."""
+        df = pl.DataFrame(
+            {
+                "invoice_line_ids": [102],
+                "x_pdl": ["99999999999999"],
+                "x_lisse": [False],
+                "name_account_move": ["INV/2025/0002"],
+                "name_product_category": ["HP"],
+                "name_product_product": ["Énergie HP"],
+                "quantity": [0.0],
+                "quantite_enedis": [None],
+                "memo_puissance": [None],
+                "ref_situation_contractuelle": [None],
+                "pdl": [None],
+                "data_complete": [None],
+                "debut": [None],
+                "fin": [None],
+                "turpe_fixe_eur": [None],
+                "turpe_variable_eur": [None],
+                "num_compteur": [None],
+                "type_compteur": [None],
+            },
+            schema_overrides={
+                "debut": pl.Datetime("us", "Europe/Paris"),
+                "fin": pl.Datetime("us", "Europe/Paris"),
+                "quantite_enedis": pl.Float64,
+                "turpe_fixe_eur": pl.Float64,
+                "turpe_variable_eur": pl.Float64,
+                "data_complete": pl.Boolean,
+            },
+        )
+
+        LignesFactureRapprochees.validate(df)
 
 
 class TestLeftJoin:
@@ -154,9 +300,9 @@ class TestLeftJoin:
         lignes = pl.concat([lignes_avec_match, lignes_sans_match])
         fact = _fact_mensuelle(rsc="RSC001", energie_hp_kwh=123.45)
 
-        resultat = rapprocher_facturation_mensuelle(lignes_odoo=lignes, fact_mensuelle=fact, mois="2025-01-01").sort(
-            "invoice_line_ids"
-        )
+        resultat = rapprocher_facturation_mensuelle(
+            lignes_odoo=lignes, fact_mensuelle=fact, historique=_historique(), mois="2025-01-01"
+        ).sort("invoice_line_ids")
 
         assert len(resultat) == 2
         assert resultat["invoice_line_ids"].to_list() == [101, 102]

--- a/tests/unit/test_rapprochement_facturation.py
+++ b/tests/unit/test_rapprochement_facturation.py
@@ -23,6 +23,8 @@ def _ligne_odoo(
     invoice_line_ids: int = 101,
     quantity: float = 0.0,
     memo_puissance: str = "",
+    a_facturer: bool = True,
+    a_supprimer: bool = False,
 ) -> pl.DataFrame:
     return pl.DataFrame(
         {
@@ -34,6 +36,8 @@ def _ligne_odoo(
             "name_product_category": [categorie],
             "name_product_product": [f"Énergie {categorie}"],
             "quantity": [quantity],
+            "a_facturer": [a_facturer],
+            "a_supprimer": [a_supprimer],
         }
     )
 
@@ -179,6 +183,9 @@ class TestColonnesSortie:
             # Identifiants compteur
             "num_compteur",
             "type_compteur",
+            # Flags d'état de facturation (ADR-0014)
+            "a_facturer",
+            "a_supprimer",
         ]
     )
 
@@ -192,6 +199,26 @@ class TestColonnesSortie:
         )
 
         assert frozenset(resultat.columns) == self.COLONNES_ATTENDUES
+
+
+class TestPropagationFlags:
+    """`a_facturer` et `a_supprimer` venant de lignes_odoo doivent traverser le rapprochement."""
+
+    def test_propage_a_facturer_et_a_supprimer(self):
+        lignes = _ligne_odoo(categorie="HP").with_columns(
+            [
+                pl.lit(True).alias("a_facturer"),
+                pl.lit(False).alias("a_supprimer"),
+            ]
+        )
+        fact = _fact_mensuelle(energie_hp_kwh=10.0)
+
+        resultat = rapprocher_facturation_mensuelle(
+            lignes_odoo=lignes, fact_mensuelle=fact, historique=_historique(), mois="2025-01-01"
+        )
+
+        assert resultat["a_facturer"].item() is True
+        assert resultat["a_supprimer"].item() is False
 
 
 class TestJoinHistorique:
@@ -226,7 +253,7 @@ class TestSchemaLignesFactureRapprochees:
     """Le modèle Pandera transporte aussi les méta-données Enedis et compteur."""
 
     def test_modele_accepte_les_colonnes_etendues(self):
-        """Le modèle accepte les 9 colonnes Odoo originales + 9 colonnes Enedis/compteur."""
+        """Le modèle accepte 9 colonnes Odoo + 9 méta Enedis/compteur + 2 flags."""
         df = pl.DataFrame(
             {
                 # 9 colonnes existantes (Odoo + quantité Enedis)
@@ -239,7 +266,7 @@ class TestSchemaLignesFactureRapprochees:
                 "quantity": [100.0],
                 "quantite_enedis": [123.45],
                 "memo_puissance": [""],
-                # 9 colonnes nouvelles (méta Enedis + identifiants compteur)
+                # 9 colonnes méta Enedis + identifiants compteur
                 "ref_situation_contractuelle": ["RSC001"],
                 "pdl": ["12345678901234"],
                 "data_complete": [True],
@@ -249,6 +276,9 @@ class TestSchemaLignesFactureRapprochees:
                 "turpe_variable_eur": [56.78],
                 "num_compteur": ["12345678"],
                 "type_compteur": ["LINKY"],
+                # 2 flags (cf. ADR-0014)
+                "a_facturer": [True],
+                "a_supprimer": [False],
             }
         )
 


### PR DESCRIPTION
## Summary

Refonte de la facturation côté Odoo et migration du notebook vers l'API, en deux temps :

### 1. Extension du contrat `LignesFactureRapprochees` (cycle initial)
- Modèle passe de 9 → 18 → 20 colonnes nullable : méta-période Enedis (`debut`, `fin`, `data_complete`, `turpe_*`, `ref_situation_contractuelle`, `pdl`), identifiants compteur (`num_compteur`, `type_compteur`) joints depuis l'Historique, et flags d'état.
- `rapprocher_facturation_mensuelle` : nouveau param `historique` (LazyFrame), join `.unique(keep='last')` sur RSC pour récupérer compteur ; stop projecting away les colonnes méta.

### 2. ADR-0014 — `lignes_factures_du_mois` + flags `a_facturer` / `a_supprimer`
- Nouvelle fonction `lignes_factures_du_mois(odoo, mois)` qui ne filtre Odoo que par `sale.order.state == 'sale'` et `invoice_date` du mois.
- Pas de filtre sur `x_invoicing_state` ni `account.move.state` : le filtre métier devient explicite côté consommateur via les flags calculés.
- Helper pur `flags_etat_facturation(lf)` :
  - `a_facturer` = drafts + `quantity > 0` (réplique l'ex-`lignes_a_facturer`).
  - `a_supprimer` = drafts + `quantity == 0` (réplique l'ex-`lignes_quantite_zero`).
- Suppression de `lignes_a_facturer` et `lignes_quantite_zero`.
- Résout la douleur dev/test : le notebook fonctionne hors période de facturation.

### 3. Migration `notebooks/facturation.py`
- Un seul call `client.facturation(mois)` côté Enedis + `lignes_factures_du_mois(odoo, mois)` côté Odoo pour les colonnes non-exposées par l'API (`sale_order_id`, `invoice_ids`).
- `lignes_a_facturer_df` et `lignes_a_supprimer` dérivés par `.filter()` sur les flags côté client.
- UI `mois_input` par défaut au 1er du mois courant.
- `sim_mode=True` par défaut + `run_button` gate préservés.

### 4. ADRs et glossaire
- ADR-0013 (Renommage Périmètre → Historique) déjà mergé via #14.
- ADR-0014 (lignes_factures_du_mois + flags) créé.
- Glossaire `electricore/core/CONTEXT.md` mis à jour pour `lignes_facture_rapprochees`.

## Test plan

- [x] `uv run --group test pytest -q` : 250 passed, 36 skipped (légitimes)
- [x] TDD complet : 4 cycles RED→GREEN sur `flags_etat_facturation`, 1 cycle sur la propagation des flags par `rapprocher_facturation_mensuelle`, fixtures unit+smoke adaptées
- [x] `uvx ruff format` / `uvx ruff check` : propres
- [x] Pre-commit hook : Passed (ruff)
- [x] **Validation manuelle hors période de facturation** : notebook lancé sur mois 2026-06-01 via uvicorn local sur la branche. Comportement correct : `lignes_factures_du_mois` rapatrie les lignes du mois (toutes a_supprimer/non-draft → 0 ligne avec `a_facturer=True`), le notebook affiche un récap propre sans crasher, sim_mode=True empêche toute écriture Odoo
- [x] Pandera `x_lisse`, `x_pdl`, `name_product_category`, `name_product_product` rendus nullable (cf. commit 05733d6) — données réelles ont des nulls sur lignes hors périmètre draft historique
- [x] Fix naming `state_account_move` (commit 84f5a52) — convention de rename OdooQuery
- [x] Fix notebook preview vide (commit 03e1faa) — schéma explicite préserve les colonnes à 0 ligne

Closes #13 (qui closera #10 par cascade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)