### PR TITLE
feat: support multi-instance (1 VPS par fournisseur)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,16 @@
 # Copiez ce fichier vers .env et adaptez les valeurs selon votre environnement
 
 # ===========================================
+# IDENTITÉ DE L'INSTANCE (cf. ADR-0015)
+# ===========================================
+
+# Identifiant court de l'instance (ex : edn, enargia). Doit matcher le
+# sous-domaine de déploiement (<slug>.electricore.fr). Apparaît dans /health,
+# dans le titre /docs, et préfixe le nom des backups DuckDB.
+# Laisser vide en développement local.
+INSTANCE_SLUG=
+
+# ===========================================
 # CONFIGURATION DES CLÉS API
 # ===========================================
 

--- a/deploy/docker/backup_duckdb.sh
+++ b/deploy/docker/backup_duckdb.sh
@@ -3,15 +3,20 @@
 # Exécuté par supercronic dans le conteneur etl-scheduler.
 #
 # Variables d'environnement attendues :
-#   DUCKDB_PATH  — chemin de la base (par défaut /data/flux_enedis_pipeline.duckdb)
-#   BACKUP_DIR   — répertoire des snapshots (par défaut /backups)
-#   RETAIN_DAYS  — nombre de snapshots à conserver (par défaut 14)
+#   DUCKDB_PATH    — chemin de la base (par défaut /data/flux_enedis_pipeline.duckdb)
+#   BACKUP_DIR     — répertoire des snapshots (par défaut /backups)
+#   RETAIN_DAYS    — nombre de snapshots à conserver (par défaut 14)
+#   INSTANCE_SLUG  — identifiant de l'instance (ADR-0015). Si défini, les snapshots
+#                    sont nommés snapshot_<slug>_<TS>.tar.gz pour éviter les
+#                    collisions cross-instance lorsque les backups sont poussés
+#                    vers un store central. Sinon : snapshot_<TS>.tar.gz.
 
 set -eu
 
 DUCKDB_PATH="${DUCKDB_PATH:-/data/flux_enedis_pipeline.duckdb}"
 BACKUP_DIR="${BACKUP_DIR:-/backups}"
 RETAIN_DAYS="${RETAIN_DAYS:-14}"
+INSTANCE_SLUG="${INSTANCE_SLUG:-}"
 
 if [ ! -f "$DUCKDB_PATH" ]; then
     echo "[backup_duckdb] Aucune base à sauvegarder ($DUCKDB_PATH absent), rien à faire." >&2
@@ -19,8 +24,13 @@ if [ ! -f "$DUCKDB_PATH" ]; then
 fi
 
 TS=$(date -u +%Y%m%dT%H%M%SZ)
-SNAPSHOT_DIR="${BACKUP_DIR}/snapshot_${TS}"
-ARCHIVE="${BACKUP_DIR}/snapshot_${TS}.tar.gz"
+if [ -n "$INSTANCE_SLUG" ]; then
+    NAME="snapshot_${INSTANCE_SLUG}_${TS}"
+else
+    NAME="snapshot_${TS}"
+fi
+SNAPSHOT_DIR="${BACKUP_DIR}/${NAME}"
+ARCHIVE="${BACKUP_DIR}/${NAME}.tar.gz"
 
 mkdir -p "$BACKUP_DIR"
 
@@ -30,7 +40,7 @@ echo "[backup_duckdb] Snapshot vers $SNAPSHOT_DIR"
 duckdb -readonly "$DUCKDB_PATH" "EXPORT DATABASE '$SNAPSHOT_DIR' (FORMAT PARQUET)"
 
 echo "[backup_duckdb] Compression vers $ARCHIVE"
-tar -C "$BACKUP_DIR" -czf "$ARCHIVE" "snapshot_${TS}"
+tar -C "$BACKUP_DIR" -czf "$ARCHIVE" "$NAME"
 rm -rf "$SNAPSHOT_DIR"
 
 # Rétention : on garde les N plus récents

--- a/docs/adr/0011-deploiement-vps-docker.md
+++ b/docs/adr/0011-deploiement-vps-docker.md
@@ -6,4 +6,4 @@ ElectriCore tourne en production sur un VPS unique avec une stack `docker-compos
 
 - **VPS unique** : pas de haute dispo, pas de réplication. Une panne du VPS = indisponibilité totale jusqu'au redémarrage.
 - **Volume DuckDB local** : la base vit sur le disque du VPS. Sauvegardes nocturnes via `EXPORT DATABASE` (voir [docs/deploiement.md](../deploiement.md)) ; restauration manuelle.
-- **Mono-tenant** : la stack est conçue pour un fournisseur d'énergie à la fois. Multi-tenant nécessiterait des changements significatifs (segmentation des clés API, isolation des bases).
+- **Mono-tenant par stack** : un déploiement = un fournisseur. Multi-tenant applicatif (1 stack, plusieurs fournisseurs en isolation logique) n'est pas l'approche retenue — cf. [ADR-0015](0015-deploiement-multi-instance.md), qui acte le modèle « un VPS par instance » pour servir plusieurs fournisseurs.

--- a/docs/adr/0015-deploiement-multi-instance.md
+++ b/docs/adr/0015-deploiement-multi-instance.md
@@ -1,0 +1,34 @@
+# Déploiement multi-instance (un VPS par fournisseur)
+
+Pour servir plusieurs fournisseurs (EDN, Enargia, …) sans réécrire ElectriCore en multi-tenant, chaque fournisseur reçoit une *instance* dédiée : un VPS, sa propre stack `docker-compose`, sa propre base DuckDB, ses clés AES, sa config Odoo, sa source SFTP, son bot Telegram, son sous-domaine. Approche assumée : on duplique le déploiement mono-tenant de l'[ADR-0011](0011-deploiement-vps-docker.md) plutôt que d'isoler logiquement dans le code.
+
+## Identification d'une instance
+
+Une variable `INSTANCE_SLUG` (ex : `edn`, `enargia`) figure dans le `.env` de chaque instance et est lue par l'app pour matérialiser l'identité :
+
+- `/health` retourne `{"status": "ok", "instance": "edn"}` — utile pour le monitoring distant.
+- Le titre OpenAPI affiche `ElectriCore API — EDN`.
+- Les backups DuckDB sont nommés `backup_edn_<date>.duckdb` (évite les collisions si plusieurs instances poussent vers un store central).
+- Au boot, l'API logue `Instance=edn connectée à odoo_db=<db>, sftp=<host>` — garde-fou minimal contre un `.env` mal copié (responsabilité humaine en dernier ressort, pas de blocage strict).
+
+`INSTANCE_SLUG` n'apparaît **pas** dans les logs structurés ni dans les messages Telegram : un bot = une instance, le bot lui-même indique l'origine.
+
+## DNS et certificats
+
+Le domaine `electricore.fr` héberge un sous-domaine par instance (`edn.electricore.fr`, `enargia.electricore.fr`). Chaque VPS gère son propre certificat Let's Encrypt via le challenge HTTP-01 de Caddy ([deploy/docker/Caddyfile.example](../../deploy/docker/Caddyfile.example)) — pas de wildcard (incompatible avec l'isolation par VPS, exigerait DNS-01).
+
+## Cycles de release indépendants
+
+Chaque instance pin `ELECTRICORE_VERSION` dans son `.env`. Le déclenchement est manuel (SSH `docker compose pull && up -d` à 2-3 instances ; un script Ansible deviendra rentable au-delà). Conséquence assumée : roll-out progressif (tester sur une instance, valider, puis bumper la suivante), rollback indépendant, divergences temporaires de version acceptées.
+
+## Alternatives écartées
+
+- **Multi-tenant applicatif** (1 stack, `tenant_id` partout) : refactor profond (toutes les requêtes DuckDB, services API, scheduler, bot). Bénéfice nul à 2-3 fournisseurs, coût élevé.
+- **Multi-stack sur 1 VPS** (N `docker-compose` isolés, Caddy mutualisé) : économise ~5 €/mois × N mais réintroduit une coordination opérationnelle (nommage des containers et volumes, partage des ressources, `down/up` croisés). Pas justifié au-delà de la simple économie marginale.
+- **Watchtower (auto-pull `latest`)** : déploiement non maîtrisé, une régression toucherait toutes les instances simultanément. Incompatible avec le besoin de roll-out progressif.
+
+## Limites
+
+- **2-3 instances reste l'horizon assumé.** Au-delà de ~5, le provisioning manuel et la coordination des releases deviennent pénibles ; il faudra alors investir dans Ansible/Terraform ou reconsidérer le multi-tenant applicatif.
+- **Pas de garde-fou strict** contre un `.env` mal configuré (mauvaise base Odoo). Le log de boot signale, mais la responsabilité finale reste humaine.
+- **Le bot Telegram d'une instance ne voit que cette instance.** Pas de vue globale cross-instance ; le monitoring transverse repose sur les endpoints `/health` distincts.

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -7,13 +7,14 @@ Guide opérationnel pour déployer ElectriCore sur un VPS via la stack Docker
 
 1. [Prérequis](#prérequis)
 2. [Installation initiale](#installation-initiale)
-3. [Accès distant depuis un notebook Python](#accès-distant-depuis-un-notebook-python)
-4. [Mode SFTP distant vs fichiers collocés](#mode-sftp-distant-vs-fichiers-collocés)
-5. [Rotation des clés AES](#rotation-des-clés-aes)
-6. [Sauvegarde et restauration](#sauvegarde-et-restauration)
-7. [Mise à jour de version](#mise-à-jour-de-version)
-8. [Fenêtre ETL et concurrence DuckDB](#fenêtre-etl-et-concurrence-duckdb)
-9. [Dépannage](#dépannage)
+3. [Provisionner une nouvelle instance](#provisionner-une-nouvelle-instance)
+4. [Accès distant depuis un notebook Python](#accès-distant-depuis-un-notebook-python)
+5. [Mode SFTP distant vs fichiers collocés](#mode-sftp-distant-vs-fichiers-collocés)
+6. [Rotation des clés AES](#rotation-des-clés-aes)
+7. [Sauvegarde et restauration](#sauvegarde-et-restauration)
+8. [Mise à jour de version](#mise-à-jour-de-version)
+9. [Fenêtre ETL et concurrence DuckDB](#fenêtre-etl-et-concurrence-duckdb)
+10. [Dépannage](#dépannage)
 
 ---
 
@@ -63,6 +64,7 @@ curl -fsSL -o /opt/electricore/.env "$BASE/.env.example"
 
 Éditer `/opt/electricore/.env` :
 
+- `INSTANCE_SLUG` : identifiant court de l'instance (ex : `edn`, `enargia`). Voir [ADR-0015](adr/0015-deploiement-multi-instance.md). Apparaît dans `/health`, dans le titre `/docs`, et préfixe le nom des backups DuckDB.
 - `ELECTRICORE_VERSION` : tag de l'image GHCR à déployer (ex : `1.4.0`).
 - `API_KEY` : générer une clé sécurisée (`python -c "import secrets; print(secrets.token_urlsafe(32))"`).
 - `SFTP__URL` : URL SFTP distante ou `file:///var/enedis/` selon le mode.
@@ -128,6 +130,134 @@ docker compose exec etl-scheduler curl -X POST \
     -d '{"mode":"test"}' \
     http://api:8001/etl/run
 ```
+
+## Provisionner une nouvelle instance
+
+ElectriCore est déployé en **multi-instance** : un VPS dédié par fournisseur (EDN, Enargia, …), chacun avec sa propre stack, sa base DuckDB, ses clés AES, sa config Odoo, sa source SFTP, son bot Telegram, et son sous-domaine sur `electricore.fr`. Le rationale et les alternatives écartées sont consignés dans [ADR-0015](adr/0015-deploiement-multi-instance.md).
+
+Cette section décrit la procédure complète pour monter `<slug>.electricore.fr` de zéro. Elle suit la même trame que l'[Installation initiale](#installation-initiale), en insistant sur les points spécifiques au multi-instance.
+
+### 1. Choisir le slug
+
+Le slug est l'identifiant court de l'instance, en minuscules sans accent (ex : `edn`, `enargia`). Il sert à la fois de sous-domaine, de valeur `INSTANCE_SLUG`, et de préfixe de backup. Une fois choisi, il est difficile à changer sans casser les références DNS et les noms de fichiers de sauvegarde — choisir soigneusement.
+
+### 2. Provisionner le VPS
+
+Spécifications minimales : 2 vCPU, 4 Go RAM, 40 Go SSD, Ubuntu 22.04+ ou Debian 12+. Installer Docker Engine ≥ 24 et le plugin Compose. Ouvrir les ports 80 et 443 au pare-feu.
+
+### 3. Créer le A-record DNS
+
+Dans la zone `electricore.fr`, ajouter un enregistrement :
+
+```
+<slug>.electricore.fr.   A   <IP-VPS>
+```
+
+Vérifier la propagation avant de continuer :
+
+```bash
+dig +short <slug>.electricore.fr
+```
+
+Pas de wildcard (`*.electricore.fr`) — chaque VPS gère son propre certificat via HTTP-01 (cf. ADR-0015).
+
+### 4. Récupérer les fichiers de configuration
+
+Suivre l'étape [§1 de l'installation initiale](#1-préparer-le-dossier-et-récupérer-les-fichiers-de-config) (téléchargement de `docker-compose.yml`, `Caddyfile`, `crontab`, `.env.example`).
+
+### 5. Configurer le `.env` (variables par catégorie)
+
+Le `.env` est **la source de vérité de l'identité de l'instance**. Toutes les variables ci-dessous sont **spécifiques par instance** — ne jamais partager un `.env` entre deux instances.
+
+**Identité de l'instance**
+
+| Variable | Exemple | Notes |
+|---|---|---|
+| `INSTANCE_SLUG` | `edn` | Identifiant court, minuscule. Doit matcher le sous-domaine. |
+| `ELECTRICORE_VERSION` | `1.6.0` | Tag de l'image GHCR. Pin explicite — chaque instance contrôle sa version. |
+
+**API**
+
+| Variable | Notes |
+|---|---|
+| `API_KEY` | Générer une clé dédiée (`python -c "import secrets; print(secrets.token_urlsafe(32))"`). Ne pas réutiliser une clé d'une autre instance. |
+| `API_KEYS` | Optionnel, clés multiples séparées par virgule. |
+
+**Odoo**
+
+| Variable | Notes |
+|---|---|
+| `ODOO_ENV` | `prod` (ou `test` pour une instance d'essai). |
+| `ODOO_PROD_URL` | URL de l'instance Odoo du fournisseur (ex : `https://edn.odoo.com`). |
+| `ODOO_PROD_DB` | Nom de la base Odoo. Vérifier que ce nom apparaîtra dans le log de boot (cf. §8). |
+| `ODOO_PROD_USERNAME` | Compte utilisateur Odoo dédié à ElectriCore. |
+| `ODOO_PROD_PASSWORD` | Mot de passe ou clé API Odoo. |
+
+**SFTP Enedis**
+
+| Variable | Notes |
+|---|---|
+| `SFTP__URL` | `sftp://utilisateur:motdepasse@hote:22/chemin` ou `file:///var/enedis/` en mode collocé. Chaque fournisseur a son propre compte SFTP Enedis. |
+
+**Clés AES Enedis**
+
+| Variable | Notes |
+|---|---|
+| `AES__CURRENT__KEY` | Clé en hexadécimal, fournie par Enedis au fournisseur. **Distincte par fournisseur.** |
+| `AES__CURRENT__IV` | IV en hexadécimal. |
+| `AES__PREVIOUS__*` | Optionnel pendant ~4 semaines après une rotation (cf. [Rotation des clés AES](#rotation-des-clés-aes)). |
+
+**Bot Telegram**
+
+| Variable | Notes |
+|---|---|
+| `TELEGRAM_BOT_TOKEN` | Créer un bot dédié via [@BotFather](https://t.me/BotFather) (commande `/newbot`). Convention de nommage : `<slug>_electricore_bot`. |
+| `TELEGRAM_ALLOWED_USERS` | IDs Telegram autorisés (allowlist propre à l'équipe du fournisseur). |
+
+### 6. Configurer le Caddyfile
+
+Dans le `Caddyfile`, substituer :
+
+- `electricore.exemple.fr` → `<slug>.electricore.fr`
+- `votre-email@example.com` → email valide (notifications Let's Encrypt).
+
+### 7. Ajuster le crontab
+
+Vérifier l'horaire ETL (`0 2 * * *` par défaut, 02:00 Europe/Paris). Si plusieurs instances tournent sur le même VPS Enedis source (rare), décaler les fenêtres pour éviter les pics simultanés.
+
+### 8. Démarrer la stack et vérifier
+
+```bash
+cd /opt/electricore/deploy/docker
+docker compose up -d
+docker compose logs -f api
+```
+
+**Checklist de vérification post-déploiement** :
+
+- [ ] Les logs au boot de l'API contiennent une ligne `Instance=<slug>, odoo_db=<db>, sftp=<host>` — vérifier que le slug, la DB Odoo et le SFTP correspondent bien à l'instance attendue (garde-fou contre un `.env` copié à tort depuis une autre instance).
+- [ ] `curl https://<slug>.electricore.fr/health` retourne `{"status": "ok", "instance": "<slug>", ...}`.
+- [ ] `https://<slug>.electricore.fr/docs` s'ouvre et affiche un titre incluant le slug (ex : `ElectriCore API — EDN`).
+- [ ] Le certificat Let's Encrypt est valide (badge cadenas dans le navigateur, pas d'avertissement).
+- [ ] Le bot Telegram répond à `/start` pour un user listé dans `TELEGRAM_ALLOWED_USERS`.
+- [ ] Premier ETL test :
+  ```bash
+  docker compose exec etl-scheduler curl -X POST \
+      -H "X-API-Key:$(grep ^API_KEY= .env | cut -d= -f2)" \
+      -H "Content-Type: application/json" \
+      -d '{"mode":"test"}' \
+      http://api:8001/etl/run
+  ```
+  Vérifier dans les logs `etl-scheduler` que les fichiers sont déchiffrés (clés AES correctes) et ingérés.
+- [ ] Premier backup nocturne : après la fenêtre 03:30, vérifier `docker compose exec etl-scheduler ls -lh /backups/` — le fichier produit doit être préfixé par le slug (ex : `backup_edn_<date>.duckdb`).
+
+### 9. Documenter et archiver
+
+- Noter les coordonnées de l'instance (slug, IP VPS, contacts du fournisseur, registrar DNS) dans un endroit sûr.
+- Sauvegarder le `.env` dans un gestionnaire de secrets (1Password, Bitwarden, Vaultwarden auto-hébergé…).
+- Ajouter le sous-domaine à votre monitoring distant (ping `/health` régulier).
+
+---
 
 ## Accès distant depuis un notebook Python
 

--- a/electricore/api/config.py
+++ b/electricore/api/config.py
@@ -28,6 +28,9 @@ class APISettings(BaseModel):
     api_version: str = Field(default="0.1.0")
     api_description: str = Field(default="API sécurisée pour accéder aux données flux Enedis")
 
+    # Identité de l'instance (cf. ADR-0015 — déploiement multi-instance)
+    instance_slug: str = Field(default="")
+
     # Configuration des clés API
     api_key: str = Field(default="")
     api_keys: str = Field(default="")
@@ -67,6 +70,7 @@ class APISettings(BaseModel):
             "api_title": os.getenv("API_TITLE", "ElectriCore API"),
             "api_version": os.getenv("API_VERSION", "0.1.0"),
             "api_description": os.getenv("API_DESCRIPTION", "API sécurisée pour accéder aux données flux Enedis"),
+            "instance_slug": os.getenv("INSTANCE_SLUG", ""),
             "api_key": os.getenv("API_KEY", ""),
             "api_keys": os.getenv("API_KEYS", ""),
             "enable_api_key_header": os.getenv("ENABLE_API_KEY_HEADER", "true").lower() == "true",

--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -5,7 +5,9 @@ Expose les données Enedis via endpoints génériques avec authentification par 
 
 import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
+from urllib.parse import urlparse
 
 from fastapi import Depends, FastAPI, HTTPException, Query
 from fastapi.responses import Response
@@ -32,9 +34,30 @@ logger = logging.getLogger(__name__)
 _tg_app = None
 
 
+def _format_sftp_source() -> str:
+    """Identifiant lisible de la source SFTP, sans secret (cf. ADR-0015)."""
+    raw = os.getenv("SFTP__URL", "")
+    if not raw:
+        return "(unset)"
+    parsed = urlparse(raw)
+    if parsed.scheme == "file":
+        return raw
+    if parsed.hostname:
+        return f"{parsed.scheme}://{parsed.hostname}"
+    return parsed.scheme or "(unset)"
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global _tg_app
+    odoo_db = os.getenv(f"ODOO_{settings.odoo_env.upper()}_DB", "(unset)")
+    logger.info(
+        "Instance=%s, odoo_env=%s, odoo_db=%s, sftp=%s",
+        settings.instance_slug or "(unset)",
+        settings.odoo_env,
+        odoo_db,
+        _format_sftp_source(),
+    )
     if settings.telegram_bot_token:
         from electricore.bot.bot import build_application
 
@@ -57,10 +80,12 @@ async def lifespan(app: FastAPI):
         logger.info("Bot Telegram arrêté.")
 
 
+_instance_suffix = f" — {settings.instance_slug.upper()}" if settings.instance_slug else ""
+
 # Configuration de l'application avec métadonnées de sécurité
 app = FastAPI(
     lifespan=lifespan,
-    title=settings.api_title,
+    title=f"{settings.api_title}{_instance_suffix}",
     version=settings.api_version,
     description=f"{settings.api_description}\n\n"
     "**Authentification requise** : Utilisez une clé API valide via :\n"
@@ -293,6 +318,7 @@ async def health():
     freshness = duckdb_service.get_freshness()
     return {
         "status": "ok",
+        "instance": settings.instance_slug,
         "api_version": settings.api_version,
         "database": freshness,
         "bot": {"running": _tg_app is not None},

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -19,6 +19,11 @@ Régulateur français qui fixe les tarifs d'acheminement (TURPE) et arbitre les 
 **Fournisseur** :
 Acteur commercial qui vend l'électricité au consommateur final. Utilise les flux Enedis pour facturer ses clients.
 _Éviter_ : vendeur, opérateur (ambigus).
+_Note_ : « Fournisseur » est générique — il désigne aussi bien le fournisseur opérant une *instance* ElectriCore (ex : EDN, Enargia) que les autres fournisseurs cités dans les événements C15 (CFNE/CFNS). Préférer *instance* quand on parle du fournisseur opérant.
+
+**Instance** :
+Déploiement ElectriCore dédié à un *fournisseur* particulier (EDN, Enargia…). Chaque instance a sa propre base DuckDB, ses clés AES, sa config Odoo, sa source SFTP, son sous-domaine. Identifiée par un slug court (`edn`, `enargia`).
+_Éviter_ : tenant (anglicisme), déploiement (confus avec l'opération de release).
 
 **Gestionnaire de réseau** :
 Synonyme métier d'Enedis dans la majeure partie du territoire. À distinguer du *transporteur* (RTE, haute tension).

--- a/tests/integration/test_health_endpoint.py
+++ b/tests/integration/test_health_endpoint.py
@@ -1,0 +1,25 @@
+"""Tests d'intégration de l'endpoint `GET /health` — identité d'instance (ADR-0015)."""
+
+from fastapi.testclient import TestClient
+
+from electricore.api.config import settings
+from electricore.api.main import app
+
+
+def test_health_expose_instance_slug_when_set(monkeypatch):
+    monkeypatch.setattr(settings, "instance_slug", "edn")
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["instance"] == "edn"
+
+
+def test_health_expose_empty_instance_when_unset(monkeypatch):
+    monkeypatch.setattr(settings, "instance_slug", "")
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["instance"] == ""


### PR DESCRIPTION
## Summary

Implémente le modèle de déploiement multi-instance acté dans **ADR-0015** : chaque fournisseur (EDN, Enargia…) a son propre VPS, son sous-domaine `<slug>.electricore.fr`, sa stack `docker-compose` isolée. Issu d'une session de grilling sur l'architecture qui a écarté le multi-tenant applicatif et le multi-stack 1 VPS.

- **Architecture** : ADR-0015 + amendement ADR-0011 + terme `Instance` ajouté au glossaire `core/CONTEXT.md` (disambigué de `Fournisseur` générique).
- **Code** : `INSTANCE_SLUG` lu par l'API et exposé dans `/health`, le titre OpenAPI (`/docs`), et le log de boot (avec `odoo_env`, `odoo_db`, `sftp` masqué — garde-fou contre un `.env` mal copié).
- **Ops** : `backup_duckdb.sh` préfixe les snapshots par le slug pour éviter les collisions cross-instance dans un éventuel store central.
- **Doc** : section dédiée « Provisionner une nouvelle instance » dans `docs/deploiement.md` (9 étapes, checklist de vérification post-déploiement).

Pas de changement applicatif structurel : la stack mono-tenant existante est simplement dupliquée par instance, conformément à la limite déjà notée dans ADR-0011.

## Test plan

- [x] `uv run --group test pytest -q` : 265 passed, 36 skipped (légitimes)
- [x] 2 nouveaux tests d'intégration sur `/health` (slug défini / vide)
- [x] `uvx ruff format` + `uvx ruff check` : All checks passed
- [x] Pre-commit hooks ruff verts sur les commits applicatifs
- [x] Smoke test du script de backup : produit `snapshot_edn_<TS>.tar.gz` avec slug, `snapshot_<TS>.tar.gz` sans (compat ascendante)
- [ ] À valider en review : format exact du titre OpenAPI (`ElectriCore API — EDN`) et format exact de la ligne de log de boot

Closes #20
Closes #21
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)