### PR TITLE
refactor: extraire api/serializers (XLSX, Arrow, ZIP) (#41)

### DIFF
--- a/electricore/api/serializers/__init__.py
+++ b/electricore/api/serializers/__init__.py
@@ -1,0 +1,67 @@
+"""Sérialiseurs des artefacts API (XLSX multi-onglets, Arrow IPC, ZIP CSV) — issue #41.
+
+Factorisent les patterns de sérialisation dupliqués entre les services pour
+que les `api/services/*.py` se réduisent à `df = orchestration(...)` →
+`return serialize(df)`.
+"""
+
+import io
+import zipfile
+
+import polars as pl
+import xlsxwriter
+
+
+def xlsx_multi_sheet(onglets: dict[str, pl.DataFrame]) -> bytes:
+    """Construit un fichier XLSX multi-onglets à partir d'un dict {nom: DataFrame}.
+
+    L'option `remove_timezone=True` est appliquée — nécessaire pour les DataFrames
+    qui portent des colonnes `Europe/Paris` (XLSX ne stocke pas les timezones).
+
+    Args:
+        onglets: dict ordonné `{nom_onglet: DataFrame}`. Les onglets apparaissent
+            dans l'ordre d'insertion.
+
+    Returns:
+        Bytes du XLSX (container ZIP).
+    """
+    buf = io.BytesIO()
+    wb = xlsxwriter.Workbook(buf, {"remove_timezone": True})
+    for nom, df in onglets.items():
+        df.write_excel(workbook=wb, worksheet=nom)
+    wb.close()
+    return buf.getvalue()
+
+
+def arrow_stream(df: pl.DataFrame) -> bytes:
+    """Sérialise un DataFrame Polars en flux Arrow IPC.
+
+    Args:
+        df: DataFrame à sérialiser.
+
+    Returns:
+        Bytes du flux Arrow IPC, re-lisible via `pl.read_ipc_stream(BytesIO(...))`.
+    """
+    buf = io.BytesIO()
+    df.write_ipc_stream(buf)
+    return buf.getvalue()
+
+
+def zip_csv(documents: dict[str, pl.DataFrame]) -> bytes:
+    """Construit un ZIP (deflated) où chaque entrée est un CSV Polars.
+
+    Args:
+        documents: dict `{nom_fichier_dans_le_zip: DataFrame}`. Chaque DataFrame
+            est sérialisé via `df.write_csv()`.
+
+    Returns:
+        Bytes du ZIP.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for nom, df in documents.items():
+            zf.writestr(nom, df.write_csv())
+    return buf.getvalue()
+
+
+__all__ = ["xlsx_multi_sheet", "arrow_stream", "zip_csv"]

--- a/electricore/api/services/facturation_service.py
+++ b/electricore/api/services/facturation_service.py
@@ -5,16 +5,13 @@ Le calcul et l'orchestration métier vivent dans
 
 1. Ouvrir la connexion `OdooReader` (responsabilité HTTP)
 2. Déléguer à l'orchestration
-3. Sérialiser le résultat (XLSX / Arrow IPC / ZIP)
+3. Sérialiser le résultat via `api/serializers/` (XLSX / Arrow IPC / ZIP)
 """
 
-import io
-import zipfile
-
 import polars as pl
-import xlsxwriter
 
 from electricore.api.config import settings
+from electricore.api.serializers import arrow_stream, xlsx_multi_sheet, zip_csv
 from electricore.integrations.odoo import OdooReader
 from electricore.integrations.odoo.facturation import (
     documents_facturation_du_mois,
@@ -37,31 +34,20 @@ def calculer_lignes_facture_rapprochees(mois: str | None = None) -> pl.DataFrame
 
 
 def generer_facturation_xlsx(mois: str | None = None) -> bytes:
-    """Réconciliation Odoo ↔ Enedis du mois (défaut : dernier mois disponible).
-
-    Args:
-        mois: format "YYYY-MM-DD" (premier jour du mois). None = dernier mois des données.
-
-    Returns:
-        XLSX bytes — 2 onglets : "Lignes fusionnées" et "Changements puissance".
-    """
+    """Réconciliation Odoo ↔ Enedis du mois sérialisée en XLSX (2 onglets)."""
     lignes_rapprochees = calculer_lignes_facture_rapprochees(mois)
     changements_puissance = lignes_rapprochees.filter(pl.col("memo_puissance") != "")
-
-    buf = io.BytesIO()
-    wb = xlsxwriter.Workbook(buf, {"remove_timezone": True})
-    lignes_rapprochees.write_excel(workbook=wb, worksheet="Lignes fusionnées")
-    changements_puissance.write_excel(workbook=wb, worksheet="Changements puissance")
-    wb.close()
-    return buf.getvalue()
+    return xlsx_multi_sheet(
+        {
+            "Lignes fusionnées": lignes_rapprochees,
+            "Changements puissance": changements_puissance,
+        }
+    )
 
 
 def generer_facturation_arrow(mois: str | None = None) -> bytes:
     """Sérialise `lignes_facture_rapprochees` en flux Arrow IPC."""
-    lignes_rapprochees = calculer_lignes_facture_rapprochees(mois)
-    buf = io.BytesIO()
-    lignes_rapprochees.write_ipc_stream(buf)
-    return buf.getvalue()
+    return arrow_stream(calculer_lignes_facture_rapprochees(mois))
 
 
 def generer_documents_facturation(mois: str | None = None) -> tuple[bytes, str]:
@@ -75,9 +61,4 @@ def generer_documents_facturation(mois: str | None = None) -> tuple[bytes, str]:
     """
     with OdooReader(config=settings.get_odoo_config()) as odoo:
         documents, suffix = documents_facturation_du_mois(odoo, mois)
-
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for name, df in documents.items():
-            zf.writestr(name, df.write_csv())
-    return buf.getvalue(), suffix
+    return zip_csv(documents), suffix

--- a/electricore/api/services/taxes_service.py
+++ b/electricore/api/services/taxes_service.py
@@ -9,12 +9,10 @@ Le calcul et l'orchestration métier vivent dans
    agrégations « par taux » / « résumé » spécifiques au livrable.
 """
 
-import io
-
 import polars as pl
-import xlsxwriter
 
 from electricore.api.config import settings
+from electricore.api.serializers import arrow_stream, xlsx_multi_sheet
 from electricore.integrations.odoo import OdooReader
 from electricore.integrations.odoo.taxes import accise_du_trimestre, cta_du_trimestre
 
@@ -32,10 +30,7 @@ def calculer_accise_detail(trimestre: str | None = None) -> pl.DataFrame:
 
 def generer_accise_arrow(trimestre: str | None = None) -> bytes:
     """Sérialise le détail accise en flux Arrow IPC."""
-    df = calculer_accise_detail(trimestre)
-    buf = io.BytesIO()
-    df.write_ipc_stream(buf)
-    return buf.getvalue()
+    return arrow_stream(calculer_accise_detail(trimestre))
 
 
 def generer_accise_xlsx(trimestre: str | None = None) -> bytes:
@@ -74,7 +69,7 @@ def generer_accise_xlsx(trimestre: str | None = None) -> bytes:
         .sort("trimestre")
     )
 
-    return _construire_xlsx(
+    return xlsx_multi_sheet(
         {
             "Résumé": df_resume,
             "Par taux": df_par_taux,
@@ -96,10 +91,7 @@ def calculer_cta_detail(trimestre: str | None = None) -> pl.DataFrame:
 
 def generer_cta_arrow(trimestre: str | None = None) -> bytes:
     """Sérialise le détail CTA mensuel en flux Arrow IPC."""
-    df = calculer_cta_detail(trimestre)
-    buf = io.BytesIO()
-    df.write_ipc_stream(buf)
-    return buf.getvalue()
+    return arrow_stream(calculer_cta_detail(trimestre))
 
 
 def generer_cta_xlsx(trimestre: str | None = None) -> bytes:
@@ -160,20 +152,10 @@ def generer_cta_xlsx(trimestre: str | None = None) -> bytes:
         .sort("trimestre")
     )
 
-    return _construire_xlsx(
+    return xlsx_multi_sheet(
         {
             "Résumé": df_resume,
             "Par taux": df_par_taux,
             "Détail": df_detail_cta,
         }
     )
-
-
-def _construire_xlsx(onglets: dict[str, pl.DataFrame]) -> bytes:
-    """Construit un fichier XLSX multi-onglets à partir d'un dict {nom: DataFrame}."""
-    buf = io.BytesIO()
-    wb = xlsxwriter.Workbook(buf, {"remove_timezone": True})
-    for nom, df in onglets.items():
-        df.write_excel(workbook=wb, worksheet=nom)
-    wb.close()
-    return buf.getvalue()

--- a/tests/unit/test_api_serializers.py
+++ b/tests/unit/test_api_serializers.py
@@ -1,0 +1,67 @@
+"""Tests des sérialiseurs `api/serializers/` (issue #41).
+
+Vérifient que chaque sérialiseur produit des bytes conformes au format
+attendu — sans présumer de l'implémentation (xlsxwriter, polars, zipfile…).
+"""
+
+import io
+import zipfile
+
+import polars as pl
+
+
+def test_xlsx_multi_sheet_produit_xlsx_valide_avec_onglets_nommes() -> None:
+    """`xlsx_multi_sheet({nom: df, ...})` produit un XLSX (signature ZIP) avec un onglet par entrée."""
+    from electricore.api.serializers import xlsx_multi_sheet
+
+    onglets = {
+        "Résumé": pl.DataFrame({"total": [42]}),
+        "Détail": pl.DataFrame({"ligne": ["a", "b"], "valeur": [1, 2]}),
+    }
+    output = xlsx_multi_sheet(onglets)
+
+    assert isinstance(output, bytes)
+    assert output[:4] == b"PK\x03\x04", "XLSX = container ZIP, doit commencer par PK\\x03\\x04"
+
+    with zipfile.ZipFile(io.BytesIO(output)) as zf:
+        names = zf.namelist()
+        assert "xl/workbook.xml" in names, "Structure XLSX attendue : xl/workbook.xml"
+        # Un xl/worksheets/sheetN.xml par onglet
+        sheet_files = [n for n in names if n.startswith("xl/worksheets/sheet")]
+        assert len(sheet_files) == len(onglets), (
+            f"Attendu {len(onglets)} feuilles, trouvé {len(sheet_files)} : {sheet_files}"
+        )
+
+
+def test_arrow_stream_produit_flux_relisable_avec_donnees_identiques() -> None:
+    """`arrow_stream(df)` produit un flux Arrow IPC re-lisible avec les mêmes données."""
+    from polars.testing import assert_frame_equal
+
+    from electricore.api.serializers import arrow_stream
+
+    df = pl.DataFrame({"pdl": ["123", "456"], "energie_kwh": [100.5, 200.0]})
+    output = arrow_stream(df)
+
+    assert isinstance(output, bytes)
+    assert len(output) > 0
+
+    df_round_trip = pl.read_ipc_stream(io.BytesIO(output))
+    assert_frame_equal(df_round_trip, df)
+
+
+def test_zip_csv_produit_zip_avec_chaque_csv_nomme_et_non_vide() -> None:
+    """`zip_csv({nom: df, ...})` produit un ZIP avec un CSV par entrée, contenu = CSV Polars."""
+    from electricore.api.serializers import zip_csv
+
+    documents = {
+        "tableau_a.csv": pl.DataFrame({"x": [1, 2]}),
+        "tableau_b.csv": pl.DataFrame({"y": ["a"]}),
+    }
+    output = zip_csv(documents)
+
+    assert isinstance(output, bytes)
+    with zipfile.ZipFile(io.BytesIO(output)) as zf:
+        assert set(zf.namelist()) == set(documents.keys())
+        # Chaque entrée contient le CSV Polars correspondant
+        for nom, df in documents.items():
+            assert zf.read(nom).decode("utf-8") == df.write_csv()


### PR DESCRIPTION
## Summary
- Nouveau sous-package `electricore/api/serializers/` qui factorise les patterns de sérialisation dupliqués (#41 — résolution du candidate #4 de la revue d'archi du 2026-06-05).
- 3 fonctions exposées : `xlsx_multi_sheet`, `arrow_stream`, `zip_csv`. Remplacent 6 sites de duplication (`_construire_xlsx` privé dans `taxes_service`, bloc `xlsxwriter.Workbook` inline dans `facturation_service`, 4 sites de `df.write_ipc_stream`, construction ZIP inline).
- Les `api/services/*.py` se réduisent à `df = orchestration(...)` → `return serialize(df)`. `facturation_service` perd 25 lignes, `taxes_service` 34 lignes.
- 3 nouveaux smoke tests qui vérifient le format de sortie sans présumer de l'implémentation (signature magique XLSX, round-trip Arrow IPC, noms ZIP + contenu CSV).
- 369 passants au total (+3 vs main), 0 régression.

## Test plan
- [ ] `uv run --group test pytest -q` → attendu **369 passed, 35 skipped, 0 failed**
- [ ] `uvx ruff format --check electricore/ tests/` et `uvx ruff check electricore/ tests/` → propre
- [ ] `from electricore.api.serializers import xlsx_multi_sheet, arrow_stream, zip_csv` fonctionne dans un shell python
- [ ] Smoke-test des endpoints API : `/facturation/xlsx`, `/facturation/arrow`, `/facturation/documents`, `/taxes/accise/xlsx`, `/taxes/accise/arrow`, `/taxes/cta/xlsx`, `/taxes/cta/arrow` servent les mêmes payloads qu'avant
- [ ] Test de pureté `core/` toujours vert (les sérialiseurs vivent en `api/`, pas en `core/`)

## Notes de conception
- Placement choisi : `electricore/api/serializers/`. Les sérialiseurs ne dépendent ni de `core/` ni de `integrations/` ; ils sont consommés par les services HTTP. Le top-level `electricore/serializers/` aurait été possible mais sur-dimensionné aujourd'hui (un seul consommateur).
- `xlsx_multi_sheet` conserve `remove_timezone=True` — nécessaire pour les DataFrames avec colonnes `Europe/Paris` (XLSX ne stocke pas les TZ).
- Les **agrégations XLSX-shape** (`df_par_taux`, `df_resume`, `df_detail_cta` côté taxes) **restent dans le service** parce qu'elles décrivent la forme du livrable Excel — pas de la sérialisation pure. Si elles deviennent réutilisables ailleurs, migration vers `integrations/odoo/taxes` (avec les orchestrations).

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)