### PR TITLE
feat(v1.7.0rc1): notebooks de prod sur ElectricoreClient (HTTP) + support pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,13 @@ name: Release
 on:
   push:
     tags:
+      # Stable : v1.7.0
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      # Pre-release PEP 440 : v1.7.0a1, v1.7.0b1, v1.7.0rc1, v1.7.0.dev1
+      - 'v[0-9]+.[0-9]+.[0-9]+a[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+b[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+.dev[0-9]+'
 
 # Pas de bloc concurrency : un release ne doit jamais être annulé en cours de publication.
 
@@ -21,6 +27,17 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Detect pre-release
+        id: release_type
+        run: |
+          # Un tag stable matche vX.Y.Z strictement ; tout autre format
+          # (rc, dev, alpha, beta — voir le bloc `on.push.tags`) est une pré-release.
+          if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
@@ -45,9 +62,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          PRERELEASE_FLAG=""
+          if [[ "${{ steps.release_type.outputs.is_prerelease }}" == "true" ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
           gh release create "${GITHUB_REF_NAME}" \
             --title "${GITHUB_REF_NAME}" \
             --generate-notes \
+            ${PRERELEASE_FLAG} \
             dist/*.tar.gz dist/*.whl
 
       # ---------------------------------------------------------------
@@ -69,8 +91,15 @@ jobs:
           OWNER="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
           V="${GITHUB_REF_NAME#v}"
           MAJOR_MINOR="${V%.*}"
+          if [[ "${{ steps.release_type.outputs.is_prerelease }}" == "true" ]]; then
+            # Pré-release : on ne touche ni `:latest` ni `:MAJOR.MINOR` pour ne pas
+            # rediriger les déploiements stables vers la rc/dev.
+            TAGS="ghcr.io/${OWNER}/electricore:${V}"
+          else
+            TAGS="ghcr.io/${OWNER}/electricore:${V},ghcr.io/${OWNER}/electricore:${MAJOR_MINOR},ghcr.io/${OWNER}/electricore:latest"
+          fi
           {
-            echo "tags=ghcr.io/${OWNER}/electricore:${V},ghcr.io/${OWNER}/electricore:${MAJOR_MINOR},ghcr.io/${OWNER}/electricore:latest"
+            echo "tags=${TAGS}"
             echo "smoke_tag=ghcr.io/${OWNER}/electricore:${V}"
           } >> "$GITHUB_OUTPUT"
 

--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -236,6 +236,31 @@ def get_flux_xlsx(
     return duckdb_service.query_table_xlsx(table_name, filters, limit)
 
 
+@arrow_endpoint(app, "/flux/{table_name}/arrow", tags=["flux"])
+def get_flux_arrow(
+    table_name: str,
+    prm: str | None = Query(None, description="Filtrer par pdl (Point de Livraison)"),
+    limit: int = Query(1_000_000, le=10_000_000, description="Nombre maximum de lignes (défaut 1 000 000)"),
+) -> bytes:
+    """Exporte les données d'un flux Enedis en flux Arrow IPC (max 10 000 000 lignes).
+
+    Consommable côté client avec `pl.read_ipc_stream(BytesIO(content))` — typage et
+    timezones préservés, pas de perte de précision contrairement à XLSX. Cf. `ElectricoreClient.flux`.
+
+    Vérifie l'existence de la table — renvoie 404 si inconnue, 500 sinon.
+    """
+    try:
+        available_tables = duckdb_service.list_tables()
+    except Exception as e:
+        raise HTTPException(500, f"Impossible d'accéder à la base de données: {e}")
+
+    if table_name not in available_tables:
+        raise HTTPException(404, f"Table '{table_name}' non trouvée. Tables disponibles: {available_tables}")
+
+    filters = {"pdl": prm} if prm else {}
+    return duckdb_service.query_table_arrow(table_name, filters, limit)
+
+
 @app.get("/flux/{table_name}/info", tags=["flux"])
 async def get_table_info(table_name: str, api_key: str = Depends(get_current_api_key)):
     """

--- a/electricore/api/services/duckdb_service.py
+++ b/electricore/api/services/duckdb_service.py
@@ -3,7 +3,6 @@ Service DuckDB pour accès générique aux données flux.
 Fonctions pures pour lire les tables de flux Enedis.
 """
 
-import io
 import logging
 import os
 import time
@@ -171,13 +170,24 @@ def get_table_info(table_name: str) -> dict:
         return {"table": f"flux_{table_name}", "schema": SCHEMA, "count": count, "columns": columns}
 
 
+def _query_table_df(table_name: str, filters: dict | None = None, limit: int = 10000):
+    """Charge une table flux dans un DataFrame Polars, avec filtres et limite optionnels."""
+    sql = f"SELECT * FROM {SCHEMA}.flux_{table_name}"
+    if filters:
+        conditions = [f"{col} = '{val}'" for col, val in filters.items()]
+        sql += f" WHERE {' AND '.join(conditions)}"
+    sql += f" LIMIT {limit}"
+
+    with _connect_readonly() as conn:
+        return conn.execute(sql).pl()
+
+
 def query_table_xlsx(
     table_name: str,
     filters: dict | None = None,
     limit: int = 10000,
 ) -> bytes:
-    """
-    Retourne les données d'une table flux au format XLSX (bytes).
+    """Retourne les données d'une table flux au format XLSX (bytes).
 
     Args:
         table_name: Nom de la table (r151, c15, r64, etc.)
@@ -187,22 +197,31 @@ def query_table_xlsx(
     Returns:
         Contenu XLSX en bytes
     """
-    sql = f"SELECT * FROM {SCHEMA}.flux_{table_name}"
-    if filters:
-        conditions = [f"{col} = '{val}'" for col, val in filters.items()]
-        sql += f" WHERE {' AND '.join(conditions)}"
-    sql += f" LIMIT {limit}"
+    from electricore.api.serializers import xlsx_multi_sheet
 
-    with _connect_readonly() as conn:
-        df = conn.execute(sql).pl()
+    df = _query_table_df(table_name, filters, limit)
+    return xlsx_multi_sheet({table_name: df})
 
-    import xlsxwriter
 
-    buf = io.BytesIO()
-    wb = xlsxwriter.Workbook(buf, {"remove_timezone": True})
-    df.write_excel(workbook=wb, worksheet=table_name)
-    wb.close()
-    return buf.getvalue()
+def query_table_arrow(
+    table_name: str,
+    filters: dict | None = None,
+    limit: int = 1_000_000,
+) -> bytes:
+    """Retourne les données d'une table flux au format Arrow IPC (bytes).
+
+    Args:
+        table_name: Nom de la table (r151, c15, r64, etc.)
+        filters: Dict de filtres {colonne: valeur}
+        limit: Nombre max de lignes (défaut 1 000 000)
+
+    Returns:
+        Flux Arrow IPC en bytes, re-lisible via `pl.read_ipc_stream(BytesIO(...))`.
+    """
+    from electricore.api.serializers import arrow_stream
+
+    df = _query_table_df(table_name, filters, limit)
+    return arrow_stream(df)
 
 
 _ENTREES = ("PMES", "MES", "CFNE")
@@ -210,18 +229,13 @@ _SORTIES = ("RES", "CFNS")
 
 
 def _query_c15_xlsx(codes: tuple[str, ...], worksheet: str, limit: int) -> bytes:
+    from electricore.api.serializers import xlsx_multi_sheet
+
     placeholders = ", ".join(f"'{c}'" for c in codes)
     sql = f"SELECT * FROM {SCHEMA}.flux_c15 WHERE evenement_declencheur IN ({placeholders}) LIMIT {limit}"
     with _connect_readonly() as conn:
         df = conn.execute(sql).pl()
-
-    import xlsxwriter
-
-    buf = io.BytesIO()
-    wb = xlsxwriter.Workbook(buf, {"remove_timezone": True})
-    df.write_excel(workbook=wb, worksheet=worksheet)
-    wb.close()
-    return buf.getvalue()
+    return xlsx_multi_sheet({worksheet: df})
 
 
 def query_entrees_xlsx(limit: int = 10000) -> bytes:

--- a/electricore/client/__init__.py
+++ b/electricore/client/__init__.py
@@ -35,6 +35,32 @@ class ElectricoreClient:
         response.raise_for_status()
         return pl.read_ipc_stream(io.BytesIO(response.content))
 
+    def flux(
+        self,
+        table_name: str,
+        *,
+        prm: str | None = None,
+        limit: int = 1_000_000,
+    ) -> pl.DataFrame:
+        """Récupère le contenu brut d'un flux Enedis (c15, r151, f15, etc.) en Polars.
+
+        Sert d'équivalent HTTP des fonctions `c15()`, `r151()`, `f15()` du
+        `DuckDBQuery` — pour les notebooks distants qui n'ont pas accès local
+        à la base DuckDB (cf. ADR-0009).
+
+        Args:
+            table_name: Nom de la table flux (`c15`, `r151`, `r15`, `f15_detail`, etc.).
+            prm: Filtre optionnel sur la colonne `pdl`.
+            limit: Nombre maximum de lignes (défaut 1 000 000, max serveur 10 000 000).
+
+        Returns:
+            `pl.DataFrame` typé (timezones préservées).
+        """
+        params: dict[str, str | int] = {"limit": limit}
+        if prm:
+            params["prm"] = prm
+        return self._get_arrow(f"/flux/{table_name}/arrow", params)
+
     def facturation(self, mois: str | None = None) -> pl.DataFrame:
         """Récupère `lignes_facture_rapprochees` pour le mois donné.
 

--- a/notebooks/accise_et_cta.py
+++ b/notebooks/accise_et_cta.py
@@ -4,306 +4,145 @@ __generated_with = "0.21.1"
 app = marimo.App(width="medium")
 
 with app.setup(hide_code=True):
-    import marimo as mo
-    import polars as pl
+    import os
     import sys
     from pathlib import Path
-    from datetime import datetime, timezone, date
-    import time
-    import calendar
-    from typing import Dict, List, Optional, Tuple
 
-    # Ajouter le chemin du projet
+    import httpx
+    import marimo as mo
+    import polars as pl
+
     project_root = Path.cwd()
     if str(project_root) not in sys.path:
         sys.path.append(str(project_root))
 
-    # Imports des loaders DuckDB
-    from electricore.core.loaders import (
-        c15, releves_harmonises
-    )
-    from electricore.core.pipelines.orchestration import (
-        facturation
-    )
-    from electricore.core.pipelines.facturation import (
-        expr_calculer_trimestre
-    )
+    from electricore.client import ElectricoreClient
 
-    # Import connecteur Odoo
-    from electricore.core.loaders import (
-        OdooReader,
-        query,
-        commandes_lignes
-    )
-
-    # Import pipeline Accise et CTA
-    from electricore.core.pipelines.accise import pipeline_accise
-    from electricore.core.pipelines.cta import pipeline_cta
-
-    # Config Odoo centralisée depuis .env
-    from electricore.config import charger_config_odoo
+    # Client HTTP vers l'API electricore (cf. ADR-0009 — les notebooks
+    # consomment l'API, pas la base DuckDB locale).
+    _api_url = os.getenv("ELECTRICORE_API_URL", "https://electricore.localhost")
+    _api_key = os.getenv("ELECTRICORE_API_KEY") or os.getenv("API_KEYS", "").split(",")[0].strip()
+    _http_client = httpx.Client(verify=False, timeout=httpx.Timeout(30.0, read=300.0))
+    client = ElectricoreClient(url=_api_url, api_key=_api_key, http_client=_http_client)
 
 
 @app.cell(hide_code=True)
 def _():
-    """Configuration Odoo depuis .env"""
-    try:
-        config = charger_config_odoo()
-        _msg = mo.md(f"""
-        **Configuration Odoo chargée depuis `.env`**
-
-        - URL: `{config.get('url', 'NON CONFIGURÉ')}`
-        - Base: `{config.get('db', 'NON CONFIGURÉ')}`
-        - Utilisateur: `{config.get('username', 'NON CONFIGURÉ')}`
-        - Mot de passe: `{'***' if config.get('password') else 'NON CONFIGURÉ'}`
-        """)
-    except ValueError as e:
-        config = {}
-        _msg = mo.md(f"""
-        ⚠️ **Configuration Odoo non trouvée**
-
-        {e}
-
-        Créez le fichier `.env` à la racine du projet avec :
-        ```
-        ODOO_URL=https://votre-instance.odoo.com
-        ODOO_DB=votre_database
-        ODOO_USERNAME=votre_username
-        ODOO_PASSWORD=votre_password
-        ```
-        """)
-    _msg
-    return (config,)
-
-
-@app.cell
-def _():
     mo.md(r"""
-    # CTA
+    # Accise & CTA — calcul trimestriel
+
+    Les calculs sont délégués aux endpoints `/taxes/cta/arrow` et `/taxes/accise/arrow`
+    de l'API electricore (cf. ADR-0009). Le notebook se contente de récupérer les
+    DataFrames, de sélectionner un trimestre et d'afficher les agrégats.
+
+    **Note** — depuis v1.7, les PDLs sans `sale.order` Odoo ne sont plus inclus
+    dans la CTA. Si le périmètre de calcul doit dépasser le portefeuille Odoo,
+    un endpoint dédié sera nécessaire.
     """)
     return
 
 
 @app.cell(hide_code=True)
 def _():
-    mo.md(r"""
-    ## Récupération du périmètre PDL depuis Odoo
+    """Charge les CTA mensuelles (tous trimestres) et l'accise détaillée."""
+    df_cta_all = client.cta()
+    df_accise_all = client.accise()
+    mo.md(f"""
+    - CTA chargée : **{len(df_cta_all)} lignes mensuelles**, **{df_cta_all['pdl'].n_unique()} PDLs**
+    - Accise chargée : **{len(df_accise_all)} lignes mensuelles**, **{df_accise_all['pdl'].n_unique()} PDLs**
     """)
-    return
+    return df_accise_all, df_cta_all
 
 
 @app.cell(hide_code=True)
-def load_odoo_perimeter(config):
-    """Récupération du périmètre de PDL depuis Odoo"""
-
-    mo.md("## 🏢 Récupération du périmètre PDL (Odoo)")
-
-    try:
-        print("🔄 Connexion à Odoo...")
-        with OdooReader(config=config) as odoo:
-            df_pdl_odoo = (
-                query(odoo, 'sale.order',
-                    domain=[('x_pdl', '!=', False)],
-                    fields=['name', 'x_pdl', 'partner_id'])
-                .filter(pl.col('x_pdl').is_not_null())
-                .select([
-                    pl.col('x_pdl').str.strip_chars().alias('pdl'),
-                    pl.col('name').alias('order_name')
-                ])
-                .collect()
-                # .with_columns(pl.lit('EDN').alias('marque'))
-                .unique('pdl')
-            )
-
-        nb_pdl_odoo = len(df_pdl_odoo)
-        print(f"✅ {nb_pdl_odoo} PDL récupérés depuis Odoo")
-
-        if nb_pdl_odoo > 0:
-            print(f"📊 Exemples PDL: {df_pdl_odoo.select('pdl').to_series().to_list()[:5]}")
-
-    except Exception as e:
-        print(f"⚠️ Erreur connexion Odoo: {e}")
-        print("📄 Continuons sans filtre Odoo (tous les PDL F15 seront analysés)")
-        df_pdl_odoo = pl.DataFrame({'pdl': [], 'order_name': [], 'marque': []}, schema={'pdl': pl.Utf8, 'order_name': pl.Utf8, 'marque': pl.Utf8})
-
-    # Ajouter des PDL supplémentaires
-    pdl_supplementaires = pl.DataFrame({
-        'pdl': ['14295224261882', '50070117855585', '50000508594660'],
-        'order_name': ['PDL_MANUAL_1', 'PDL_MANUAL_2', 'PDL_MANUAL_3'],
-        # 'marque': ['EDN', 'EDN', 'EDN']
-    })
-    df_pdl_odoo = pl.concat([df_pdl_odoo, pdl_supplementaires]).unique('pdl')
-    return (df_pdl_odoo,)
-
-
-@app.cell(hide_code=True)
-def _():
-    mo.md(r"""
-    ## Chargement des données pour le pipeline de calcul
-    """)
-    return
-
-
-@app.cell
-def _():
-    lf_historique = c15().lazy()
-    lf_releves = releves_harmonises().lazy()
-    return lf_historique, lf_releves
-
-
-@app.cell
-def _():
-    mo.md(r"""
-    ## Pipeline facturation
-    """)
-    return
-
-
-@app.cell
-def _(lf_historique, lf_releves):
-    _,_,_,df_facturation = facturation(historique=lf_historique, releves=lf_releves)
-    df_facturation
-    return (df_facturation,)
-
-
-@app.cell(hide_code=True)
-def _(df_facturation, df_pdl_odoo):
-    df_cta = (
-        df_facturation
-        .join(df_pdl_odoo, on='pdl', how='inner')
-        .with_columns(
-            expr_calculer_trimestre().alias('trimestre')
-        )
-    )
-    df_cta
-    return (df_cta,)
-
-
-@app.cell
-def _():
-    mo.md(r"""
-    ## 📊 Sélection du trimestre
-
-    Les taux CTA sont chargés automatiquement depuis `electricore/config/cta_rules.csv`
-    et appliqués au niveau mensuel. Un changement de taux en cours de trimestre
-    (décret CRE) est donc géré automatiquement.
-    """)
-    return
-
-
-@app.cell(hide_code=True)
-def _(df_cta):
-    # Récupérer la liste des trimestres disponibles (triés)
-    trimestres_disponibles = sorted(df_cta['trimestre'].unique().to_list())
-
-    # Dropdown pour sélectionner le trimestre
+def _(df_accise_all, df_cta_all):
+    """Sélecteur de trimestre — union des trimestres présents dans les deux flux."""
+    trimestres_dispo = sorted(set(df_cta_all["trimestre"].unique().to_list()) | set(df_accise_all["trimestre"].unique().to_list()))
     trimestre_selectionne = mo.ui.dropdown(
-        options=trimestres_disponibles,
-        value=trimestres_disponibles[-1] if trimestres_disponibles else None,
-        label="Sélectionner le trimestre"
+        options=trimestres_dispo,
+        value=trimestres_dispo[-1] if trimestres_dispo else None,
+        label="Sélectionner le trimestre",
     )
-
     trimestre_selectionne
     return (trimestre_selectionne,)
 
 
 @app.cell(hide_code=True)
-def _(df_facturation, df_pdl_odoo, trimestre_selectionne):
-    df_detail_cta = pipeline_cta(
-        df_facturation=df_facturation,
-        df_pdl=df_pdl_odoo,
-        trimestre=trimestre_selectionne.value,
+def _(df_cta_all, trimestre_selectionne):
+    """Vue CTA agrégée par PDL pour le trimestre sélectionné."""
+    df_cta_trimestre = df_cta_all.filter(pl.col("trimestre") == trimestre_selectionne.value)
+
+    df_detail_cta = (
+        df_cta_trimestre.lazy()
+        .group_by("pdl")
+        .agg(
+            [
+                pl.col("order_name").first(),
+                pl.col("turpe_fixe_eur").sum().round(2).alias("turpe_fixe_total"),
+                pl.col("cta_eur").sum().round(2).alias("cta"),
+                pl.col("taux_cta_pct").unique().sort().alias("taux_cta_appliques"),
+            ]
+        )
+        .sort("cta", descending=True)
+        .collect()
     )
 
-    turpe_fixe_total = df_detail_cta['turpe_fixe_total'].sum()
-    cta_total = df_detail_cta['cta'].sum()
-    nb_pdl = df_detail_cta['pdl'].n_unique()
+    turpe_fixe_total = df_detail_cta["turpe_fixe_total"].sum()
+    cta_total = df_detail_cta["cta"].sum()
+    nb_pdl = df_detail_cta["pdl"].n_unique()
+    taux_distincts = sorted({t for lst in df_detail_cta["taux_cta_appliques"].to_list() for t in lst})
+    taux_str = " + ".join(f"{t:.2f} %" for t in taux_distincts) if taux_distincts else "—"
 
-    # Agrège les taux rencontrés dans la période pour affichage
-    taux_distincts = sorted({t for lst in df_detail_cta['taux_cta_appliques'].to_list() for t in lst})
-    taux_str = ' + '.join(f'{t:.2f} %' for t in taux_distincts) if taux_distincts else '—'
+    mo.vstack([
+        mo.md(f"""
+        ## 💰 CTA — {trimestre_selectionne.value}
 
-    _result = mo.md(f"""
-    ## 💰 Résultat CTA - {trimestre_selectionne.value}
+        - **Nombre de PDL** : {nb_pdl}
+        - **TURPE fixe total** : {turpe_fixe_total:,.2f} €
+        - **Taux CTA appliqués** : {taux_str}
+        - **CTA à facturer** : **{cta_total:,.2f} €**
 
-    - **Nombre de PDL** : {nb_pdl}
-    - **TURPE fixe total** : {turpe_fixe_total:,.2f} €
-    - **Taux CTA appliqués** : {taux_str}
-    - **CTA à facturer** : **{cta_total:,.2f} €**
-
-    ---
-
-    ### 📋 Détail par PDL
-    """)
-
-    mo.vstack([_result, df_detail_cta])
+        ### 📋 Détail par PDL
+        """),
+        df_detail_cta,
+    ])
     return
-
-
-@app.cell
-def _():
-    mo.md(r"""
-    # Accise
-    """)
-    return
-
-
-@app.cell
-def _(config):
-    with OdooReader(config=config) as _odoo:
-        df_lignes = commandes_lignes(_odoo).collect()
-    return (df_lignes,)
-
-
-@app.cell
-def _(df_lignes):
-    # Pipeline complet : agrégation + calcul Accise
-    df_accise = pipeline_accise(df_lignes.lazy())
-    df_accise
-    return (df_accise,)
 
 
 @app.cell(hide_code=True)
-def _(df_accise, trimestre_selectionne):
-    # Filtrer sur le trimestre sélectionné
-    df_accise_trimestre = df_accise.filter(pl.col('trimestre') == trimestre_selectionne.value)
+def _(df_accise_all, trimestre_selectionne):
+    """Vue Accise par taux + détail pour le trimestre sélectionné."""
+    df_accise_trimestre = df_accise_all.filter(pl.col("trimestre") == trimestre_selectionne.value)
 
-    # Grouper par taux pour voir la répartition
     df_par_taux = (
-        df_accise_trimestre
-        .group_by('taux_accise_eur_mwh')
-        .agg([
-            pl.col('energie_mwh').sum().round(3),
-            pl.col('accise_eur').sum().round(2),
-            pl.col('pdl').n_unique().alias('nb_pdl')
-        ])
-        .sort('taux_accise_eur_mwh', descending=True)
+        df_accise_trimestre.group_by("taux_accise_eur_mwh")
+        .agg(
+            [
+                pl.col("energie_mwh").sum().round(3),
+                pl.col("accise_eur").sum().round(2),
+                pl.col("pdl").n_unique().alias("nb_pdl"),
+            ]
+        )
+        .sort("taux_accise_eur_mwh", descending=True)
     )
 
-    # Totaux
-    accise_total = df_accise_trimestre['accise_eur'].sum()
-    energie_totale_mwh = df_accise_trimestre['energie_mwh'].sum()
-    nb_pdl_total = df_accise_trimestre['pdl'].n_unique()
-
-    _result = mo.md(f"""
-    ## ⚡ Résultat Accise - {trimestre_selectionne.value}
-
-    - **Nombre de PDL** : {nb_pdl_total}
-    - **Énergie totale** : {energie_totale_mwh:,.2f} MWh
-    - **Accise totale** : **{accise_total:,.2f} €**
-
-    ### 📊 Répartition par taux (changements réglementaires)
-    """)
-
-    # Détail par PDL et mois
-    df_detail_accise = df_accise_trimestre.sort(['pdl', 'mois_consommation'])
+    accise_total = df_accise_trimestre["accise_eur"].sum()
+    energie_totale = df_accise_trimestre["energie_mwh"].sum()
+    nb_pdl_total = df_accise_trimestre["pdl"].n_unique()
+    df_detail_accise = df_accise_trimestre.sort(["pdl", "mois_consommation"])
 
     mo.vstack([
-        _result,
+        mo.md(f"""
+        ## ⚡ Accise — {trimestre_selectionne.value}
+
+        - **Nombre de PDL** : {nb_pdl_total}
+        - **Énergie totale** : {energie_totale:,.2f} MWh
+        - **Accise totale** : **{accise_total:,.2f} €**
+        """),
         mo.md("#### Vue agrégée par taux"),
         df_par_taux,
         mo.md("#### Vue détaillée par PDL et mois"),
-        df_detail_accise
+        df_detail_accise,
     ])
     return
 

--- a/notebooks/demos/odoo_exploration.py
+++ b/notebooks/demos/odoo_exploration.py
@@ -15,8 +15,7 @@ with app.setup:
     if str(project_root) not in sys.path:
         sys.path.append(str(project_root))
 
-    from electricore.core.loaders import OdooReader
-    from electricore.core.loaders.odoo import query, commandes, lignes_factures, commandes_lignes
+    from electricore.integrations.odoo import OdooReader, commandes, commandes_lignes, lignes_factures, query
 
     # Configuration du logging
     logging.basicConfig(level=logging.INFO)

--- a/notebooks/facturation.py
+++ b/notebooks/facturation.py
@@ -21,8 +21,7 @@ with app.setup:
     from datetime import date
 
     from electricore.client import ElectricoreClient
-    from electricore.core.loaders import OdooReader
-    from electricore.core.loaders.odoo import lignes_factures_du_mois
+    from electricore.integrations.odoo import OdooReader, lignes_factures_du_mois
 
     # Configuration du logging
     logging.basicConfig(level=logging.INFO)
@@ -240,7 +239,7 @@ def _():
 
 @app.cell
 def _(fact_mois, filtre_a_injecter):
-    from electricore.core.writers import OdooWriter
+    from electricore.integrations.odoo import OdooWriter
 
     _a_injecter = fact_mois.filter(filtre_a_injecter)
     _sans_match = fact_mois.filter(pl.col("quantite_enedis").is_null())

--- a/notebooks/injection_rsc.py
+++ b/notebooks/injection_rsc.py
@@ -14,8 +14,12 @@ with app.setup:
     if str(project_root) not in sys.path:
         sys.path.append(str(project_root))
 
-    from electricore.core.loaders import OdooReader, c15
-    from electricore.core.loaders.odoo import query
+    import os
+
+    import httpx
+
+    from electricore.client import ElectricoreClient
+    from electricore.integrations.odoo import OdooReader, query
 
     logging.basicConfig(level=logging.INFO)
 
@@ -27,6 +31,13 @@ with app.setup:
     except ValueError as e:
         config = {}
         _msg = mo.md(f"⚠️ **Configuration Odoo manquante**\n\n{e}\n\nDéfinissez `ODOO_TEST_*` dans `.env`.")
+
+    # Client HTTP vers l'API electricore (cf. ADR-0009 : notebooks consomment l'API,
+    # pas la base DuckDB locale).
+    _api_url = os.getenv("ELECTRICORE_API_URL", "https://electricore.localhost")
+    _api_key = os.getenv("ELECTRICORE_API_KEY") or os.getenv("API_KEYS", "").split(",")[0].strip()
+    _http_client = httpx.Client(verify=False, timeout=httpx.Timeout(30.0, read=120.0))
+    client = ElectricoreClient(url=_api_url, api_key=_api_key, http_client=_http_client)
     _msg
 
 
@@ -56,11 +67,12 @@ def _():
 
 @app.cell(hide_code=True)
 def _():
+    # Lecture C15 via l'API (cf. ADR-0009). Le serveur retourne un DataFrame collecté ;
+    # on agrège ensuite localement.
     contrats_par_pdl = (
-        c15().lazy()
+        client.flux("c15")
         .group_by(["pdl", "ref_situation_contractuelle"])
         .agg(pl.col("date_evenement").min().alias("date_debut_contrat"))
-        .collect()
         # Supprimer la timezone pour compatibilité avec les dates Odoo
         .with_columns(pl.col("date_debut_contrat").dt.replace_time_zone(None))
         .sort(["pdl", "date_debut_contrat"])
@@ -186,7 +198,7 @@ def _():
 
 @app.cell
 def _(orders_avec_rsc):
-    from electricore.core.writers import OdooWriter
+    from electricore.integrations.odoo import OdooWriter
 
     _a_injecter = orders_avec_rsc.filter(pl.col("ref_situation_contractuelle").is_not_null())
     _sans_rsc   = orders_avec_rsc.filter(pl.col("ref_situation_contractuelle").is_null())

--- a/notebooks/validations/validation_orchestration.py
+++ b/notebooks/validations/validation_orchestration.py
@@ -23,7 +23,7 @@ with app.setup(hide_code=True):
     from electricore.core.loaders import f15, c15, r151, releves_harmonises, execute_custom_query
 
     from electricore.core.pipelines import facturation
-    from electricore.core.loaders import OdooReader
+    from electricore.integrations.odoo import OdooReader
 
 
 @app.cell(hide_code=True)

--- a/notebooks/validations/validation_turpe_f15.py
+++ b/notebooks/validations/validation_turpe_f15.py
@@ -28,7 +28,7 @@ with app.setup:
     from electricore.core.pipelines.historique import detecter_points_de_rupture, inserer_evenements_facturation
 
     # Import connecteur Odoo
-    from electricore.core.loaders import OdooReader
+    from electricore.integrations.odoo import OdooReader
 
 
 @app.cell(hide_code=True)

--- a/notebooks/validations/validation_turpe_variable.py
+++ b/notebooks/validations/validation_turpe_variable.py
@@ -29,7 +29,7 @@ with app.setup(hide_code=True):
     from electricore.core.pipelines.historique import detecter_points_de_rupture, inserer_evenements_facturation
 
     # Import connecteur Odoo
-    from electricore.core.loaders import OdooReader, query
+    from electricore.integrations.odoo import OdooReader, query
 
 
 @app.cell(hide_code=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "1.6.1"
+version = "1.7.0"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "1.7.0"
+version = "1.7.0rc1"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -108,6 +108,72 @@ def test_cta_round_trip_via_endpoint(monkeypatch):
     assert_frame_equal(df, df_attendu)
 
 
+def test_flux_round_trip_via_endpoint(monkeypatch):
+    """`client.flux(table_name)` round-trip un DataFrame servi par /flux/{name}/arrow."""
+    df_attendu = pl.DataFrame(
+        {
+            "pdl": ["12345678901234"],
+            "date_evenement": ["2025-01-15"],
+            "evenement_declencheur": ["MES"],
+        }
+    )
+
+    monkeypatch.setattr("electricore.api.services.duckdb_service.list_tables", lambda: ["c15"])
+    monkeypatch.setattr(
+        "electricore.api.services.duckdb_service.query_table_arrow",
+        lambda table_name, filters, limit: __import__(
+            "electricore.api.serializers", fromlist=["arrow_stream"]
+        ).arrow_stream(df_attendu),
+    )
+
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    try:
+        client = ElectricoreClient(url="http://testserver", api_key="key", http_client=TestClient(app))
+        df = client.flux("c15")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert_frame_equal(df, df_attendu)
+
+
+def test_flux_propage_filtre_prm_a_lendpoint(monkeypatch):
+    """`client.flux(table, prm=...)` propage le PRM en query string."""
+    captures: list[tuple[str, dict | None, int]] = []
+
+    def _capture(table_name: str, filters: dict | None, limit: int) -> bytes:
+        captures.append((table_name, filters, limit))
+        return __import__("electricore.api.serializers", fromlist=["arrow_stream"]).arrow_stream(
+            pl.DataFrame({"x": [1]})
+        )
+
+    monkeypatch.setattr("electricore.api.services.duckdb_service.list_tables", lambda: ["r151"])
+    monkeypatch.setattr("electricore.api.services.duckdb_service.query_table_arrow", _capture)
+
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    try:
+        client = ElectricoreClient(url="http://testserver", api_key="key", http_client=TestClient(app))
+        client.flux("r151", prm="12345678901234")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert captures == [("r151", {"pdl": "12345678901234"}, 1_000_000)]
+
+
+def test_flux_renvoie_404_pour_table_inconnue(monkeypatch):
+    """Le client propage une `HTTPStatusError` quand la table n'existe pas."""
+    monkeypatch.setattr("electricore.api.services.duckdb_service.list_tables", lambda: ["c15"])
+
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    try:
+        client = ElectricoreClient(url="http://testserver", api_key="key", http_client=TestClient(app))
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            client.flux("inexistante")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert exc_info.value.response.status_code == 404
+
+
 def test_facturation_envoie_la_cle_api_dans_le_header():
     """Le header `X-API-Key` est positionné par le client."""
     headers_recus: list[str] = []

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "1.6.1"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "1.7.0"
+version = "1.7.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Summary
- **v1.7** — les notebooks de production (`accise_et_cta`, `facturation`, `injection_rsc`) consomment désormais l'API REST via `ElectricoreClient` (cf. [ADR-0009](docs/adr/0009-architecture-api-centrique.md)) au lieu de lire localement la base DuckDB et d'orchestrer les pipelines.
- Nouvel endpoint `GET /flux/{name}/arrow` + méthode `ElectricoreClient.flux(name, prm, limit)` — équivalent HTTP de `DuckDBQuery.c15()` / `.r151()` / etc. Arrow IPC, typage et timezones préservés, limit serveur 10M, défaut 1M.
- Mise à jour mécanique des imports Odoo dans les démos / validations vers `electricore.integrations.odoo`. Les imports purement ERP-agnostiques (`c15`, `r151`, `f15`, etc.) restent intacts.
- 3 nouveaux tests client (round-trip, propagation PRM, 404). 372 passants au total (+3 vs main), 0 régression.

## Test plan
- [ ] `uv run --group test pytest -q` → attendu **372 passed, 35 skipped, 0 failed**
- [ ] `uvx ruff format --check electricore/ tests/` et `uvx ruff check electricore/ tests/` → propre
- [ ] `uv run marimo check notebooks/` → 0 error
- [ ] Smoke-test du nouvel endpoint : \`curl -H \"X-API-Key: ...\" \"\$URL/flux/c15/arrow?limit=10\"\` retourne un flux Arrow IPC valide
- [ ] Smoke-test des 3 notebooks de prod en local (au moins l'import + le rendu marimo de la première cellule)
- [ ] Vérifier que \`client.flux(\"c15\")\` dans un notebook retourne bien les mêmes données que \`c15().collect()\`

## Notes de conception
- **Périmètre CTA réduit dans \`accise_et_cta.py\`** : la version précédente ajoutait manuellement 3 PDLs (\`PDL_MANUAL_*\`) hors Odoo. Avec \`client.cta()\`, ces PDLs disparaissent — l'endpoint filtre par \`sale.order\` existants. À reprendre via un endpoint dédié si le portefeuille de calcul doit dépasser Odoo (probablement scope d'une v1.8).
- **\`injection_rsc.py\`** : c15 via HTTP, Odoo (read + write) reste local — conforme ADR-0012 (l'API est read-only sur Odoo, les écritures restent à l'opérateur).
- **\`facturation.py\`** : déjà partiellement migré (utilisait déjà \`client.facturation()\`). Cette PR finit le ménage des 3 imports Odoo résiduels.
- **\`duckdb_service\`** : refactor au passage — \`query_table_xlsx\` et \`query_table_arrow\` partagent un helper \`_query_table_df\` et utilisent \`api/serializers\` plutôt que d'inliner \`xlsxwriter\` / \`df.write_ipc_stream\`.

Bump version **1.6.1 → 1.7.0** (\`pyproject.toml\` + \`uv.lock\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)