### PR TITLE
refactor(duckdb): bake retry-on-lock into DuckDBQuery (#52)

### DIFF
--- a/electricore/api/services/duckdb_service.py
+++ b/electricore/api/services/duckdb_service.py
@@ -5,76 +5,17 @@ Fonctions pures pour lire les tables de flux Enedis.
 
 import logging
 import os
-import time
-from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
 import duckdb
 
+from electricore.core.loaders.duckdb import duckdb_readonly_conn
+
 logger = logging.getLogger(__name__)
 
 DB_PATH = Path(os.getenv("DUCKDB_PATH", "electricore/etl/flux_enedis_pipeline.duckdb"))
 SCHEMA = "flux_enedis"
-
-# Politique de retry lorsque le writer ETL détient le verrou exclusif.
-# 3 essais × 1s couvrent les fenêtres typiques de checkpoint DLT.
-_LOCK_RETRY_ATTEMPTS = 3
-_LOCK_RETRY_BACKOFF_S = 1.0
-
-
-def _is_lock_error(exc: duckdb.IOException) -> bool:
-    """
-    Discrimine un verrou (récupérable par retry) d'une condition non récupérable
-    comme un fichier inexistant.
-
-    DuckDB ne propose pas de hiérarchie d'exceptions plus fine que `IOException`,
-    on inspecte donc le message. Les marqueurs typiques :
-      - verrou exclusif : "Could not set lock", "Conflicting lock"
-      - fichier absent  : "does not exist"
-    """
-    msg = str(exc).lower()
-    if "does not exist" in msg or "no such file" in msg:
-        return False
-    return True
-
-
-@contextmanager
-def _connect_readonly():
-    """
-    Ouvre une connexion DuckDB read-only en réessayant si le fichier est verrouillé.
-
-    Le writer ETL (autre conteneur) peut prendre un lock exclusif pendant un
-    checkpoint ou pendant `EXPORT DATABASE`. On retente brièvement avant de
-    propager l'erreur, pour absorber les pics courts sans casser les requêtes API.
-    On ne réessaie PAS si l'erreur est "fichier introuvable" — c'est non
-    récupérable et un retry ne ferait que masquer l'erreur jusqu'au timeout.
-    """
-    last_exc: Exception | None = None
-    for attempt in range(_LOCK_RETRY_ATTEMPTS):
-        try:
-            conn = duckdb.connect(str(DB_PATH), read_only=True)
-        except duckdb.IOException as exc:
-            last_exc = exc
-            if not _is_lock_error(exc):
-                raise
-            if attempt < _LOCK_RETRY_ATTEMPTS - 1:
-                logger.warning(
-                    "DuckDB verrouillé (tentative %d/%d), nouvelle tentative dans %.1fs",
-                    attempt + 1,
-                    _LOCK_RETRY_ATTEMPTS,
-                    _LOCK_RETRY_BACKOFF_S,
-                )
-                time.sleep(_LOCK_RETRY_BACKOFF_S)
-                continue
-            raise
-        try:
-            yield conn
-        finally:
-            conn.close()
-        return
-    # Ne devrait jamais être atteint (le `raise` ci-dessus le couvre)
-    raise last_exc if last_exc else RuntimeError("Échec ouverture DuckDB")
 
 
 def get_freshness() -> dict:
@@ -100,7 +41,7 @@ def get_freshness() -> dict:
         return payload
 
     try:
-        with _connect_readonly() as conn:
+        with duckdb_readonly_conn(DB_PATH) as conn:
             rows = conn.execute(
                 "SELECT table_name, estimated_size FROM duckdb_tables() "
                 "WHERE schema_name = ? AND table_name LIKE 'flux_%' "
@@ -136,7 +77,7 @@ def query_table(table_name: str, filters: dict | None = None, limit: int = 100, 
 
     sql += f" LIMIT {limit} OFFSET {offset}"
 
-    with _connect_readonly() as conn:
+    with duckdb_readonly_conn(DB_PATH) as conn:
         result = conn.execute(sql)
         columns = [desc[0] for desc in result.description]
         return [dict(zip(columns, row, strict=False)) for row in result.fetchall()]
@@ -152,7 +93,7 @@ def get_table_info(table_name: str) -> dict:
     Returns:
         Dict avec table, count, columns
     """
-    with _connect_readonly() as conn:
+    with duckdb_readonly_conn(DB_PATH) as conn:
         # Nombre de lignes
         count = conn.execute(f"SELECT COUNT(*) FROM {SCHEMA}.flux_{table_name}").fetchone()[0]
 
@@ -178,7 +119,7 @@ def _query_table_df(table_name: str, filters: dict | None = None, limit: int = 1
         sql += f" WHERE {' AND '.join(conditions)}"
     sql += f" LIMIT {limit}"
 
-    with _connect_readonly() as conn:
+    with duckdb_readonly_conn(DB_PATH) as conn:
         return conn.execute(sql).pl()
 
 
@@ -233,7 +174,7 @@ def _query_c15_xlsx(codes: tuple[str, ...], worksheet: str, limit: int) -> bytes
 
     placeholders = ", ".join(f"'{c}'" for c in codes)
     sql = f"SELECT * FROM {SCHEMA}.flux_c15 WHERE evenement_declencheur IN ({placeholders}) LIMIT {limit}"
-    with _connect_readonly() as conn:
+    with duckdb_readonly_conn(DB_PATH) as conn:
         df = conn.execute(sql).pl()
     return xlsx_multi_sheet({worksheet: df})
 
@@ -255,7 +196,7 @@ def list_tables() -> list[str]:
     Returns:
         Liste des noms de tables (sans préfixe flux_)
     """
-    with _connect_readonly() as conn:
+    with duckdb_readonly_conn(DB_PATH) as conn:
         tables = conn.execute(f"""
             SELECT table_name 
             FROM information_schema.tables 

--- a/electricore/core/loaders/duckdb/__init__.py
+++ b/electricore/core/loaders/duckdb/__init__.py
@@ -22,7 +22,7 @@ API publique :
 """
 
 # Imports internes
-from .config import DuckDBConfig, duckdb_connection
+from .config import DuckDBConfig, duckdb_readonly_conn
 from .helpers import (
     # API fluide
     c15,
@@ -48,7 +48,7 @@ from .query import DuckDBQuery
 __all__ = [
     # Configuration
     "DuckDBConfig",
-    "duckdb_connection",
+    "duckdb_readonly_conn",
     # Query builder
     "DuckDBQuery",
     # API fluide (recommandée)

--- a/electricore/core/loaders/duckdb/config.py
+++ b/electricore/core/loaders/duckdb/config.py
@@ -5,12 +5,21 @@ Ce module fournit les primitives de configuration et de connexion
 pour l'accès aux bases DuckDB dans un style fonctionnel.
 """
 
+import logging
 import os
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
 import duckdb
+
+logger = logging.getLogger(__name__)
+
+# Politique de retry lorsque le writer ETL détient le verrou exclusif.
+# 3 essais × 1s couvrent les fenêtres typiques de checkpoint DLT.
+_LOCK_RETRY_ATTEMPTS = 3
+_LOCK_RETRY_BACKOFF_S = 1.0
 
 
 class DuckDBConfig:
@@ -41,21 +50,41 @@ class DuckDBConfig:
         }
 
 
+def _is_lock_error(exc: duckdb.IOException) -> bool:
+    """Discrimine un verrou (récupérable) d'une erreur non récupérable.
+
+    DuckDB n'expose qu'`IOException` ; on inspecte le message.
+    """
+    msg = str(exc).lower()
+    if "does not exist" in msg or "no such file" in msg:
+        return False
+    return True
+
+
 @contextmanager
-def duckdb_connection(database_path: str | Path) -> Iterator[duckdb.DuckDBPyConnection]:
-    """
-    Context manager pour connexions DuckDB.
+def duckdb_readonly_conn(database_path: str | Path) -> Iterator[duckdb.DuckDBPyConnection]:
+    """Ouvre une connexion DuckDB read-only avec retry sur lock exclusif.
 
-    Args:
-        database_path: Chemin vers la base DuckDB
-
-    Yields:
-        duckdb.DuckDBPyConnection: Connexion active
+    Le writer ETL peut prendre un lock pendant un checkpoint DLT ou un
+    `EXPORT DATABASE` ; on retente brièvement pour absorber ces pics sans
+    casser les lectures API/notebooks. Pas de retry sur fichier introuvable.
     """
-    conn = None
-    try:
-        conn = duckdb.connect(str(database_path), read_only=True)
-        yield conn
-    finally:
-        if conn:
+    for attempt in range(_LOCK_RETRY_ATTEMPTS):
+        try:
+            conn = duckdb.connect(str(database_path), read_only=True)
+        except duckdb.IOException as exc:
+            if not _is_lock_error(exc) or attempt == _LOCK_RETRY_ATTEMPTS - 1:
+                raise
+            logger.warning(
+                "DuckDB verrouillé (tentative %d/%d), nouvelle tentative dans %.1fs",
+                attempt + 1,
+                _LOCK_RETRY_ATTEMPTS,
+                _LOCK_RETRY_BACKOFF_S,
+            )
+            time.sleep(_LOCK_RETRY_BACKOFF_S)
+            continue
+        try:
+            yield conn
+        finally:
             conn.close()
+        return

--- a/electricore/core/loaders/duckdb/helpers.py
+++ b/electricore/core/loaders/duckdb/helpers.py
@@ -16,7 +16,7 @@ import polars as pl
 # Imports de validation
 from electricore.core.models.releve_index import RelevéIndex
 
-from .config import DuckDBConfig, duckdb_connection
+from .config import DuckDBConfig, duckdb_readonly_conn
 from .query import DuckDBQuery, QueryConfig, make_query
 from .registry import FLUX_CONFIGS
 from .sql import BASE_QUERY_RELEVES_HARMONISES, BASE_QUERY_RELEVES_UNIFIES, FluxSchema
@@ -282,7 +282,7 @@ def get_available_tables(database_path: str | Path | None = None) -> list[str]:
     """
     config = DuckDBConfig(database_path)
 
-    with duckdb_connection(config.database_path) as conn:
+    with duckdb_readonly_conn(config.database_path) as conn:
         result = conn.execute("""
             SELECT table_schema, table_name
             FROM information_schema.tables
@@ -309,7 +309,7 @@ def execute_custom_query(
     """
     config = DuckDBConfig(database_path)
 
-    with duckdb_connection(config.database_path) as conn:
+    with duckdb_readonly_conn(config.database_path) as conn:
         if lazy:
             return pl.read_database(query=query, connection=conn).lazy()
         else:

--- a/electricore/core/loaders/duckdb/query.py
+++ b/electricore/core/loaders/duckdb/query.py
@@ -16,7 +16,7 @@ from typing import Any
 import pandera.polars as pa
 import polars as pl
 
-from .config import DuckDBConfig, duckdb_connection
+from .config import DuckDBConfig, duckdb_readonly_conn
 from .sql import FluxSchema, build_base_query
 
 # =============================================================================
@@ -230,7 +230,7 @@ class DuckDBQuery:
         final_query = self._build_final_query()
 
         # Connexion et exécution (impure - IO)
-        with duckdb_connection(config.database_path) as conn:
+        with duckdb_readonly_conn(config.database_path) as conn:
             lazy_frame = conn.execute(final_query).pl().lazy()
 
         # Application des transformations (pure)

--- a/notebooks/surveillance_perimetre.py
+++ b/notebooks/surveillance_perimetre.py
@@ -14,7 +14,7 @@ with app.setup(hide_code=True):
     if str(project_root) not in sys.path:
         sys.path.append(str(project_root))
 
-    from electricore.core.loaders.duckdb import duckdb_connection, DuckDBConfig
+    from electricore.core.loaders.duckdb import duckdb_readonly_conn, DuckDBConfig
 
 
 @app.cell(hide_code=True)
@@ -33,7 +33,7 @@ def _():
 @app.cell
 def _():
     _config = DuckDBConfig()
-    with duckdb_connection(_config.database_path) as _conn:
+    with duckdb_readonly_conn(_config.database_path) as _conn:
         _entrees = _conn.execute("""
             SELECT pdl, ref_situation_contractuelle, MIN(date_evenement)::DATE AS date_entree
             FROM flux_enedis.flux_c15
@@ -80,7 +80,7 @@ def _(periodes):
 @app.cell
 def _():
     _config = DuckDBConfig()
-    with duckdb_connection(_config.database_path) as _conn:
+    with duckdb_readonly_conn(_config.database_path) as _conn:
         r64_mois = _conn.execute("""
             SELECT DISTINCT pdl, DATE_TRUNC('month', date_releve::DATE)::DATE AS debut_mois
             FROM flux_enedis.flux_r64

--- a/tests/core/loaders/test_duckdb_loader.py
+++ b/tests/core/loaders/test_duckdb_loader.py
@@ -16,7 +16,7 @@ from electricore.core.loaders.duckdb import (
     DuckDBConfig,
     DuckDBQuery,
     c15,
-    duckdb_connection,
+    duckdb_readonly_conn,
     execute_custom_query,
     get_available_tables,
     load_historique,
@@ -70,7 +70,7 @@ class TestDuckDBConnection:
         mock_conn = Mock()
         mock_connect.return_value = mock_conn
 
-        with duckdb_connection("test.duckdb") as conn:
+        with duckdb_readonly_conn("test.duckdb") as conn:
             assert conn == mock_conn
 
         # Vérifier que la connexion est fermée
@@ -83,7 +83,7 @@ class TestDuckDBConnection:
         mock_connect.return_value = mock_conn
 
         try:
-            with duckdb_connection("test.duckdb"):
+            with duckdb_readonly_conn("test.duckdb"):
                 raise Exception("Test error")
         except Exception:
             pass
@@ -319,7 +319,7 @@ class TestLoadFunctions:
 class TestUtilityFunctions:
     """Tests pour les fonctions utilitaires."""
 
-    @patch("electricore.core.loaders.duckdb.helpers.duckdb_connection")
+    @patch("electricore.core.loaders.duckdb.helpers.duckdb_readonly_conn")
     def test_get_available_tables(self, mock_conn_context):
         """Test de récupération des tables disponibles."""
         # Setup du mock
@@ -344,7 +344,7 @@ class TestUtilityFunctions:
             ORDER BY table_schema, table_name
         """)
 
-    @patch("electricore.core.loaders.duckdb.helpers.duckdb_connection")
+    @patch("electricore.core.loaders.duckdb.helpers.duckdb_readonly_conn")
     @patch("electricore.core.loaders.duckdb.helpers.pl.read_database")
     def test_execute_custom_query_lazy(self, mock_read_db, mock_conn_context):
         """Test d'exécution de requête personnalisée (lazy)."""
@@ -361,7 +361,7 @@ class TestUtilityFunctions:
         assert result == mock_lazy_frame
         mock_read_db.assert_called_once()
 
-    @patch("electricore.core.loaders.duckdb.helpers.duckdb_connection")
+    @patch("electricore.core.loaders.duckdb.helpers.duckdb_readonly_conn")
     @patch("electricore.core.loaders.duckdb.helpers.pl.read_database")
     def test_execute_custom_query_eager(self, mock_read_db, mock_conn_context):
         """Test d'exécution de requête personnalisée (eager)."""

--- a/tests/core/loaders/test_duckdb_retry.py
+++ b/tests/core/loaders/test_duckdb_retry.py
@@ -1,0 +1,68 @@
+"""Tests pour `duckdb_readonly_conn` — context manager avec retry sur lock."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pytest
+
+from electricore.core.loaders.duckdb.helpers import duckdb_readonly_conn
+
+
+class TestDuckdbReadonlyConn:
+    """Politique : 3 essais × 1s backoff sur lock, propagation immédiate sinon."""
+
+    def test_first_attempt_yields_conn_and_logs_nothing(self, caplog):
+        """Connexion réussie au premier essai → pas de warning, conn yieldée."""
+        fake_conn = MagicMock(spec=duckdb.DuckDBPyConnection)
+
+        with patch("duckdb.connect", return_value=fake_conn) as mock_connect:
+            with caplog.at_level(logging.WARNING, logger="electricore.core.loaders.duckdb.helpers"):
+                with duckdb_readonly_conn("/fake/path.duckdb") as conn:
+                    assert conn is fake_conn
+
+        mock_connect.assert_called_once_with("/fake/path.duckdb", read_only=True)
+        fake_conn.close.assert_called_once()
+        assert caplog.records == []
+
+    def test_does_not_exist_propagates_without_retry(self):
+        """Erreur 'does not exist' = non récupérable → 1 seul appel, pas de sleep."""
+        exc = duckdb.IOException("IO Error: File does not exist")
+
+        with patch("duckdb.connect", side_effect=exc) as mock_connect:
+            with patch("time.sleep") as mock_sleep:
+                with pytest.raises(duckdb.IOException, match="does not exist"):
+                    with duckdb_readonly_conn("/missing.duckdb"):
+                        pass  # pragma: no cover
+
+        assert mock_connect.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_lock_then_success_retries_and_yields(self, caplog):
+        """Lock au 1er essai, succès au 2e → 2 connect, 1 sleep, 1 warning."""
+        fake_conn = MagicMock(spec=duckdb.DuckDBPyConnection)
+        lock_exc = duckdb.IOException("IO Error: Could not set lock on file")
+
+        with patch("duckdb.connect", side_effect=[lock_exc, fake_conn]) as mock_connect:
+            with patch("time.sleep") as mock_sleep:
+                with caplog.at_level(logging.WARNING, logger="electricore.core.loaders.duckdb.helpers"):
+                    with duckdb_readonly_conn("/locked.duckdb") as conn:
+                        assert conn is fake_conn
+
+        assert mock_connect.call_count == 2
+        mock_sleep.assert_called_once_with(1.0)
+        assert len(caplog.records) == 1
+        assert "verrouill" in caplog.records[0].message.lower()
+
+    def test_persistent_lock_raises_after_all_attempts(self):
+        """Lock à chaque essai → 3 connect, 2 sleep, IOException propagée."""
+        lock_exc = duckdb.IOException("IO Error: Conflicting lock is held")
+
+        with patch("duckdb.connect", side_effect=lock_exc) as mock_connect:
+            with patch("time.sleep") as mock_sleep:
+                with pytest.raises(duckdb.IOException, match="Conflicting lock"):
+                    with duckdb_readonly_conn("/locked.duckdb"):
+                        pass  # pragma: no cover
+
+        assert mock_connect.call_count == 3
+        assert mock_sleep.call_count == 2


### PR DESCRIPTION
## Summary
- Move DuckDB read-only retry policy from `electricore/api/services/duckdb_service.py` into the canonical seam at `electricore/core/loaders/duckdb/config.py` (new `duckdb_readonly_conn` context manager).
- `DuckDBQuery.lazy()` + every `duckdb_service.py` caller inherit the 3×1s retry transparently — notebooks, API endpoints, future bot commands all benefit.
- Drop the duplicated `_connect_readonly` / `_is_lock_error` / retry constants from `duckdb_service.py`; rename `duckdb_connection` → `duckdb_readonly_conn` for symmetry.

## TDD cycles
4 RED→GREEN cycles in `tests/core/loaders/test_duckdb_retry.py`:
1. First attempt succeeds → conn yielded, no warning logged
2. `"does not exist"` → propagates immediately, no retry, no sleep
3. Lock then success → 2 connects, 1 sleep, 1 warning
4. Persistent lock → 3 connects, 2 sleeps, `IOException` propagated

## Test plan
- [x] `uv run --group test pytest -q` — 376 passed, 35 legitimate skips
- [x] `uvx pre-commit run --all-files` — clean (ruff check/format, secrets detection)
- [x] No regression on `get_freshness`, `c15()`, `r151()`, `releves()`, notebooks, API endpoints

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)