### PR TITLE
feat(duckdb): promote C15 entrées/sorties to builder methods (#53)

### DIFF
--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -145,7 +145,11 @@ def get_entrees_xlsx(
     limit: int = Query(10000, le=100000, description="Nombre maximum de lignes"),
 ) -> bytes:
     """Exporte les **entrées** C15 au format XLSX (PMES, MES, CFNE)."""
-    return duckdb_service.query_entrees_xlsx(limit)
+    from electricore.api.serializers import xlsx_multi_sheet
+    from electricore.core.loaders.duckdb import c15
+
+    df = c15().entrees().limit(limit).collect()
+    return xlsx_multi_sheet({"entrees": df})
 
 
 @xlsx_endpoint(app, "/flux/c15/sorties/xlsx", filename="sorties_c15.xlsx", error_status=500, tags=["flux"])
@@ -153,7 +157,11 @@ def get_sorties_xlsx(
     limit: int = Query(10000, le=100000, description="Nombre maximum de lignes"),
 ) -> bytes:
     """Exporte les **sorties** C15 au format XLSX (RES, CFNS)."""
-    return duckdb_service.query_sorties_xlsx(limit)
+    from electricore.api.serializers import xlsx_multi_sheet
+    from electricore.core.loaders.duckdb import c15
+
+    df = c15().sorties().limit(limit).collect()
+    return xlsx_multi_sheet({"sorties": df})
 
 
 @app.get("/flux/{table_name}", tags=["flux"])

--- a/electricore/api/services/duckdb_service.py
+++ b/electricore/api/services/duckdb_service.py
@@ -165,30 +165,6 @@ def query_table_arrow(
     return arrow_stream(df)
 
 
-_ENTREES = ("PMES", "MES", "CFNE")
-_SORTIES = ("RES", "CFNS")
-
-
-def _query_c15_xlsx(codes: tuple[str, ...], worksheet: str, limit: int) -> bytes:
-    from electricore.api.serializers import xlsx_multi_sheet
-
-    placeholders = ", ".join(f"'{c}'" for c in codes)
-    sql = f"SELECT * FROM {SCHEMA}.flux_c15 WHERE evenement_declencheur IN ({placeholders}) LIMIT {limit}"
-    with duckdb_readonly_conn(DB_PATH) as conn:
-        df = conn.execute(sql).pl()
-    return xlsx_multi_sheet({worksheet: df})
-
-
-def query_entrees_xlsx(limit: int = 10000) -> bytes:
-    """Export XLSX des entrées C15 (PMES, MES, CFNE)."""
-    return _query_c15_xlsx(_ENTREES, "entrees", limit)
-
-
-def query_sorties_xlsx(limit: int = 10000) -> bytes:
-    """Export XLSX des sorties C15 (RES, CFNS)."""
-    return _query_c15_xlsx(_SORTIES, "sorties", limit)
-
-
 def list_tables() -> list[str]:
     """
     Liste toutes les tables flux disponibles.

--- a/electricore/core/loaders/duckdb/__init__.py
+++ b/electricore/core/loaders/duckdb/__init__.py
@@ -40,6 +40,7 @@ from .helpers import (
     releves_harmonises,
 )
 from .query import DuckDBQuery
+from .registry import ENTREES_C15, SORTIES_C15
 
 # =============================================================================
 # EXPORTS PUBLICS
@@ -59,6 +60,9 @@ __all__ = [
     "r64",
     "releves",
     "releves_harmonises",
+    # Groupings C15 canoniques (cf. CONTEXT.md)
+    "ENTREES_C15",
+    "SORTIES_C15",
     # API legacy (compatibilité)
     "load_historique",
     "load_releves",

--- a/electricore/core/loaders/duckdb/query.py
+++ b/electricore/core/loaders/duckdb/query.py
@@ -141,6 +141,34 @@ class DuckDBQuery:
         """
         return replace(self, valider=enable)
 
+    def entrees(self) -> "DuckDBQuery":
+        """Filtre sur les codes d'entrée canoniques C15 (PMES, MES, CFNE).
+
+        Raises:
+            ValueError: Si le builder n'est pas configuré pour le flux C15.
+        """
+        from .registry import ENTREES_C15
+
+        self._assert_c15(".entrees()")
+        return self.filter({"evenement_declencheur": list(ENTREES_C15)})
+
+    def sorties(self) -> "DuckDBQuery":
+        """Filtre sur les codes de sortie canoniques C15 (RES, CFNS).
+
+        Raises:
+            ValueError: Si le builder n'est pas configuré pour le flux C15.
+        """
+        from .registry import SORTIES_C15
+
+        self._assert_c15(".sorties()")
+        return self.filter({"evenement_declencheur": list(SORTIES_C15)})
+
+    def _assert_c15(self, method_name: str) -> None:
+        """Garde-fou : les groupings entrées/sorties n'existent que pour C15."""
+        flux = self.config.schema.flux_name
+        if flux != "C15":
+            raise ValueError(f"{method_name} ne s'applique qu'au flux C15, reçu : {flux}")
+
     # =========================================================================
     # CONSTRUCTION SQL (Fonctions pures)
     # =========================================================================

--- a/electricore/core/loaders/duckdb/registry.py
+++ b/electricore/core/loaders/duckdb/registry.py
@@ -21,6 +21,11 @@ from .transforms import (
 # REGISTRE FONCTIONNEL DES FLUX
 # =============================================================================
 
+# Codes événementiels C15 — cf. electricore/core/CONTEXT.md
+ENTREES_C15: tuple[str, ...] = ("PMES", "MES", "CFNE")
+SORTIES_C15: tuple[str, ...] = ("RES", "CFNS")
+
+
 FLUX_CONFIGS: dict[str, QueryConfig] = {
     "c15": QueryConfig(schema=FLUX_SCHEMAS["c15"], transform=transform_historique, validator=None),
     "r151": QueryConfig(schema=FLUX_SCHEMAS["r151"], transform=transform_releves, validator=RelevéIndex),

--- a/tests/core/loaders/test_c15_entrees_sorties.py
+++ b/tests/core/loaders/test_c15_entrees_sorties.py
@@ -1,0 +1,64 @@
+"""Tests pour les méthodes builder .entrees() / .sorties() sur le flux C15."""
+
+import pytest
+
+from electricore.core.loaders.duckdb import ENTREES_C15, SORTIES_C15, c15, r151
+
+
+class TestC15GroupingConstants:
+    """Codes événementiels canoniques C15 (cf. CONTEXT.md)."""
+
+    def test_entrees_codes(self):
+        assert ENTREES_C15 == ("PMES", "MES", "CFNE")
+
+    def test_sorties_codes(self):
+        assert SORTIES_C15 == ("RES", "CFNS")
+
+
+class TestC15EntreesMethod:
+    """`.entrees()` filtre sur les codes d'entrée canoniques."""
+
+    def test_adds_filter_on_evenement_declencheur(self):
+        """`c15().entrees()` ajoute un filtre IN sur les 3 codes d'entrée."""
+        q = c15().entrees()
+
+        assert q.filters == (("evenement_declencheur", list(ENTREES_C15)),)
+
+    def test_generates_in_clause(self):
+        """Le SQL final contient une clause IN avec les 3 codes."""
+        sql = c15().entrees()._build_final_query()
+
+        assert "evenement_declencheur IN ('PMES', 'MES', 'CFNE')" in sql
+
+    def test_chainable_with_limit(self):
+        """`.entrees()` retourne un DuckDBQuery chainable."""
+        q = c15().entrees().limit(50)
+
+        assert q.limit_value == 50
+        assert q.filters == (("evenement_declencheur", list(ENTREES_C15)),)
+
+
+class TestC15SortiesMethod:
+    """`.sorties()` filtre sur les codes de sortie canoniques."""
+
+    def test_adds_filter_on_evenement_declencheur(self):
+        q = c15().sorties()
+
+        assert q.filters == (("evenement_declencheur", list(SORTIES_C15)),)
+
+    def test_generates_in_clause(self):
+        sql = c15().sorties()._build_final_query()
+
+        assert "evenement_declencheur IN ('RES', 'CFNS')" in sql
+
+
+class TestGuardOnNonC15:
+    """`.entrees()` / `.sorties()` ne s'appliquent qu'au flux C15."""
+
+    def test_entrees_on_r151_raises(self):
+        with pytest.raises(ValueError, match=r"\.entrees\(\) ne s'applique qu'au flux C15"):
+            r151().entrees()
+
+    def test_sorties_on_r151_raises(self):
+        with pytest.raises(ValueError, match=r"\.sorties\(\) ne s'applique qu'au flux C15"):
+            r151().sorties()


### PR DESCRIPTION
## Summary
- Codify the canonical C15 groupings already defined in [`electricore/core/CONTEXT.md`](electricore/core/CONTEXT.md) as first-class constants (`ENTREES_C15 = ("PMES", "MES", "CFNE")`, `SORTIES_C15 = ("RES", "CFNS")`) and as methods on the `c15()` query builder.
- `c15().entrees()` and `c15().sorties()` return chainable `DuckDBQuery` instances. Guarded by flux name — `r151().entrees()` raises `ValueError`.
- Methods inherit the retry-on-lock policy from #52 transparently — no extra wiring.
- API endpoints `/flux/c15/entrees/xlsx` and `/flux/c15/sorties/xlsx` rewired to use the new path; dead code in `duckdb_service.py` removed.

## TDD cycles
4 RED→GREEN cycles in `tests/core/loaders/test_c15_entrees_sorties.py` (9 tests total):
1. Constants exist and exported with correct values
2. `c15().entrees()` adds the right filter / generates the `IN ('PMES', 'MES', 'CFNE')` clause / remains chainable with `.limit()`
3. `c15().sorties()` symmetrical
4. Guard: `r151().entrees()` and `r151().sorties()` raise `ValueError` with clear message

## Test plan
- [x] `uv run --group test pytest -q` — 385 passed (was 376), 35 legitimate skips
- [x] `uvx pre-commit run --all-files` — clean
- [x] `duckdb_service.py`: `_ENTREES`, `_SORTIES`, `_query_c15_xlsx`, `query_entrees_xlsx`, `query_sorties_xlsx` all deleted; no stragglers

## Note
The new path goes through the canonical `c15()` builder (which applies `transform_historique`) rather than raw `SELECT *`, so the XLSX payload schema is the canonical C15 column layout. Endpoint contract preserved (same path, same sheet names).

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)