### PR TITLE
fix(duckdb): validate query_table filters via FluxSchema, kill SQL injection (#54)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,12 @@ repos:
     rev: v8.21.2
     hooks:
       - id: gitleaks
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: uv run --group test pytest -q
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,9 @@ uv sync --extra etl --group test --group typecheck
 
 # Installer les hooks pre-commit (ruff lint + format à chaque commit local)
 uvx pre-commit install
+
+# Installer le hook pre-push (testsuite avant chaque git push)
+uvx pre-commit install --hook-type pre-push
 ```
 
 Python 3.12 ou 3.13 requis.
@@ -34,6 +37,12 @@ uv run --group test pytest --cov=electricore
 ```
 
 La suite compte ~216 tests qui passent en moins d'une seconde. 35 tests sont volontairement skippés (intégration Odoo nécessitant des secrets, génération de snapshots).
+
+Le hook **pre-push** exécute automatiquement la suite avant chaque `git push` (cf. installation ci-dessus). Pour le lancer manuellement sans pousser :
+
+```bash
+uvx pre-commit run --hook-stage pre-push --all-files
+```
 
 **Pas besoin de secrets Enedis/Odoo** pour développer : les tests qui en dépendent se skippent automatiquement quand `secrets.toml` ou les variables d'environnement sont absents.
 

--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -164,6 +164,27 @@ def get_sorties_xlsx(
     return xlsx_multi_sheet({"sorties": df})
 
 
+def _load_flux_df(table_name: str, prm: str | None, limit: int):
+    """Charge un flux via DuckDBQuery + serializer. Whitelist déclarative via FLUX_CONFIGS.
+
+    Test seam : monkeypatch ce helper pour court-circuiter l'IO DuckDB dans les
+    tests d'endpoint (le SQL est paramétré et la sécurité est testée séparément).
+    """
+    from electricore.core.loaders.duckdb.helpers import make_query
+    from electricore.core.loaders.duckdb.registry import FLUX_CONFIGS
+
+    if table_name not in FLUX_CONFIGS:
+        raise HTTPException(
+            404,
+            f"Table '{table_name}' non trouvée. Tables disponibles: {sorted(FLUX_CONFIGS.keys())}",
+        )
+
+    query = make_query(FLUX_CONFIGS[table_name])
+    if prm:
+        query = query.filter({"pdl": prm})
+    return query.limit(limit).collect()
+
+
 @app.get("/flux/{table_name}", tags=["flux"])
 async def get_flux(
     table_name: str,
@@ -181,45 +202,16 @@ async def get_flux(
     - /flux/r151 : Relevés quotidiens
     - /flux/c15 : Changements contractuels
     - /flux/r64 : Relevés demandés sur SGE
-    - /flux/f15_detail : Facturation Enedis détaillée
-
-    Args:
-        table_name: Nom de la table flux (r151, c15, r64, etc.)
-        prm: Filtre optionnel par Point de Livraison
-        limit: Nombre max de lignes (max 1000)
-        offset: Pagination - lignes à ignorer
-        api_key: Clé API (automatiquement validée)
-
-    Returns:
-        Dict contenant les données filtrées et métadonnées de pagination
+    - /flux/f15 : Facturation Enedis détaillée
     """
-    # Vérifier que la table existe
-    try:
-        available_tables = duckdb_service.list_tables()
-    except Exception as e:
-        raise HTTPException(500, f"Impossible d'accéder à la base de données: {e}")
-
-    if table_name not in available_tables:
-        raise HTTPException(404, f"Table '{table_name}' non trouvée. Tables disponibles: {available_tables}")
-
-    # Construire les filtres
-    filters = {}
-    if prm:
-        # Toutes les tables utilisent 'pdl' pour l'identifiant PRM
-        filters["pdl"] = prm
-
-    # Récupérer les données
-    try:
-        data = duckdb_service.query_table(table_name, filters, limit, offset)
-
-        return {
-            "table": f"flux_{table_name}",
-            "filters": filters if filters else None,
-            "pagination": {"limit": limit, "offset": offset, "returned": len(data)},
-            "data": data,
-        }
-    except Exception as e:
-        raise HTTPException(500, f"Erreur lors de la lecture des données: {e}")
+    df = _load_flux_df(table_name, prm, limit + offset)
+    rows = df.slice(offset, limit).to_dicts()
+    return {
+        "table": f"flux_{table_name}",
+        "filters": {"pdl": prm} if prm else None,
+        "pagination": {"limit": limit, "offset": offset, "returned": len(rows)},
+        "data": rows,
+    }
 
 
 @xlsx_endpoint(app, "/flux/{table_name}/xlsx", filename="flux_{table_name}.xlsx", error_status=500, tags=["flux"])
@@ -228,20 +220,11 @@ def get_flux_xlsx(
     prm: str | None = Query(None, description="Filtrer par pdl (Point de Livraison)"),
     limit: int = Query(10000, le=100000, description="Nombre maximum de lignes"),
 ) -> bytes:
-    """Exporte les données d'un flux Enedis au format XLSX (max 100 000 lignes).
+    """Exporte les données d'un flux Enedis au format XLSX (max 100 000 lignes)."""
+    from electricore.api.serializers import xlsx_multi_sheet
 
-    Vérifie l'existence de la table — renvoie 404 si inconnue, 500 sinon.
-    """
-    try:
-        available_tables = duckdb_service.list_tables()
-    except Exception as e:
-        raise HTTPException(500, f"Impossible d'accéder à la base de données: {e}")
-
-    if table_name not in available_tables:
-        raise HTTPException(404, f"Table '{table_name}' non trouvée. Tables disponibles: {available_tables}")
-
-    filters = {"pdl": prm} if prm else {}
-    return duckdb_service.query_table_xlsx(table_name, filters, limit)
+    df = _load_flux_df(table_name, prm, limit)
+    return xlsx_multi_sheet({table_name: df})
 
 
 @arrow_endpoint(app, "/flux/{table_name}/arrow", tags=["flux"])
@@ -254,19 +237,11 @@ def get_flux_arrow(
 
     Consommable côté client avec `pl.read_ipc_stream(BytesIO(content))` — typage et
     timezones préservés, pas de perte de précision contrairement à XLSX. Cf. `ElectricoreClient.flux`.
-
-    Vérifie l'existence de la table — renvoie 404 si inconnue, 500 sinon.
     """
-    try:
-        available_tables = duckdb_service.list_tables()
-    except Exception as e:
-        raise HTTPException(500, f"Impossible d'accéder à la base de données: {e}")
+    from electricore.api.serializers import arrow_stream
 
-    if table_name not in available_tables:
-        raise HTTPException(404, f"Table '{table_name}' non trouvée. Tables disponibles: {available_tables}")
-
-    filters = {"pdl": prm} if prm else {}
-    return duckdb_service.query_table_arrow(table_name, filters, limit)
+    df = _load_flux_df(table_name, prm, limit)
+    return arrow_stream(df)
 
 
 @app.get("/flux/{table_name}/info", tags=["flux"])

--- a/electricore/api/services/duckdb_service.py
+++ b/electricore/api/services/duckdb_service.py
@@ -55,34 +55,6 @@ def get_freshness() -> dict:
     return payload
 
 
-def query_table(table_name: str, filters: dict | None = None, limit: int = 100, offset: int = 0) -> list[dict]:
-    """
-    Fonction générique pour lire n'importe quelle table flux.
-
-    Args:
-        table_name: Nom de la table (r151, c15, r64, etc.)
-        filters: Dict de filtres {colonne: valeur}
-        limit: Nombre max de lignes
-        offset: Pagination
-
-    Returns:
-        Liste de dictionnaires représentant les lignes
-    """
-    sql = f"SELECT * FROM {SCHEMA}.flux_{table_name}"
-
-    # Ajout des filtres WHERE
-    if filters:
-        conditions = [f"{col} = '{val}'" for col, val in filters.items()]
-        sql += f" WHERE {' AND '.join(conditions)}"
-
-    sql += f" LIMIT {limit} OFFSET {offset}"
-
-    with duckdb_readonly_conn(DB_PATH) as conn:
-        result = conn.execute(sql)
-        columns = [desc[0] for desc in result.description]
-        return [dict(zip(columns, row, strict=False)) for row in result.fetchall()]
-
-
 def get_table_info(table_name: str) -> dict:
     """
     Retourne les informations sur une table (colonnes, nombre de lignes).
@@ -109,60 +81,6 @@ def get_table_info(table_name: str) -> dict:
         columns = [{"name": col[0], "type": col[1]} for col in columns_result]
 
         return {"table": f"flux_{table_name}", "schema": SCHEMA, "count": count, "columns": columns}
-
-
-def _query_table_df(table_name: str, filters: dict | None = None, limit: int = 10000):
-    """Charge une table flux dans un DataFrame Polars, avec filtres et limite optionnels."""
-    sql = f"SELECT * FROM {SCHEMA}.flux_{table_name}"
-    if filters:
-        conditions = [f"{col} = '{val}'" for col, val in filters.items()]
-        sql += f" WHERE {' AND '.join(conditions)}"
-    sql += f" LIMIT {limit}"
-
-    with duckdb_readonly_conn(DB_PATH) as conn:
-        return conn.execute(sql).pl()
-
-
-def query_table_xlsx(
-    table_name: str,
-    filters: dict | None = None,
-    limit: int = 10000,
-) -> bytes:
-    """Retourne les données d'une table flux au format XLSX (bytes).
-
-    Args:
-        table_name: Nom de la table (r151, c15, r64, etc.)
-        filters: Dict de filtres {colonne: valeur}
-        limit: Nombre max de lignes (défaut 10 000)
-
-    Returns:
-        Contenu XLSX en bytes
-    """
-    from electricore.api.serializers import xlsx_multi_sheet
-
-    df = _query_table_df(table_name, filters, limit)
-    return xlsx_multi_sheet({table_name: df})
-
-
-def query_table_arrow(
-    table_name: str,
-    filters: dict | None = None,
-    limit: int = 1_000_000,
-) -> bytes:
-    """Retourne les données d'une table flux au format Arrow IPC (bytes).
-
-    Args:
-        table_name: Nom de la table (r151, c15, r64, etc.)
-        filters: Dict de filtres {colonne: valeur}
-        limit: Nombre max de lignes (défaut 1 000 000)
-
-    Returns:
-        Flux Arrow IPC en bytes, re-lisible via `pl.read_ipc_stream(BytesIO(...))`.
-    """
-    from electricore.api.serializers import arrow_stream
-
-    df = _query_table_df(table_name, filters, limit)
-    return arrow_stream(df)
 
 
 def list_tables() -> list[str]:

--- a/electricore/core/loaders/duckdb/query.py
+++ b/electricore/core/loaders/duckdb/query.py
@@ -8,6 +8,7 @@ Ce module fournit un builder de requêtes suivant les principes fonctionnels :
 - Séparation claire entre construction et exécution
 """
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -91,9 +92,21 @@ class DuckDBQuery:
         Returns:
             Nouvelle instance DuckDBQuery avec les filtres ajoutés
 
+        Raises:
+            ValueError: Si une colonne n'appartient pas au schéma du flux.
+
         Example:
             >>> query.filter({"Date_Evenement": ">= '2024-01-01'", "pdl": ["PDL123"]})
         """
+        allowed = {c.name for c in self.config.schema.columns}
+        # Schémas CTE/UNION (base_sql) sans colonnes typées : on saute l'allowlist
+        if allowed:
+            unknown = [col for col in filters if col not in allowed]
+            if unknown:
+                raise ValueError(
+                    f"colonne inconnue {unknown!r} pour le flux {self.config.schema.flux_name}. "
+                    f"Colonnes valides : {sorted(allowed)}"
+                )
         new_filters = self.filters + tuple(filters.items())
         return replace(self, filters=new_filters)
 
@@ -173,64 +186,67 @@ class DuckDBQuery:
     # CONSTRUCTION SQL (Fonctions pures)
     # =========================================================================
 
-    def _build_filter_clause(self, column: str, condition: Any) -> str:
-        """
-        Construit une clause WHERE depuis un filtre (fonction pure).
+    _OPERATOR_RE = re.compile(r"^\s*(>=|<=|<>|!=|>|<|=)\s*(.+?)\s*$")
 
-        Args:
-            column: Nom de la colonne
-            condition: Condition (liste, string avec opérateur, ou valeur simple)
+    def _build_filter_clause(self, column: str, condition: Any) -> tuple[str, list[Any]]:
+        """Construit une clause WHERE paramétrée depuis un filtre (fonction pure).
 
         Returns:
-            Clause WHERE formatée
+            (sql_fragment_avec_?, params) — les valeurs ne sont JAMAIS interpolées
+            dans le SQL ; elles transitent par le binding `conn.execute(sql, params)`.
         """
-        # Condition brute
+        # Condition brute (échappée, non exposée HTTP, validée allowlist au constructeur)
         if column == "__raw_condition":
-            return condition
+            return condition, []
 
         # Liste de valeurs (IN)
         if isinstance(condition, list):
-            values = "', '".join(str(v) for v in condition)
-            return f"{column} IN ('{values}')"
+            placeholders = ", ".join(["?"] * len(condition))
+            return f"{column} IN ({placeholders})", list(condition)
 
-        # String avec opérateur (>=, <=, etc.)
-        if isinstance(condition, str) and any(op in condition for op in [">=", "<=", ">", "<", "="]):
-            return f"{column} {condition}"
+        # String avec opérateur préfixe : ">= '2024-01-01'", "< 100", etc.
+        if isinstance(condition, str):
+            match = self._OPERATOR_RE.match(condition)
+            if match:
+                op, raw_value = match.group(1), match.group(2)
+                # Strip enclosing quotes (simple ou double) si présentes
+                if len(raw_value) >= 2 and raw_value[0] == raw_value[-1] and raw_value[0] in ("'", '"'):
+                    raw_value = raw_value[1:-1]
+                return f"{column} {op} ?", [raw_value]
 
         # Égalité simple
-        return f"{column} = '{condition}'"
+        return f"{column} = ?", [condition]
 
-    def _build_final_query(self) -> str:
-        """
-        Construit la requête SQL finale avec filtres et limite (fonction pure).
+    def _build_final_query(self) -> tuple[str, list[Any]]:
+        """Construit la requête SQL finale + ses paramètres (fonction pure).
 
         Returns:
-            Requête SQL complète prête à être exécutée
+            (sql_avec_placeholders, params) — à passer à `conn.execute(sql, params)`.
         """
         # Si base_sql fourni (CTE/UNION), l'utiliser directement
         if self.base_sql:
             query = self.base_sql
         else:
-            # Requête de base depuis le schéma
             query = build_base_query(self.config.schema)
 
-        # Ajouter les filtres
+        params: list[Any] = []
         if self.filters:
-            where_clauses = [self._build_filter_clause(col, val) for col, val in self.filters]
+            fragments = []
+            for col, val in self.filters:
+                fragment, frag_params = self._build_filter_clause(col, val)
+                fragments.append(fragment)
+                params.extend(frag_params)
 
-            # Vérifier si la requête a déjà une clause WHERE
             if "WHERE" in query.upper():
-                # Ajouter les conditions avec AND
-                query += " AND " + " AND ".join(where_clauses)
+                query += " AND " + " AND ".join(fragments)
             else:
-                # Ajouter une nouvelle clause WHERE
-                query += "\nWHERE " + " AND ".join(where_clauses)
+                query += "\nWHERE " + " AND ".join(fragments)
 
-        # Ajouter la limite
+        # LIMIT est un entier injecté en dur — pas une donnée utilisateur, sûr
         if self.limit_value:
             query += f"\nLIMIT {self.limit_value}"
 
-        return query
+        return query, params
 
     # =========================================================================
     # EXÉCUTION (Fonctions impures - IO)
@@ -254,12 +270,12 @@ class DuckDBQuery:
         if not config.database_path.exists():
             raise FileNotFoundError(f"Base DuckDB non trouvée : {config.database_path}")
 
-        # Construction SQL (pure)
-        final_query = self._build_final_query()
+        # Construction SQL paramétrée (pure)
+        final_query, params = self._build_final_query()
 
-        # Connexion et exécution (impure - IO)
+        # Connexion et exécution (impure - IO) ; valeurs liées, jamais interpolées
         with duckdb_readonly_conn(config.database_path) as conn:
-            lazy_frame = conn.execute(final_query).pl().lazy()
+            lazy_frame = conn.execute(final_query, params).pl().lazy()
 
         # Application des transformations (pure)
         lazy_frame = self.config.transform(lazy_frame)

--- a/tests/core/loaders/test_c15_entrees_sorties.py
+++ b/tests/core/loaders/test_c15_entrees_sorties.py
@@ -25,10 +25,11 @@ class TestC15EntreesMethod:
         assert q.filters == (("evenement_declencheur", list(ENTREES_C15)),)
 
     def test_generates_in_clause(self):
-        """Le SQL final contient une clause IN avec les 3 codes."""
-        sql = c15().entrees()._build_final_query()
+        """Le SQL final contient une clause IN paramétrée avec les 3 codes."""
+        sql, params = c15().entrees()._build_final_query()
 
-        assert "evenement_declencheur IN ('PMES', 'MES', 'CFNE')" in sql
+        assert "evenement_declencheur IN (?, ?, ?)" in sql
+        assert params == ["PMES", "MES", "CFNE"]
 
     def test_chainable_with_limit(self):
         """`.entrees()` retourne un DuckDBQuery chainable."""
@@ -47,9 +48,10 @@ class TestC15SortiesMethod:
         assert q.filters == (("evenement_declencheur", list(SORTIES_C15)),)
 
     def test_generates_in_clause(self):
-        sql = c15().sorties()._build_final_query()
+        sql, params = c15().sorties()._build_final_query()
 
-        assert "evenement_declencheur IN ('RES', 'CFNS')" in sql
+        assert "evenement_declencheur IN (?, ?)" in sql
+        assert params == ["RES", "CFNS"]
 
 
 class TestGuardOnNonC15:

--- a/tests/core/loaders/test_duckdb_query_filter_safety.py
+++ b/tests/core/loaders/test_duckdb_query_filter_safety.py
@@ -1,0 +1,100 @@
+"""Tests pour la validation/paramétrisation des filtres `DuckDBQuery.filter()`.
+
+Vérifie que :
+- Les noms de colonnes inconnus sont rejetés (allowlist via FluxSchema).
+- Les valeurs sont passées en paramètres liés (pas d'interpolation f-string).
+- Une tentative d'injection SQL est neutralisée.
+"""
+
+import pytest
+
+from electricore.core.loaders.duckdb import c15
+
+
+class TestColumnAllowlist:
+    """`.filter()` rejette les colonnes absentes du schéma du flux."""
+
+    def test_unknown_column_raises_value_error(self):
+        """Un nom de colonne hors schéma déclenche une erreur claire avant tout SQL."""
+        with pytest.raises(ValueError, match="colonne inconnue"):
+            c15().filter({"nonexistent_column": "X"})
+
+    def test_error_message_lists_allowed_columns(self):
+        """L'erreur cite quelques colonnes valides pour aider à corriger l'appel."""
+        with pytest.raises(ValueError) as excinfo:
+            c15().filter({"nonexistent_column": "X"})
+        # Au moins une colonne connue de C15 doit apparaître pour orienter l'utilisateur
+        assert "pdl" in str(excinfo.value)
+
+    def test_known_column_passes(self):
+        """Une colonne valide ne lève pas d'erreur."""
+        q = c15().filter({"pdl": "PDL123"})
+        assert q.filters == (("pdl", "PDL123"),)
+
+    def test_raw_condition_bypasses_validation(self):
+        """`.where(...)` reste une échappée pour expressions SQL brutes (non exposée HTTP)."""
+        q = c15().where("pdl LIKE 'PDL%'")
+        assert q.filters == (("__raw_condition", "pdl LIKE 'PDL%'"),)
+
+
+class TestParameterizedFilters:
+    """`.filter()` produit du SQL paramétré (`?` placeholders + params séparés)."""
+
+    def test_single_value_is_parameterized(self):
+        """Égalité simple → `col = ?`, valeur dans params, jamais interpolée."""
+        sql, params = c15().filter({"pdl": "PDL123"})._build_final_query()
+
+        assert "pdl = ?" in sql
+        assert "'PDL123'" not in sql
+        assert params == ["PDL123"]
+
+    def test_no_filter_yields_empty_params(self):
+        """Sans filtre, params est une liste vide."""
+        sql, params = c15()._build_final_query()
+
+        assert "?" not in sql
+        assert params == []
+
+    def test_list_filter_in_clause_parameterized(self):
+        """Filtre liste → `col IN (?, ?, ...)`, valeurs dans params."""
+        sql, params = c15().filter({"pdl": ["A", "B", "C"]})._build_final_query()
+
+        assert "pdl IN (?, ?, ?)" in sql
+        assert "'A'" not in sql
+        assert params == ["A", "B", "C"]
+
+    def test_operator_filter_parsed_and_parameterized(self):
+        """`{date: ">= '2024-01-01'"}` → `date >= ?`, valeur sans quotes dans params."""
+        sql, params = c15().filter({"date_evenement": ">= '2024-01-01'"})._build_final_query()
+
+        assert "date_evenement >= ?" in sql
+        assert "'2024-01-01'" not in sql
+        assert params == ["2024-01-01"]
+
+    def test_operator_without_quotes(self):
+        """Opérateur avec valeur sans quotes (cas numérique)."""
+        sql, params = c15().filter({"puissance_souscrite_kva": "> 6"})._build_final_query()
+
+        assert "puissance_souscrite_kva > ?" in sql
+        assert params == ["6"]
+
+
+class TestSqlInjectionBlocked:
+    """Une tentative d'injection SQL via une valeur de filtre est neutralisée."""
+
+    def test_quote_injection_in_value_is_bound_as_literal(self):
+        """`pdl = "X' OR '1'='1"` est passé comme paramètre, jamais interpolé."""
+        sql, params = c15().filter({"pdl": "X' OR '1'='1"})._build_final_query()
+
+        # La valeur d'attaque n'apparaît pas dans le SQL — uniquement le placeholder
+        assert "X' OR '1'='1" not in sql
+        assert "pdl = ?" in sql
+        # Elle vit dans params, où DuckDB la traitera comme un littéral chaîne
+        assert params == ["X' OR '1'='1"]
+
+    def test_semicolon_injection_in_value_is_bound_as_literal(self):
+        """Une valeur contenant `; DROP TABLE` reste un littéral."""
+        sql, params = c15().filter({"pdl": "X'; DROP TABLE flux_c15; --"})._build_final_query()
+
+        assert "DROP TABLE" not in sql
+        assert params == ["X'; DROP TABLE flux_c15; --"]

--- a/tests/integration/test_flux_endpoint_whitelist.py
+++ b/tests/integration/test_flux_endpoint_whitelist.py
@@ -1,0 +1,32 @@
+"""Tests d'intégration : `/flux/{table_name}*` reposent sur le whitelist FLUX_CONFIGS."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from electricore.api.main import app
+from electricore.api.security import get_current_api_key
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()
+
+
+class TestUnknownTableReturns404:
+    """Une table absente de FLUX_CONFIGS renvoie 404 sur tous les exports."""
+
+    def test_get_flux_unknown(self, client):
+        response = client.get("/flux/totalement_inexistant")
+        assert response.status_code == 404
+
+    def test_get_flux_xlsx_unknown(self, client):
+        response = client.get("/flux/totalement_inexistant/xlsx")
+        assert response.status_code == 404
+
+    def test_get_flux_arrow_unknown(self, client):
+        response = client.get("/flux/totalement_inexistant/arrow")
+        assert response.status_code == 404

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -118,12 +118,9 @@ def test_flux_round_trip_via_endpoint(monkeypatch):
         }
     )
 
-    monkeypatch.setattr("electricore.api.services.duckdb_service.list_tables", lambda: ["c15"])
     monkeypatch.setattr(
-        "electricore.api.services.duckdb_service.query_table_arrow",
-        lambda table_name, filters, limit: __import__(
-            "electricore.api.serializers", fromlist=["arrow_stream"]
-        ).arrow_stream(df_attendu),
+        "electricore.api.main._load_flux_df",
+        lambda table_name, prm, limit: df_attendu,
     )
 
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
@@ -138,16 +135,13 @@ def test_flux_round_trip_via_endpoint(monkeypatch):
 
 def test_flux_propage_filtre_prm_a_lendpoint(monkeypatch):
     """`client.flux(table, prm=...)` propage le PRM en query string."""
-    captures: list[tuple[str, dict | None, int]] = []
+    captures: list[tuple[str, str | None, int]] = []
 
-    def _capture(table_name: str, filters: dict | None, limit: int) -> bytes:
-        captures.append((table_name, filters, limit))
-        return __import__("electricore.api.serializers", fromlist=["arrow_stream"]).arrow_stream(
-            pl.DataFrame({"x": [1]})
-        )
+    def _capture(table_name: str, prm: str | None, limit: int):
+        captures.append((table_name, prm, limit))
+        return pl.DataFrame({"x": [1]})
 
-    monkeypatch.setattr("electricore.api.services.duckdb_service.list_tables", lambda: ["r151"])
-    monkeypatch.setattr("electricore.api.services.duckdb_service.query_table_arrow", _capture)
+    monkeypatch.setattr("electricore.api.main._load_flux_df", _capture)
 
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
     try:
@@ -156,13 +150,11 @@ def test_flux_propage_filtre_prm_a_lendpoint(monkeypatch):
     finally:
         app.dependency_overrides.clear()
 
-    assert captures == [("r151", {"pdl": "12345678901234"}, 1_000_000)]
+    assert captures == [("r151", "12345678901234", 1_000_000)]
 
 
-def test_flux_renvoie_404_pour_table_inconnue(monkeypatch):
-    """Le client propage une `HTTPStatusError` quand la table n'existe pas."""
-    monkeypatch.setattr("electricore.api.services.duckdb_service.list_tables", lambda: ["c15"])
-
+def test_flux_renvoie_404_pour_table_inconnue():
+    """Le client propage une `HTTPStatusError` quand la table n'est pas dans FLUX_CONFIGS."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
     try:
         client = ElectricoreClient(url="http://testserver", api_key="key", http_client=TestClient(app))


### PR DESCRIPTION
## Summary
Rebuild `/flux/{table_name}*` on top of `DuckDBQuery` so the f-string SQL in `duckdb_service.query_table` disappears by construction. Also closes a latent SQL injection in `DuckDBQuery._build_filter_clause` itself — not exploited today (all callers pass literal strings) but the same vulnerability shape.

## Query builder changes
- **Column allowlist**: `.filter({col: ...})` validates `col` against the `FluxSchema` column set. Unknown column → `ValueError` listing valid columns.
- **Parameter binding**: `_build_filter_clause` and `_build_final_query` now return `(sql_with_?_placeholders, params)`. All three filter branches parameterized:
  - single value → `col = ?`
  - list IN → `col IN (?, ?, ...)`
  - operator-prefix string → regex-extract operator + strip enclosing quotes from value → `col {op} ?`
- `lazy()` passes `params` to `conn.execute(sql, params)`. Values are never interpolated.
- `.where("raw SQL")` escape hatch unchanged (caller-internal, not HTTP-exposed).

## API edge
- `/flux/{table_name}`, `/xlsx`, `/arrow` now whitelist `table_name` against `FLUX_CONFIGS.keys()` — declarative, no DB hit. Unknown → 404.
- Narrows accepted tables to `{c15, r151, r15, f15, r64}` (drops `/flux/f12` and `/flux/r15_acc` — they had no `FluxSchema` anyway).
- `_load_flux_df()` helper at module level: DRY for the three endpoints + clean test seam.

## Service-layer cleanup
Deleted `query_table`, `_query_table_df`, `query_table_xlsx`, `query_table_arrow` from `duckdb_service.py`. Kept `list_tables` (root informational endpoint) and `get_table_info` (`/flux/{name}/info`).

## TDD cycles
6 RED→GREEN cycles → 11 unit tests + 3 integration tests:
1. Unknown column → `ValueError` with allowed list
2. Single-value filter parameterized
3. List-IN filter parameterized
4. Operator filter parsed and parameterized (handles both quoted and unquoted values)
5. SQL injection attempts (`X' OR '1'='1`, `X'; DROP TABLE...`) bound as literals
6. `/flux/{unknown}` returns 404 via `FLUX_CONFIGS`

## Known limitations (per issue spec)
- **Source-table filtering**: `WHERE` applies to source columns. For R151 `date_releve` (where `sql_expr` is `CAST(...) + INTERVAL '1 day'`), filtering on the projected name reaches the raw column. Same behaviour as today.
- **Synthetic columns** (`col_literal` like `source`): pass allowlist but produce SQL referencing a non-existent source column. DuckDB error surfaces as 500. Not regressing existing behaviour.

## Test plan
- [x] `uv run --group test pytest -q` — 399 passed (was 376 on main, +9 from #53 and +14 from #54), 35 legitimate skips
- [x] `uvx pre-commit run --all-files` — clean
- [x] No straggler references to deleted helpers

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)