### PR TITLE
feat(taxes): split accise into rapport + accise_par_contrat (#56)

### DIFF
--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -24,8 +24,9 @@ from electricore.api.services.facturation_service import (
     generer_facturation_xlsx,
 )
 from electricore.api.services.taxes_service import (
-    generer_accise_arrow,
-    generer_accise_xlsx,
+    generer_accise_detail_arrow,
+    generer_accise_detail_xlsx,
+    generer_accise_rapport_xlsx,
     generer_cta_arrow,
     generer_cta_xlsx,
 )
@@ -414,28 +415,44 @@ async def list_api_keys(api_key: str = Depends(get_current_api_key), key_info: A
     }
 
 
-@xlsx_endpoint(app, "/taxes/accise/xlsx", filename="accise{trimestre}.xlsx", requires_odoo=True, tags=["taxes"])
-def export_accise_xlsx(
+@xlsx_endpoint(
+    app, "/taxes/accise/rapport.xlsx", filename="accise_rapport{trimestre}.xlsx", requires_odoo=True, tags=["taxes"]
+)
+def export_accise_rapport_xlsx(
     trimestre: str | None = Query(
         default=None,
         examples=["2025-T1"],
         description="Filtre par trimestre au format YYYY-TX. Sans filtre : toutes les données.",
     ),
 ) -> bytes:
-    """Calcule l'Accise TICFE et retourne un fichier XLSX (3 onglets : Résumé, Par taux, Détail)."""
-    return generer_accise_xlsx(trimestre)
+    """Livrable facturiste : Accise TICFE en XLSX multi-onglets (Résumé / Par taux / Détail)."""
+    return generer_accise_rapport_xlsx(trimestre)
 
 
-@arrow_endpoint(app, "/taxes/accise/arrow", requires_odoo=True, tags=["taxes"])
-def export_accise_arrow(
+@xlsx_endpoint(
+    app, "/taxes/accise/detail.xlsx", filename="accise_detail{trimestre}.xlsx", requires_odoo=True, tags=["taxes"]
+)
+def export_accise_detail_xlsx(
     trimestre: str | None = Query(
         default=None,
         examples=["2025-T1"],
         description="Filtre par trimestre au format YYYY-TX. Sans filtre : toutes les données.",
     ),
 ) -> bytes:
-    """Détail Accise TICFE sérialisé en Arrow IPC stream (table PDL × mois)."""
-    return generer_accise_arrow(trimestre)
+    """Détail Accise TICFE en XLSX mono-onglet (table PDL × mois, cas technique)."""
+    return generer_accise_detail_xlsx(trimestre)
+
+
+@arrow_endpoint(app, "/taxes/accise/detail.arrow", requires_odoo=True, tags=["taxes"])
+def export_accise_detail_arrow(
+    trimestre: str | None = Query(
+        default=None,
+        examples=["2025-T1"],
+        description="Filtre par trimestre au format YYYY-TX. Sans filtre : toutes les données.",
+    ),
+) -> bytes:
+    """Détail Accise TICFE en Arrow IPC stream (table PDL × mois, cas technique)."""
+    return generer_accise_detail_arrow(trimestre)
 
 
 @xlsx_endpoint(app, "/taxes/cta/xlsx", filename="cta{trimestre}.xlsx", requires_odoo=True, tags=["taxes"])

--- a/electricore/api/services/taxes_service.py
+++ b/electricore/api/services/taxes_service.py
@@ -4,9 +4,11 @@ Le calcul et l'orchestration métier vivent dans
 `electricore.integrations.odoo.taxes`. Ce service ne fait que :
 
 1. Ouvrir la connexion `OdooReader` (responsabilité HTTP)
-2. Déléguer à l'orchestration
-3. Sérialiser le résultat (XLSX multi-onglets / Arrow IPC), avec les
-   agrégations « par taux » / « résumé » spécifiques au livrable.
+2. Déléguer à l'orchestration (`accise_par_contrat` / `rapport_accise` / `cta_du_trimestre`)
+3. Sérialiser le résultat (XLSX multi-onglets / Arrow IPC).
+
+La shape du livrable (`Résumé` / `Par taux` / `Détail`) vit désormais dans
+`integrations.odoo.taxes.rapport_accise` (cf. issue #56).
 """
 
 import polars as pl
@@ -14,66 +16,38 @@ import polars as pl
 from electricore.api.config import settings
 from electricore.api.serializers import arrow_stream, xlsx_multi_sheet
 from electricore.integrations.odoo import OdooReader
-from electricore.integrations.odoo.taxes import accise_du_trimestre, cta_du_trimestre
+from electricore.integrations.odoo.taxes import (
+    accise_par_contrat,
+    cta_du_trimestre,
+    rapport_accise,
+)
 
 
 def calculer_accise_detail(trimestre: str | None = None) -> pl.DataFrame:
-    """Binding HTTP : ouvre Odoo + délègue à `accise_du_trimestre`.
-
-    Seam testable au niveau du service (les endpoints peuvent la monkeypatch
-    pour bypasser Odoo). La logique métier vit dans
-    `electricore.integrations.odoo.taxes.accise_du_trimestre`.
-    """
+    """Binding HTTP : ouvre Odoo + délègue à `accise_par_contrat`."""
     with OdooReader(config=settings.get_odoo_config()) as odoo:
-        return accise_du_trimestre(odoo, trimestre)
+        return accise_par_contrat(odoo, trimestre)
 
 
-def generer_accise_arrow(trimestre: str | None = None) -> bytes:
-    """Sérialise le détail accise en flux Arrow IPC."""
+def generer_accise_detail_arrow(trimestre: str | None = None) -> bytes:
+    """Sérialise le détail accise (PDL × mois) en flux Arrow IPC."""
     return arrow_stream(calculer_accise_detail(trimestre))
 
 
-def generer_accise_xlsx(trimestre: str | None = None) -> bytes:
-    """Calcule l'accise TICFE et retourne un fichier XLSX multi-onglets.
+def generer_accise_detail_xlsx(trimestre: str | None = None) -> bytes:
+    """Sérialise le détail accise (PDL × mois) en XLSX mono-onglet."""
+    return xlsx_multi_sheet({"Détail": calculer_accise_detail(trimestre)})
 
-    Args:
-        trimestre: Filtre optionnel au format "YYYY-TX" (ex: "2025-T1").
-            Si None, retourne toutes les données disponibles.
 
-    Returns:
-        Contenu XLSX en bytes avec 3 onglets : Résumé, Par taux, Détail.
-    """
-    df_accise = calculer_accise_detail(trimestre)
-
-    df_par_taux = (
-        df_accise.group_by("taux_accise_eur_mwh")
-        .agg(
-            [
-                pl.col("energie_mwh").sum().round(3),
-                pl.col("accise_eur").sum().round(2),
-                pl.col("pdl").n_unique().alias("nb_pdl"),
-            ]
-        )
-        .sort("taux_accise_eur_mwh", descending=True)
-    )
-
-    df_resume = (
-        df_accise.group_by("trimestre")
-        .agg(
-            [
-                pl.col("pdl").n_unique().alias("Nombre de PDL"),
-                pl.col("energie_mwh").sum().round(3).alias("Énergie totale (MWh)"),
-                pl.col("accise_eur").sum().round(2).alias("Accise totale (€)"),
-            ]
-        )
-        .sort("trimestre")
-    )
-
+def generer_accise_rapport_xlsx(trimestre: str | None = None) -> bytes:
+    """Livrable facturiste : 3 onglets (Résumé / Par taux / Détail) depuis `rapport_accise`."""
+    with OdooReader(config=settings.get_odoo_config()) as odoo:
+        r = rapport_accise(odoo, trimestre)
     return xlsx_multi_sheet(
         {
-            "Résumé": df_resume,
-            "Par taux": df_par_taux,
-            "Détail": df_accise.sort(["pdl", "mois_consommation"]),
+            "Résumé": r.resume,
+            "Par taux": r.par_taux,
+            "Détail": r.detail.sort(["pdl", "mois_consommation"]),
         }
     )
 

--- a/electricore/bot/client.py
+++ b/electricore/bot/client.py
@@ -73,7 +73,9 @@ class ElectriCoreClient:
         if trimestre:
             params["trimestre"] = trimestre
         async with httpx.AsyncClient() as c:
-            r = await c.get(f"{self._base}/taxes/accise/xlsx", headers=self._headers, params=params, timeout=300)
+            r = await c.get(
+                f"{self._base}/taxes/accise/rapport.xlsx", headers=self._headers, params=params, timeout=300
+            )
             r.raise_for_status()
             return r.content
 

--- a/electricore/client/__init__.py
+++ b/electricore/client/__init__.py
@@ -75,7 +75,7 @@ class ElectricoreClient:
         Args:
             trimestre: "YYYY-TX" (ex: "2025-T1") — défaut : tous les trimestres.
         """
-        return self._get_arrow("/taxes/accise/arrow", {"trimestre": trimestre} if trimestre else {})
+        return self._get_arrow("/taxes/accise/detail.arrow", {"trimestre": trimestre} if trimestre else {})
 
     def cta(self, trimestre: str | None = None) -> pl.DataFrame:
         """Récupère le détail CTA mensuel pour le trimestre donné.

--- a/electricore/integrations/odoo/models/rapport_accise.py
+++ b/electricore/integrations/odoo/models/rapport_accise.py
@@ -1,0 +1,37 @@
+"""Schémas Pandera pour le livrable `rapport_accise` (issue #56).
+
+Trois `DataFrameModel` qui reflètent les onglets XLSX livrés au facturiste pour
+la déclaration trimestrielle d'accise TICFE.
+"""
+
+import pandera.polars as pa
+import polars as pl
+
+
+class RapportAcciseResume(pa.DataFrameModel):
+    """Totaux trimestriels : un résumé par trimestre."""
+
+    trimestre: pl.Utf8 = pa.Field(nullable=False)
+    nb_pdl: pl.Int64 = pa.Field(nullable=False, ge=0)
+    energie_mwh_total: pl.Float64 = pa.Field(nullable=False)
+    accise_eur_total: pl.Float64 = pa.Field(nullable=False)
+
+
+class RapportAcciseParTaux(pa.DataFrameModel):
+    """Décomposition par taux d'accise applicable."""
+
+    taux_accise_eur_mwh: pl.Float64 = pa.Field(nullable=False)
+    energie_mwh: pl.Float64 = pa.Field(nullable=False)
+    accise_eur: pl.Float64 = pa.Field(nullable=False)
+    nb_pdl: pl.Int64 = pa.Field(nullable=False, ge=0)
+
+
+class RapportAcciseDetail(pa.DataFrameModel):
+    """Détail PDL × mois (= sortie de `accise_par_contrat`)."""
+
+    pdl: pl.Utf8 = pa.Field(nullable=False)
+    mois_consommation: pl.Utf8 = pa.Field(nullable=False)
+    trimestre: pl.Utf8 = pa.Field(nullable=False)
+    taux_accise_eur_mwh: pl.Float64 = pa.Field(nullable=False)
+    energie_mwh: pl.Float64 = pa.Field(nullable=False)
+    accise_eur: pl.Float64 = pa.Field(nullable=False)

--- a/electricore/integrations/odoo/taxes.py
+++ b/electricore/integrations/odoo/taxes.py
@@ -4,9 +4,18 @@ Compose les calculs `core/` (pipelines accise / CTA, contexte mensuel) avec
 l'adaptateur Odoo (lecture des lignes de factures, des PDLs des `sale.order`)
 pour produire les DataFrames consommés par les endpoints API et les notebooks.
 
+Deux interfaces cohabitent (cf. issue #56) :
+
+- `accise_par_contrat` / `cta_du_trimestre` : calcul brut par PDL × période, pour
+  exploration et réinjection (Arrow / XLSX mono-onglet).
+- `rapport_accise` : livrable agrégé (`Résumé` / `Par taux` / `Détail`) destiné à
+  la déclaration trimestrielle facturiste (XLSX multi-onglets).
+
 EDN-shaped aujourd'hui ; sert de prototype pour un futur module Odoo libre
 couvrant les fournisseurs alternatifs (cf. CONTEXT.md, ADR-0016).
 """
+
+from typing import NamedTuple
 
 import polars as pl
 
@@ -16,11 +25,27 @@ from electricore.core.pipelines.cta import ajouter_cta
 from electricore.core.pipelines.facturation import expr_calculer_trimestre
 
 from .helpers import commandes_lignes, query
+from .models.rapport_accise import (
+    RapportAcciseDetail,
+    RapportAcciseParTaux,
+    RapportAcciseResume,
+)
 from .reader import OdooReader
 
 
-def accise_du_trimestre(odoo: OdooReader, trimestre: str | None = None) -> pl.DataFrame:
-    """Charge les lignes Odoo et applique `pipeline_accise` (+ filtre trimestre).
+class RapportAccise(NamedTuple):
+    """Livrable trimestriel d'accise (= les 3 onglets de l'export XLSX facturiste)."""
+
+    resume: pl.DataFrame
+    par_taux: pl.DataFrame
+    detail: pl.DataFrame
+
+
+def accise_par_contrat(odoo: OdooReader, trimestre: str | None = None) -> pl.DataFrame:
+    """Calcul brut de l'accise par PDL × mois de consommation.
+
+    Interface "brute" pour les cas techniques (exploration, réinjection, Arrow stream).
+    Pour le livrable agrégé destiné au facturiste, utiliser `rapport_accise(...)`.
 
     Args:
         odoo: `OdooReader` déjà ouvert (le caller est responsable de la connexion).
@@ -35,6 +60,49 @@ def accise_du_trimestre(odoo: OdooReader, trimestre: str | None = None) -> pl.Da
     if trimestre is not None:
         df_accise = df_accise.filter(pl.col("trimestre") == trimestre)
     return df_accise
+
+
+def rapport_accise(odoo: OdooReader, trimestre: str | None = None) -> RapportAccise:
+    """Livrable agrégé pour déclaration trimestrielle d'accise TICFE.
+
+    Compose `accise_par_contrat` (calcul brut) avec les agrégations « Par taux »
+    et « Résumé » nécessaires au facturiste. Les 3 frames du `NamedTuple` sont
+    validées Pandera avant retour.
+
+    Args:
+        odoo: `OdooReader` déjà ouvert.
+        trimestre: format "YYYY-TX". `None` = tous les trimestres.
+
+    Returns:
+        `RapportAccise(resume, par_taux, detail)`.
+    """
+    detail = accise_par_contrat(odoo, trimestre)
+    par_taux = (
+        detail.group_by("taux_accise_eur_mwh")
+        .agg(
+            [
+                pl.col("energie_mwh").sum().round(3),
+                pl.col("accise_eur").sum().round(2),
+                pl.col("pdl").n_unique().cast(pl.Int64).alias("nb_pdl"),
+            ]
+        )
+        .sort("taux_accise_eur_mwh", descending=True)
+    )
+    resume = (
+        detail.group_by("trimestre")
+        .agg(
+            [
+                pl.col("pdl").n_unique().cast(pl.Int64).alias("nb_pdl"),
+                pl.col("energie_mwh").sum().round(3).alias("energie_mwh_total"),
+                pl.col("accise_eur").sum().round(2).alias("accise_eur_total"),
+            ]
+        )
+        .sort("trimestre")
+    )
+    RapportAcciseResume.validate(resume)
+    RapportAcciseParTaux.validate(par_taux)
+    RapportAcciseDetail.validate(detail)
+    return RapportAccise(resume=resume, par_taux=par_taux, detail=detail)
 
 
 def cta_du_trimestre(odoo: OdooReader, trimestre: str | None = None) -> pl.DataFrame:

--- a/notebooks/accise_et_cta.py
+++ b/notebooks/accise_et_cta.py
@@ -31,7 +31,7 @@ def _():
     mo.md(r"""
     # Accise & CTA — calcul trimestriel
 
-    Les calculs sont délégués aux endpoints `/taxes/cta/arrow` et `/taxes/accise/arrow`
+    Les calculs sont délégués aux endpoints `/taxes/cta/arrow` et `/taxes/accise/detail.arrow`
     de l'API electricore (cf. ADR-0009). Le notebook se contente de récupérer les
     DataFrames, de sélectionner un trimestre et d'afficher les agrégats.
 

--- a/tests/architecture/test_integrations_odoo_orchestrations.py
+++ b/tests/architecture/test_integrations_odoo_orchestrations.py
@@ -13,7 +13,7 @@ import pytest
 
 FACTURATION_ORCHESTRATIONS = ("facturation_du_mois", "documents_facturation_du_mois")
 
-TAXES_ORCHESTRATIONS = ("accise_du_trimestre", "cta_du_trimestre")
+TAXES_ORCHESTRATIONS = ("rapport_accise", "accise_par_contrat", "cta_du_trimestre")
 
 
 @pytest.mark.parametrize("name", FACTURATION_ORCHESTRATIONS)

--- a/tests/integration/test_taxes_arrow_endpoints.py
+++ b/tests/integration/test_taxes_arrow_endpoints.py
@@ -1,4 +1,4 @@
-"""Tests d'intégration des endpoints `/taxes/accise/arrow` et `/taxes/cta/arrow`."""
+"""Tests d'intégration des endpoints `/taxes/accise/*` et `/taxes/cta/arrow`."""
 
 import io
 
@@ -12,6 +12,7 @@ from electricore.api.main import app
 from electricore.api.security import get_current_api_key
 
 ARROW_IPC = "application/vnd.apache.arrow.stream"
+XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 
 @pytest.fixture(autouse=True)
@@ -21,8 +22,21 @@ def _mock_odoo_configured(monkeypatch):
 
 
 @pytest.fixture
+def _mock_odoo_reader(monkeypatch):
+    """Court-circuite `OdooReader` (les tests mockent directement `accise_par_contrat`)."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_reader(config):
+        yield None
+
+    monkeypatch.setattr("electricore.integrations.odoo.OdooReader", _fake_reader)
+    monkeypatch.setattr("electricore.api.services.taxes_service.OdooReader", _fake_reader)
+
+
+@pytest.fixture
 def df_accise_detail() -> pl.DataFrame:
-    """Échantillon ressemblant à la sortie de pipeline_accise."""
+    """Échantillon ressemblant à la sortie de `accise_par_contrat`."""
     return pl.DataFrame(
         {
             "pdl": ["12345678901234", "12345678901234"],
@@ -36,20 +50,20 @@ def df_accise_detail() -> pl.DataFrame:
 
 
 # =============================================================================
-# /taxes/accise/arrow
+# /taxes/accise/detail.arrow
 # =============================================================================
 
 
-def test_accise_endpoint_retourne_arrow_ipc_stream(monkeypatch, df_accise_detail):
+def test_accise_detail_arrow_retourne_arrow_ipc_stream(monkeypatch, _mock_odoo_reader, df_accise_detail):
     """L'endpoint sert le détail accise en Arrow IPC."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
     monkeypatch.setattr(
-        "electricore.api.services.taxes_service.calculer_accise_detail",
-        lambda trimestre=None: df_accise_detail,
+        "electricore.api.services.taxes_service.accise_par_contrat",
+        lambda odoo, trimestre=None: df_accise_detail,
     )
 
     try:
-        response = TestClient(app).get("/taxes/accise/arrow")
+        response = TestClient(app).get("/taxes/accise/detail.arrow")
     finally:
         app.dependency_overrides.clear()
 
@@ -60,30 +74,119 @@ def test_accise_endpoint_retourne_arrow_ipc_stream(monkeypatch, df_accise_detail
     assert_frame_equal(df, df_accise_detail)
 
 
-def test_accise_endpoint_refuse_sans_api_key():
+def test_accise_detail_arrow_refuse_sans_api_key():
     """Sans clé API → 401."""
-    response = TestClient(app).get("/taxes/accise/arrow")
+    response = TestClient(app).get("/taxes/accise/detail.arrow")
     assert response.status_code == 401
 
 
-def test_accise_endpoint_propage_trimestre(monkeypatch, df_accise_detail):
-    """Le query param `trimestre` est transmis au service de calcul."""
+def test_accise_detail_arrow_propage_trimestre(monkeypatch, _mock_odoo_reader, df_accise_detail):
+    """Le query param `trimestre` est transmis à `accise_par_contrat`."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
     appels: list[str | None] = []
 
-    def fake_calculer(trimestre: str | None = None) -> pl.DataFrame:
+    def _capture(odoo, trimestre=None):
         appels.append(trimestre)
         return df_accise_detail
 
-    monkeypatch.setattr("electricore.api.services.taxes_service.calculer_accise_detail", fake_calculer)
+    monkeypatch.setattr("electricore.api.services.taxes_service.accise_par_contrat", _capture)
 
     try:
-        response = TestClient(app).get("/taxes/accise/arrow", params={"trimestre": "2025-T1"})
+        response = TestClient(app).get("/taxes/accise/detail.arrow", params={"trimestre": "2025-T1"})
     finally:
         app.dependency_overrides.clear()
 
     assert response.status_code == 200
     assert appels == ["2025-T1"]
+
+
+# =============================================================================
+# /taxes/accise/detail.xlsx
+# =============================================================================
+
+
+def test_accise_detail_xlsx_retourne_xlsx_mono_onglet(monkeypatch, _mock_odoo_reader, df_accise_detail):
+    """L'endpoint sert le détail accise en XLSX mono-onglet."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.services.taxes_service.accise_par_contrat",
+        lambda odoo, trimestre=None: df_accise_detail,
+    )
+
+    try:
+        response = TestClient(app).get("/taxes/accise/detail.xlsx")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(XLSX_MIME)
+    assert "attachment" in response.headers.get("content-disposition", "")
+
+
+# =============================================================================
+# /taxes/accise/rapport.xlsx
+# =============================================================================
+
+
+@pytest.fixture
+def fake_rapport_accise(df_accise_detail):
+    """`RapportAccise` synthétique (les 3 onglets minimaux pour la sérialisation XLSX)."""
+    from electricore.integrations.odoo.taxes import RapportAccise
+
+    return RapportAccise(
+        resume=pl.DataFrame(
+            {"trimestre": ["2025-T1"], "nb_pdl": [1], "energie_mwh_total": [3.579], "accise_eur_total": [80.53]}
+        ),
+        par_taux=pl.DataFrame(
+            {"taux_accise_eur_mwh": [22.5], "energie_mwh": [3.579], "accise_eur": [80.53], "nb_pdl": [1]}
+        ),
+        detail=df_accise_detail,
+    )
+
+
+def test_accise_rapport_xlsx_retourne_xlsx_multi_onglets(monkeypatch, _mock_odoo_reader, fake_rapport_accise):
+    """L'endpoint sert le rapport multi-onglets (Résumé / Par taux / Détail)."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.services.taxes_service.rapport_accise",
+        lambda odoo, trimestre=None: fake_rapport_accise,
+    )
+
+    try:
+        response = TestClient(app).get("/taxes/accise/rapport.xlsx")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(XLSX_MIME)
+    assert "attachment" in response.headers.get("content-disposition", "")
+
+
+def test_accise_rapport_xlsx_propage_trimestre(monkeypatch, _mock_odoo_reader, fake_rapport_accise):
+    """Le query param `trimestre` est propagé jusqu'à `rapport_accise`."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    appels: list[str | None] = []
+
+    def _capture(odoo, trimestre=None):
+        appels.append(trimestre)
+        return fake_rapport_accise
+
+    monkeypatch.setattr("electricore.api.services.taxes_service.rapport_accise", _capture)
+
+    try:
+        response = TestClient(app).get("/taxes/accise/rapport.xlsx", params={"trimestre": "2025-T2"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert appels == ["2025-T2"]
+
+
+def test_anciens_endpoints_accise_404(_mock_odoo_reader):
+    """Les anciens paths sont supprimés."""
+    for path in ("/taxes/accise/xlsx", "/taxes/accise/arrow"):
+        response = TestClient(app).get(path)
+        assert response.status_code == 404, f"{path} devrait être 404"
 
 
 # =============================================================================

--- a/tests/unit/integrations/odoo/test_rapport_accise.py
+++ b/tests/unit/integrations/odoo/test_rapport_accise.py
@@ -1,0 +1,180 @@
+"""Tests pour `accise_par_contrat` et `rapport_accise` (Candidate 1, issue #56).
+
+Pattern testé : interface brute (`accise_par_contrat`) vs interface agrégée
+(`rapport_accise`). Les agrégations vivent désormais dans `integrations/odoo/`
+(shape leak corrigé depuis `taxes_service.py`).
+"""
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+
+def test_accise_par_contrat_exists_and_is_callable():
+    """`accise_par_contrat` est exporté depuis `integrations.odoo.taxes`."""
+    from electricore.integrations.odoo import taxes
+
+    assert hasattr(taxes, "accise_par_contrat")
+    assert callable(taxes.accise_par_contrat)
+
+
+def test_accise_par_contrat_delegates_to_pipeline_accise(monkeypatch):
+    """`accise_par_contrat(odoo, trimestre)` = pipeline_accise filtré + sort."""
+    from electricore.integrations.odoo import taxes
+
+    df_lignes = pl.DataFrame({"x_pdl": ["A"], "name": ["SO/1"]})
+    df_accise_full = pl.DataFrame(
+        {
+            "pdl": ["A", "A", "B"],
+            "mois_consommation": ["2025-01", "2025-04", "2025-01"],
+            "trimestre": ["2025-T1", "2025-T2", "2025-T1"],
+            "energie_mwh": [1.0, 2.0, 3.0],
+            "taux_accise_eur_mwh": [22.5, 22.5, 22.5],
+            "accise_eur": [22.50, 45.00, 67.50],
+        }
+    )
+
+    # Mocke la frontière externe : commandes_lignes + pipeline_accise
+    monkeypatch.setattr(taxes, "commandes_lignes", lambda _odoo: df_lignes.lazy())
+    monkeypatch.setattr(taxes, "pipeline_accise", lambda _lf: df_accise_full)
+
+    result_all = taxes.accise_par_contrat(odoo=None)
+    assert result_all.height == 3
+
+    result_q1 = taxes.accise_par_contrat(odoo=None, trimestre="2025-T1")
+    assert result_q1.height == 2
+    assert set(result_q1["trimestre"].unique().to_list()) == {"2025-T1"}
+
+
+def test_accise_du_trimestre_is_removed():
+    """L'ancien nom `accise_du_trimestre` n'existe plus."""
+    from electricore.integrations.odoo import taxes
+
+    assert not hasattr(taxes, "accise_du_trimestre")
+
+
+class TestRapportAcciseSchemas:
+    """Les 3 `DataFrameModel` Pandera valident bien des frames conformes."""
+
+    def test_resume_schema_validates_correct_frame(self):
+        from electricore.integrations.odoo.models.rapport_accise import RapportAcciseResume
+
+        df = pl.DataFrame(
+            {
+                "trimestre": ["2025-T1"],
+                "nb_pdl": [2],
+                "energie_mwh_total": [10.0],
+                "accise_eur_total": [225.0],
+            }
+        )
+        RapportAcciseResume.validate(df)
+
+    def test_par_taux_schema_validates_correct_frame(self):
+        from electricore.integrations.odoo.models.rapport_accise import RapportAcciseParTaux
+
+        df = pl.DataFrame(
+            {
+                "taux_accise_eur_mwh": [22.5],
+                "energie_mwh": [10.0],
+                "accise_eur": [225.0],
+                "nb_pdl": [2],
+            }
+        )
+        RapportAcciseParTaux.validate(df)
+
+    def test_detail_schema_validates_correct_frame(self):
+        from electricore.integrations.odoo.models.rapport_accise import RapportAcciseDetail
+
+        df = pl.DataFrame(
+            {
+                "pdl": ["A"],
+                "mois_consommation": ["2025-01"],
+                "trimestre": ["2025-T1"],
+                "taux_accise_eur_mwh": [22.5],
+                "energie_mwh": [1.0],
+                "accise_eur": [22.5],
+            }
+        )
+        RapportAcciseDetail.validate(df)
+
+
+def _detail_synthetique() -> pl.DataFrame:
+    """Détail synthétique : 2 PDL × 2 trimestres × 2 taux différents."""
+    return pl.DataFrame(
+        {
+            "pdl": ["A", "A", "B", "B", "C"],
+            "mois_consommation": ["2025-01", "2025-02", "2025-01", "2025-04", "2025-04"],
+            "trimestre": ["2025-T1", "2025-T1", "2025-T1", "2025-T2", "2025-T2"],
+            "taux_accise_eur_mwh": [22.5, 22.5, 22.5, 25.0, 25.0],
+            "energie_mwh": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "accise_eur": [22.5, 45.0, 67.5, 100.0, 125.0],
+        }
+    )
+
+
+class TestRapportAccise:
+    """`rapport_accise` produit un `RapportAccise(resume, par_taux, detail)`."""
+
+    def test_returns_namedtuple_with_three_fields(self, monkeypatch):
+        from electricore.integrations.odoo import taxes
+
+        monkeypatch.setattr(taxes, "accise_par_contrat", lambda odoo, trimestre=None: _detail_synthetique())
+        result = taxes.rapport_accise(odoo=None)
+
+        # NamedTuple: accès par attribut
+        assert hasattr(result, "resume")
+        assert hasattr(result, "par_taux")
+        assert hasattr(result, "detail")
+
+    def test_detail_is_identity_of_accise_par_contrat(self, monkeypatch):
+        """`rapport.detail` est exactement la sortie de `accise_par_contrat`."""
+        from electricore.integrations.odoo import taxes
+
+        detail_attendu = _detail_synthetique()
+        monkeypatch.setattr(taxes, "accise_par_contrat", lambda odoo, trimestre=None: detail_attendu)
+        result = taxes.rapport_accise(odoo=None)
+
+        assert_frame_equal(result.detail, detail_attendu)
+
+    def test_par_taux_groups_by_taux_descending(self, monkeypatch):
+        """`par_taux` groupé par taux décroissant avec sommes + n_unique(pdl) corrects."""
+        from electricore.integrations.odoo import taxes
+
+        monkeypatch.setattr(taxes, "accise_par_contrat", lambda odoo, trimestre=None: _detail_synthetique())
+        result = taxes.rapport_accise(odoo=None)
+
+        # Tri descendant sur taux : 25.0 d'abord, puis 22.5
+        assert result.par_taux["taux_accise_eur_mwh"].to_list() == [25.0, 22.5]
+        # Taux 25.0 : 4+5=9.0 mwh, 100+125=225.0 €, 2 PDL distincts (B, C)
+        # Taux 22.5 : 1+2+3=6.0 mwh, 22.5+45+67.5=135.0 €, 2 PDL distincts (A, B)
+        assert result.par_taux["energie_mwh"].to_list() == [9.0, 6.0]
+        assert result.par_taux["accise_eur"].to_list() == [225.0, 135.0]
+        assert result.par_taux["nb_pdl"].to_list() == [2, 2]
+
+    def test_resume_groups_by_trimestre_ascending(self, monkeypatch):
+        """`resume` groupé par trimestre avec totaux + n_unique(pdl) corrects."""
+        from electricore.integrations.odoo import taxes
+
+        monkeypatch.setattr(taxes, "accise_par_contrat", lambda odoo, trimestre=None: _detail_synthetique())
+        result = taxes.rapport_accise(odoo=None)
+
+        assert result.resume["trimestre"].to_list() == ["2025-T1", "2025-T2"]
+        # T1: PDL = {A, B} -> 2 distinct ; énergie = 1+2+3 = 6.0 ; accise = 22.5+45+67.5 = 135.0
+        # T2: PDL = {B, C} -> 2 distinct ; énergie = 4+5 = 9.0 ; accise = 100+125 = 225.0
+        assert result.resume["nb_pdl"].to_list() == [2, 2]
+        assert result.resume["energie_mwh_total"].to_list() == [6.0, 9.0]
+        assert result.resume["accise_eur_total"].to_list() == [135.0, 225.0]
+
+    def test_rapport_accise_propagates_trimestre_filter(self, monkeypatch):
+        """`rapport_accise(odoo, trimestre)` propage le filtre à `accise_par_contrat`."""
+        from electricore.integrations.odoo import taxes
+
+        appels: list[str | None] = []
+
+        def fake_accise_par_contrat(odoo, trimestre=None):
+            appels.append(trimestre)
+            return _detail_synthetique()
+
+        monkeypatch.setattr(taxes, "accise_par_contrat", fake_accise_par_contrat)
+        taxes.rapport_accise(odoo=None, trimestre="2025-T1")
+
+        assert appels == ["2025-T1"]

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -59,7 +59,7 @@ def test_facturation_retourne_le_dataframe_servi_par_endpoint(client_electricore
 
 
 def test_accise_round_trip_via_endpoint(monkeypatch):
-    """`client.accise(trimestre)` round-trip un DataFrame servi par /taxes/accise/arrow."""
+    """`client.accise(trimestre)` round-trip un DataFrame servi par /taxes/accise/detail.arrow."""
     df_attendu = pl.DataFrame(
         {
             "pdl": ["12345678901234"],


### PR DESCRIPTION
## Summary
Issue #56 — Architectural Review Candidate 1 (push tax-report shape down). Prototype of the `rapport_X` / `X_par_contrat` pattern that will be replicated on CTA and facturation.

**Before**: the accise report structure (Résumé / Par taux / Détail with their groupby + agg + rounds) lived inside `taxes_service.generer_accise_xlsx` — a shape leak from HTTP layer into business orchestration. And two distinct use cases (facturiste = aggregate, technical = raw) shared the same path.

**After**: two explicit interfaces in `electricore/integrations/odoo/taxes.py`:
- `accise_par_contrat` (renamed from `accise_du_trimestre`) — raw PDL × month calculation for exploration / reinjection.
- `rapport_accise` — aggregated quarterly deliverable, returns `RapportAccise = NamedTuple(resume, par_taux, detail)` validated against 3 Pandera schemas before return.

## New Pandera schemas
`electricore/integrations/odoo/models/rapport_accise.py`:
- `RapportAcciseResume` — trimestre, nb_pdl, energie_mwh_total, accise_eur_total
- `RapportAcciseParTaux` — taux_accise_eur_mwh, energie_mwh, accise_eur, nb_pdl
- `RapportAcciseDetail` — pdl, mois_consommation, trimestre, taux, energie_mwh, accise_eur

## HTTP endpoints (extension-suffix convention prototype)

| Path | Use case | Serializer |
|---|---|---|
| `GET /taxes/accise/rapport.xlsx` | Facturiste, multi-sheet | `rapport_accise(...)` → `xlsx_multi_sheet({Résumé, Par taux, Détail})` |
| `GET /taxes/accise/detail.xlsx` | Technical, single-sheet | `accise_par_contrat(...)` → `xlsx_multi_sheet({Détail})` |
| `GET /taxes/accise/detail.arrow` | Technical, stream | `accise_par_contrat(...)` → `arrow_stream` |

Old `/taxes/accise/xlsx` and `/taxes/accise/arrow` removed (verified 404).

## Consumers updated
- `bot/client.py:get_accise_xlsx` → `/taxes/accise/rapport.xlsx` (bot still serves the rapport to the facturiste)
- `client/__init__.py:accise()` → `/taxes/accise/detail.arrow`
- `notebooks/accise_et_cta.py` (docstring path bump — automatically follows via Python client)
- `taxes_service.py` — agg logic gone, now 4 thin wrapper functions

## TDD cycles
5 RED→GREEN cycles in `tests/unit/integrations/odoo/test_rapport_accise.py` (11 tests):
1. `accise_par_contrat` exists, delegates to `pipeline_accise`, `accise_du_trimestre` removed
2. 3 Pandera schemas validate well-formed frames
3. `rapport_accise` returns a `RapportAccise` NamedTuple, `detail` is identity of `accise_par_contrat`
4. `par_taux` correctly groups by taux descending with right aggs (`n_unique(pdl)` cast to Int64)
5. `resume` correctly groups by trimestre with right totals

Plus smoke tests in `tests/integration/test_taxes_arrow_endpoints.py` for the 3 new endpoints + 404 on the old paths.

## Architecture test
`TAXES_ORCHESTRATIONS = ("rapport_accise", "accise_par_contrat", "cta_du_trimestre")` — CTA follows in PR 2 of the C1 series.

## Test plan
- [x] `uv run --group test pytest -q` — 415 passed (was 399 → +16 from this PR), 35 legitimate skips
- [x] `uvx pre-commit run --all-files` — clean
- [x] No straggler references to deleted names (verified)

## Out of scope (per issue spec)
- CTA equivalent (`rapport_cta` + `cta_par_contrat`) — PR 2 of C1 series
- Facturation equivalent — PR 3 of C1 series
- Migration des autres endpoints vers la convention extension-suffix — séparée
- Service-layer collapse via `@with_odoo` — Candidate 3

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)