### PR TITLE
fix(deploy): --version pilote ref Git + ELECTRICORE_VERSION + nano par défaut

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -120,7 +120,7 @@ fi
 
 # ─── Étape 2 : paquets ──────────────────────────────────────────────────
 log_step "Paquets système"
-ensure_packages curl jq cron dnsutils
+ensure_packages curl jq cron dnsutils nano
 
 # ─── Étape 3 : Docker ───────────────────────────────────────────────────
 log_step "Docker"
@@ -142,7 +142,7 @@ chown_instance_home "$OPT_SLUG"
 
 # ─── Étape 7 : substitutions ────────────────────────────────────────────
 log_step "Patch des templates (slug + domaine + email)"
-substitute_env "$ENV_FILE" "$OPT_SLUG"
+substitute_env "$ENV_FILE" "$OPT_SLUG" "$OPT_VERSION"
 substitute_caddyfile "$CADDYFILE" "$OPT_DOMAIN" "$OPT_EMAIL"
 if [[ -z "$OPT_EMAIL" ]]; then
     log_warn "email Let's Encrypt non fourni — placeholder conservé dans ${CADDYFILE}." \
@@ -164,11 +164,11 @@ if [[ -n "$OPT_ENV_FROM" ]]; then
     chmod 600 "$ENV_FILE"
     log_info "chargement depuis $OPT_ENV_FROM"
 else
-    log_info "ouverture de $ENV_FILE dans \${EDITOR:-vi}…"
+    log_info "ouverture de $ENV_FILE dans \${EDITOR:-nano}…"
 fi
 while true; do
     if [[ -z "$OPT_ENV_FROM" ]]; then
-        sudo -u "$OPT_SLUG" "${EDITOR:-vi}" "$ENV_FILE"
+        sudo -u "$OPT_SLUG" "${EDITOR:-nano}" "$ENV_FILE"
     fi
     if errs=$(validate_env_file "$ENV_FILE" "$OPT_SLUG"); then
         log_ok ".env valide"

--- a/deploy/lib/config.sh
+++ b/deploy/lib/config.sh
@@ -4,6 +4,20 @@
 
 CONFIG_BASE_URL="${CONFIG_BASE_URL:-https://raw.githubusercontent.com/Energie-De-Nantes/electricore}"
 
+# map_version_to_git_ref <version>
+# Convertit l'option `--version` (qui désigne un tag d'image Docker) vers le ref
+# Git correspondant pour récupérer les configs depuis raw.githubusercontent :
+#   latest                  → main          (alias Docker, pas un ref Git)
+#   1.7.0, 1.8.0rc1, 2.0.0a1 → v<version>   (les tags Git portent un préfixe `v`)
+#   main, dev, abc1234      → inchangé       (branche ou SHA)
+map_version_to_git_ref() {
+    case "$1" in
+        latest)                 echo "main" ;;
+        [0-9]*.[0-9]*.[0-9]*)   echo "v$1" ;;
+        *)                      echo "$1" ;;
+    esac
+}
+
 # download_config_files <version> <home_dir>
 # Télécharge depuis le tag <version> vers <home_dir>/{.env,deploy/docker/*}.
 # Idempotent : si .env existe déjà, on ne l'écrase pas (mode reconfigure).
@@ -11,10 +25,7 @@ download_config_files() {
     local version="$1"
     local home="$2"
     local docker_dir="${home}/deploy/docker"
-    # `latest` est un alias Docker mais pas un ref Git → bascule vers `main`
-    # pour récupérer les configs depuis raw.githubusercontent.
-    local ref="$version"
-    [[ "$ref" == "latest" ]] && ref="main"
+    local ref; ref=$(map_version_to_git_ref "$version")
     local base="${CONFIG_BASE_URL}/${ref}/deploy/docker"
     install -d "$docker_dir"
     # .env : ne pas écraser si présent (rerun)
@@ -39,17 +50,24 @@ download_config_files() {
     log_ok "fichiers compose téléchargés dans ${docker_dir}/"
 }
 
-# substitute_env <env_file> <slug>
-# Remplace INSTANCE_SLUG= et BACKUPS_PATH= par les valeurs réelles.
+# substitute_env <env_file> <slug> [<version>]
+# Remplace INSTANCE_SLUG=, BACKUPS_PATH= et — si fourni — ELECTRICORE_VERSION=
+# par les valeurs réelles. `--version` étant la source de vérité de la version
+# Docker à pin, on évite de devoir l'éditer à la main dans le step EDITOR.
 # Préserve l'ownership du fichier (sed -i peut le casser).
 substitute_env() {
     local env_file="$1"
     local slug="$2"
+    local version="${3:-}"
     local owner; owner=$(stat -c '%u:%g' "$env_file" 2>/dev/null || echo "")
-    sed -i \
-        -e "s|^INSTANCE_SLUG=.*|INSTANCE_SLUG=${slug}|" \
-        -e "s|^BACKUPS_PATH=.*|BACKUPS_PATH=/srv/${slug}/backups|" \
-        "$env_file"
+    local sed_exprs=(
+        -e "s|^INSTANCE_SLUG=.*|INSTANCE_SLUG=${slug}|"
+        -e "s|^BACKUPS_PATH=.*|BACKUPS_PATH=/srv/${slug}/backups|"
+    )
+    if [[ -n "$version" ]]; then
+        sed_exprs+=(-e "s|^ELECTRICORE_VERSION=.*|ELECTRICORE_VERSION=${version}|")
+    fi
+    sed -i "${sed_exprs[@]}" "$env_file"
     [[ -n "$owner" ]] && chown "$owner" "$env_file" 2>/dev/null || true
 }
 

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -84,12 +84,32 @@ assert_fail "parse_args sans --domain"    parse_args --slug edn
 assert_fail "parse_args flag inconnu"     parse_args --slug edn --domain edn.fr --foo
 
 echo
+echo "→ config.sh / map_version_to_git_ref"
+assert_eq "$(map_version_to_git_ref latest)"      "main"       "latest → main (alias Docker)"
+assert_eq "$(map_version_to_git_ref 1.7.0rc2)"    "v1.7.0rc2"  "rc → v-prefixed tag"
+assert_eq "$(map_version_to_git_ref 1.6.1)"       "v1.6.1"     "stable → v-prefixed tag"
+assert_eq "$(map_version_to_git_ref 2.0.0)"       "v2.0.0"     "major bump → v-prefixé"
+assert_eq "$(map_version_to_git_ref 1.8.0a1)"     "v1.8.0a1"   "alpha PEP 440"
+assert_eq "$(map_version_to_git_ref main)"        "main"       "branche main inchangée"
+assert_eq "$(map_version_to_git_ref dev)"         "dev"        "branche dev inchangée"
+assert_eq "$(map_version_to_git_ref abc1234)"     "abc1234"    "SHA inchangé"
+
+echo
 echo "→ config.sh / substitute_*"
 tmp_env=$(mktemp)
 cp "${FIXTURES_DIR}/env-template" "$tmp_env"
 substitute_env "$tmp_env" "edn"
 grep -q "^INSTANCE_SLUG=edn$" "$tmp_env" && ok "substitute_env: INSTANCE_SLUG=edn" || ko "substitute_env INSTANCE_SLUG"
 grep -q "^BACKUPS_PATH=/srv/edn/backups$" "$tmp_env" && ok "substitute_env: BACKUPS_PATH=/srv/edn/backups" || ko "substitute_env BACKUPS_PATH"
+grep -q "^ELECTRICORE_VERSION=latest$" "$tmp_env" && ok "substitute_env: ELECTRICORE_VERSION inchangée si non passée" || ko "substitute_env touche ELECTRICORE_VERSION sans argument"
+rm -f "$tmp_env"
+
+# substitute_env avec version explicite
+tmp_env=$(mktemp)
+cp "${FIXTURES_DIR}/env-template" "$tmp_env"
+substitute_env "$tmp_env" "edn" "1.7.0rc3"
+grep -q "^ELECTRICORE_VERSION=1.7.0rc3$" "$tmp_env" && ok "substitute_env: ELECTRICORE_VERSION=1.7.0rc3 (3e arg)" || ko "substitute_env n'écrit pas ELECTRICORE_VERSION"
+grep -q "^INSTANCE_SLUG=edn$" "$tmp_env" && ok "substitute_env: INSTANCE_SLUG préservé avec version" || ko "substitute_env INSTANCE_SLUG cassé avec version"
 rm -f "$tmp_env"
 
 tmp_caddy=$(mktemp)

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -32,25 +32,23 @@ Sur un VPS Ubuntu 22.04+/24.04+ ou Debian 12+ fraîchement provisionné, en root
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Energie-De-Nantes/electricore/main/deploy/install.sh -o install.sh
-EDITOR=nano sudo -E bash install.sh \
+sudo bash install.sh \
     --slug <slug> --domain <slug>.electricore.fr --email ops@example.com
 ```
 
-> **Note sur l'éditeur** : `sudo` strip les variables d'environnement par
-> défaut, donc même si tu as `EDITOR=nano` dans ton shell, le script
-> tombera sur `vi` (défaut Ubuntu) sans le préfixe `EDITOR=nano sudo -E`.
-> Pour celles et ceux qui maîtrisent vi, `sudo bash install.sh ...` suffit.
-> Pour sortir de vi : `Esc`, `:q!`, `Enter` (sans sauver) ou `:wq` (sauver).
+> **Note sur l'éditeur** : `nano` est l'éditeur par défaut (installé par le
+> script s'il manque). Pour utiliser vim/vi : `EDITOR=vim sudo -E bash install.sh ...`
+> (le `-E` est nécessaire car `sudo` strip les variables d'environnement par défaut).
 
 Le script :
 
-1. Détecte l'OS et installe les paquets requis (`curl`, `jq`, `cron`, `dnsutils`).
+1. Détecte l'OS et installe les paquets requis (`curl`, `jq`, `cron`, `dnsutils`, `nano`).
 2. Installe Docker si absent (via `get-docker.com`).
 3. Configure UFW (OpenSSH + 80/tcp + 443/tcp + 443/udp).
 4. Crée un user système `<slug>` (home `/srv/<slug>/`, groupe `docker`).
 5. Télécharge la config (`docker-compose.yml`, `Caddyfile`, `crontab`, `.env`).
 6. Substitue les valeurs (`INSTANCE_SLUG`, `BACKUPS_PATH`, domaine, email).
-7. Ouvre `.env` dans `$EDITOR` (vi par défaut) — tu remplis les `# TODO:`.
+7. Ouvre `.env` dans `$EDITOR` (nano par défaut) — tu remplis les `# TODO:`.
 8. Vérifie le DNS (`<domain>` doit pointer vers l'IP publique du VPS).
 9. Démarre la stack `docker compose up -d`.
 10. Lance un ETL test (vérifie clés AES + SFTP + DuckDB).
@@ -170,18 +168,19 @@ HTTP-01 (cf. [ADR-0015](adr/0015-deploiement-multi-instance.md)).
 ```bash
 ssh root@<vps>
 curl -fsSL https://raw.githubusercontent.com/Energie-De-Nantes/electricore/main/deploy/install.sh -o install.sh
-EDITOR=nano sudo -E bash install.sh \
+sudo bash install.sh \
     --slug <slug> \
     --domain <slug>.electricore.fr \
     --email ops@example.com \
     --version 1.7.0
 ```
 
-> `EDITOR=nano sudo -E` force le script à utiliser nano à l'étape d'édition
-> du `.env` (sinon vi par défaut sur Ubuntu). Omettre si tu préfères vi.
+> L'éditeur par défaut est `nano`. Pour vim/vi : préfixer par
+> `EDITOR=vim sudo -E bash install.sh ...` (le `-E` passe l'env à sudo).
 
 Options notables :
-- `--version <tag>` — pin la version GHCR (recommandé en prod, défaut `latest`).
+- `--version <tag>` — pin la version GHCR + écrit `ELECTRICORE_VERSION` dans `.env`
+  (recommandé en prod, défaut `latest`). Accepte `1.7.0`, `1.8.0rc1`, etc.
 - `--ssh-pubkey "ssh-ed25519 ..."` — clé SSH dédiée pour `<slug>`. Sans cette
   option, le script copie `~root/.ssh/authorized_keys`.
 - `--env-from <fichier>` — charge un `.env` pré-rempli (utile pour les déploiements
@@ -248,7 +247,7 @@ d'écriture vers Odoo (cf. [ADR-0012](adr/0012-api-read-only-odoo.md)).
 | Endpoint | Sortie | Paramètre |
 |---|---|---|
 | `GET /facturation/arrow` | `lignes_facture_rapprochees` (rapprochement Odoo ↔ Enedis du mois) | `mois=YYYY-MM-DD` (défaut : dernier mois) |
-| `GET /taxes/accise/arrow` | Détail Accise TICFE | `trimestre=YYYY-TX` |
+| `GET /taxes/accise/detail.arrow` | Détail Accise TICFE | `trimestre=YYYY-TX` |
 | `GET /taxes/cta/arrow` | Détail CTA mensuel | idem |
 
 Les endpoints `xlsx` existants restent inchangés.
@@ -432,8 +431,8 @@ Le script :
 1. Détecte l'instance existante (mode reconfigure).
 2. Re-télécharge `docker-compose.yml`, `Caddyfile`, `crontab` au tag demandé
    (utile si la stack a évolué).
-3. Backup `.env`, ouvre `$EDITOR` — tu peux ajuster `ELECTRICORE_VERSION`
-   si différent du `--version`.
+3. Backup `.env`, écrit `ELECTRICORE_VERSION=<--version>` automatiquement, ouvre
+   `$EDITOR` (nano par défaut) pour les ajustements éventuels.
 4. `docker compose pull` puis `up -d` (recrée les conteneurs avec la nouvelle image).
 5. ETL test.
 


### PR DESCRIPTION
## Summary
Le flag `--version` était cassé à deux endroits, et le défaut d'éditeur (`vi`) sur Ubuntu surprenait à chaque install. Cette PR fait du flag une vraie source de vérité et bascule l'éditeur sur nano.

## Bugs fixés
**1. URL de download — 404 sur les tags release**

`download_config_files` utilisait `${version}` verbatim comme ref Git, mais les tags Git sont `v1.7.0rc2` (avec `v`) alors que les tags Docker sont `1.7.0rc2` (sans). D'où :

```
curl -fsSL https://raw.githubusercontent.com/.../1.7.0rc2/deploy/docker/.env.example
# → 404
```

Reproduit ce matin sur le test server avec `--version 1.7.0rc2`.

**2. `ELECTRICORE_VERSION` jamais patché**

Le flag pilotait uniquement l'URL de download. La valeur dans `.env` (qui contrôle le `docker compose pull`) restait `latest` — la doc demandait d'éditer à la main dans le step EDITOR. Flag à moitié décoratif.

## Fix
- Nouveau helper `map_version_to_git_ref` dans `deploy/lib/config.sh` :
  - `latest` → `main`
  - `1.7.0`, `1.8.0rc1`, `2.0.0a1` → `v<version>`
  - `main`, `dev`, `abc1234` → unchanged
- `download_config_files` utilise le helper.
- `substitute_env` accepte un 3e argument optionnel `<version>` et patche `ELECTRICORE_VERSION=<version>`. Sans argument, comportement inchangé (compat ascendante).
- `install.sh:145` passe `$OPT_VERSION` à `substitute_env`.

Résultat : `bash install.sh --version 1.7.0rc3` fait tout d'un coup — URL valide, `.env` correct, `docker compose pull` ramène la bonne image.

## UX éditeur
- `nano` ajouté à `ensure_packages` (Ubuntu minimal ne l'a pas toujours).
- `${EDITOR:-vi}` → `${EDITOR:-nano}` aux deux call sites.
- Doc : suppression du préfixe `EDITOR=nano sudo -E` (redondant), remplacé par la note inverse pour les fans de vim.

## Tests
- 8 cas pour `map_version_to_git_ref` (latest, rc, stable, major, alpha, branches, SHA)
- 2 cas pour `substitute_env` (ELECTRICORE_VERSION inchangée sans 3e arg, patchée avec, INSTANCE_SLUG préservé)
- 67/67 deploy unit + 415/35 Python tests verts
- Pre-commit clean

## Next
Une fois mergé → cut `v1.7.0rc3`, puis sur le test server :
```bash
sudo bash /srv/edn/deploy/install.sh \
    --slug edn --domain edn.electricore.fr --version 1.7.0rc3
```
Just works, no `v` prefix gymnastics, no `EDITOR=nano sudo -E`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)