### PR TITLE
feat(taxes): split CTA into rapport_cta + cta_par_contrat (#63)

### DIFF
--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -27,8 +27,9 @@ from electricore.api.services.taxes_service import (
     generer_accise_detail_arrow,
     generer_accise_detail_xlsx,
     generer_accise_rapport_xlsx,
-    generer_cta_arrow,
-    generer_cta_xlsx,
+    generer_cta_detail_arrow,
+    generer_cta_detail_xlsx,
+    generer_cta_rapport_xlsx,
 )
 
 logger = logging.getLogger(__name__)
@@ -455,28 +456,42 @@ def export_accise_detail_arrow(
     return generer_accise_detail_arrow(trimestre)
 
 
-@xlsx_endpoint(app, "/taxes/cta/xlsx", filename="cta{trimestre}.xlsx", requires_odoo=True, tags=["taxes"])
-def export_cta_xlsx(
+@xlsx_endpoint(
+    app, "/taxes/cta/rapport.xlsx", filename="cta_rapport{trimestre}.xlsx", requires_odoo=True, tags=["taxes"]
+)
+def export_cta_rapport_xlsx(
     trimestre: str | None = Query(
         default=None,
         examples=["2025-T1"],
         description="Filtre par trimestre au format YYYY-TX. Sans filtre : toutes les données.",
     ),
 ) -> bytes:
-    """Calcule la CTA et retourne un fichier XLSX (3 onglets : Résumé, Par taux, Détail)."""
-    return generer_cta_xlsx(trimestre)
+    """Livrable facturiste : CTA en XLSX multi-onglets (Résumé / Par taux / Détail)."""
+    return generer_cta_rapport_xlsx(trimestre)
 
 
-@arrow_endpoint(app, "/taxes/cta/arrow", requires_odoo=True, tags=["taxes"])
-def export_cta_arrow(
+@xlsx_endpoint(app, "/taxes/cta/detail.xlsx", filename="cta_detail{trimestre}.xlsx", requires_odoo=True, tags=["taxes"])
+def export_cta_detail_xlsx(
     trimestre: str | None = Query(
         default=None,
         examples=["2025-T1"],
         description="Filtre par trimestre au format YYYY-TX. Sans filtre : toutes les données.",
     ),
 ) -> bytes:
-    """Détail CTA mensuel sérialisé en Arrow IPC stream (pdl × mois avec cta_eur, taux_cta_pct)."""
-    return generer_cta_arrow(trimestre)
+    """Détail CTA mensuel en XLSX mono-onglet (PDL × mois, cas technique)."""
+    return generer_cta_detail_xlsx(trimestre)
+
+
+@arrow_endpoint(app, "/taxes/cta/detail.arrow", requires_odoo=True, tags=["taxes"])
+def export_cta_detail_arrow(
+    trimestre: str | None = Query(
+        default=None,
+        examples=["2025-T1"],
+        description="Filtre par trimestre au format YYYY-TX. Sans filtre : toutes les données.",
+    ),
+) -> bytes:
+    """Détail CTA mensuel en Arrow IPC stream (PDL × mois, cas technique)."""
+    return generer_cta_detail_arrow(trimestre)
 
 
 @xlsx_endpoint(app, "/facturation/xlsx", filename="facturation{mois}.xlsx", requires_odoo=True, tags=["facturation"])

--- a/electricore/api/services/taxes_service.py
+++ b/electricore/api/services/taxes_service.py
@@ -4,11 +4,12 @@ Le calcul et l'orchestration métier vivent dans
 `electricore.integrations.odoo.taxes`. Ce service ne fait que :
 
 1. Ouvrir la connexion `OdooReader` (responsabilité HTTP)
-2. Déléguer à l'orchestration (`accise_par_contrat` / `rapport_accise` / `cta_du_trimestre`)
+2. Déléguer à l'orchestration (`accise_par_contrat`, `rapport_accise`,
+   `cta_par_contrat`, `rapport_cta`)
 3. Sérialiser le résultat (XLSX multi-onglets / Arrow IPC).
 
-La shape du livrable (`Résumé` / `Par taux` / `Détail`) vit désormais dans
-`integrations.odoo.taxes.rapport_accise` (cf. issue #56).
+La shape des livrables (`Résumé` / `Par taux` / `Détail`) vit désormais dans
+`integrations.odoo.taxes.rapport_accise` et `.rapport_cta` (cf. issues #56, #63).
 """
 
 import polars as pl
@@ -18,8 +19,9 @@ from electricore.api.serializers import arrow_stream, xlsx_multi_sheet
 from electricore.integrations.odoo import OdooReader
 from electricore.integrations.odoo.taxes import (
     accise_par_contrat,
-    cta_du_trimestre,
+    cta_par_contrat,
     rapport_accise,
+    rapport_cta,
 )
 
 
@@ -53,83 +55,34 @@ def generer_accise_rapport_xlsx(trimestre: str | None = None) -> bytes:
 
 
 def calculer_cta_detail(trimestre: str | None = None) -> pl.DataFrame:
-    """Binding HTTP : ouvre Odoo + délègue à `cta_du_trimestre`.
-
-    Seam testable au niveau du service (les endpoints peuvent la monkeypatch
-    pour bypasser Odoo). La logique métier vit dans
-    `electricore.integrations.odoo.taxes.cta_du_trimestre`.
-    """
+    """Binding HTTP : ouvre Odoo + délègue à `cta_par_contrat`."""
     with OdooReader(config=settings.get_odoo_config()) as odoo:
-        return cta_du_trimestre(odoo, trimestre)
+        return cta_par_contrat(odoo, trimestre)
 
 
-def generer_cta_arrow(trimestre: str | None = None) -> bytes:
-    """Sérialise le détail CTA mensuel en flux Arrow IPC."""
+def generer_cta_detail_arrow(trimestre: str | None = None) -> bytes:
+    """Sérialise le détail CTA mensuel (PDL × mois) en flux Arrow IPC."""
     return arrow_stream(calculer_cta_detail(trimestre))
 
 
-def generer_cta_xlsx(trimestre: str | None = None) -> bytes:
-    """Calcule la CTA et retourne un fichier XLSX multi-onglets.
+def generer_cta_detail_xlsx(trimestre: str | None = None) -> bytes:
+    """Sérialise le détail CTA mensuel (PDL × mois) en XLSX mono-onglet."""
+    return xlsx_multi_sheet({"Détail": calculer_cta_detail(trimestre)})
 
-    Les taux sont chargés automatiquement depuis electricore/config/cta_rules.csv
-    et appliqués au niveau mensuel. Un changement de taux en cours de trimestre
-    (décret CRE) est donc géré automatiquement dans l'agrégation trimestrielle.
 
-    Args:
-        trimestre: Filtre optionnel au format "YYYY-TX" (ex: "2025-T1").
-            Si None, retourne toutes les données disponibles.
+def generer_cta_rapport_xlsx(trimestre: str | None = None) -> bytes:
+    """Livrable facturiste : 3 onglets (Résumé / Par taux / Détail) depuis `rapport_cta`.
 
-    Returns:
-        Contenu XLSX en bytes avec 3 onglets : Résumé, Par taux, Détail.
+    Le décret CRE peut faire varier `taux_cta_pct` en cours de trimestre ;
+    l'onglet `Par taux` reflète cette dimensionalité, et l'onglet `Détail`
+    list les taux successifs par PDL en string joined ` ; `.
     """
-    df_mensuel = calculer_cta_detail(trimestre)
-
-    df_detail_cta = (
-        df_mensuel.lazy()
-        .group_by("pdl")
-        .agg(
-            [
-                pl.col("order_name").first(),
-                pl.col("turpe_fixe_eur").sum().round(2).alias("turpe_fixe_total"),
-                pl.col("cta_eur").sum().round(2).alias("cta"),
-                pl.col("taux_cta_pct").unique().sort().alias("taux_cta_appliques"),
-            ]
-        )
-        .sort("cta", descending=True)
-        .collect()
-        # Sérialiser la liste des taux en string pour un rendu XLSX lisible
-        .with_columns(pl.col("taux_cta_appliques").list.eval(pl.element().cast(pl.Utf8)).list.join(" ; "))
-    )
-
-    df_par_taux = (
-        df_mensuel.group_by(["trimestre", "taux_cta_pct"])
-        .agg(
-            [
-                pl.col("pdl").n_unique().alias("Nombre de PDL"),
-                pl.col("turpe_fixe_eur").sum().round(2).alias("TURPE fixe (€)"),
-                pl.col("cta_eur").sum().round(2).alias("CTA (€)"),
-            ]
-        )
-        .sort(["trimestre", "taux_cta_pct"])
-        .rename({"taux_cta_pct": "Taux CTA (%)"})
-    )
-
-    df_resume = (
-        df_mensuel.group_by("trimestre")
-        .agg(
-            [
-                pl.col("pdl").n_unique().alias("Nombre de PDL"),
-                pl.col("turpe_fixe_eur").sum().round(2).alias("TURPE fixe total (€)"),
-                pl.col("cta_eur").sum().round(2).alias("CTA totale (€)"),
-            ]
-        )
-        .sort("trimestre")
-    )
-
+    with OdooReader(config=settings.get_odoo_config()) as odoo:
+        r = rapport_cta(odoo, trimestre)
     return xlsx_multi_sheet(
         {
-            "Résumé": df_resume,
-            "Par taux": df_par_taux,
-            "Détail": df_detail_cta,
+            "Résumé": r.resume,
+            "Par taux": r.par_taux,
+            "Détail": r.detail,
         }
     )

--- a/electricore/bot/client.py
+++ b/electricore/bot/client.py
@@ -82,7 +82,7 @@ class ElectriCoreClient:
     async def get_cta_xlsx(self, trimestre: str | None = None) -> bytes:
         params: dict = {"trimestre": trimestre} if trimestre else {}
         async with httpx.AsyncClient() as c:
-            r = await c.get(f"{self._base}/taxes/cta/xlsx", headers=self._headers, params=params, timeout=300)
+            r = await c.get(f"{self._base}/taxes/cta/rapport.xlsx", headers=self._headers, params=params, timeout=300)
             r.raise_for_status()
             return r.content
 

--- a/electricore/client/__init__.py
+++ b/electricore/client/__init__.py
@@ -83,7 +83,7 @@ class ElectricoreClient:
         Args:
             trimestre: "YYYY-TX" (ex: "2025-T1") — défaut : tous les trimestres.
         """
-        return self._get_arrow("/taxes/cta/arrow", {"trimestre": trimestre} if trimestre else {})
+        return self._get_arrow("/taxes/cta/detail.arrow", {"trimestre": trimestre} if trimestre else {})
 
 
 __all__ = ["ElectricoreClient"]

--- a/electricore/integrations/odoo/models/rapport_cta.py
+++ b/electricore/integrations/odoo/models/rapport_cta.py
@@ -1,0 +1,50 @@
+"""Schémas Pandera pour le livrable `rapport_cta` (issue #63).
+
+Trois `DataFrameModel` qui reflètent les onglets XLSX livrés au facturiste pour
+la déclaration trimestrielle CTA.
+
+Les noms de champs restent en snake_case ; le mapping vers les libellés
+facturiste (« Nombre de PDL », « CTA (€) »…) se fait à la couche de
+sérialisation XLSX, comme pour `rapport_accise`.
+"""
+
+import pandera.polars as pa
+import polars as pl
+
+
+class RapportCtaResume(pa.DataFrameModel):
+    """Totaux trimestriels : un résumé par trimestre."""
+
+    trimestre: pl.Utf8 = pa.Field(nullable=False)
+    nb_pdl: pl.Int64 = pa.Field(nullable=False, ge=0)
+    turpe_fixe_total_eur: pl.Float64 = pa.Field(nullable=False)
+    cta_total_eur: pl.Float64 = pa.Field(nullable=False)
+
+
+class RapportCtaParTaux(pa.DataFrameModel):
+    """Décomposition par (trimestre, taux CTA applicable).
+
+    Le décret CRE peut faire varier le taux en cours de trimestre ;
+    `taux_cta_pct` est dimensionné mensuellement avant agrégation.
+    """
+
+    trimestre: pl.Utf8 = pa.Field(nullable=False)
+    taux_cta_pct: pl.Float64 = pa.Field(nullable=False)
+    nb_pdl: pl.Int64 = pa.Field(nullable=False, ge=0)
+    turpe_fixe_eur: pl.Float64 = pa.Field(nullable=False)
+    cta_eur: pl.Float64 = pa.Field(nullable=False)
+
+
+class RapportCtaDetail(pa.DataFrameModel):
+    """Détail par PDL (= un PDL × order × totaux annuels) — agrégation du brut mensuel.
+
+    Spécificité CTA : `taux_cta_appliques` est une string joined ` ; ` qui
+    liste les taux successifs touchés par le PDL au cours de la période
+    (utile quand un changement de décret tombe au milieu du trimestre).
+    """
+
+    pdl: pl.Utf8 = pa.Field(nullable=False)
+    order_name: pl.Utf8 = pa.Field(nullable=False)
+    turpe_fixe_total_eur: pl.Float64 = pa.Field(nullable=False)
+    cta_total_eur: pl.Float64 = pa.Field(nullable=False)
+    taux_cta_appliques: pl.Utf8 = pa.Field(nullable=False)

--- a/electricore/integrations/odoo/taxes.py
+++ b/electricore/integrations/odoo/taxes.py
@@ -6,10 +6,10 @@ pour produire les DataFrames consommés par les endpoints API et les notebooks.
 
 Deux interfaces cohabitent (cf. issue #56) :
 
-- `accise_par_contrat` / `cta_du_trimestre` : calcul brut par PDL × période, pour
+- `accise_par_contrat` / `cta_par_contrat` : calcul brut par PDL × période, pour
   exploration et réinjection (Arrow / XLSX mono-onglet).
-- `rapport_accise` : livrable agrégé (`Résumé` / `Par taux` / `Détail`) destiné à
-  la déclaration trimestrielle facturiste (XLSX multi-onglets).
+- `rapport_accise` / `rapport_cta` : livrable agrégé (`Résumé` / `Par taux` /
+  `Détail`) destiné à la déclaration trimestrielle facturiste (XLSX multi-onglets).
 
 EDN-shaped aujourd'hui ; sert de prototype pour un futur module Odoo libre
 couvrant les fournisseurs alternatifs (cf. CONTEXT.md, ADR-0016).
@@ -30,11 +30,28 @@ from .models.rapport_accise import (
     RapportAcciseParTaux,
     RapportAcciseResume,
 )
+from .models.rapport_cta import (
+    RapportCtaDetail,
+    RapportCtaParTaux,
+    RapportCtaResume,
+)
 from .reader import OdooReader
 
 
 class RapportAccise(NamedTuple):
     """Livrable trimestriel d'accise (= les 3 onglets de l'export XLSX facturiste)."""
+
+    resume: pl.DataFrame
+    par_taux: pl.DataFrame
+    detail: pl.DataFrame
+
+
+class RapportCta(NamedTuple):
+    """Livrable trimestriel CTA (= les 3 onglets de l'export XLSX facturiste).
+
+    `detail` est une agrégation par PDL (sommes + taux successifs string-joined),
+    pas la sortie brute de `cta_par_contrat` (qui reste mensuelle).
+    """
 
     resume: pl.DataFrame
     par_taux: pl.DataFrame
@@ -105,8 +122,11 @@ def rapport_accise(odoo: OdooReader, trimestre: str | None = None) -> RapportAcc
     return RapportAccise(resume=resume, par_taux=par_taux, detail=detail)
 
 
-def cta_du_trimestre(odoo: OdooReader, trimestre: str | None = None) -> pl.DataFrame:
-    """Charge Odoo + flux, applique la pipeline CTA mensuelle (+ filtre trimestre).
+def cta_par_contrat(odoo: OdooReader, trimestre: str | None = None) -> pl.DataFrame:
+    """Calcul brut de la CTA mensuelle par PDL × mois (interface technique).
+
+    Pour le livrable facturiste (multi-onglets Résumé / Par taux / Détail),
+    utiliser `rapport_cta(...)`.
 
     Args:
         odoo: `OdooReader` déjà ouvert.
@@ -145,3 +165,70 @@ def cta_du_trimestre(odoo: OdooReader, trimestre: str | None = None) -> pl.DataF
     if trimestre is not None:
         df_mensuel = df_mensuel.filter(pl.col("trimestre") == trimestre)
     return df_mensuel
+
+
+def rapport_cta(odoo: OdooReader, trimestre: str | None = None) -> RapportCta:
+    """Livrable agrégé pour déclaration trimestrielle CTA.
+
+    Compose `cta_par_contrat` (mensuel brut) avec les agrégations « Par taux »,
+    « Résumé » et une synthèse « Détail » par PDL où la liste des taux appliqués
+    est sérialisée en string (utile quand un décret CRE découpe le trimestre).
+
+    Les 3 frames du `NamedTuple` sont validées Pandera avant retour.
+
+    Args:
+        odoo: `OdooReader` déjà ouvert.
+        trimestre: format "YYYY-TX". `None` = tous les trimestres.
+
+    Returns:
+        `RapportCta(resume, par_taux, detail)`.
+    """
+    df_mensuel = cta_par_contrat(odoo, trimestre)
+
+    par_taux = (
+        df_mensuel.group_by(["trimestre", "taux_cta_pct"])
+        .agg(
+            [
+                pl.col("pdl").n_unique().cast(pl.Int64).alias("nb_pdl"),
+                pl.col("turpe_fixe_eur").sum().round(2),
+                pl.col("cta_eur").sum().round(2),
+            ]
+        )
+        .sort(["trimestre", "taux_cta_pct"])
+    )
+
+    resume = (
+        df_mensuel.group_by("trimestre")
+        .agg(
+            [
+                pl.col("pdl").n_unique().cast(pl.Int64).alias("nb_pdl"),
+                pl.col("turpe_fixe_eur").sum().round(2).alias("turpe_fixe_total_eur"),
+                pl.col("cta_eur").sum().round(2).alias("cta_total_eur"),
+            ]
+        )
+        .sort("trimestre")
+    )
+
+    detail = (
+        df_mensuel.lazy()
+        .group_by("pdl")
+        .agg(
+            [
+                pl.col("order_name").first(),
+                pl.col("turpe_fixe_eur").sum().round(2).alias("turpe_fixe_total_eur"),
+                pl.col("cta_eur").sum().round(2).alias("cta_total_eur"),
+                pl.col("taux_cta_pct").unique().sort().alias("_taux_list"),
+            ]
+        )
+        .sort("cta_total_eur", descending=True)
+        .collect()
+        .with_columns(
+            pl.col("_taux_list").list.eval(pl.element().cast(pl.Utf8)).list.join(" ; ").alias("taux_cta_appliques")
+        )
+        .drop("_taux_list")
+    )
+
+    RapportCtaResume.validate(resume)
+    RapportCtaParTaux.validate(par_taux)
+    RapportCtaDetail.validate(detail)
+    return RapportCta(resume=resume, par_taux=par_taux, detail=detail)

--- a/notebooks/accise_et_cta.py
+++ b/notebooks/accise_et_cta.py
@@ -31,7 +31,7 @@ def _():
     mo.md(r"""
     # Accise & CTA — calcul trimestriel
 
-    Les calculs sont délégués aux endpoints `/taxes/cta/arrow` et `/taxes/accise/detail.arrow`
+    Les calculs sont délégués aux endpoints `/taxes/cta/detail.arrow` et `/taxes/accise/detail.arrow`
     de l'API electricore (cf. ADR-0009). Le notebook se contente de récupérer les
     DataFrames, de sélectionner un trimestre et d'afficher les agrégats.
 

--- a/tests/architecture/test_integrations_odoo_orchestrations.py
+++ b/tests/architecture/test_integrations_odoo_orchestrations.py
@@ -13,7 +13,7 @@ import pytest
 
 FACTURATION_ORCHESTRATIONS = ("facturation_du_mois", "documents_facturation_du_mois")
 
-TAXES_ORCHESTRATIONS = ("rapport_accise", "accise_par_contrat", "cta_du_trimestre")
+TAXES_ORCHESTRATIONS = ("rapport_accise", "accise_par_contrat", "rapport_cta", "cta_par_contrat")
 
 
 @pytest.mark.parametrize("name", FACTURATION_ORCHESTRATIONS)

--- a/tests/integration/test_taxes_arrow_endpoints.py
+++ b/tests/integration/test_taxes_arrow_endpoints.py
@@ -190,18 +190,17 @@ def test_anciens_endpoints_accise_404(_mock_odoo_reader):
 
 
 # =============================================================================
-# /taxes/cta/arrow
+# /taxes/cta/detail.arrow
 # =============================================================================
 
 
 @pytest.fixture
 def df_cta_detail() -> pl.DataFrame:
-    """Échantillon ressemblant à la sortie mensuelle de la pipeline CTA."""
+    """Échantillon ressemblant à la sortie mensuelle de `cta_par_contrat`."""
     return pl.DataFrame(
         {
             "pdl": ["12345678901234"],
             "order_name": ["SO/2025/0001"],
-            "mois_annee": ["janvier 2025"],
             "trimestre": ["2025-T1"],
             "turpe_fixe_eur": [42.50],
             "cta_eur": [9.18],
@@ -210,16 +209,16 @@ def df_cta_detail() -> pl.DataFrame:
     )
 
 
-def test_cta_endpoint_retourne_arrow_ipc_stream(monkeypatch, df_cta_detail):
+def test_cta_detail_arrow_retourne_arrow_ipc_stream(monkeypatch, _mock_odoo_reader, df_cta_detail):
     """L'endpoint sert le détail CTA en Arrow IPC."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
     monkeypatch.setattr(
-        "electricore.api.services.taxes_service.calculer_cta_detail",
-        lambda trimestre=None: df_cta_detail,
+        "electricore.api.services.taxes_service.cta_par_contrat",
+        lambda odoo, trimestre=None: df_cta_detail,
     )
 
     try:
-        response = TestClient(app).get("/taxes/cta/arrow")
+        response = TestClient(app).get("/taxes/cta/detail.arrow")
     finally:
         app.dependency_overrides.clear()
 
@@ -230,25 +229,134 @@ def test_cta_endpoint_retourne_arrow_ipc_stream(monkeypatch, df_cta_detail):
     assert_frame_equal(df, df_cta_detail)
 
 
-def test_cta_endpoint_refuse_sans_api_key():
-    response = TestClient(app).get("/taxes/cta/arrow")
+def test_cta_detail_arrow_refuse_sans_api_key():
+    response = TestClient(app).get("/taxes/cta/detail.arrow")
     assert response.status_code == 401
 
 
-def test_cta_endpoint_propage_trimestre(monkeypatch, df_cta_detail):
+def test_cta_detail_arrow_propage_trimestre(monkeypatch, _mock_odoo_reader, df_cta_detail):
+    """Le query param `trimestre` est transmis à `cta_par_contrat`."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
     appels: list[str | None] = []
 
-    def fake_calculer(trimestre: str | None = None) -> pl.DataFrame:
+    def _capture(odoo, trimestre=None):
         appels.append(trimestre)
         return df_cta_detail
 
-    monkeypatch.setattr("electricore.api.services.taxes_service.calculer_cta_detail", fake_calculer)
+    monkeypatch.setattr("electricore.api.services.taxes_service.cta_par_contrat", _capture)
 
     try:
-        response = TestClient(app).get("/taxes/cta/arrow", params={"trimestre": "2025-T2"})
+        response = TestClient(app).get("/taxes/cta/detail.arrow", params={"trimestre": "2025-T2"})
     finally:
         app.dependency_overrides.clear()
 
     assert response.status_code == 200
     assert appels == ["2025-T2"]
+
+
+# =============================================================================
+# /taxes/cta/detail.xlsx
+# =============================================================================
+
+
+def test_cta_detail_xlsx_retourne_xlsx_mono_onglet(monkeypatch, _mock_odoo_reader, df_cta_detail):
+    """L'endpoint sert le détail CTA en XLSX mono-onglet."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.services.taxes_service.cta_par_contrat",
+        lambda odoo, trimestre=None: df_cta_detail,
+    )
+
+    try:
+        response = TestClient(app).get("/taxes/cta/detail.xlsx")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(XLSX_MIME)
+    assert "attachment" in response.headers.get("content-disposition", "")
+
+
+# =============================================================================
+# /taxes/cta/rapport.xlsx
+# =============================================================================
+
+
+@pytest.fixture
+def fake_rapport_cta(df_cta_detail):
+    """`RapportCta` synthétique pour la sérialisation XLSX."""
+    from electricore.integrations.odoo.taxes import RapportCta
+
+    return RapportCta(
+        resume=pl.DataFrame(
+            {
+                "trimestre": ["2025-T1"],
+                "nb_pdl": [1],
+                "turpe_fixe_total_eur": [42.50],
+                "cta_total_eur": [9.18],
+            }
+        ),
+        par_taux=pl.DataFrame(
+            {
+                "trimestre": ["2025-T1"],
+                "taux_cta_pct": [21.61],
+                "nb_pdl": [1],
+                "turpe_fixe_eur": [42.50],
+                "cta_eur": [9.18],
+            }
+        ),
+        detail=pl.DataFrame(
+            {
+                "pdl": ["12345678901234"],
+                "order_name": ["SO/2025/0001"],
+                "turpe_fixe_total_eur": [42.50],
+                "cta_total_eur": [9.18],
+                "taux_cta_appliques": ["21.61"],
+            }
+        ),
+    )
+
+
+def test_cta_rapport_xlsx_retourne_xlsx_multi_onglets(monkeypatch, _mock_odoo_reader, fake_rapport_cta):
+    """L'endpoint sert le rapport multi-onglets (Résumé / Par taux / Détail)."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.services.taxes_service.rapport_cta",
+        lambda odoo, trimestre=None: fake_rapport_cta,
+    )
+
+    try:
+        response = TestClient(app).get("/taxes/cta/rapport.xlsx")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(XLSX_MIME)
+    assert "attachment" in response.headers.get("content-disposition", "")
+
+
+def test_cta_rapport_xlsx_propage_trimestre(monkeypatch, _mock_odoo_reader, fake_rapport_cta):
+    """Le query param `trimestre` est propagé jusqu'à `rapport_cta`."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    appels: list[str | None] = []
+
+    def _capture(odoo, trimestre=None):
+        appels.append(trimestre)
+        return fake_rapport_cta
+
+    monkeypatch.setattr("electricore.api.services.taxes_service.rapport_cta", _capture)
+
+    try:
+        response = TestClient(app).get("/taxes/cta/rapport.xlsx", params={"trimestre": "2025-T2"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert appels == ["2025-T2"]
+
+
+def test_anciens_endpoints_cta_404(_mock_odoo_reader):
+    """Les anciens paths CTA sont supprimés."""
+    for path in ("/taxes/cta/xlsx", "/taxes/cta/arrow"):
+        response = TestClient(app).get(path)
+        assert response.status_code == 404, f"{path} devrait être 404"

--- a/tests/integration/test_taxes_service_smoke.py
+++ b/tests/integration/test_taxes_service_smoke.py
@@ -35,7 +35,7 @@ def df_facturation_mensuelle_cta() -> pl.DataFrame:
 
 
 def test_calculer_cta_detail_delegue_a_charger_contexte_facturation(monkeypatch, df_facturation_mensuelle_cta):
-    """`cta_du_trimestre` consomme `ContexteFacturation` (issue #19 + #40, ADR-0016).
+    """`cta_par_contrat` consomme `ContexteFacturation` (issue #19 + #40, ADR-0016).
 
     Depuis #40, l'orchestration vit dans `integrations.odoo.taxes`. Le test vérifie
     que la chaîne service → orchestration délègue toujours à `charger_contexte_facturation`

--- a/tests/unit/integrations/odoo/test_rapport_cta.py
+++ b/tests/unit/integrations/odoo/test_rapport_cta.py
@@ -1,0 +1,164 @@
+"""Tests pour `cta_par_contrat` et `rapport_cta` (Candidate 1.2, issue #63).
+
+Réplique du pattern validé par #56 (accise) sur le domaine CTA. Spécificité :
+le `detail` du livrable est une **agrégation par PDL** (sommes + liste de taux
+sérialisée), pas la sortie brute de `cta_par_contrat` (qui reste mensuelle).
+"""
+
+import polars as pl
+
+
+def test_cta_par_contrat_exists_and_is_callable():
+    """`cta_par_contrat` est exporté depuis `integrations.odoo.taxes`."""
+    from electricore.integrations.odoo import taxes
+
+    assert hasattr(taxes, "cta_par_contrat")
+    assert callable(taxes.cta_par_contrat)
+
+
+def test_cta_du_trimestre_is_removed():
+    """L'ancien nom `cta_du_trimestre` n'existe plus."""
+    from electricore.integrations.odoo import taxes
+
+    assert not hasattr(taxes, "cta_du_trimestre")
+
+
+class TestRapportCtaSchemas:
+    """Les 3 `DataFrameModel` Pandera valident bien des frames conformes."""
+
+    def test_resume_schema_validates_correct_frame(self):
+        from electricore.integrations.odoo.models.rapport_cta import RapportCtaResume
+
+        df = pl.DataFrame(
+            {
+                "trimestre": ["2025-T1"],
+                "nb_pdl": [3],
+                "turpe_fixe_total_eur": [120.50],
+                "cta_total_eur": [26.04],
+            }
+        )
+        RapportCtaResume.validate(df)
+
+    def test_par_taux_schema_validates_correct_frame(self):
+        from electricore.integrations.odoo.models.rapport_cta import RapportCtaParTaux
+
+        df = pl.DataFrame(
+            {
+                "trimestre": ["2025-T1"],
+                "taux_cta_pct": [21.61],
+                "nb_pdl": [3],
+                "turpe_fixe_eur": [120.50],
+                "cta_eur": [26.04],
+            }
+        )
+        RapportCtaParTaux.validate(df)
+
+    def test_detail_schema_validates_correct_frame(self):
+        from electricore.integrations.odoo.models.rapport_cta import RapportCtaDetail
+
+        df = pl.DataFrame(
+            {
+                "pdl": ["12345678901234"],
+                "order_name": ["SO/2025/0001"],
+                "turpe_fixe_total_eur": [42.50],
+                "cta_total_eur": [9.18],
+                "taux_cta_appliques": ["21.61"],
+            }
+        )
+        RapportCtaDetail.validate(df)
+
+
+def _monthly_synthetique() -> pl.DataFrame:
+    """`cta_par_contrat` synthétique : 3 PDL × plusieurs mois × 2 taux distincts.
+
+    PDL "A" : T1 (taux 21.61 sur 2 mois) → 2 lignes
+    PDL "B" : T1 (taux 21.61 sur 1 mois) + T2 (taux 22.10 sur 2 mois — décret CRE) → 3 lignes
+    PDL "C" : T2 (taux 22.10 sur 1 mois) → 1 ligne
+    """
+    return pl.DataFrame(
+        {
+            "pdl": ["A", "A", "B", "B", "B", "C"],
+            "order_name": ["SO/A", "SO/A", "SO/B", "SO/B", "SO/B", "SO/C"],
+            "trimestre": ["2025-T1", "2025-T1", "2025-T1", "2025-T2", "2025-T2", "2025-T2"],
+            "taux_cta_pct": [21.61, 21.61, 21.61, 22.10, 22.10, 22.10],
+            "turpe_fixe_eur": [10.0, 12.0, 8.0, 14.0, 14.0, 20.0],
+            "cta_eur": [2.16, 2.59, 1.73, 3.09, 3.09, 4.42],
+        }
+    )
+
+
+class TestRapportCta:
+    """`rapport_cta` produit un `RapportCta(resume, par_taux, detail)`."""
+
+    def test_returns_namedtuple_with_three_fields(self, monkeypatch):
+        from electricore.integrations.odoo import taxes
+
+        monkeypatch.setattr(taxes, "cta_par_contrat", lambda odoo, trimestre=None: _monthly_synthetique())
+        result = taxes.rapport_cta(odoo=None)
+
+        assert hasattr(result, "resume")
+        assert hasattr(result, "par_taux")
+        assert hasattr(result, "detail")
+
+    def test_par_taux_groups_by_trimestre_and_taux(self, monkeypatch):
+        """`par_taux` indexé par (trimestre, taux_cta_pct), sommes + n_unique(pdl)."""
+        from electricore.integrations.odoo import taxes
+
+        monkeypatch.setattr(taxes, "cta_par_contrat", lambda odoo, trimestre=None: _monthly_synthetique())
+        result = taxes.rapport_cta(odoo=None)
+
+        # Trié sur (trimestre, taux_cta_pct) — 2 lignes : T1 @ 21.61 et T2 @ 22.10
+        assert result.par_taux["trimestre"].to_list() == ["2025-T1", "2025-T2"]
+        assert result.par_taux["taux_cta_pct"].to_list() == [21.61, 22.10]
+        # T1 @ 21.61 : PDLs {A, B} = 2 ; turpe 10+12+8 = 30.0 ; cta 2.16+2.59+1.73 = 6.48
+        # T2 @ 22.10 : PDLs {B, C} = 2 ; turpe 14+14+20 = 48.0 ; cta 3.09+3.09+4.42 = 10.60
+        assert result.par_taux["nb_pdl"].to_list() == [2, 2]
+        assert result.par_taux["turpe_fixe_eur"].to_list() == [30.0, 48.0]
+        assert result.par_taux["cta_eur"].to_list() == [6.48, 10.60]
+
+    def test_resume_groups_by_trimestre(self, monkeypatch):
+        """`resume` groupé par trimestre avec totaux + n_unique(pdl) corrects."""
+        from electricore.integrations.odoo import taxes
+
+        monkeypatch.setattr(taxes, "cta_par_contrat", lambda odoo, trimestre=None: _monthly_synthetique())
+        result = taxes.rapport_cta(odoo=None)
+
+        assert result.resume["trimestre"].to_list() == ["2025-T1", "2025-T2"]
+        # T1: PDL = {A, B} → 2 distinct ; turpe 10+12+8 = 30.0 ; cta 2.16+2.59+1.73 = 6.48
+        # T2: PDL = {B, C} → 2 distinct ; turpe 14+14+20 = 48.0 ; cta 3.09+3.09+4.42 = 10.60
+        assert result.resume["nb_pdl"].to_list() == [2, 2]
+        assert result.resume["turpe_fixe_total_eur"].to_list() == [30.0, 48.0]
+        assert result.resume["cta_total_eur"].to_list() == [6.48, 10.60]
+
+    def test_detail_per_pdl_with_taux_appliques_joined(self, monkeypatch):
+        """`detail` agrégé par PDL ; PDL avec 2 taux successifs → string joined ` ; `."""
+        from electricore.integrations.odoo import taxes
+
+        monkeypatch.setattr(taxes, "cta_par_contrat", lambda odoo, trimestre=None: _monthly_synthetique())
+        result = taxes.rapport_cta(odoo=None)
+
+        # 3 PDL distincts → 3 lignes
+        assert sorted(result.detail["pdl"].to_list()) == ["A", "B", "C"]
+
+        # PDL B subit la transition de taux (21.61 → 22.10) — string concat des deux
+        # Note : Polars cast Float64 → Utf8 drop le trailing zero (`22.10` → `"22.1"`).
+        # C'est le comportement historique du XLSX facturiste, on le préserve tel quel.
+        pdl_b = result.detail.filter(pl.col("pdl") == "B").row(0, named=True)
+        assert pdl_b["taux_cta_appliques"] == "21.61 ; 22.1"
+        # PDL A ne touche qu'un taux
+        pdl_a = result.detail.filter(pl.col("pdl") == "A").row(0, named=True)
+        assert pdl_a["taux_cta_appliques"] == "21.61"
+
+    def test_rapport_cta_propagates_trimestre_filter(self, monkeypatch):
+        from electricore.integrations.odoo import taxes
+
+        appels: list[str | None] = []
+
+        def fake_cta_par_contrat(odoo, trimestre=None):
+            appels.append(trimestre)
+            return _monthly_synthetique()
+
+        monkeypatch.setattr(taxes, "cta_par_contrat", fake_cta_par_contrat)
+        taxes.rapport_cta(odoo=None, trimestre="2025-T1")
+
+        assert appels == ["2025-T1"]

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -83,7 +83,7 @@ def test_accise_round_trip_via_endpoint(monkeypatch):
 
 
 def test_cta_round_trip_via_endpoint(monkeypatch):
-    """`client.cta(trimestre)` round-trip un DataFrame servi par /taxes/cta/arrow."""
+    """`client.cta(trimestre)` round-trip un DataFrame servi par /taxes/cta/detail.arrow."""
     df_attendu = pl.DataFrame(
         {
             "pdl": ["12345678901234"],


### PR DESCRIPTION
## Summary
Architectural Review Candidate 1.2 — réplique du pattern validé par #56 (accise) sur le domaine CTA.

**Avant** : la structure du rapport CTA (Résumé / Par taux / Détail, groupby + agg + rounds, sérialisation `taux_cta_appliques` en string ` ; `-joined) vivait dans `taxes_service.generer_cta_xlsx` — même shape leak qu'accise avant #56.

**Après** : deux interfaces explicites dans `electricore/integrations/odoo/taxes.py`:
- `cta_par_contrat` (renamed de `cta_du_trimestre`) — mensuel brut par PDL × mois
- `rapport_cta` — `RapportCta(resume, par_taux, detail)` validé Pandera

## Spécificité CTA vs accise
- `par_taux` est indexé par **(trimestre, taux_cta_pct)** — le décret CRE peut découper un trimestre en taux successifs, on garde la dimension.
- `detail` est une **agrégation par PDL** (pas la sortie brute), avec `taux_cta_appliques` = string-joined des taux successifs. Asymétrie vs accise (où `detail == accise_par_contrat`), tracée dans la docstring du NamedTuple. C'est ce que voit aujourd'hui le facturiste dans le XLSX, on préserve.

## 3 nouveaux schémas Pandera
`electricore/integrations/odoo/models/rapport_cta.py` — snake_case, mapping vers libellés facturiste se fait au layer XLSX (comme #56).

## HTTP endpoints (extension-suffix convention)

| Path | Use case | Serializer |
|---|---|---|
| `GET /taxes/cta/rapport.xlsx` | Facturiste, multi-sheet | `rapport_cta(...)` → 3 onglets |
| `GET /taxes/cta/detail.xlsx` | Technical, single-sheet | `cta_par_contrat(...)` → mono-onglet |
| `GET /taxes/cta/detail.arrow` | Technical, stream | `cta_par_contrat(...)` → Arrow IPC |

Anciens `/taxes/cta/xlsx` et `/taxes/cta/arrow` supprimés (404 vérifié).

## Consumers
- `bot/client.py:get_cta_xlsx` → `/taxes/cta/rapport.xlsx`
- `client/__init__.py:cta()` → `/taxes/cta/detail.arrow`
- `notebooks/accise_et_cta.py` (path bump dans docstring)
- `taxes_service.py` — agg logic supprimée, 4 thin wrappers
- `tests/architecture` — `TAXES_ORCHESTRATIONS = (rapport_accise, accise_par_contrat, rapport_cta, cta_par_contrat)`

## TDD cycles
6 RED→GREEN cycles in `tests/unit/integrations/odoo/test_rapport_cta.py` (10 tests):
1. `cta_par_contrat` exists, `cta_du_trimestre` removed
2. 3 Pandera schemas validate well-formed frames
3. `rapport_cta` returns NamedTuple with `resume`, `par_taux`, `detail`
4. `par_taux` indexé par (trimestre, taux_cta_pct), sommes + `n_unique(pdl)` corrects
5. `resume` groupé par trimestre, totaux corrects
6. `detail` par PDL avec `taux_cta_appliques` string-joined (PDL B subit 21.61 → 22.10 → "21.61 ; 22.1")

Plus smoke tests d'intégration pour les 3 nouveaux endpoints + 404 sur anciens.

## Note sur `22.10` → `"22.1"`
Polars `cast(Utf8)` sur Float64 drop le trailing zero. C'est le comportement historique du XLSX facturiste (cf. ancien `generer_cta_xlsx`), on préserve tel quel.

## Test plan
- [x] `uv run --group test pytest -q` — 430 passed (was 415, +15 from this PR), 35 legitimate skips
- [x] `uvx pre-commit run --all-files` — clean
- [x] No straggler references to `cta_du_trimestre`, `generer_cta_xlsx`, `generer_cta_arrow`

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)