### PR TITLE
feat(facturation): split into rapport_facturation + facturation_du_mois (#64)

### DIFF
--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -20,8 +20,9 @@ from electricore.api.services import duckdb_service, etl_service
 from electricore.api.services.check_facturation_service import verifier_odoo
 from electricore.api.services.facturation_service import (
     generer_documents_facturation,
-    generer_facturation_arrow,
-    generer_facturation_xlsx,
+    generer_facturation_detail_arrow,
+    generer_facturation_detail_xlsx,
+    generer_facturation_rapport_xlsx,
 )
 from electricore.api.services.taxes_service import (
     generer_accise_detail_arrow,
@@ -494,28 +495,52 @@ def export_cta_detail_arrow(
     return generer_cta_detail_arrow(trimestre)
 
 
-@xlsx_endpoint(app, "/facturation/xlsx", filename="facturation{mois}.xlsx", requires_odoo=True, tags=["facturation"])
-def export_facturation_xlsx(
+@xlsx_endpoint(
+    app,
+    "/facturation/rapport.xlsx",
+    filename="facturation_rapport{mois}.xlsx",
+    requires_odoo=True,
+    tags=["facturation"],
+)
+def export_facturation_rapport_xlsx(
     mois: str | None = Query(
         default=None,
         examples=["2025-01-01"],
         description="Mois au format YYYY-MM-DD (défaut : dernier mois disponible dans les données)",
     ),
 ) -> bytes:
-    """Réconciliation des lignes Odoo à facturer avec les données Enedis (2 onglets XLSX)."""
-    return generer_facturation_xlsx(mois)
+    """Livrable facturiste : 3 onglets (Résumé / Lignes / Changements puissance)."""
+    return generer_facturation_rapport_xlsx(mois)
 
 
-@arrow_endpoint(app, "/facturation/arrow", requires_odoo=True, tags=["facturation"])
-def export_facturation_arrow(
+@xlsx_endpoint(
+    app,
+    "/facturation/detail.xlsx",
+    filename="facturation_detail{mois}.xlsx",
+    requires_odoo=True,
+    tags=["facturation"],
+)
+def export_facturation_detail_xlsx(
     mois: str | None = Query(
         default=None,
         examples=["2025-01-01"],
         description="Mois au format YYYY-MM-DD (défaut : dernier mois disponible dans les données)",
     ),
 ) -> bytes:
-    """Réconciliation Odoo↔Enedis sérialisée en Arrow IPC stream (`lignes_facture_rapprochees`)."""
-    return generer_facturation_arrow(mois)
+    """Lignes brutes du rapprochement Odoo↔Enedis en XLSX mono-onglet (cas technique)."""
+    return generer_facturation_detail_xlsx(mois)
+
+
+@arrow_endpoint(app, "/facturation/detail.arrow", requires_odoo=True, tags=["facturation"])
+def export_facturation_detail_arrow(
+    mois: str | None = Query(
+        default=None,
+        examples=["2025-01-01"],
+        description="Mois au format YYYY-MM-DD (défaut : dernier mois disponible dans les données)",
+    ),
+) -> bytes:
+    """Lignes brutes du rapprochement Odoo↔Enedis en Arrow IPC stream (cas technique)."""
+    return generer_facturation_detail_arrow(mois)
 
 
 @app.get("/facturation/check/odoo", tags=["facturation"])

--- a/electricore/api/services/facturation_service.py
+++ b/electricore/api/services/facturation_service.py
@@ -4,8 +4,11 @@ Le calcul et l'orchestration métier vivent dans
 `electricore.integrations.odoo.facturation`. Ce service ne fait que :
 
 1. Ouvrir la connexion `OdooReader` (responsabilité HTTP)
-2. Déléguer à l'orchestration
+2. Déléguer à `facturation_du_mois` ou `rapport_facturation`
 3. Sérialiser le résultat via `api/serializers/` (XLSX / Arrow IPC / ZIP)
+
+La shape du livrable (`Résumé` / `Lignes` / `Changements puissance`) vit
+désormais dans `integrations.odoo.facturation.rapport_facturation` (#64).
 """
 
 import polars as pl
@@ -16,38 +19,37 @@ from electricore.integrations.odoo import OdooReader
 from electricore.integrations.odoo.facturation import (
     documents_facturation_du_mois,
     facturation_du_mois,
+    rapport_facturation,
 )
 
 
 def calculer_lignes_facture_rapprochees(mois: str | None = None) -> pl.DataFrame:
-    """Binding HTTP : ouvre la connexion Odoo + délègue à l'orchestration `facturation_du_mois`.
-
-    Cette fonction existe comme seam testable au niveau du service (les endpoints peuvent
-    la monkeypatch pour bypasser Odoo). La logique métier (chargement contexte + rapprochement)
-    vit dans `electricore.integrations.odoo.facturation.facturation_du_mois`.
-
-    Args:
-        mois: format "YYYY-MM-DD" (premier jour du mois). None = dernier mois des données.
-    """
+    """Binding HTTP : ouvre Odoo + délègue à `facturation_du_mois`."""
     with OdooReader(config=settings.get_odoo_config()) as odoo:
         return facturation_du_mois(odoo, mois)
 
 
-def generer_facturation_xlsx(mois: str | None = None) -> bytes:
-    """Réconciliation Odoo ↔ Enedis du mois sérialisée en XLSX (2 onglets)."""
-    lignes_rapprochees = calculer_lignes_facture_rapprochees(mois)
-    changements_puissance = lignes_rapprochees.filter(pl.col("memo_puissance") != "")
+def generer_facturation_detail_arrow(mois: str | None = None) -> bytes:
+    """Sérialise les lignes brutes du mois en flux Arrow IPC (cas technique)."""
+    return arrow_stream(calculer_lignes_facture_rapprochees(mois))
+
+
+def generer_facturation_detail_xlsx(mois: str | None = None) -> bytes:
+    """Sérialise les lignes brutes du mois en XLSX mono-onglet (cas technique)."""
+    return xlsx_multi_sheet({"Détail": calculer_lignes_facture_rapprochees(mois)})
+
+
+def generer_facturation_rapport_xlsx(mois: str | None = None) -> bytes:
+    """Livrable facturiste : 3 onglets (Résumé / Lignes / Changements puissance)."""
+    with OdooReader(config=settings.get_odoo_config()) as odoo:
+        r = rapport_facturation(odoo, mois)
     return xlsx_multi_sheet(
         {
-            "Lignes fusionnées": lignes_rapprochees,
-            "Changements puissance": changements_puissance,
+            "Résumé": r.resume,
+            "Lignes": r.lignes,
+            "Changements puissance": r.changements_puissance,
         }
     )
-
-
-def generer_facturation_arrow(mois: str | None = None) -> bytes:
-    """Sérialise `lignes_facture_rapprochees` en flux Arrow IPC."""
-    return arrow_stream(calculer_lignes_facture_rapprochees(mois))
 
 
 def generer_documents_facturation(mois: str | None = None) -> tuple[bytes, str]:

--- a/electricore/bot/client.py
+++ b/electricore/bot/client.py
@@ -89,7 +89,7 @@ class ElectriCoreClient:
     async def get_facturation_xlsx(self, mois: str | None = None) -> bytes:
         params = {"mois": mois} if mois else {}
         async with httpx.AsyncClient() as c:
-            r = await c.get(f"{self._base}/facturation/xlsx", headers=self._headers, params=params, timeout=300)
+            r = await c.get(f"{self._base}/facturation/rapport.xlsx", headers=self._headers, params=params, timeout=300)
             r.raise_for_status()
             return r.content
 

--- a/electricore/client/__init__.py
+++ b/electricore/client/__init__.py
@@ -67,7 +67,7 @@ class ElectricoreClient:
         Args:
             mois: "YYYY-MM-DD" — défaut : dernier mois disponible côté serveur.
         """
-        return self._get_arrow("/facturation/arrow", {"mois": mois} if mois else {})
+        return self._get_arrow("/facturation/detail.arrow", {"mois": mois} if mois else {})
 
     def accise(self, trimestre: str | None = None) -> pl.DataFrame:
         """Récupère le détail Accise TICFE pour le trimestre donné.

--- a/electricore/integrations/odoo/facturation.py
+++ b/electricore/integrations/odoo/facturation.py
@@ -4,18 +4,43 @@ Compose les calculs `core/` (rapprochement facturation mensuelle, contexte
 mensuel) avec l'adaptateur Odoo (lecture des lignes de factures du mois)
 pour produire les artefacts consommés par les endpoints API et les notebooks.
 
+Deux interfaces cohabitent (cf. issue #64, calque de #56 / #63) :
+
+- `facturation_du_mois` : calcul brut, une ligne par ligne de facture Odoo
+  enrichie Enedis. Pour exploration et streaming Arrow.
+- `rapport_facturation` : livrable agrégé (`Résumé` / `Lignes` /
+  `Changements puissance`) destiné au facturiste, XLSX multi-onglets.
+
 EDN-shaped aujourd'hui ; sert de prototype pour un futur module Odoo libre
 couvrant les fournisseurs alternatifs (cf. CONTEXT.md, ADR-0016).
 """
+
+from typing import NamedTuple
 
 import polars as pl
 
 from electricore.core.loaders import c15, f15
 from electricore.core.loaders.contexte_mensuel import charger_contexte_facturation
+from electricore.core.models.lignes_facture_rapprochees import LignesFactureRapprochees
 from electricore.core.pipelines.facturation import rapprocher_facturation_mensuelle
 
 from .helpers import lignes_factures_du_mois
+from .models.rapport_facturation import RapportFacturationResume
 from .reader import OdooReader
+
+
+class RapportFacturation(NamedTuple):
+    """Livrable mensuel de facturation (= les 3 onglets de l'XLSX facturiste).
+
+    - `resume` : totaux du mois (1 ligne).
+    - `lignes` : sortie brute de `facturation_du_mois` (toutes les lignes).
+    - `changements_puissance` : sous-ensemble de `lignes` où `memo_puissance != ""`.
+      Les lignes apparaissent dans les deux onglets (drill-down, pas partition exclusive).
+    """
+
+    resume: pl.DataFrame
+    lignes: pl.DataFrame
+    changements_puissance: pl.DataFrame
 
 
 def facturation_du_mois(odoo: OdooReader, mois: str | None = None) -> pl.DataFrame:
@@ -42,6 +67,39 @@ def facturation_du_mois(odoo: OdooReader, mois: str | None = None) -> pl.DataFra
         historique=contexte.historique_enrichi,
         mois=contexte.mois,
     )
+
+
+def rapport_facturation(odoo: OdooReader, mois: str | None = None) -> RapportFacturation:
+    """Livrable mensuel facturation : `Résumé` / `Lignes` / `Changements puissance`.
+
+    Compose `facturation_du_mois` avec un sous-ensemble (`memo_puissance != ""`)
+    et un résumé des compteurs `a_facturer` / `a_supprimer`.
+
+    Args:
+        odoo: `OdooReader` déjà ouvert.
+        mois: format "YYYY-MM-DD". `None` = dernier mois disponible.
+
+    Returns:
+        `RapportFacturation(resume, lignes, changements_puissance)`.
+    """
+    lignes = facturation_du_mois(odoo, mois)
+    changements_puissance = lignes.filter(pl.col("memo_puissance") != "")
+
+    # Mois effectif (= ce que `lignes` a vu — peut différer de l'arg si `mois=None`)
+    mois_effectif = mois if mois is not None else lignes.select(pl.col("debut").min().dt.strftime("%Y-%m-%d")).item()
+    resume = pl.DataFrame(
+        {
+            "mois": [mois_effectif or ""],
+            "nb_pdl": [lignes["pdl"].drop_nulls().n_unique()],
+            "total_a_facturer": [int(lignes["a_facturer"].fill_null(False).sum())],
+            "total_a_supprimer": [int(lignes["a_supprimer"].fill_null(False).sum())],
+        }
+    )
+
+    RapportFacturationResume.validate(resume)
+    LignesFactureRapprochees.validate(lignes)
+    LignesFactureRapprochees.validate(changements_puissance)
+    return RapportFacturation(resume=resume, lignes=lignes, changements_puissance=changements_puissance)
 
 
 def documents_facturation_du_mois(odoo: OdooReader, mois: str | None = None) -> tuple[dict[str, pl.DataFrame], str]:

--- a/electricore/integrations/odoo/models/rapport_facturation.py
+++ b/electricore/integrations/odoo/models/rapport_facturation.py
@@ -1,0 +1,22 @@
+"""Schémas Pandera pour le livrable `rapport_facturation` (issue #64).
+
+Spécificité vs `rapport_accise` / `rapport_cta` :
+- Les onglets `lignes` et `changements_puissance` partagent la **même** shape
+  (le second est un filtre du premier). On réutilise donc le schéma existant
+  `electricore.core.models.lignes_facture_rapprochees.LignesFactureRapprochees`
+  pour ces deux frames — pas de duplication ici.
+- Seul l'onglet `resume` introduit une shape nouvelle : une ligne de totaux
+  pour le mois (nb PDL, lignes à facturer, lignes à supprimer).
+"""
+
+import pandera.polars as pa
+import polars as pl
+
+
+class RapportFacturationResume(pa.DataFrameModel):
+    """Totaux mensuels (= une ligne par mois cible)."""
+
+    mois: pl.Utf8 = pa.Field(nullable=False)  # "YYYY-MM-DD"
+    nb_pdl: pl.Int64 = pa.Field(nullable=False, ge=0)
+    total_a_facturer: pl.Int64 = pa.Field(nullable=False, ge=0)
+    total_a_supprimer: pl.Int64 = pa.Field(nullable=False, ge=0)

--- a/tests/architecture/test_integrations_odoo_orchestrations.py
+++ b/tests/architecture/test_integrations_odoo_orchestrations.py
@@ -11,7 +11,11 @@ import importlib
 
 import pytest
 
-FACTURATION_ORCHESTRATIONS = ("facturation_du_mois", "documents_facturation_du_mois")
+FACTURATION_ORCHESTRATIONS = (
+    "facturation_du_mois",
+    "rapport_facturation",
+    "documents_facturation_du_mois",
+)
 
 TAXES_ORCHESTRATIONS = ("rapport_accise", "accise_par_contrat", "rapport_cta", "cta_par_contrat")
 

--- a/tests/integration/test_facturation_arrow_endpoint.py
+++ b/tests/integration/test_facturation_arrow_endpoint.py
@@ -1,6 +1,10 @@
-"""Tests d'intégration de l'endpoint `GET /facturation/arrow`."""
+"""Tests d'intégration des endpoints `/facturation/*` (issue #64).
+
+3 endpoints : `rapport.xlsx` (facturiste), `detail.xlsx` + `detail.arrow` (technique).
+"""
 
 import io
+from contextlib import contextmanager
 
 import polars as pl
 import pytest
@@ -11,6 +15,9 @@ from electricore.api.config import settings
 from electricore.api.main import app
 from electricore.api.security import get_current_api_key
 
+ARROW_IPC = "application/vnd.apache.arrow.stream"
+XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
 
 @pytest.fixture(autouse=True)
 def _mock_odoo_configured(monkeypatch):
@@ -19,8 +26,20 @@ def _mock_odoo_configured(monkeypatch):
 
 
 @pytest.fixture
+def _mock_odoo_reader(monkeypatch):
+    """Court-circuite `OdooReader` (les tests mockent directement les orchestrations)."""
+
+    @contextmanager
+    def _fake_reader(config):
+        yield None
+
+    monkeypatch.setattr("electricore.integrations.odoo.OdooReader", _fake_reader)
+    monkeypatch.setattr("electricore.api.services.facturation_service.OdooReader", _fake_reader)
+
+
+@pytest.fixture
 def lignes_rapprochees_attendues() -> pl.DataFrame:
-    """Petit DataFrame qui mime la sortie de rapprocher_facturation_mensuelle."""
+    """Petit DataFrame qui mime la sortie de `facturation_du_mois`."""
     return pl.DataFrame(
         {
             "invoice_line_ids": [101, 102],
@@ -36,53 +55,141 @@ def lignes_rapprochees_attendues() -> pl.DataFrame:
     )
 
 
-@pytest.fixture
-def client_avec_service_mock(monkeypatch, lignes_rapprochees_attendues):
-    """TestClient avec auth + service de facturation moqués."""
+# =============================================================================
+# /facturation/detail.arrow
+# =============================================================================
+
+
+def test_detail_arrow_retourne_arrow_ipc_stream(monkeypatch, lignes_rapprochees_attendues):
+    """L'endpoint sert le DataFrame brut en Arrow IPC."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
     monkeypatch.setattr(
         "electricore.api.services.facturation_service.calculer_lignes_facture_rapprochees",
         lambda mois=None: lignes_rapprochees_attendues,
     )
-    yield TestClient(app)
-    app.dependency_overrides.clear()
-
-
-def test_endpoint_retourne_arrow_ipc_stream(client_avec_service_mock, lignes_rapprochees_attendues):
-    """L'endpoint sert le DataFrame `lignes_facture_rapprochees` en Arrow IPC."""
-    response = client_avec_service_mock.get("/facturation/arrow")
+    try:
+        response = TestClient(app).get("/facturation/detail.arrow")
+    finally:
+        app.dependency_overrides.clear()
 
     assert response.status_code == 200
-    assert response.headers["content-type"] == "application/vnd.apache.arrow.stream"
+    assert response.headers["content-type"] == ARROW_IPC
 
     df = pl.read_ipc_stream(io.BytesIO(response.content))
     assert_frame_equal(df, lignes_rapprochees_attendues)
 
 
-def test_endpoint_refuse_sans_api_key():
-    """Sans header `X-API-Key`, l'endpoint répond 401."""
-    response = TestClient(app).get("/facturation/arrow")
+def test_detail_arrow_refuse_sans_api_key():
+    response = TestClient(app).get("/facturation/detail.arrow")
     assert response.status_code == 401
 
 
-def test_endpoint_propage_le_parametre_mois_au_service(monkeypatch, lignes_rapprochees_attendues):
-    """Le query param `mois` est transmis au service de calcul."""
+def test_detail_arrow_propage_mois(monkeypatch, lignes_rapprochees_attendues):
+    """Le query param `mois` est transmis à `calculer_lignes_facture_rapprochees`."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
-    appels_avec_mois: list[str | None] = []
+    appels: list[str | None] = []
 
     def fake_calculer(mois: str | None = None) -> pl.DataFrame:
-        appels_avec_mois.append(mois)
+        appels.append(mois)
         return lignes_rapprochees_attendues
 
     monkeypatch.setattr(
         "electricore.api.services.facturation_service.calculer_lignes_facture_rapprochees",
         fake_calculer,
     )
-
     try:
-        response = TestClient(app).get("/facturation/arrow", params={"mois": "2025-03-01"})
+        response = TestClient(app).get("/facturation/detail.arrow", params={"mois": "2025-03-01"})
     finally:
         app.dependency_overrides.clear()
 
     assert response.status_code == 200
-    assert appels_avec_mois == ["2025-03-01"]
+    assert appels == ["2025-03-01"]
+
+
+# =============================================================================
+# /facturation/detail.xlsx
+# =============================================================================
+
+
+def test_detail_xlsx_retourne_xlsx_mono_onglet(monkeypatch, lignes_rapprochees_attendues):
+    """L'endpoint sert les lignes brutes en XLSX mono-onglet."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.services.facturation_service.calculer_lignes_facture_rapprochees",
+        lambda mois=None: lignes_rapprochees_attendues,
+    )
+    try:
+        response = TestClient(app).get("/facturation/detail.xlsx")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(XLSX_MIME)
+    assert "attachment" in response.headers.get("content-disposition", "")
+
+
+# =============================================================================
+# /facturation/rapport.xlsx
+# =============================================================================
+
+
+@pytest.fixture
+def fake_rapport_facturation(lignes_rapprochees_attendues):
+    """`RapportFacturation` synthétique pour la sérialisation XLSX."""
+    from electricore.integrations.odoo.facturation import RapportFacturation
+
+    return RapportFacturation(
+        resume=pl.DataFrame(
+            {
+                "mois": ["2025-03-01"],
+                "nb_pdl": [2],
+                "total_a_facturer": [2],
+                "total_a_supprimer": [0],
+            }
+        ),
+        lignes=lignes_rapprochees_attendues,
+        changements_puissance=lignes_rapprochees_attendues.head(0),
+    )
+
+
+def test_rapport_xlsx_retourne_xlsx_multi_onglets(monkeypatch, _mock_odoo_reader, fake_rapport_facturation):
+    """L'endpoint sert le rapport multi-onglets (Résumé / Lignes / Changements puissance)."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.services.facturation_service.rapport_facturation",
+        lambda odoo, mois=None: fake_rapport_facturation,
+    )
+    try:
+        response = TestClient(app).get("/facturation/rapport.xlsx")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(XLSX_MIME)
+    assert "attachment" in response.headers.get("content-disposition", "")
+
+
+def test_rapport_xlsx_propage_mois(monkeypatch, _mock_odoo_reader, fake_rapport_facturation):
+    """Le query param `mois` est propagé jusqu'à `rapport_facturation`."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    appels: list[str | None] = []
+
+    def _capture(odoo, mois=None):
+        appels.append(mois)
+        return fake_rapport_facturation
+
+    monkeypatch.setattr("electricore.api.services.facturation_service.rapport_facturation", _capture)
+    try:
+        response = TestClient(app).get("/facturation/rapport.xlsx", params={"mois": "2025-04-01"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert appels == ["2025-04-01"]
+
+
+def test_anciens_endpoints_facturation_404(_mock_odoo_reader):
+    """Les anciens paths `/facturation/xlsx` et `/facturation/arrow` sont supprimés."""
+    for path in ("/facturation/xlsx", "/facturation/arrow"):
+        response = TestClient(app).get(path)
+        assert response.status_code == 404, f"{path} devrait être 404"

--- a/tests/integration/test_facturation_service_smoke.py
+++ b/tests/integration/test_facturation_service_smoke.py
@@ -90,7 +90,7 @@ def service_loaders_mockes(
 ):
     """Patch tous les loaders et l'orchestration utilisés par le service.
 
-    `generer_facturation_xlsx` et `generer_documents_facturation` chargent
+    `generer_facturation_*_xlsx` et `generer_documents_facturation` chargent
     Odoo + DuckDB + lancent la pipeline facturation. On stub tout ce qui
     parle au monde extérieur pour pouvoir exercer la logique du service
     sans dépendances.
@@ -145,12 +145,20 @@ def service_loaders_mockes(
     monkeypatch.setattr(settings_cls, "get_odoo_config", lambda self: {})
 
 
-def test_generer_facturation_xlsx_smoke(service_loaders_mockes):
-    """generer_facturation_xlsx s'exécute sans NameError et produit un XLSX valide."""
-    xlsx_bytes = facturation_service.generer_facturation_xlsx(mois="2025-01-01")
+def test_generer_facturation_rapport_xlsx_smoke(service_loaders_mockes):
+    """generer_facturation_rapport_xlsx s'exécute sans NameError et produit un XLSX valide."""
+    xlsx_bytes = facturation_service.generer_facturation_rapport_xlsx(mois="2025-01-01")
 
     assert isinstance(xlsx_bytes, bytes)
     assert xlsx_bytes[:2] == b"PK"  # signature ZIP / XLSX
+
+
+def test_generer_facturation_detail_xlsx_smoke(service_loaders_mockes):
+    """generer_facturation_detail_xlsx s'exécute et produit un XLSX mono-onglet valide."""
+    xlsx_bytes = facturation_service.generer_facturation_detail_xlsx(mois="2025-01-01")
+
+    assert isinstance(xlsx_bytes, bytes)
+    assert xlsx_bytes[:2] == b"PK"
 
 
 def test_generer_documents_facturation_smoke(service_loaders_mockes):
@@ -172,9 +180,9 @@ def test_generer_documents_facturation_smoke(service_loaders_mockes):
     }
 
 
-def test_generer_facturation_arrow_smoke(service_loaders_mockes):
-    """generer_facturation_arrow s'exécute et retourne un flux Arrow IPC valide."""
-    arrow_bytes = facturation_service.generer_facturation_arrow(mois="2025-01-01")
+def test_generer_facturation_detail_arrow_smoke(service_loaders_mockes):
+    """generer_facturation_detail_arrow s'exécute et retourne un flux Arrow IPC valide."""
+    arrow_bytes = facturation_service.generer_facturation_detail_arrow(mois="2025-01-01")
 
     df = pl.read_ipc_stream(io.BytesIO(arrow_bytes))
     assert len(df) == 1  # une ligne du fixture

--- a/tests/unit/integrations/odoo/test_rapport_facturation.py
+++ b/tests/unit/integrations/odoo/test_rapport_facturation.py
@@ -1,0 +1,140 @@
+"""Tests pour `rapport_facturation` (Candidate 1.3, issue #64).
+
+Réplique du pattern `rapport_X` / `X_brut` validé par #56 (accise) et #63 (CTA)
+sur le domaine facturation. Spécificités :
+
+- Le nom de l'interface brute reste `facturation_du_mois` (sémantique by-month,
+  pas by-contract — cf. arbitrage de la PR).
+- Le rapport porte une **partition** explicite : les lignes flaguées
+  `memo_puissance != ""` ressortent dans un onglet dédié `Changements puissance`.
+"""
+
+import polars as pl
+
+
+def test_facturation_du_mois_exists_and_is_callable():
+    """`facturation_du_mois` est exporté depuis `integrations.odoo.facturation`."""
+    from electricore.integrations.odoo import facturation
+
+    assert hasattr(facturation, "facturation_du_mois")
+    assert callable(facturation.facturation_du_mois)
+
+
+class TestRapportFacturationResumeSchema:
+    """Le schéma `RapportFacturationResume` valide une frame une-ligne de totaux."""
+
+    def test_resume_schema_validates_one_row_frame(self):
+        from electricore.integrations.odoo.models.rapport_facturation import RapportFacturationResume
+
+        df = pl.DataFrame(
+            {
+                "mois": ["2025-03-01"],
+                "nb_pdl": [42],
+                "total_a_facturer": [156],
+                "total_a_supprimer": [3],
+            }
+        )
+        RapportFacturationResume.validate(df)
+
+
+def _lignes_synthetique() -> pl.DataFrame:
+    """`facturation_du_mois` synthétique avec mix de flags + un changement puissance."""
+    return pl.DataFrame(
+        {
+            "invoice_line_ids": [1, 2, 3, 4, 5],
+            "x_pdl": ["A", "A", "B", "C", "B"],
+            "x_lisse": [False, False, True, False, True],
+            "name_account_move": ["INV/1", "INV/1", "INV/2", "INV/3", "INV/2"],
+            "name_product_category": ["Base", "HP", "Base", "Base", "Base"],
+            "name_product_product": ["P1", "P2", "P1", "P1", "P1"],
+            "quantity": [100.0, 50.0, 80.0, 60.0, 0.0],
+            "quantite_enedis": [100.0, 50.0, 80.0, 60.0, 0.0],
+            # Spécificité : 2 lignes avec memo_puissance non vide (B sur 2 lignes)
+            "memo_puissance": ["", "", "", "", "Hausse 6 → 9 kVA"],
+            "ref_situation_contractuelle": ["R-A", "R-A", "R-B", "R-C", "R-B"],
+            "pdl": ["A", "A", "B", "C", "B"],
+            "debut": [None, None, None, None, None],
+            "fin": [None, None, None, None, None],
+            "data_complete": [True, True, True, True, True],
+            "turpe_fixe_eur": [10.0, 0.0, 12.0, 8.0, 0.0],
+            "turpe_variable_eur": [5.0, 2.5, 4.0, 3.0, 0.0],
+            "num_compteur": ["N-A", "N-A", "N-B", "N-C", "N-B"],
+            "type_compteur": ["L", "L", "L", "L", "L"],
+            "a_facturer": [True, True, True, False, True],
+            "a_supprimer": [False, False, False, True, False],
+        },
+        # Coerce dtypes pour matcher LignesFactureRapprochees (debut/fin DateTime tz)
+        schema_overrides={
+            "debut": pl.Datetime(time_unit="us", time_zone="Europe/Paris"),
+            "fin": pl.Datetime(time_unit="us", time_zone="Europe/Paris"),
+        },
+    )
+
+
+class TestRapportFacturation:
+    """`rapport_facturation` produit `RapportFacturation(resume, lignes, changements_puissance)`."""
+
+    def test_returns_namedtuple_with_three_fields(self, monkeypatch):
+        from electricore.integrations.odoo import facturation
+
+        monkeypatch.setattr(facturation, "facturation_du_mois", lambda odoo, mois=None: _lignes_synthetique())
+        result = facturation.rapport_facturation(odoo=None, mois="2025-03-01")
+
+        assert hasattr(result, "resume")
+        assert hasattr(result, "lignes")
+        assert hasattr(result, "changements_puissance")
+
+    def test_lignes_is_identity_of_facturation_du_mois(self, monkeypatch):
+        """`rapport.lignes` = la sortie brute, sans filtrage."""
+        from electricore.integrations.odoo import facturation
+
+        lignes_attendues = _lignes_synthetique()
+        monkeypatch.setattr(facturation, "facturation_du_mois", lambda odoo, mois=None: lignes_attendues)
+        result = facturation.rapport_facturation(odoo=None, mois="2025-03-01")
+
+        assert result.lignes.height == lignes_attendues.height
+        assert set(result.lignes.columns) == set(lignes_attendues.columns)
+
+    def test_changements_puissance_filters_on_memo(self, monkeypatch):
+        """`changements_puissance` = lignes où `memo_puissance != ''`."""
+        from electricore.integrations.odoo import facturation
+
+        monkeypatch.setattr(facturation, "facturation_du_mois", lambda odoo, mois=None: _lignes_synthetique())
+        result = facturation.rapport_facturation(odoo=None, mois="2025-03-01")
+
+        # Une seule ligne dans le synthétique a memo_puissance != ""
+        assert result.changements_puissance.height == 1
+        assert result.changements_puissance["x_pdl"][0] == "B"
+        assert result.changements_puissance["memo_puissance"][0] == "Hausse 6 → 9 kVA"
+
+    def test_resume_totals_correct(self, monkeypatch):
+        """`resume` = une ligne (mois, nb_pdl, total_a_facturer, total_a_supprimer)."""
+        from electricore.integrations.odoo import facturation
+
+        monkeypatch.setattr(facturation, "facturation_du_mois", lambda odoo, mois=None: _lignes_synthetique())
+        result = facturation.rapport_facturation(odoo=None, mois="2025-03-01")
+
+        assert result.resume.height == 1
+        row = result.resume.row(0, named=True)
+        assert row["mois"] == "2025-03-01"
+        # 3 PDL distincts : A, B, C
+        assert row["nb_pdl"] == 3
+        # 4 lignes a_facturer == True (1, 2, 3, 5)
+        assert row["total_a_facturer"] == 4
+        # 1 ligne a_supprimer == True (4)
+        assert row["total_a_supprimer"] == 1
+
+    def test_propagates_mois_filter(self, monkeypatch):
+        """Le query param `mois` est propagé jusqu'à `facturation_du_mois`."""
+        from electricore.integrations.odoo import facturation
+
+        appels: list[str | None] = []
+
+        def fake_facturation(odoo, mois=None):
+            appels.append(mois)
+            return _lignes_synthetique()
+
+        monkeypatch.setattr(facturation, "facturation_du_mois", fake_facturation)
+        facturation.rapport_facturation(odoo=None, mois="2025-04-01")
+
+        assert appels == ["2025-04-01"]


### PR DESCRIPTION
## Summary
Architectural Review Candidate 1.3 — réplique du pattern validé par #56 (accise) et #63 (CTA) sur le domaine facturation. Complète la phase C1 du review.

**Avant**: la shape du rapport facturation (Lignes fusionnées / Changements puissance, et le `filter(memo_puissance != "")`) vivait dans `facturation_service.generer_facturation_xlsx` — shape leak depuis la couche HTTP.

**Après**: deux interfaces explicites dans `electricore/integrations/odoo/facturation.py`:
- `facturation_du_mois` (nom préservé) — sortie brute par-line. Le rename `par_contrat` ne s'applique pas sémantiquement (facturation est by-line, pas by-PDL).
- `rapport_facturation` — `RapportFacturation(resume, lignes, changements_puissance)` validé Pandera.

## Spécificités vs accise/CTA
- **Pas de schémas dédiés pour lignes + changements_puissance** : ils partagent `LignesFactureRapprochees` (déjà existant dans `core/models/`). Le second est juste un filtre du premier.
- **Resume est un schéma neuf mini** : `RapportFacturationResume(mois, nb_pdl, total_a_facturer, total_a_supprimer)` — 4 champs.
- **Drill-down, pas partition exclusive** : les lignes flaguées `memo_puissance != ""` apparaissent dans les **deux** onglets (Lignes ET Changements puissance), comme dans le XLSX actuel.

## HTTP endpoints (extension-suffix convention)

| Path | Use case | Serializer |
|---|---|---|
| `GET /facturation/rapport.xlsx` | Facturiste, multi-sheet | `rapport_facturation(...)` → 3 onglets |
| `GET /facturation/detail.xlsx` | Technical, single-sheet | `facturation_du_mois(...)` → mono-onglet |
| `GET /facturation/detail.arrow` | Technical, stream | `facturation_du_mois(...)` → Arrow IPC |

Anciens `/facturation/xlsx` et `/facturation/arrow` supprimés (404 vérifié).

## Note sur `documents_facturation_du_mois`
Reste inchangé. Le ZIP de 6 CSV est un **workflow spécifique EDN** (audit + injection campagne facturation), pas une shape de livrable au sens du rapport. C'est `f15_complet`, `c15_sorties`, etc. — distinct du rapport rapprochement. Pas dans le scope de C1.

## Consumers
- `bot/client.py:get_facturation_xlsx` → `/facturation/rapport.xlsx`
- `client/__init__.py:facturation()` → `/facturation/detail.arrow`
- `facturation_service.py` — agg logic supprimée, 4 thin wrappers
- `tests/architecture` — `FACTURATION_ORCHESTRATIONS = (facturation_du_mois, rapport_facturation, documents_facturation_du_mois)`

## TDD cycles
6 RED→GREEN cycles → 7 unit tests in `tests/unit/integrations/odoo/test_rapport_facturation.py`:
1. `facturation_du_mois` exists (no rename)
2. `RapportFacturationResume` schema validates a 1-row totals frame
3. `rapport_facturation` returns NamedTuple with `resume`, `lignes`, `changements_puissance`
4. `lignes` is identity of `facturation_du_mois` (same height, same columns)
5. `changements_puissance` filters on `memo_puissance != ""`
6. `resume` totals correct (nb_pdl distinct, total_a_facturer count, total_a_supprimer count)

Plus smoke tests d'intégration pour les 3 nouveaux endpoints + 404 sur anciens.

## C1 phase complete
Avec cette PR, la phase **Candidate 1** (push tax/billing report shape down) est complète : accise (#56), CTA (#63), facturation (#64). Débloque la grabbabilité de #67 (Candidate 3 — `@with_odoo` collapse) qui dépendait de #63 + #64.

## Test plan
- [x] `uv run --group test pytest -q` — 443 passed (was 430, +13 from this PR), 35 legitimate skips
- [x] `uvx pre-commit run --all-files` — clean
- [x] No straggler references to `generer_facturation_xlsx`/`arrow` ou anciens paths

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)