### PR TITLE
refactor(api): collapse pass-through services via @with_odoo (#67)

### DIFF
--- a/electricore/api/services/facturation_service.py
+++ b/electricore/api/services/facturation_service.py
@@ -3,19 +3,19 @@
 Le calcul et l'orchestration métier vivent dans
 `electricore.integrations.odoo.facturation`. Ce service ne fait que :
 
-1. Ouvrir la connexion `OdooReader` (responsabilité HTTP)
-2. Déléguer à `facturation_du_mois` ou `rapport_facturation`
-3. Sérialiser le résultat via `api/serializers/` (XLSX / Arrow IPC / ZIP)
+1. Ouvrir la connexion Odoo via `@with_odoo` (cf. issue #67)
+2. Déléguer à `facturation_du_mois`, `rapport_facturation` ou
+   `documents_facturation_du_mois`
+3. Sérialiser le résultat (XLSX / Arrow IPC / ZIP)
 
-La shape du livrable (`Résumé` / `Lignes` / `Changements puissance`) vit
-désormais dans `integrations.odoo.facturation.rapport_facturation` (#64).
+La shape des livrables (`Résumé` / `Lignes` / `Changements puissance`) vit
+dans `integrations.odoo.facturation.rapport_facturation` (#64).
 """
 
 import polars as pl
 
-from electricore.api.config import settings
 from electricore.api.serializers import arrow_stream, xlsx_multi_sheet, zip_csv
-from electricore.integrations.odoo import OdooReader
+from electricore.integrations.odoo.decorators import with_odoo
 from electricore.integrations.odoo.facturation import (
     documents_facturation_du_mois,
     facturation_du_mois,
@@ -23,10 +23,10 @@ from electricore.integrations.odoo.facturation import (
 )
 
 
-def calculer_lignes_facture_rapprochees(mois: str | None = None) -> pl.DataFrame:
-    """Binding HTTP : ouvre Odoo + délègue à `facturation_du_mois`."""
-    with OdooReader(config=settings.get_odoo_config()) as odoo:
-        return facturation_du_mois(odoo, mois)
+@with_odoo
+def calculer_lignes_facture_rapprochees(odoo, mois: str | None = None) -> pl.DataFrame:
+    """Binding HTTP : délègue à `facturation_du_mois` avec OdooReader auto-géré."""
+    return facturation_du_mois(odoo, mois)
 
 
 def generer_facturation_detail_arrow(mois: str | None = None) -> bytes:
@@ -39,10 +39,14 @@ def generer_facturation_detail_xlsx(mois: str | None = None) -> bytes:
     return xlsx_multi_sheet({"Détail": calculer_lignes_facture_rapprochees(mois)})
 
 
+@with_odoo
+def _facturation_rapport(odoo, mois: str | None = None):
+    return rapport_facturation(odoo, mois)
+
+
 def generer_facturation_rapport_xlsx(mois: str | None = None) -> bytes:
     """Livrable facturiste : 3 onglets (Résumé / Lignes / Changements puissance)."""
-    with OdooReader(config=settings.get_odoo_config()) as odoo:
-        r = rapport_facturation(odoo, mois)
+    r = _facturation_rapport(mois)
     return xlsx_multi_sheet(
         {
             "Résumé": r.resume,
@@ -50,6 +54,11 @@ def generer_facturation_rapport_xlsx(mois: str | None = None) -> bytes:
             "Changements puissance": r.changements_puissance,
         }
     )
+
+
+@with_odoo
+def _documents_facturation(odoo, mois: str | None = None):
+    return documents_facturation_du_mois(odoo, mois)
 
 
 def generer_documents_facturation(mois: str | None = None) -> tuple[bytes, str]:
@@ -61,6 +70,5 @@ def generer_documents_facturation(mois: str | None = None) -> tuple[bytes, str]:
     Returns:
         Tuple (zip_bytes, suffix) — suffix au format "YYYY-MM" pour le nom du fichier.
     """
-    with OdooReader(config=settings.get_odoo_config()) as odoo:
-        documents, suffix = documents_facturation_du_mois(odoo, mois)
+    documents, suffix = _documents_facturation(mois)
     return zip_csv(documents), suffix

--- a/electricore/api/services/taxes_service.py
+++ b/electricore/api/services/taxes_service.py
@@ -3,20 +3,18 @@
 Le calcul et l'orchestration métier vivent dans
 `electricore.integrations.odoo.taxes`. Ce service ne fait que :
 
-1. Ouvrir la connexion `OdooReader` (responsabilité HTTP)
-2. Déléguer à l'orchestration (`accise_par_contrat`, `rapport_accise`,
-   `cta_par_contrat`, `rapport_cta`)
+1. Ouvrir la connexion Odoo via `@with_odoo` (cf. issue #67)
+2. Déléguer à l'orchestration
 3. Sérialiser le résultat (XLSX multi-onglets / Arrow IPC).
 
-La shape des livrables (`Résumé` / `Par taux` / `Détail`) vit désormais dans
-`integrations.odoo.taxes.rapport_accise` et `.rapport_cta` (cf. issues #56, #63).
+La shape des livrables (`Résumé` / `Par taux` / `Détail`) vit dans
+`integrations.odoo.taxes.rapport_accise` et `.rapport_cta` (#56, #63).
 """
 
 import polars as pl
 
-from electricore.api.config import settings
 from electricore.api.serializers import arrow_stream, xlsx_multi_sheet
-from electricore.integrations.odoo import OdooReader
+from electricore.integrations.odoo.decorators import with_odoo
 from electricore.integrations.odoo.taxes import (
     accise_par_contrat,
     cta_par_contrat,
@@ -24,11 +22,15 @@ from electricore.integrations.odoo.taxes import (
     rapport_cta,
 )
 
+# =============================================================================
+# Accise — détail brut + rapport agrégé
+# =============================================================================
 
-def calculer_accise_detail(trimestre: str | None = None) -> pl.DataFrame:
-    """Binding HTTP : ouvre Odoo + délègue à `accise_par_contrat`."""
-    with OdooReader(config=settings.get_odoo_config()) as odoo:
-        return accise_par_contrat(odoo, trimestre)
+
+@with_odoo
+def calculer_accise_detail(odoo, trimestre: str | None = None) -> pl.DataFrame:
+    """Binding HTTP : délègue à `accise_par_contrat` avec OdooReader auto-géré."""
+    return accise_par_contrat(odoo, trimestre)
 
 
 def generer_accise_detail_arrow(trimestre: str | None = None) -> bytes:
@@ -41,10 +43,14 @@ def generer_accise_detail_xlsx(trimestre: str | None = None) -> bytes:
     return xlsx_multi_sheet({"Détail": calculer_accise_detail(trimestre)})
 
 
+@with_odoo
+def _accise_rapport(odoo, trimestre: str | None = None):
+    return rapport_accise(odoo, trimestre)
+
+
 def generer_accise_rapport_xlsx(trimestre: str | None = None) -> bytes:
     """Livrable facturiste : 3 onglets (Résumé / Par taux / Détail) depuis `rapport_accise`."""
-    with OdooReader(config=settings.get_odoo_config()) as odoo:
-        r = rapport_accise(odoo, trimestre)
+    r = _accise_rapport(trimestre)
     return xlsx_multi_sheet(
         {
             "Résumé": r.resume,
@@ -54,10 +60,15 @@ def generer_accise_rapport_xlsx(trimestre: str | None = None) -> bytes:
     )
 
 
-def calculer_cta_detail(trimestre: str | None = None) -> pl.DataFrame:
-    """Binding HTTP : ouvre Odoo + délègue à `cta_par_contrat`."""
-    with OdooReader(config=settings.get_odoo_config()) as odoo:
-        return cta_par_contrat(odoo, trimestre)
+# =============================================================================
+# CTA — détail brut + rapport agrégé
+# =============================================================================
+
+
+@with_odoo
+def calculer_cta_detail(odoo, trimestre: str | None = None) -> pl.DataFrame:
+    """Binding HTTP : délègue à `cta_par_contrat` avec OdooReader auto-géré."""
+    return cta_par_contrat(odoo, trimestre)
 
 
 def generer_cta_detail_arrow(trimestre: str | None = None) -> bytes:
@@ -70,6 +81,11 @@ def generer_cta_detail_xlsx(trimestre: str | None = None) -> bytes:
     return xlsx_multi_sheet({"Détail": calculer_cta_detail(trimestre)})
 
 
+@with_odoo
+def _cta_rapport(odoo, trimestre: str | None = None):
+    return rapport_cta(odoo, trimestre)
+
+
 def generer_cta_rapport_xlsx(trimestre: str | None = None) -> bytes:
     """Livrable facturiste : 3 onglets (Résumé / Par taux / Détail) depuis `rapport_cta`.
 
@@ -77,8 +93,7 @@ def generer_cta_rapport_xlsx(trimestre: str | None = None) -> bytes:
     l'onglet `Par taux` reflète cette dimensionalité, et l'onglet `Détail`
     list les taux successifs par PDL en string joined ` ; `.
     """
-    with OdooReader(config=settings.get_odoo_config()) as odoo:
-        r = rapport_cta(odoo, trimestre)
+    r = _cta_rapport(trimestre)
     return xlsx_multi_sheet(
         {
             "Résumé": r.resume,

--- a/electricore/integrations/odoo/decorators.py
+++ b/electricore/integrations/odoo/decorators.py
@@ -1,0 +1,37 @@
+"""Décorateurs pour l'adaptateur Odoo (issue #67).
+
+`@with_odoo` capture le pattern récurrent côté services HTTP : ouvrir
+`OdooReader`, déléguer à une orchestration, fermer proprement. Permet aux
+endpoints de consommer les orchestrations sans répéter le `with` block.
+"""
+
+import functools
+from collections.abc import Callable
+from typing import Any
+
+from electricore.api.config import settings
+
+from .reader import OdooReader
+
+
+def with_odoo[T](func: Callable[..., T]) -> Callable[..., T]:
+    """Ouvre `OdooReader` avec la config courante et injecte-le en 1er arg.
+
+    La fonction décorée prend `odoo` comme premier paramètre ; le wrapper
+    expose la signature publique sans ce paramètre (utile pour FastAPI).
+
+    Example:
+        @with_odoo
+        def calculer_accise_detail(odoo, trimestre=None):
+            return accise_par_contrat(odoo, trimestre)
+
+        # Au call-site :
+        df = calculer_accise_detail(trimestre="2025-T1")  # odoo injecté
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        with OdooReader(config=settings.get_odoo_config()) as odoo:
+            return func(odoo, *args, **kwargs)
+
+    return wrapper

--- a/tests/integration/test_facturation_arrow_endpoint.py
+++ b/tests/integration/test_facturation_arrow_endpoint.py
@@ -27,14 +27,13 @@ def _mock_odoo_configured(monkeypatch):
 
 @pytest.fixture
 def _mock_odoo_reader(monkeypatch):
-    """Court-circuite `OdooReader` (les tests mockent directement les orchestrations)."""
+    """Court-circuite `OdooReader` au sein du décorateur `@with_odoo` (#67)."""
 
     @contextmanager
     def _fake_reader(config):
         yield None
 
-    monkeypatch.setattr("electricore.integrations.odoo.OdooReader", _fake_reader)
-    monkeypatch.setattr("electricore.api.services.facturation_service.OdooReader", _fake_reader)
+    monkeypatch.setattr("electricore.integrations.odoo.decorators.OdooReader", _fake_reader)
 
 
 @pytest.fixture

--- a/tests/integration/test_facturation_service_smoke.py
+++ b/tests/integration/test_facturation_service_smoke.py
@@ -119,8 +119,11 @@ def service_loaders_mockes(
         def filter(self, *args, **kwargs):
             return _QueryMock(self.lazy().filter(*args, **kwargs))
 
-    # OdooReader reste importé dans le service (binding HTTP).
-    monkeypatch.setattr(facturation_service, "OdooReader", _OdooReaderMock)
+    # Depuis #67 : `OdooReader` est ouvert par le décorateur `@with_odoo`
+    # qui vit dans `electricore.integrations.odoo.decorators`.
+    from electricore.integrations.odoo import decorators as odoo_decorators
+
+    monkeypatch.setattr(odoo_decorators, "OdooReader", _OdooReaderMock)
 
     # Depuis #39 (ADR-0016) : l'orchestration vit dans `integrations.odoo.facturation`,
     # donc les mocks ciblent ce module-là plutôt que le service.
@@ -141,7 +144,7 @@ def service_loaders_mockes(
     monkeypatch.setattr(facturation_orchestration, "charger_contexte_facturation", _fake_charger_contexte)
 
     # pydantic Settings interdit setattr — on patche la méthode sur la classe.
-    settings_cls = type(facturation_service.settings)
+    settings_cls = type(odoo_decorators.settings)
     monkeypatch.setattr(settings_cls, "get_odoo_config", lambda self: {})
 
 
@@ -228,11 +231,13 @@ def test_calculer_lignes_facture_rapprochees_delegue_a_charger_contexte_facturat
         def collect(self):
             return self._df
 
-    monkeypatch.setattr(facturation_service, "OdooReader", _OdooReaderMock)
+    from electricore.integrations.odoo import decorators as odoo_decorators
+
+    monkeypatch.setattr(odoo_decorators, "OdooReader", _OdooReaderMock)
     monkeypatch.setattr(
         facturation_orchestration, "lignes_factures_du_mois", lambda odoo, mois: _QueryMock(df_lignes_odoo_minimal)
     )
-    settings_cls = type(facturation_service.settings)
+    settings_cls = type(odoo_decorators.settings)
     monkeypatch.setattr(settings_cls, "get_odoo_config", lambda self: {})
 
     result = facturation_service.calculer_lignes_facture_rapprochees(mois="2025-01-01")

--- a/tests/integration/test_taxes_arrow_endpoints.py
+++ b/tests/integration/test_taxes_arrow_endpoints.py
@@ -23,15 +23,14 @@ def _mock_odoo_configured(monkeypatch):
 
 @pytest.fixture
 def _mock_odoo_reader(monkeypatch):
-    """Court-circuite `OdooReader` (les tests mockent directement `accise_par_contrat`)."""
+    """Court-circuite `OdooReader` au sein du décorateur `@with_odoo` (#67)."""
     from contextlib import contextmanager
 
     @contextmanager
     def _fake_reader(config):
         yield None
 
-    monkeypatch.setattr("electricore.integrations.odoo.OdooReader", _fake_reader)
-    monkeypatch.setattr("electricore.api.services.taxes_service.OdooReader", _fake_reader)
+    monkeypatch.setattr("electricore.integrations.odoo.decorators.OdooReader", _fake_reader)
 
 
 @pytest.fixture

--- a/tests/integration/test_taxes_service_smoke.py
+++ b/tests/integration/test_taxes_service_smoke.py
@@ -85,9 +85,11 @@ def test_calculer_cta_detail_delegue_a_charger_contexte_facturation(monkeypatch,
         }
     )
 
-    monkeypatch.setattr(taxes_service, "OdooReader", _OdooReaderMock)
+    from electricore.integrations.odoo import decorators as odoo_decorators
+
+    monkeypatch.setattr(odoo_decorators, "OdooReader", _OdooReaderMock)
     monkeypatch.setattr(taxes_orchestration, "query", lambda odoo, model, domain, fields: _QueryMock(df_pdl_brut))
-    settings_cls = type(taxes_service.settings)
+    settings_cls = type(odoo_decorators.settings)
     monkeypatch.setattr(settings_cls, "get_odoo_config", lambda self: {})
 
     result = taxes_service.calculer_cta_detail()

--- a/tests/unit/integrations/odoo/test_with_odoo.py
+++ b/tests/unit/integrations/odoo/test_with_odoo.py
@@ -1,0 +1,112 @@
+"""Tests pour le décorateur `@with_odoo` (issue #67).
+
+Le décorateur encapsule le pattern récurrent :
+
+    with OdooReader(config=settings.get_odoo_config()) as odoo:
+        return f(odoo, *args, **kwargs)
+
+…dans `electricore/api/services/{taxes,facturation}_service.py`. Préserve la
+signature publique de `f` (sans le premier arg `odoo`) pour FastAPI.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+
+def test_with_odoo_injects_odoo_as_first_arg(monkeypatch):
+    """`@with_odoo` ouvre OdooReader et le passe en 1er à la fonction décorée."""
+    from electricore.integrations.odoo.decorators import with_odoo
+
+    fake_odoo = MagicMock(name="fake_odoo")
+
+    @contextmanager
+    def _fake_reader(config):
+        yield fake_odoo
+
+    monkeypatch.setattr("electricore.integrations.odoo.decorators.OdooReader", _fake_reader)
+    # pydantic Settings interdit setattr — on patche la méthode sur la classe.
+    from electricore.integrations.odoo.decorators import settings as decorator_settings
+
+    monkeypatch.setattr(type(decorator_settings), "get_odoo_config", lambda self: {"url": "fake://"})
+
+    received: dict = {}
+
+    @with_odoo
+    def calc(odoo, value: int) -> int:
+        received["odoo"] = odoo
+        received["value"] = value
+        return value * 2
+
+    result = calc(7)
+
+    assert result == 14
+    assert received["odoo"] is fake_odoo
+    assert received["value"] == 7
+
+
+def test_with_odoo_closes_reader_on_exception(monkeypatch):
+    """`@with_odoo` ferme l'OdooReader même si la fonction décorée lève."""
+    from electricore.integrations.odoo.decorators import with_odoo
+
+    closed = {"yes": False}
+
+    @contextmanager
+    def _fake_reader(config):
+        try:
+            yield MagicMock(name="odoo")
+        finally:
+            closed["yes"] = True
+
+    monkeypatch.setattr("electricore.integrations.odoo.decorators.OdooReader", _fake_reader)
+    from electricore.integrations.odoo.decorators import settings as decorator_settings
+
+    monkeypatch.setattr(type(decorator_settings), "get_odoo_config", lambda self: {})
+
+    @with_odoo
+    def boom(odoo):
+        raise RuntimeError("planned failure")
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="planned failure"):
+        boom()
+
+    assert closed["yes"], "OdooReader doit être fermé même quand la fonction décorée lève"
+
+
+def test_with_odoo_preserves_name_and_doc():
+    """`@functools.wraps` préserve __name__ et __doc__ — FastAPI introspection."""
+    from electricore.integrations.odoo.decorators import with_odoo
+
+    @with_odoo
+    def calculer_accise_detail(odoo, trimestre=None):
+        """Docstring originale."""
+        return None
+
+    assert calculer_accise_detail.__name__ == "calculer_accise_detail"
+    assert calculer_accise_detail.__doc__ == "Docstring originale."
+
+
+def test_with_odoo_uses_settings_get_odoo_config(monkeypatch):
+    """Le décorateur appelle `settings.get_odoo_config()` à chaque invocation."""
+    from electricore.integrations.odoo.decorators import with_odoo
+
+    captured_configs = []
+
+    @contextmanager
+    def _fake_reader(config):
+        captured_configs.append(config)
+        yield MagicMock()
+
+    monkeypatch.setattr("electricore.integrations.odoo.decorators.OdooReader", _fake_reader)
+    from electricore.integrations.odoo.decorators import settings as decorator_settings
+
+    monkeypatch.setattr(type(decorator_settings), "get_odoo_config", lambda self: {"url": "specific://here"})
+
+    @with_odoo
+    def noop(odoo):
+        return None
+
+    noop()
+
+    assert captured_configs == [{"url": "specific://here"}]


### PR DESCRIPTION
## Summary
Architectural Review Candidate 3. With C1 complete (#56 accise, #63 CTA, #64 facturation), the services `taxes_service.py` and `facturation_service.py` had nothing left to do but open `OdooReader`, delegate, serialize. This PR encapsulates the open/close in a `@with_odoo` decorator.

**Before** — same `with` block 7 times:
```python
def calculer_accise_detail(trimestre=None):
    with OdooReader(config=settings.get_odoo_config()) as odoo:
        return accise_par_contrat(odoo, trimestre)
```

**After**:
```python
@with_odoo
def calculer_accise_detail(odoo, trimestre=None):
    return accise_par_contrat(odoo, trimestre)
```

## Decorator
New module `electricore/integrations/odoo/decorators.py` (parallel to `electricore/api/decorators.py`):
- `@with_odoo` opens `OdooReader(config=settings.get_odoo_config())` at call-site
- Injects `odoo` as first positional arg
- Cleans up on exception (context manager semantics preserved)
- `@functools.wraps` preserves `__name__` / `__doc__` for FastAPI introspection
- PEP 695 generic syntax: `def with_odoo[T](func: Callable[..., T]) -> ...`

## Why the inner-function form (not `f = with_odoo(g)`)
Critical for test stability. The form:
```python
@with_odoo
def calculer_accise_detail(odoo, trimestre=None):
    return accise_par_contrat(odoo, trimestre)
```
Resolves `accise_par_contrat` in `taxes_service`'s globals **at call time**, not at decoration time. This means existing integration tests that `monkeypatch.setattr("electricore.api.services.taxes_service.accise_par_contrat", fake)` keep working without modification.

The shorter form `calculer_accise_detail = with_odoo(accise_par_contrat)` would capture the reference at module-load time and break all the existing mocks. Chose the inner-function form deliberately.

## Wired consumers
- `taxes_service.py`: `calculer_accise_detail`, `calculer_cta_detail`, `_accise_rapport`, `_cta_rapport` all decorated.
- `facturation_service.py`: `calculer_lignes_facture_rapprochees`, `_facturation_rapport`, `_documents_facturation` all decorated.
- `OdooReader` and `settings` imports removed from both services — now live exclusively in `decorators`.

## TDD cycles
4 RED→GREEN cycles in `tests/unit/integrations/odoo/test_with_odoo.py`:
1. `@with_odoo` opens OdooReader and injects it as first arg
2. OdooReader is closed even when the decorated function raises
3. `__name__` and `__doc__` preserved (FastAPI introspection)
4. `settings.get_odoo_config()` called at each invocation

## Fixture updates
The only binding that moved is `OdooReader` (from `taxes_service` / `facturation_service` to `decorators`). All fixtures `_mock_odoo_reader` and the two smoke-test files updated to monkeypatch the new location.

## Test plan
- [x] `uv run --group test pytest -q` — 447 passed (was 443, +4 from with_odoo decorator), 35 legitimate skips
- [x] `uvx pre-commit run --all-files` — clean
- [x] No `with OdooReader(...)` block remaining in `taxes_service.py` or `facturation_service.py`

## Result
Architectural Review C1 + C2 + C3 now all shipped. `services/` is pure serialization (Pandera → bytes). Shape lives in `integrations/odoo/`. Connection lifecycle lives in `@with_odoo`. Three concerns, three places, no overlap.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)