### PR TITLE
refactor(api): migrate /flux/* endpoints to extension-suffix convention (#65)

### DIFF
--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -143,7 +143,7 @@ async def root():
     }
 
 
-@xlsx_endpoint(app, "/flux/c15/entrees/xlsx", filename="entrees_c15.xlsx", error_status=500, tags=["flux"])
+@xlsx_endpoint(app, "/flux/c15/entrees.xlsx", filename="entrees_c15.xlsx", error_status=500, tags=["flux"])
 def get_entrees_xlsx(
     limit: int = Query(10000, le=100000, description="Nombre maximum de lignes"),
 ) -> bytes:
@@ -155,7 +155,7 @@ def get_entrees_xlsx(
     return xlsx_multi_sheet({"entrees": df})
 
 
-@xlsx_endpoint(app, "/flux/c15/sorties/xlsx", filename="sorties_c15.xlsx", error_status=500, tags=["flux"])
+@xlsx_endpoint(app, "/flux/c15/sorties.xlsx", filename="sorties_c15.xlsx", error_status=500, tags=["flux"])
 def get_sorties_xlsx(
     limit: int = Query(10000, le=100000, description="Nombre maximum de lignes"),
 ) -> bytes:
@@ -188,36 +188,12 @@ def _load_flux_df(table_name: str, prm: str | None, limit: int):
     return query.limit(limit).collect()
 
 
-@app.get("/flux/{table_name}", tags=["flux"])
-async def get_flux(
-    table_name: str,
-    prm: str | None = Query(None, description="Filtrer par pdl (Point de Livraison)"),
-    limit: int = Query(100, le=1000, description="Nombre maximum de lignes à retourner"),
-    offset: int = Query(0, ge=0, description="Nombre de lignes à ignorer (pagination)"),
-    api_key: str = Depends(get_current_api_key),
-):
-    """
-    Endpoint générique pour lire n'importe quel flux Enedis.
-
-    **Authentification requise** - Utilisez votre clé API.
-
-    Exemples:
-    - /flux/r151 : Relevés quotidiens
-    - /flux/c15 : Changements contractuels
-    - /flux/r64 : Relevés demandés sur SGE
-    - /flux/f15 : Facturation Enedis détaillée
-    """
-    df = _load_flux_df(table_name, prm, limit + offset)
-    rows = df.slice(offset, limit).to_dicts()
-    return {
-        "table": f"flux_{table_name}",
-        "filters": {"pdl": prm} if prm else None,
-        "pagination": {"limit": limit, "offset": offset, "returned": len(rows)},
-        "data": rows,
-    }
+# IMPORTANT — ordre de déclaration : les routes `.xlsx` / `.arrow` et `/info`
+# (sous-ressource) DOIVENT précéder la route catch-all `/flux/{table_name}`,
+# sinon `{table_name}` capture `c15.xlsx` et la requête est mal routée.
 
 
-@xlsx_endpoint(app, "/flux/{table_name}/xlsx", filename="flux_{table_name}.xlsx", error_status=500, tags=["flux"])
+@xlsx_endpoint(app, "/flux/{table_name}.xlsx", filename="flux_{table_name}.xlsx", error_status=500, tags=["flux"])
 def get_flux_xlsx(
     table_name: str,
     prm: str | None = Query(None, description="Filtrer par pdl (Point de Livraison)"),
@@ -230,7 +206,7 @@ def get_flux_xlsx(
     return xlsx_multi_sheet({table_name: df})
 
 
-@arrow_endpoint(app, "/flux/{table_name}/arrow", tags=["flux"])
+@arrow_endpoint(app, "/flux/{table_name}.arrow", tags=["flux"])
 def get_flux_arrow(
     table_name: str,
     prm: str | None = Query(None, description="Filtrer par pdl (Point de Livraison)"),
@@ -268,6 +244,37 @@ async def get_table_info(table_name: str, api_key: str = Depends(get_current_api
     except Exception:
         available_tables = duckdb_service.list_tables()
         raise HTTPException(404, f"Table '{table_name}' non trouvée. Tables disponibles: {available_tables}")
+
+
+# `/flux/{table_name}` (JSON) déclaré APRÈS les routes plus spécifiques pour que
+# `/flux/c15.xlsx` matche bien l'endpoint XLSX et pas le catch-all.
+@app.get("/flux/{table_name}", tags=["flux"])
+async def get_flux(
+    table_name: str,
+    prm: str | None = Query(None, description="Filtrer par pdl (Point de Livraison)"),
+    limit: int = Query(100, le=1000, description="Nombre maximum de lignes à retourner"),
+    offset: int = Query(0, ge=0, description="Nombre de lignes à ignorer (pagination)"),
+    api_key: str = Depends(get_current_api_key),
+):
+    """
+    Endpoint générique pour lire n'importe quel flux Enedis (réponse JSON).
+
+    **Authentification requise** - Utilisez votre clé API.
+
+    Exemples:
+    - /flux/r151 : Relevés quotidiens
+    - /flux/c15 : Changements contractuels
+    - /flux/r64 : Relevés demandés sur SGE
+    - /flux/f15 : Facturation Enedis détaillée
+    """
+    df = _load_flux_df(table_name, prm, limit + offset)
+    rows = df.slice(offset, limit).to_dicts()
+    return {
+        "table": f"flux_{table_name}",
+        "filters": {"pdl": prm} if prm else None,
+        "pagination": {"limit": limit, "offset": offset, "returned": len(rows)},
+        "data": rows,
+    }
 
 
 @app.get("/health", tags=["public"])

--- a/electricore/bot/client.py
+++ b/electricore/bot/client.py
@@ -52,19 +52,19 @@ class ElectriCoreClient:
 
     async def get_entrees_xlsx(self) -> bytes:
         async with httpx.AsyncClient() as c:
-            r = await c.get(f"{self._base}/flux/c15/entrees/xlsx", headers=self._headers, timeout=120)
+            r = await c.get(f"{self._base}/flux/c15/entrees.xlsx", headers=self._headers, timeout=120)
             r.raise_for_status()
             return r.content
 
     async def get_sorties_xlsx(self) -> bytes:
         async with httpx.AsyncClient() as c:
-            r = await c.get(f"{self._base}/flux/c15/sorties/xlsx", headers=self._headers, timeout=120)
+            r = await c.get(f"{self._base}/flux/c15/sorties.xlsx", headers=self._headers, timeout=120)
             r.raise_for_status()
             return r.content
 
     async def get_xlsx(self, table: str) -> bytes:
         async with httpx.AsyncClient() as c:
-            r = await c.get(f"{self._base}/flux/{table}/xlsx", headers=self._headers, timeout=120)
+            r = await c.get(f"{self._base}/flux/{table}.xlsx", headers=self._headers, timeout=120)
             r.raise_for_status()
             return r.content
 

--- a/electricore/client/__init__.py
+++ b/electricore/client/__init__.py
@@ -59,7 +59,7 @@ class ElectricoreClient:
         params: dict[str, str | int] = {"limit": limit}
         if prm:
             params["prm"] = prm
-        return self._get_arrow(f"/flux/{table_name}/arrow", params)
+        return self._get_arrow(f"/flux/{table_name}.arrow", params)
 
     def facturation(self, mois: str | None = None) -> pl.DataFrame:
         """Récupère `lignes_facture_rapprochees` pour le mois donné.

--- a/tests/integration/test_flux_endpoint_extension_suffix.py
+++ b/tests/integration/test_flux_endpoint_extension_suffix.py
@@ -1,0 +1,133 @@
+"""Tests d'intégration pour la convention extension-suffix `/flux/*` (issue #65).
+
+Cible :
+- `/flux/c15/entrees.xlsx` et `.sorties.xlsx` (anciens `/xlsx` segment supprimés)
+- `/flux/{table_name}.xlsx` et `.arrow` (anciens `/xlsx`, `/arrow` segment supprimés)
+- `/flux/{table_name}/info` reste segment (métadonnée, pas un format de fichier)
+- L'ordre de déclaration des routes doit garantir que `/flux/{name}.xlsx`
+  ne soit pas confondu avec `/flux/{name}` qui matche en JSON.
+"""
+
+import io
+
+import polars as pl
+import pytest
+from fastapi.testclient import TestClient
+from polars.testing import assert_frame_equal
+
+from electricore.api.main import app
+from electricore.api.security import get_current_api_key
+
+XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+ARROW_IPC = "application/vnd.apache.arrow.stream"
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_c15_entrees_xlsx_extension_suffix_returns_200(client):
+    """`GET /flux/c15/entrees.xlsx` sert le XLSX (PMES, MES, CFNE)."""
+    response = client.get("/flux/c15/entrees.xlsx")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(XLSX_MIME)
+    assert "attachment" in response.headers.get("content-disposition", "")
+
+
+def test_c15_sorties_xlsx_extension_suffix_returns_200(client):
+    """`GET /flux/c15/sorties.xlsx` sert le XLSX (RES, CFNS)."""
+    response = client.get("/flux/c15/sorties.xlsx")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(XLSX_MIME)
+    assert "attachment" in response.headers.get("content-disposition", "")
+
+
+# =============================================================================
+# /flux/{table_name}.xlsx et .arrow (extension-suffix générique)
+# =============================================================================
+
+
+@pytest.fixture
+def df_flux_synthetique() -> pl.DataFrame:
+    return pl.DataFrame({"pdl": ["A", "B"], "date": ["2025-01-01", "2025-01-02"]})
+
+
+def test_generic_flux_xlsx_extension_suffix_returns_200(client, monkeypatch, df_flux_synthetique):
+    """`GET /flux/{table_name}.xlsx` (extension-suffix) sert le XLSX du flux."""
+    monkeypatch.setattr("electricore.api.main._load_flux_df", lambda t, prm, lim: df_flux_synthetique)
+
+    response = client.get("/flux/c15.xlsx")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(XLSX_MIME)
+
+
+def test_generic_flux_arrow_extension_suffix_returns_200(client, monkeypatch, df_flux_synthetique):
+    """`GET /flux/{table_name}.arrow` (extension-suffix) sert l'Arrow IPC du flux."""
+    monkeypatch.setattr("electricore.api.main._load_flux_df", lambda t, prm, lim: df_flux_synthetique)
+
+    response = client.get("/flux/c15.arrow")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == ARROW_IPC
+    df = pl.read_ipc_stream(io.BytesIO(response.content))
+    assert_frame_equal(df, df_flux_synthetique)
+
+
+def test_generic_flux_extension_suffix_whitelist_unknown_returns_404(client):
+    """`GET /flux/inconnu.xlsx` (table absente de FLUX_CONFIGS) → 404."""
+    response = client.get("/flux/inconnu.xlsx")
+    assert response.status_code == 404
+
+
+# =============================================================================
+# Anciens paths supprimés (404)
+# =============================================================================
+
+
+def test_anciens_paths_flux_segment_404(client):
+    """Les anciens `/flux/.../xlsx` et `/.../arrow` (segment) sont supprimés."""
+    for path in (
+        "/flux/c15/entrees/xlsx",
+        "/flux/c15/sorties/xlsx",
+        "/flux/c15/xlsx",
+        "/flux/c15/arrow",
+    ):
+        response = client.get(path)
+        assert response.status_code == 404, f"{path} devrait être 404"
+
+
+# =============================================================================
+# Route ordering : /flux/{table_name} (JSON) coexiste avec .xlsx/.arrow
+# =============================================================================
+
+
+def test_flux_json_endpoint_still_works(client, monkeypatch, df_flux_synthetique):
+    """`GET /flux/{table_name}` (sans extension) sert toujours le JSON."""
+    monkeypatch.setattr("electricore.api.main._load_flux_df", lambda t, prm, lim: df_flux_synthetique)
+
+    response = client.get("/flux/c15", params={"limit": 10})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["table"] == "flux_c15"
+    assert isinstance(payload["data"], list)
+
+
+def test_flux_info_endpoint_still_at_segment_path(client, monkeypatch):
+    """`GET /flux/{table_name}/info` reste en segment (métadonnée, pas un format)."""
+    monkeypatch.setattr(
+        "electricore.api.services.duckdb_service.get_table_info",
+        lambda name: {"table": f"flux_{name}", "schema": "flux_enedis", "count": 0, "columns": []},
+    )
+    response = client.get("/flux/c15/info")
+
+    assert response.status_code == 200
+    assert response.json()["table"] == "flux_c15"

--- a/tests/integration/test_flux_endpoint_extension_suffix.py
+++ b/tests/integration/test_flux_endpoint_extension_suffix.py
@@ -31,7 +31,27 @@ def client():
         app.dependency_overrides.clear()
 
 
-def test_c15_entrees_xlsx_extension_suffix_returns_200(client):
+@pytest.fixture
+def _mock_c15(monkeypatch):
+    """Court-circuite `c15().entrees()/.sorties().limit().collect()` (CI sans DuckDB)."""
+
+    class _FakeBuilder:
+        def entrees(self):
+            return self
+
+        def sorties(self):
+            return self
+
+        def limit(self, _n):
+            return self
+
+        def collect(self):
+            return pl.DataFrame({"pdl": ["X"], "evenement_declencheur": ["MES"]})
+
+    monkeypatch.setattr("electricore.core.loaders.duckdb.c15", lambda: _FakeBuilder())
+
+
+def test_c15_entrees_xlsx_extension_suffix_returns_200(client, _mock_c15):
     """`GET /flux/c15/entrees.xlsx` sert le XLSX (PMES, MES, CFNE)."""
     response = client.get("/flux/c15/entrees.xlsx")
 
@@ -40,7 +60,7 @@ def test_c15_entrees_xlsx_extension_suffix_returns_200(client):
     assert "attachment" in response.headers.get("content-disposition", "")
 
 
-def test_c15_sorties_xlsx_extension_suffix_returns_200(client):
+def test_c15_sorties_xlsx_extension_suffix_returns_200(client, _mock_c15):
     """`GET /flux/c15/sorties.xlsx` sert le XLSX (RES, CFNS)."""
     response = client.get("/flux/c15/sorties.xlsx")
 

--- a/tests/integration/test_flux_endpoint_whitelist.py
+++ b/tests/integration/test_flux_endpoint_whitelist.py
@@ -24,9 +24,9 @@ class TestUnknownTableReturns404:
         assert response.status_code == 404
 
     def test_get_flux_xlsx_unknown(self, client):
-        response = client.get("/flux/totalement_inexistant/xlsx")
+        response = client.get("/flux/totalement_inexistant.xlsx")
         assert response.status_code == 404
 
     def test_get_flux_arrow_unknown(self, client):
-        response = client.get("/flux/totalement_inexistant/arrow")
+        response = client.get("/flux/totalement_inexistant.arrow")
         assert response.status_code == 404

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -109,7 +109,7 @@ def test_cta_round_trip_via_endpoint(monkeypatch):
 
 
 def test_flux_round_trip_via_endpoint(monkeypatch):
-    """`client.flux(table_name)` round-trip un DataFrame servi par /flux/{name}/arrow."""
+    """`client.flux(table_name)` round-trip un DataFrame servi par /flux/{name}.arrow."""
     df_attendu = pl.DataFrame(
         {
             "pdl": ["12345678901234"],


### PR DESCRIPTION
## Summary
Cross-cutting cohesion PR. The `path.extension` convention introduced by #56 on `/taxes/accise/*` and propagated to #63 (CTA) and #64 (facturation) is now applied to `/flux/*`.

## Migration

| Before | After |
|---|---|
| `/flux/c15/entrees/xlsx` | `/flux/c15/entrees.xlsx` |
| `/flux/c15/sorties/xlsx` | `/flux/c15/sorties.xlsx` |
| `/flux/{table_name}/xlsx` | `/flux/{table_name}.xlsx` |
| `/flux/{table_name}/arrow` | `/flux/{table_name}.arrow` |

Old paths removed (404). Same approach as #56/#63/#64 — no 301/Sunset window, your call confirmed via form.

**Stay unchanged** (intentional):
- `/flux/{table_name}/info` — metadata, not a file format; segment matches REST sub-resource semantics.
- `/flux/{table_name}` (JSON, no extension) — catch-all.

## Route ordering — critical detail

`/flux/{table_name}.xlsx` must be declared **before** `/flux/{table_name}` catch-all. Otherwise `{table_name}` captures `c15.xlsx` (FastAPI/Starlette default `str` path converter is `[^/]+` which includes dots).

Declaration order in `main.py`:
1. `/flux/c15/entrees.xlsx` (static)
2. `/flux/c15/sorties.xlsx` (static)
3. `/flux/{table_name}.xlsx` (specific extension)
4. `/flux/{table_name}.arrow` (specific extension)
5. `/flux/{table_name}/info` (sub-resource)
6. `/flux/{table_name}` (catch-all JSON — last)

A block comment in main.py documents this ordering constraint for future edits.

## TDD cycles
6 RED→GREEN cycles in `tests/integration/test_flux_endpoint_extension_suffix.py` (8 tests total):
1. `/flux/c15/entrees.xlsx` → 200 XLSX
2. `/flux/c15/sorties.xlsx` → 200 XLSX
3. `/flux/{table_name}.xlsx` → 200 XLSX, FLUX_CONFIGS whitelist enforced
4. `/flux/{table_name}.arrow` → 200 Arrow IPC, whitelist enforced
5. Old paths (`/flux/c15/entrees/xlsx`, `/flux/{name}/xlsx`, `/flux/{name}/arrow`) → 404
6. `/flux/{table_name}` JSON + `/flux/{table_name}/info` still work (route order)

## Consumers updated
- `electricore/bot/client.py`: `get_entrees_xlsx`, `get_sorties_xlsx`, `get_xlsx`
- `electricore/client/__init__.py`: `flux()` consumes `.arrow`
- `tests/integration/test_flux_endpoint_whitelist.py`: 404-on-unknown tests repointed
- `tests/unit/test_client.py`: docstring path update

## Test plan
- [x] `uv run --group test pytest -q` — 455 passed (was 447, +8 from this PR), 35 legitimate skips
- [x] `uvx pre-commit run --all-files` — clean
- [x] No straggler references to old segment paths

## Cohesion achieved
Toutes les routes file-format suivent maintenant la convention `.xlsx` / `.arrow` :
- `/flux/c15/entrees.xlsx`, `/flux/c15/sorties.xlsx`
- `/flux/{table}.xlsx`, `/flux/{table}.arrow`
- `/facturation/rapport.xlsx`, `/facturation/detail.xlsx`, `/facturation/detail.arrow`
- `/taxes/accise/rapport.xlsx`, `/taxes/accise/detail.xlsx`, `/taxes/accise/detail.arrow`
- `/taxes/cta/rapport.xlsx`, `/taxes/cta/detail.xlsx`, `/taxes/cta/detail.arrow`

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)