### PR TITLE
fix(api): api_version suit le package au lieu d'être hardcodée

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,9 @@ API_KEY=your-secure-api-key-here
 
 # Métadonnées de l'API
 API_TITLE="ElectriCore API"
-API_VERSION="0.1.0"
+# API_VERSION: par défaut, lue depuis le package installé (pyproject.toml / tag).
+# Ne définir cette variable que pour forcer une valeur spécifique.
+# API_VERSION="0.0.0"
 API_DESCRIPTION="API sécurisée pour accéder aux données flux Enedis"
 
 # Méthode d'authentification (header X-API-Key uniquement)

--- a/electricore/api/config.py
+++ b/electricore/api/config.py
@@ -5,6 +5,8 @@ Utilise Pydantic Settings pour une configuration basée sur les variables d'envi
 
 import os
 import secrets
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 from pydantic import BaseModel, Field, validator
 
@@ -12,6 +14,14 @@ from electricore.config.env import charger_env
 
 # Charger le .env au démarrage du module
 charger_env()
+
+
+def _default_api_version() -> str:
+    """Version du package electricore (suit pyproject.toml / tag de release)."""
+    try:
+        return _pkg_version("electricore")
+    except PackageNotFoundError:
+        return "0.0.0+unknown"
 
 
 class APISettings(BaseModel):
@@ -25,7 +35,7 @@ class APISettings(BaseModel):
 
     # Configuration générale de l'API
     api_title: str = Field(default="ElectriCore API")
-    api_version: str = Field(default="0.1.0")
+    api_version: str = Field(default_factory=_default_api_version)
     api_description: str = Field(default="API sécurisée pour accéder aux données flux Enedis")
 
     # Identité de l'instance (cf. ADR-0015 — déploiement multi-instance)
@@ -68,7 +78,7 @@ class APISettings(BaseModel):
         # Charger depuis les variables d'environnement
         env_values = {
             "api_title": os.getenv("API_TITLE", "ElectriCore API"),
-            "api_version": os.getenv("API_VERSION", "0.1.0"),
+            "api_version": os.getenv("API_VERSION") or _default_api_version(),
             "api_description": os.getenv("API_DESCRIPTION", "API sécurisée pour accéder aux données flux Enedis"),
             "instance_slug": os.getenv("INSTANCE_SLUG", ""),
             "api_key": os.getenv("API_KEY", ""),


### PR DESCRIPTION
## Summary
- `/health` retournait toujours `api_version: 0.1.0` alors que le projet est à `1.7.0rcX`.
- La valeur par défaut est désormais lue via `importlib.metadata.version(\"electricore\")`, donc elle suit `pyproject.toml` (et les tags de release).
- L'override `API_VERSION` reste possible mais n'est plus défini en dur dans `.env.example`.

## Test plan
- [x] `uv run --group test pytest -q` → 455 passed, 35 skipped
- [x] `uvx pre-commit run --files .env.example electricore/api/config.py` → OK
- [x] Vérif locale : `settings.api_version` retourne bien `1.7.0rc4`
- [x] Après merge + redéploiement : `GET /health` doit renvoyer la version du tag courant

🤖 Generated with [Claude Code](https://claude.com/claude-code)