### PR TITLE
refactor(api): collapse Accise (rapport × format) Cartesian

### DIFF
--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -16,6 +16,7 @@ from electricore.api.config import settings
 from electricore.api.decorators import arrow_endpoint, xlsx_endpoint
 from electricore.api.models import ETLJobResponse, ETLRunRequest
 from electricore.api.security import APIKeyInfo, get_api_key_info, get_current_api_key
+from electricore.api.serializers import arrow_stream, xlsx_multi_sheet
 from electricore.api.services import duckdb_service, etl_service
 from electricore.api.services.check_facturation_service import verifier_odoo
 from electricore.api.services.facturation_service import (
@@ -25,12 +26,15 @@ from electricore.api.services.facturation_service import (
     generer_facturation_rapport_xlsx,
 )
 from electricore.api.services.taxes_service import (
-    generer_accise_detail_arrow,
-    generer_accise_detail_xlsx,
-    generer_accise_rapport_xlsx,
     generer_cta_detail_arrow,
     generer_cta_detail_xlsx,
     generer_cta_rapport_xlsx,
+)
+from electricore.integrations.odoo.decorators import with_odoo
+from electricore.integrations.odoo.taxes import (
+    accise_par_contrat,
+    feuilles_rapport_accise,
+    rapport_accise,
 )
 
 logger = logging.getLogger(__name__)
@@ -427,7 +431,9 @@ async def list_api_keys(api_key: str = Depends(get_current_api_key), key_info: A
 @xlsx_endpoint(
     app, "/taxes/accise/rapport.xlsx", filename="accise_rapport{trimestre}.xlsx", requires_odoo=True, tags=["taxes"]
 )
+@with_odoo
 def export_accise_rapport_xlsx(
+    odoo,
     trimestre: str | None = Query(
         default=None,
         examples=["2025-T1"],
@@ -435,13 +441,15 @@ def export_accise_rapport_xlsx(
     ),
 ) -> bytes:
     """Livrable facturiste : Accise TICFE en XLSX multi-onglets (Résumé / Par taux / Détail)."""
-    return generer_accise_rapport_xlsx(trimestre)
+    return xlsx_multi_sheet(feuilles_rapport_accise(rapport_accise(odoo, trimestre)))
 
 
 @xlsx_endpoint(
     app, "/taxes/accise/detail.xlsx", filename="accise_detail{trimestre}.xlsx", requires_odoo=True, tags=["taxes"]
 )
+@with_odoo
 def export_accise_detail_xlsx(
+    odoo,
     trimestre: str | None = Query(
         default=None,
         examples=["2025-T1"],
@@ -449,11 +457,13 @@ def export_accise_detail_xlsx(
     ),
 ) -> bytes:
     """Détail Accise TICFE en XLSX mono-onglet (table PDL × mois, cas technique)."""
-    return generer_accise_detail_xlsx(trimestre)
+    return xlsx_multi_sheet({"Détail": accise_par_contrat(odoo, trimestre)})
 
 
 @arrow_endpoint(app, "/taxes/accise/detail.arrow", requires_odoo=True, tags=["taxes"])
+@with_odoo
 def export_accise_detail_arrow(
+    odoo,
     trimestre: str | None = Query(
         default=None,
         examples=["2025-T1"],
@@ -461,7 +471,7 @@ def export_accise_detail_arrow(
     ),
 ) -> bytes:
     """Détail Accise TICFE en Arrow IPC stream (table PDL × mois, cas technique)."""
-    return generer_accise_detail_arrow(trimestre)
+    return arrow_stream(accise_par_contrat(odoo, trimestre))
 
 
 @xlsx_endpoint(

--- a/electricore/api/services/taxes_service.py
+++ b/electricore/api/services/taxes_service.py
@@ -1,14 +1,10 @@
-"""Service de sérialisation des taxes énergétiques (Accise TICFE, CTA).
+"""Service de sérialisation des taxes énergétiques (CTA).
 
-Le calcul et l'orchestration métier vivent dans
-`electricore.integrations.odoo.taxes`. Ce service ne fait que :
+Volet Accise migré : les endpoints `/taxes/accise/*` consomment désormais
+directement `feuilles_rapport_accise` + `accise_par_contrat` côté
+`integrations.odoo.taxes`, sans couche service intermédiaire (issue #75).
 
-1. Ouvrir la connexion Odoo via `@with_odoo` (cf. issue #67)
-2. Déléguer à l'orchestration
-3. Sérialiser le résultat (XLSX multi-onglets / Arrow IPC).
-
-La shape des livrables (`Résumé` / `Par taux` / `Détail`) vit dans
-`integrations.odoo.taxes.rapport_accise` et `.rapport_cta` (#56, #63).
+Le volet CTA reste ici tant qu'il n'a pas été migré au même pattern.
 """
 
 import polars as pl
@@ -16,49 +12,9 @@ import polars as pl
 from electricore.api.serializers import arrow_stream, xlsx_multi_sheet
 from electricore.integrations.odoo.decorators import with_odoo
 from electricore.integrations.odoo.taxes import (
-    accise_par_contrat,
     cta_par_contrat,
-    rapport_accise,
     rapport_cta,
 )
-
-# =============================================================================
-# Accise — détail brut + rapport agrégé
-# =============================================================================
-
-
-@with_odoo
-def calculer_accise_detail(odoo, trimestre: str | None = None) -> pl.DataFrame:
-    """Binding HTTP : délègue à `accise_par_contrat` avec OdooReader auto-géré."""
-    return accise_par_contrat(odoo, trimestre)
-
-
-def generer_accise_detail_arrow(trimestre: str | None = None) -> bytes:
-    """Sérialise le détail accise (PDL × mois) en flux Arrow IPC."""
-    return arrow_stream(calculer_accise_detail(trimestre))
-
-
-def generer_accise_detail_xlsx(trimestre: str | None = None) -> bytes:
-    """Sérialise le détail accise (PDL × mois) en XLSX mono-onglet."""
-    return xlsx_multi_sheet({"Détail": calculer_accise_detail(trimestre)})
-
-
-@with_odoo
-def _accise_rapport(odoo, trimestre: str | None = None):
-    return rapport_accise(odoo, trimestre)
-
-
-def generer_accise_rapport_xlsx(trimestre: str | None = None) -> bytes:
-    """Livrable facturiste : 3 onglets (Résumé / Par taux / Détail) depuis `rapport_accise`."""
-    r = _accise_rapport(trimestre)
-    return xlsx_multi_sheet(
-        {
-            "Résumé": r.resume,
-            "Par taux": r.par_taux,
-            "Détail": r.detail.sort(["pdl", "mois_consommation"]),
-        }
-    )
-
 
 # =============================================================================
 # CTA — détail brut + rapport agrégé

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -184,3 +184,18 @@ Booléen marquant les relevés dont la date a été décalée pendant l'harmonis
 
 **Contrat lissé** :
 Modalité de facturation où le client paie un montant mensuel constant basé sur une estimation annuelle, plutôt qu'au prorata de la consommation réelle du mois. Régularisation annuelle. S'oppose au contrat *réel* (facturation au prorata).
+
+---
+
+## Exports et livrables
+
+**Rapport** :
+Structure de données (NamedTuple) regroupant les DataFrames qu'un pipeline d'orchestration produit pour un domaine (Accise, CTA, facturation). Exemple : `RapportAccise(resume, par_taux, detail)`. Pré-trié et prêt à consommer — l'ordre des lignes est porté par la fonction `rapport_*` elle-même, pas par les consommateurs.
+
+**Livrable** :
+Export structuré destiné à un consommateur métier (facturiste, audit). Un livrable matérialise un *Rapport* sous une forme attendue par son destinataire — typiquement un XLSX multi-onglets (`Résumé` / `Par taux` / `Détail`). Distinct du *détail brut* (table unique exportée en XLSX mono-onglet ou Arrow IPC, format technique).
+_Éviter_ : export (trop générique), fichier.
+
+**Feuilles** :
+Onglets d'un *Livrable* XLSX. La fonction `feuilles_rapport_*(r) -> dict[str, DataFrame]` transforme un `Rapport*` en mapping consommable par `xlsx_multi_sheet`. Co-localisée avec la fonction `rapport_*` correspondante (même module). Les clés du dict sont les libellés d'onglets affichés à l'utilisateur (FR : `Résumé`, `Par taux`, `Détail`).
+_Éviter_ : onglets (anglicisme), sheets.

--- a/electricore/integrations/odoo/decorators.py
+++ b/electricore/integrations/odoo/decorators.py
@@ -6,6 +6,7 @@ endpoints de consommer les orchestrations sans répéter le `with` block.
 """
 
 import functools
+import inspect
 from collections.abc import Callable
 from typing import Any
 
@@ -34,4 +35,6 @@ def with_odoo[T](func: Callable[..., T]) -> Callable[..., T]:
         with OdooReader(config=settings.get_odoo_config()) as odoo:
             return func(odoo, *args, **kwargs)
 
+    sig = inspect.signature(func)
+    wrapper.__signature__ = sig.replace(parameters=list(sig.parameters.values())[1:])
     return wrapper

--- a/electricore/integrations/odoo/taxes.py
+++ b/electricore/integrations/odoo/taxes.py
@@ -91,9 +91,10 @@ def rapport_accise(odoo: OdooReader, trimestre: str | None = None) -> RapportAcc
         trimestre: format "YYYY-TX". `None` = tous les trimestres.
 
     Returns:
-        `RapportAccise(resume, par_taux, detail)`.
+        `RapportAccise(resume, par_taux, detail)`. `detail` est trié
+        `(pdl, mois_consommation)` — invariant porté par cette fonction.
     """
-    detail = accise_par_contrat(odoo, trimestre)
+    detail = accise_par_contrat(odoo, trimestre).sort(["pdl", "mois_consommation"])
     par_taux = (
         detail.group_by("taux_accise_eur_mwh")
         .agg(
@@ -120,6 +121,16 @@ def rapport_accise(odoo: OdooReader, trimestre: str | None = None) -> RapportAcc
     RapportAcciseParTaux.validate(par_taux)
     RapportAcciseDetail.validate(detail)
     return RapportAccise(resume=resume, par_taux=par_taux, detail=detail)
+
+
+def feuilles_rapport_accise(r: RapportAccise) -> dict[str, pl.DataFrame]:
+    """Mapping onglet → DataFrame pour le livrable XLSX Accise (cf. CONTEXT.md).
+
+    Consommable directement par `xlsx_multi_sheet`. Co-localisée avec
+    `rapport_accise` parce que le shape du livrable et son contenu sont
+    indissociables.
+    """
+    return {"Résumé": r.resume, "Par taux": r.par_taux, "Détail": r.detail}
 
 
 def cta_par_contrat(odoo: OdooReader, trimestre: str | None = None) -> pl.DataFrame:

--- a/tests/integration/test_taxes_arrow_endpoints.py
+++ b/tests/integration/test_taxes_arrow_endpoints.py
@@ -57,7 +57,7 @@ def test_accise_detail_arrow_retourne_arrow_ipc_stream(monkeypatch, _mock_odoo_r
     """L'endpoint sert le détail accise en Arrow IPC."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
     monkeypatch.setattr(
-        "electricore.api.services.taxes_service.accise_par_contrat",
+        "electricore.api.main.accise_par_contrat",
         lambda odoo, trimestre=None: df_accise_detail,
     )
 
@@ -88,7 +88,7 @@ def test_accise_detail_arrow_propage_trimestre(monkeypatch, _mock_odoo_reader, d
         appels.append(trimestre)
         return df_accise_detail
 
-    monkeypatch.setattr("electricore.api.services.taxes_service.accise_par_contrat", _capture)
+    monkeypatch.setattr("electricore.api.main.accise_par_contrat", _capture)
 
     try:
         response = TestClient(app).get("/taxes/accise/detail.arrow", params={"trimestre": "2025-T1"})
@@ -108,7 +108,7 @@ def test_accise_detail_xlsx_retourne_xlsx_mono_onglet(monkeypatch, _mock_odoo_re
     """L'endpoint sert le détail accise en XLSX mono-onglet."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
     monkeypatch.setattr(
-        "electricore.api.services.taxes_service.accise_par_contrat",
+        "electricore.api.main.accise_par_contrat",
         lambda odoo, trimestre=None: df_accise_detail,
     )
 
@@ -147,7 +147,7 @@ def test_accise_rapport_xlsx_retourne_xlsx_multi_onglets(monkeypatch, _mock_odoo
     """L'endpoint sert le rapport multi-onglets (Résumé / Par taux / Détail)."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
     monkeypatch.setattr(
-        "electricore.api.services.taxes_service.rapport_accise",
+        "electricore.api.main.rapport_accise",
         lambda odoo, trimestre=None: fake_rapport_accise,
     )
 
@@ -170,7 +170,7 @@ def test_accise_rapport_xlsx_propage_trimestre(monkeypatch, _mock_odoo_reader, f
         appels.append(trimestre)
         return fake_rapport_accise
 
-    monkeypatch.setattr("electricore.api.services.taxes_service.rapport_accise", _capture)
+    monkeypatch.setattr("electricore.api.main.rapport_accise", _capture)
 
     try:
         response = TestClient(app).get("/taxes/accise/rapport.xlsx", params={"trimestre": "2025-T2"})

--- a/tests/unit/integrations/odoo/test_feuilles_rapport_accise.py
+++ b/tests/unit/integrations/odoo/test_feuilles_rapport_accise.py
@@ -1,0 +1,54 @@
+"""Tests pour `feuilles_rapport_accise` (issue #75).
+
+Transforme un `RapportAccise` en `dict[str, DataFrame]` consommable par
+`xlsx_multi_sheet`. Fonction pure — pas de dépendance Odoo.
+"""
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+
+def _rapport_synthetique():
+    """`RapportAccise` minimal pour tester la sérialisation en feuilles."""
+    from electricore.integrations.odoo.taxes import RapportAccise
+
+    return RapportAccise(
+        resume=pl.DataFrame(
+            {"trimestre": ["2025-T1"], "nb_pdl": [2], "energie_mwh_total": [6.0], "accise_eur_total": [135.0]}
+        ),
+        par_taux=pl.DataFrame(
+            {"taux_accise_eur_mwh": [22.5], "energie_mwh": [6.0], "accise_eur": [135.0], "nb_pdl": [2]}
+        ),
+        detail=pl.DataFrame(
+            {
+                "pdl": ["A", "B"],
+                "mois_consommation": ["2025-01", "2025-01"],
+                "trimestre": ["2025-T1", "2025-T1"],
+                "taux_accise_eur_mwh": [22.5, 22.5],
+                "energie_mwh": [3.0, 3.0],
+                "accise_eur": [67.5, 67.5],
+            }
+        ),
+    )
+
+
+def test_feuilles_rapport_accise_returns_three_keyed_dict():
+    """La fonction retourne un dict avec les 3 onglets standards du livrable."""
+    from electricore.integrations.odoo.taxes import feuilles_rapport_accise
+
+    rapport = _rapport_synthetique()
+    feuilles = feuilles_rapport_accise(rapport)
+
+    assert set(feuilles.keys()) == {"Résumé", "Par taux", "Détail"}
+
+
+def test_feuilles_rapport_accise_maps_each_frame_to_its_sheet():
+    """Chaque feuille pointe vers le DataFrame correspondant du rapport, sans transformation."""
+    from electricore.integrations.odoo.taxes import feuilles_rapport_accise
+
+    rapport = _rapport_synthetique()
+    feuilles = feuilles_rapport_accise(rapport)
+
+    assert_frame_equal(feuilles["Résumé"], rapport.resume)
+    assert_frame_equal(feuilles["Par taux"], rapport.par_taux)
+    assert_frame_equal(feuilles["Détail"], rapport.detail)

--- a/tests/unit/integrations/odoo/test_rapport_accise.py
+++ b/tests/unit/integrations/odoo/test_rapport_accise.py
@@ -125,15 +125,23 @@ class TestRapportAccise:
         assert hasattr(result, "par_taux")
         assert hasattr(result, "detail")
 
-    def test_detail_is_identity_of_accise_par_contrat(self, monkeypatch):
-        """`rapport.detail` est exactement la sortie de `accise_par_contrat`."""
+    def test_detail_contains_same_rows_as_accise_par_contrat(self, monkeypatch):
+        """`rapport.detail` contient les mêmes lignes que `accise_par_contrat` (réordonnées).
+
+        Depuis #75, `rapport_accise` trie son `detail` par `(pdl, mois_consommation)`.
+        Les colonnes et l'ensemble des lignes restent identiques.
+        """
         from electricore.integrations.odoo import taxes
 
-        detail_attendu = _detail_synthetique()
-        monkeypatch.setattr(taxes, "accise_par_contrat", lambda odoo, trimestre=None: detail_attendu)
+        detail_source = _detail_synthetique()
+        monkeypatch.setattr(taxes, "accise_par_contrat", lambda odoo, trimestre=None: detail_source)
         result = taxes.rapport_accise(odoo=None)
 
-        assert_frame_equal(result.detail, detail_attendu)
+        # Mêmes colonnes, mêmes lignes (après tri par pdl puis mois).
+        assert_frame_equal(
+            result.detail,
+            detail_source.sort(["pdl", "mois_consommation"]),
+        )
 
     def test_par_taux_groups_by_taux_descending(self, monkeypatch):
         """`par_taux` groupé par taux décroissant avec sommes + n_unique(pdl) corrects."""
@@ -163,6 +171,32 @@ class TestRapportAccise:
         assert result.resume["nb_pdl"].to_list() == [2, 2]
         assert result.resume["energie_mwh_total"].to_list() == [6.0, 9.0]
         assert result.resume["accise_eur_total"].to_list() == [135.0, 225.0]
+
+    def test_detail_is_sorted_by_pdl_then_mois_consommation(self, monkeypatch):
+        """Invariant : `rapport_accise(...).detail` est trié `(pdl, mois_consommation)` (issue #75).
+
+        Le tri de présentation du livrable devient un contrat porté par
+        `rapport_accise` lui-même — plus une convenance de la couche service.
+        """
+        from electricore.integrations.odoo import taxes
+
+        # Détail volontairement désordonné en entrée.
+        detail_desordonne = pl.DataFrame(
+            {
+                "pdl": ["B", "A", "B", "A"],
+                "mois_consommation": ["2025-02", "2025-02", "2025-01", "2025-01"],
+                "trimestre": ["2025-T1"] * 4,
+                "taux_accise_eur_mwh": [22.5] * 4,
+                "energie_mwh": [1.0, 2.0, 3.0, 4.0],
+                "accise_eur": [22.5, 45.0, 67.5, 90.0],
+            }
+        )
+        monkeypatch.setattr(taxes, "accise_par_contrat", lambda odoo, trimestre=None: detail_desordonne)
+
+        result = taxes.rapport_accise(odoo=None)
+
+        assert result.detail["pdl"].to_list() == ["A", "A", "B", "B"]
+        assert result.detail["mois_consommation"].to_list() == ["2025-01", "2025-02", "2025-01", "2025-02"]
 
     def test_rapport_accise_propagates_trimestre_filter(self, monkeypatch):
         """`rapport_accise(odoo, trimestre)` propage le filtre à `accise_par_contrat`."""

--- a/tests/unit/integrations/odoo/test_with_odoo.py
+++ b/tests/unit/integrations/odoo/test_with_odoo.py
@@ -87,6 +87,48 @@ def test_with_odoo_preserves_name_and_doc():
     assert calculer_accise_detail.__doc__ == "Docstring originale."
 
 
+def test_with_odoo_strips_odoo_from_exposed_signature():
+    """`inspect.signature(decorated)` ne doit pas exposer `odoo` (issue #74).
+
+    FastAPI introspecte les signatures pour binder query/path params. Si `odoo`
+    reste visible, FastAPI tente de l'injecter depuis l'URL et casse l'endpoint
+    quand on stacke `@xlsx_endpoint` au-dessus de `@with_odoo`.
+    """
+    import inspect
+
+    from electricore.integrations.odoo.decorators import with_odoo
+
+    @with_odoo
+    def export_quelque_chose(odoo, trimestre: str | None = None) -> bytes:
+        return b""
+
+    sig = inspect.signature(export_quelque_chose)
+    assert "odoo" not in sig.parameters
+    assert "trimestre" in sig.parameters
+
+
+def test_with_odoo_preserves_defaults_and_annotations_on_remaining_params():
+    """Les params restants gardent default + annotation après stripping d'`odoo`.
+
+    FastAPI utilise les defaults pour distinguer params requis / optionnels et
+    les annotations pour la validation. Régression typique d'un
+    `Signature.replace(parameters=[...])` mal écrit.
+    """
+    import inspect
+
+    from electricore.integrations.odoo.decorators import with_odoo
+
+    @with_odoo
+    def f(odoo, trimestre: str | None = None, limit: int = 100) -> bytes:
+        return b""
+
+    sig = inspect.signature(f)
+    assert sig.parameters["trimestre"].default is None
+    assert sig.parameters["trimestre"].annotation == (str | None)
+    assert sig.parameters["limit"].default == 100
+    assert sig.parameters["limit"].annotation is int
+
+
 def test_with_odoo_uses_settings_get_odoo_config(monkeypatch):
     """Le décorateur appelle `settings.get_odoo_config()` à chaque invocation."""
     from electricore.integrations.odoo.decorators import with_odoo

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -60,6 +60,8 @@ def test_facturation_retourne_le_dataframe_servi_par_endpoint(client_electricore
 
 def test_accise_round_trip_via_endpoint(monkeypatch):
     """`client.accise(trimestre)` round-trip un DataFrame servi par /taxes/accise/detail.arrow."""
+    from contextlib import contextmanager
+
     df_attendu = pl.DataFrame(
         {
             "pdl": ["12345678901234"],
@@ -68,9 +70,18 @@ def test_accise_round_trip_via_endpoint(monkeypatch):
             "accise_eur": [33.75],
         }
     )
+
+    # Depuis #75, l'endpoint stacke @xlsx_endpoint + @with_odoo : il faut
+    # court-circuiter `OdooReader` *et* mocker `accise_par_contrat` au point
+    # d'import dans `main.py`.
+    @contextmanager
+    def _fake_reader(config):
+        yield None
+
+    monkeypatch.setattr("electricore.integrations.odoo.decorators.OdooReader", _fake_reader)
     monkeypatch.setattr(
-        "electricore.api.services.taxes_service.calculer_accise_detail",
-        lambda trimestre=None: df_attendu,
+        "electricore.api.main.accise_par_contrat",
+        lambda odoo, trimestre=None: df_attendu,
     )
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
     try:


### PR DESCRIPTION
## Summary

Implémente les deux issues de la review architecture (Candidate 1 — Accise) :

- **#74** — `with_odoo` strippe maintenant `odoo` de `__signature__`, permettant le stacking `@xlsx_endpoint` + `@with_odoo` sur un même endpoint.
- **#75** — Collapse du Cartésien `(rapport × format)` côté Accise. Suppression de la couche `api/services/taxes_service.py` (volet Accise). Le seam devient une fonction libre `feuilles_rapport_accise` co-localisée avec `rapport_accise`.

Pas de classe nouvelle — `RapportAccise` reste un `NamedTuple`, style pure-FP préservé. Tri `(pdl, mois_consommation)` du détail devient un invariant porté par `rapport_accise`.

Glossaire `electricore/core/CONTEXT.md` enrichi de **Rapport**, **Livrable**, **Feuilles** (nouvelle section « Exports et livrables »).

CTA reste sur l'ancien pattern tant qu'il n'est pas migré — sera fait dans une slice ultérieure (même forme).

## Test plan

- [x] `uv run --group test pytest -q` — 460 passed, 35 skipped (pré-existants), 0 failed
- [x] Pre-commit (ruff format + check) verts
- [x] Comportement HTTP inchangé — tests d'intégration `test_taxes_arrow_endpoints.py` mis à jour pour patcher au nouvel emplacement, tous verts
- [x] Round-trip client (`tests/unit/test_client.py::test_accise_round_trip_via_endpoint`) vert après mise à jour du monkey-patch

## Notes architecturales

Cette PR matérialise la candidature #1 de l'architecture review (Candidate 1 : « Collapse the (rapport × format) Cartesian behind a deep `Rapport` value-object »), reformulée en style fonctionnel pur (fonction libre `feuilles_rapport_accise` plutôt qu'une méthode sur le NamedTuple). Cohérent avec ADR-0016 (core ERP-agnostique) — le calcul vit dans `integrations/odoo/`, l'API n'est qu'un binding HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)