### PR TITLE
refactor(api): widen xlsx_endpoint & co. to accept FastAPI | APIRouter (#81)

### DIFF
--- a/electricore/api/decorators.py
+++ b/electricore/api/decorators.py
@@ -15,7 +15,7 @@ import asyncio
 import inspect
 import logging
 
-from fastapi import Depends, FastAPI, HTTPException, Response
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Response
 
 from electricore.api.config import settings
 from electricore.api.security import get_current_api_key
@@ -48,7 +48,7 @@ class _DefaultEmpty(dict):
 
 
 def binary_endpoint(
-    app: FastAPI,
+    target: FastAPI | APIRouter,
     path: str,
     *,
     media_type: str,
@@ -60,14 +60,17 @@ def binary_endpoint(
     """Enregistre un handler retournant `bytes` comme endpoint binaire générique.
 
     Args:
-        app: instance FastAPI sur laquelle enregistrer la route.
+        target: cible d'enregistrement de la route — instance `FastAPI` ou
+            `APIRouter`. Les deux exposent `.get(path, *, tags, dependencies)`
+            avec la même signature ; le décorateur ne distingue pas.
         path: chemin HTTP de l'endpoint (`GET`).
         media_type: type MIME de la réponse (XLSX, Arrow stream, ZIP…).
         filename: template du `Content-Disposition` (placeholders `{nom_arg}`
             résolus depuis les arguments du handler). Si `None`, pas de
             header `Content-Disposition` (cas Arrow streaming).
         requires_odoo: si `True`, retourne `501` quand Odoo n'est pas configuré.
-        tags: tags OpenAPI optionnels.
+        tags: tags OpenAPI optionnels (s'ajoutent à ceux déclarés sur l'`APIRouter`
+            si la cible est un router).
     """
 
     def decorator(handler):
@@ -98,14 +101,14 @@ def binary_endpoint(
         wrapper.__signature__ = inspect.signature(handler)  # type: ignore[attr-defined]
         wrapper.__name__ = handler.__name__
 
-        app.get(path, tags=tags, dependencies=[Depends(get_current_api_key)])(wrapper)
+        target.get(path, tags=tags, dependencies=[Depends(get_current_api_key)])(wrapper)
         return wrapper
 
     return decorator
 
 
 def xlsx_endpoint(
-    app: FastAPI,
+    target: FastAPI | APIRouter,
     path: str,
     *,
     filename: str,
@@ -115,7 +118,7 @@ def xlsx_endpoint(
 ):
     """Wrapper convenance de `binary_endpoint` pour les exports XLSX."""
     return binary_endpoint(
-        app,
+        target,
         path,
         media_type=XLSX_MEDIA_TYPE,
         filename=filename,
@@ -126,7 +129,7 @@ def xlsx_endpoint(
 
 
 def arrow_endpoint(
-    app: FastAPI,
+    target: FastAPI | APIRouter,
     path: str,
     *,
     requires_odoo: bool = False,
@@ -137,12 +140,12 @@ def arrow_endpoint(
     Pas de `Content-Disposition` — le flux est consommé en mémoire par le client.
     """
     return binary_endpoint(
-        app, path, media_type=ARROW_MEDIA_TYPE, filename=None, requires_odoo=requires_odoo, tags=tags
+        target, path, media_type=ARROW_MEDIA_TYPE, filename=None, requires_odoo=requires_odoo, tags=tags
     )
 
 
 def zip_endpoint(
-    app: FastAPI,
+    target: FastAPI | APIRouter,
     path: str,
     *,
     filename: str,
@@ -151,5 +154,5 @@ def zip_endpoint(
 ):
     """Wrapper convenance de `binary_endpoint` pour les archives ZIP."""
     return binary_endpoint(
-        app, path, media_type=ZIP_MEDIA_TYPE, filename=filename, requires_odoo=requires_odoo, tags=tags
+        target, path, media_type=ZIP_MEDIA_TYPE, filename=filename, requires_odoo=requires_odoo, tags=tags
     )

--- a/tests/integration/test_decorators.py
+++ b/tests/integration/test_decorators.py
@@ -123,6 +123,32 @@ def test_xlsx_endpoint_supporte_handler_synchrone():
     assert response.content == b"PK\x03\x04sync"
 
 
+def test_xlsx_endpoint_accepte_un_apirouter_via_target_kwarg():
+    """Le décorateur accepte un `APIRouter` (pas seulement `FastAPI`) via le kwarg `target` (issue #81).
+
+    Prérequis du split de `api/main.py` en routers per-domaine : `xlsx_endpoint`
+    doit pouvoir enregistrer ses routes sur un `APIRouter` aussi bien que sur
+    une instance `FastAPI`.
+    """
+    from fastapi import APIRouter
+
+    router = APIRouter()
+
+    @xlsx_endpoint(target=router, path="/test/router.xlsx", filename="depuis_router.xlsx")
+    async def handler() -> bytes:
+        return b"PK\x03\x04depuis_router"
+
+    app = _app_avec_auth_neutralisee()
+    app.include_router(router)
+
+    response = TestClient(app).get("/test/router.xlsx")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    assert "depuis_router.xlsx" in response.headers["content-disposition"]
+    assert response.content == b"PK\x03\x04depuis_router"
+
+
 def test_arrow_endpoint_emballe_handler_en_arrow_ipc_sans_content_disposition():
     """`@arrow_endpoint` jumelle de `@xlsx_endpoint` pour le streaming Arrow IPC.
 
@@ -141,3 +167,23 @@ def test_arrow_endpoint_emballe_handler_en_arrow_ipc_sans_content_disposition():
     assert response.headers["content-type"] == "application/vnd.apache.arrow.stream"
     assert "content-disposition" not in response.headers
     assert response.content == b"ARROW1\x00\x00fake"
+
+
+def test_arrow_endpoint_accepte_un_apirouter_via_target_kwarg():
+    """`@arrow_endpoint` accepte aussi un `APIRouter` via `target=` (cf. #81)."""
+    from fastapi import APIRouter
+
+    router = APIRouter()
+
+    @arrow_endpoint(target=router, path="/test/arrow_router")
+    async def handler() -> bytes:
+        return b"ARROW1\x00\x00from_router"
+
+    app = _app_avec_auth_neutralisee()
+    app.include_router(router)
+
+    response = TestClient(app).get("/test/arrow_router")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/vnd.apache.arrow.stream"
+    assert response.content == b"ARROW1\x00\x00from_router"


### PR DESCRIPTION
## Summary

Prépare #82 (split de `api/main.py` en 5 routers per-domaine) en élargissant la surface des décorateurs HTTP pour qu'ils acceptent indifféremment un `FastAPI` ou un `APIRouter`.

Le runtime ne change pas — les deux classes exposent `.get(path, *, tags, dependencies)` avec la même signature, donc le mécanisme d'enregistrement de route reste identique.

## Changements

- Renommage du premier param `app` → `target` sur 4 décorateurs (`binary_endpoint`, `xlsx_endpoint`, `arrow_endpoint`, `zip_endpoint`)
- Élargissement du type à `FastAPI | APIRouter`
- Docstrings mises à jour
- Compatibilité ascendante : tous les call sites existants (positional) fonctionnent identiquement

## Tests

- Nouveau test confirme que `xlsx_endpoint(target=router, ...)` enregistre la route sur un `APIRouter`
- Idem pour `arrow_endpoint` (le contrat est porté par la factory commune)
- Suite : **463 passed**, 35 skipped, 0 failed
- Pre-commit (ruff format + check) verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)