### PR TITLE
refactor(odoo): trim integrations.odoo public surface — remove 4 dead helpers (#85)

### DIFF
--- a/electricore/integrations/odoo/__init__.py
+++ b/electricore/integrations/odoo/__init__.py
@@ -6,14 +6,10 @@ Adaptateur ERP pour Odoo. Voir [ADR-0016](../../../docs/adr/0016-core-erp-agnost
 from .config import FieldsCache, OdooConfig
 from .helpers import (
     commandes,
-    commandes_factures,
     commandes_lignes,
-    consommations_mensuelles,
-    factures,
     flags_etat_facturation,
     lignes_factures,
     lignes_factures_du_mois,
-    partenaires,
     query,
 )
 from .query import OdooQuery
@@ -36,13 +32,9 @@ __all__ = [
     "OdooQuery",
     "OdooWriter",
     "query",
-    "factures",
     "lignes_factures",
     "commandes",
-    "partenaires",
-    "commandes_factures",
     "commandes_lignes",
-    "consommations_mensuelles",
     "lignes_factures_du_mois",
     "flags_etat_facturation",
     "normalize_many2one_fields",

--- a/electricore/integrations/odoo/helpers.py
+++ b/electricore/integrations/odoo/helpers.py
@@ -42,31 +42,6 @@ def query(odoo: OdooReader, model: str, domain: list | None = None, fields: list
     return OdooQuery(connector=odoo, lazy_frame=df.lazy(), _current_model=model)
 
 
-def factures(odoo: OdooReader, domain: list | None = None) -> OdooQuery:
-    """
-    Query builder pour factures Odoo (account.move).
-
-    Shortcut pour créer un query builder sur les factures avec champs standards.
-
-    Args:
-        odoo: Instance OdooReader connectée
-        domain: Filtre Odoo initial (ex: [('state', '=', 'posted')])
-
-    Returns:
-        OdooQuery chainable
-
-    Example:
-        >>> with OdooReader(config) as odoo:
-        ...     df = (factures(odoo, domain=[('state', '=', 'posted')])
-        ...         .enrich('partner_id', fields=['name', 'email'])
-        ...         .filter(pl.col('amount_total') > 1000)
-        ...         .collect())
-    """
-    return query(
-        odoo, "account.move", domain=domain, fields=["name", "invoice_date", "amount_total", "state", "partner_id"]
-    )
-
-
 def lignes_factures(odoo: OdooReader, domain: list | None = None) -> OdooQuery:
     """
     Query builder pour lignes de factures Odoo (account.move.line).
@@ -113,61 +88,9 @@ def commandes(odoo: OdooReader, domain: list | None = None) -> OdooQuery:
     )
 
 
-def partenaires(odoo: OdooReader, domain: list | None = None) -> OdooQuery:
-    """
-    Query builder pour partenaires Odoo (res.partner).
-
-    Args:
-        odoo: Instance OdooReader connectée
-        domain: Filtre Odoo initial (ex: [('customer_rank', '>', 0)])
-
-    Returns:
-        OdooQuery chainable
-
-    Example:
-        >>> with OdooReader(config) as odoo:
-        ...     df = (partenaires(odoo, domain=[('customer_rank', '>', 0)])
-        ...         .filter(pl.col('active') == True)
-        ...         .collect())
-    """
-    return query(odoo, "res.partner", domain=domain, fields=["name", "email", "phone", "customer_rank", "active"])
-
-
 # =============================================================================
 # HELPERS AVEC NAVIGATION - Raccourcis pour relations multi-niveaux
 # =============================================================================
-
-
-def commandes_factures(odoo: OdooReader, domain: list | None = None) -> OdooQuery:
-    """
-    Query builder pour commandes avec factures.
-
-    Navigation : sale.order → account.move
-
-    Args:
-        odoo: Instance OdooReader connectée
-        domain: Filtre Odoo initial sur sale.order
-
-    Returns:
-        OdooQuery chainable avec navigation pré-configurée
-
-    Example:
-        >>> with OdooReader(config) as odoo:
-        ...     # Utilisation simple
-        ...     df = commandes_factures(odoo, domain=[('state', '=', 'sale')]).collect()
-        ...
-        ...     # Avec filtres et transformations supplémentaires
-        ...     df = (commandes_factures(odoo)
-        ...         .filter(pl.col('invoice_date') >= '2024-01-01')
-        ...         .select(['name', 'date_order', 'name_account_move', 'invoice_date'])
-        ...         .collect())
-    """
-    return query(
-        odoo,
-        "sale.order",
-        domain=domain,
-        fields=["name", "date_order", "amount_total", "state", "x_pdl", "partner_id", "invoice_ids"],
-    ).follow("invoice_ids", fields=["name", "invoice_date", "invoice_line_ids"])
 
 
 def commandes_lignes(odoo: OdooReader, domain: list | None = None) -> OdooQuery:
@@ -226,44 +149,6 @@ def commandes_lignes(odoo: OdooReader, domain: list | None = None) -> OdooQuery:
         .follow("product_id", fields=["name", "categ_id"])
         .enrich("categ_id", fields=["name"])
     )
-
-
-def consommations_mensuelles(odoo: OdooReader, domain: list | None = None) -> OdooQuery:
-    """
-    Query builder pour consommations mensuelles agrégées.
-
-    Récupère les lignes de factures avec les informations nécessaires au calcul
-    des consommations mensuelles. Les données doivent être agrégées post-collecte
-    avec les pipelines appropriés (voir pipeline_accise).
-
-    Navigation : sale.order → account.move → account.move.line → product.product → product.category
-
-    Args:
-        odoo: Instance OdooReader connectée
-        domain: Filtre Odoo initial sur sale.order
-
-    Returns:
-        OdooQuery chainable retournant les lignes de factures
-
-    Example:
-        >>> from electricore.integrations.odoo import consommations_mensuelles
-        >>> from electricore.core.pipelines.accise import pipeline_accise
-        >>>
-        >>> with OdooReader(config) as odoo:
-        ...     # Récupérer les données et appliquer le pipeline
-        ...     lignes = consommations_mensuelles(odoo).collect()
-        ...     df_accise = pipeline_accise(lignes.lazy())
-        ...
-        ...     # Ou directement avec commandes_lignes()
-        ...     lignes = commandes_lignes(odoo).collect()
-        ...     df_accise = pipeline_accise(lignes.lazy())
-
-    Note:
-        Ce helper est identique à commandes_lignes() et existe pour cohérence
-        sémantique. Pour le calcul d'Accise, utilisez pipeline_accise() qui gère
-        l'agrégation et les calculs.
-    """
-    return commandes_lignes(odoo, domain=domain)
 
 
 def flags_etat_facturation(lf: pl.LazyFrame) -> pl.LazyFrame:

--- a/tests/architecture/test_integrations_odoo_topology.py
+++ b/tests/architecture/test_integrations_odoo_topology.py
@@ -15,13 +15,9 @@ TYPES = ("OdooConfig", "FieldsCache", "OdooReader", "OdooQuery", "OdooWriter")
 
 HELPERS = (
     "query",
-    "factures",
     "lignes_factures",
     "commandes",
-    "partenaires",
-    "commandes_factures",
     "commandes_lignes",
-    "consommations_mensuelles",
     "lignes_factures_du_mois",
     "flags_etat_facturation",
 )
@@ -120,3 +116,23 @@ def test_core_writers_no_longer_exposes_odoo_writer() -> None:
     """C : `electricore.core.writers` n'expose plus `OdooWriter`."""
     module = importlib.import_module("electricore.core.writers")
     assert not hasattr(module, "OdooWriter")
+
+
+# Helpers supprimés en #85 : 4 helpers à 0 caller retirés pour amincir la surface publique.
+# - `factures`, `partenaires`, `commandes_factures` : 0 caller (presets shallow et navigation dead code)
+# - `consommations_mensuelles` : était un alias explicite de `commandes_lignes`
+REMOVED_HELPERS = (
+    "factures",
+    "partenaires",
+    "consommations_mensuelles",
+    "commandes_factures",
+)
+
+
+@pytest.mark.parametrize("name", REMOVED_HELPERS)
+def test_removed_helper_no_longer_exposed(name: str) -> None:
+    """D : les helpers retirés en #85 ne sont plus importables depuis `integrations.odoo`."""
+    module = importlib.import_module("electricore.integrations.odoo")
+    assert not hasattr(module, name), (
+        f"{name} reste exposé par electricore.integrations.odoo — devrait avoir été retiré (#85)"
+    )


### PR DESCRIPTION
## Summary

Implémente #85 — inventaire grep révèle que 4 des 10 helpers épinglés par `test_integrations_odoo_topology.py::HELPERS` n'ont aucun consommateur réel. Suppression directe.

## Suppressions

| Helper | Type | Justification |
|---|---|---|
| `factures` | preset shallow `account.move` | 0 caller |
| `partenaires` | preset shallow `res.partner` | 0 caller |
| `consommations_mensuelles` | alias explicite de `commandes_lignes` | 0 caller, doublon |
| `commandes_factures` | navigation `sale.order → account.move` | 0 caller — dead code |

## Conservés

6 helpers réellement utilisés : `query`, `lignes_factures`, `commandes`, `commandes_lignes`, `lignes_factures_du_mois`, `flags_etat_facturation`.

## Archi-test

- Nouveau `REMOVED_HELPERS` parametrized + `test_removed_helper_no_longer_exposed` — acte le retrait et garde contre la réintroduction silencieuse
- `HELPERS` réduit de 10 → 6 noms

## Test plan

- [x] `uv run --group test pytest -q` — **455 passed**, 35 skipped (pré-existants), 0 failed
  - Δ par rapport à l'état précédent : −8 (réduction HELPERS sur 3 tests parametrized) + 4 (nouveaux REMOVED_HELPERS) = −4 net cohérent avec la suppression
- [x] Pre-commit (ruff format + check) verts
- [x] Pas de mise à jour caller nécessaire (vérifié par grep)

## Note

Le notebook démo `notebooks/demos/odoo_exploration.py` continue d'importer `commandes` et `lignes_factures` (qui restent dans la surface). Aucun caller des 4 helpers supprimés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)