### PR TITLE
cleanup(ADR-0018): classes justifiées par l'état interne

### DIFF
--- a/electricore/api/security.py
+++ b/electricore/api/security.py
@@ -3,6 +3,8 @@ Système de sécurité pour l'API ElectriCore.
 Gestion de l'authentification par clés API via header X-API-Key uniquement.
 """
 
+from dataclasses import dataclass
+
 from fastapi import HTTPException, Security, status
 from fastapi.security import APIKeyHeader
 
@@ -57,28 +59,22 @@ def is_public_endpoint(path: str) -> bool:
     return path in settings.public_endpoints
 
 
+@dataclass(frozen=True, slots=True)
 class APIKeyInfo:
-    """
-    Informations sur une clé API utilisée (pour logging/monitoring).
-    """
+    """Informations sur une clé API utilisée (pour logging/monitoring)."""
 
-    def __init__(self, key: str):
-        self.key_preview = f"{key[:8]}..." if len(key) > 8 else "***"
-        self.source = "header"  # Toujours header maintenant
-        self.is_valid = settings.is_valid_api_key(key)
+    key_preview: str
+    is_valid: bool
+    source: str = "header"
 
-    def __repr__(self):
-        return f"APIKeyInfo(key='{self.key_preview}', source='{self.source}', valid={self.is_valid})"
+    @classmethod
+    def from_key(cls, key: str) -> "APIKeyInfo":
+        return cls(
+            key_preview=f"{key[:8]}..." if len(key) > 8 else "***",
+            is_valid=settings.is_valid_api_key(key),
+        )
 
 
 def get_api_key_info(api_key: str = Security(get_api_key)) -> APIKeyInfo:
-    """
-    Obtient les informations sur la clé API utilisée (pour monitoring).
-
-    Args:
-        api_key: Clé API validée du header
-
-    Returns:
-        APIKeyInfo: Informations sur la clé API
-    """
-    return APIKeyInfo(api_key)
+    """Obtient les informations sur la clé API utilisée (pour monitoring)."""
+    return APIKeyInfo.from_key(api_key)

--- a/electricore/api/services/etl_service.py
+++ b/electricore/api/services/etl_service.py
@@ -51,7 +51,7 @@ _jobs: OrderedDict[str, "ETLJob"] = OrderedDict()
 _MAX_JOBS = 50
 
 
-@dataclass
+@dataclass(slots=True)
 class ETLJob:
     id: str
     mode: ETLMode

--- a/electricore/core/loaders/duckdb/config.py
+++ b/electricore/core/loaders/duckdb/config.py
@@ -10,6 +10,7 @@ import os
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 import duckdb
@@ -21,33 +22,36 @@ logger = logging.getLogger(__name__)
 _LOCK_RETRY_ATTEMPTS = 3
 _LOCK_RETRY_BACKOFF_S = 1.0
 
+# Mapping documentaire des tables DuckDB vers schémas métier (non utilisé en runtime).
+_TABLE_MAPPINGS = {
+    "historique": {
+        "source_tables": ["flux_enedis.flux_c15"],
+        "description": "Historique des événements contractuels avec relevés avant/après",
+    },
+    "releves": {
+        "source_tables": ["flux_enedis.flux_r151", "flux_enedis.flux_r15"],
+        "description": "Relevés de compteurs unifiés depuis R151 et R15",
+    },
+}
 
+_DEFAULT_DB_PATH = "electricore/etl/flux_enedis_pipeline.duckdb"
+
+
+@dataclass(frozen=True, slots=True)
 class DuckDBConfig:
     """Configuration pour les connexions DuckDB."""
 
-    def __init__(self, database_path: str | Path | None = None):
-        """
-        Initialise la configuration DuckDB.
+    database_path: Path
 
-        Args:
-            database_path: Chemin vers la base DuckDB. Si None, utilise la config par défaut.
-        """
-        if database_path is None:
-            self.database_path = Path(os.getenv("DUCKDB_PATH", "electricore/etl/flux_enedis_pipeline.duckdb"))
-        else:
-            self.database_path = Path(database_path)
+    @classmethod
+    def from_env(cls) -> "DuckDBConfig":
+        return cls(Path(os.getenv("DUCKDB_PATH", _DEFAULT_DB_PATH)))
 
-        # Mapping des tables DuckDB vers schémas métier
-        self.table_mappings = {
-            "historique": {
-                "source_tables": ["flux_enedis.flux_c15"],
-                "description": "Historique des événements contractuels avec relevés avant/après",
-            },
-            "releves": {
-                "source_tables": ["flux_enedis.flux_r151", "flux_enedis.flux_r15"],
-                "description": "Relevés de compteurs unifiés depuis R151 et R15",
-            },
-        }
+    @classmethod
+    def from_path(cls, path: str | Path | None) -> "DuckDBConfig":
+        if path is None:
+            return cls.from_env()
+        return cls(Path(path))
 
 
 def _is_lock_error(exc: duckdb.IOException) -> bool:

--- a/electricore/core/loaders/duckdb/helpers.py
+++ b/electricore/core/loaders/duckdb/helpers.py
@@ -280,7 +280,7 @@ def get_available_tables(database_path: str | Path | None = None) -> list[str]:
     Returns:
         Liste des noms de tables avec schéma (ex: ["flux_enedis.flux_c15"])
     """
-    config = DuckDBConfig(database_path)
+    config = DuckDBConfig.from_path(database_path)
 
     with duckdb_readonly_conn(config.database_path) as conn:
         result = conn.execute("""
@@ -307,7 +307,7 @@ def execute_custom_query(
     Returns:
         DataFrame ou LazyFrame selon le paramètre lazy
     """
-    config = DuckDBConfig(database_path)
+    config = DuckDBConfig.from_path(database_path)
 
     with duckdb_readonly_conn(config.database_path) as conn:
         if lazy:

--- a/electricore/core/loaders/duckdb/query.py
+++ b/electricore/core/loaders/duckdb/query.py
@@ -25,7 +25,7 @@ from .sql import FluxSchema, build_base_query
 # =============================================================================
 
 
-@dataclass(frozen=True)  # Immutable
+@dataclass(frozen=True, slots=True)
 class QueryConfig:
     """
     Configuration immutable d'une requête flux.
@@ -46,7 +46,7 @@ class QueryConfig:
 # =============================================================================
 
 
-@dataclass(frozen=True)  # Immutable
+@dataclass(frozen=True, slots=True)
 class DuckDBQuery:
     """
     Builder fonctionnel immutable pour construire et exécuter des requêtes DuckDB.

--- a/electricore/core/loaders/duckdb/query.py
+++ b/electricore/core/loaders/duckdb/query.py
@@ -265,7 +265,7 @@ class DuckDBQuery:
             FileNotFoundError: Si la base DuckDB n'existe pas
         """
         # Configuration
-        config = DuckDBConfig(self.database_path)
+        config = DuckDBConfig.from_path(self.database_path)
 
         if not config.database_path.exists():
             raise FileNotFoundError(f"Base DuckDB non trouvée : {config.database_path}")

--- a/electricore/core/loaders/duckdb/sql.py
+++ b/electricore/core/loaders/duckdb/sql.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 # =============================================================================
 
 
-@dataclass(frozen=True)  # Immutable
+@dataclass(frozen=True, slots=True)
 class Column:
     """
     Définition immutable d'une colonne SQL.
@@ -40,7 +40,7 @@ class Column:
         return self.sql_expr
 
 
-@dataclass(frozen=True)  # Immutable
+@dataclass(frozen=True, slots=True)
 class FluxSchema:
     """
     Schéma immutable complet d'un flux Enedis.

--- a/electricore/core/models/historique_taux.py
+++ b/electricore/core/models/historique_taux.py
@@ -3,34 +3,22 @@ Schéma d'un historique versionné de taux réglementé (Accise, CTA, …).
 
 Le nom de la colonne de taux varie selon la taxe (`taux_accise_eur_mwh`,
 `taux_cta_pct`, …) ; le schéma est donc construit dynamiquement via
-`HistoriqueTaux.to_schema(taux_col)`.
+`historique_taux_schema(taux_col)`.
 """
 
 import polars as pl
 from pandera.polars import Column, DataFrameSchema
 
 
-class HistoriqueTaux:
-    """
-    Schéma Pandera d'un historique de taux versionné par date d'entrée en vigueur.
-
-    Colonnes attendues :
-    - `start` : datetime[μs, Europe/Paris], non-null — date d'entrée en vigueur du taux.
-    - `{taux_col}` : Float64, non-null — valeur du taux (nom paramétrable).
-
-    Chaque ligne représente l'entrée en vigueur d'un nouveau taux qui remplace
-    le précédent jusqu'à la ligne suivante.
-    """
-
-    @staticmethod
-    def to_schema(taux_col: str) -> DataFrameSchema:
-        return DataFrameSchema(
-            {
-                "start": Column(
-                    pl.Datetime(time_unit="us", time_zone="Europe/Paris"),
-                    nullable=False,
-                ),
-                taux_col: Column(pl.Float64, nullable=False),
-            },
-            strict=False,
-        )
+def historique_taux_schema(taux_col: str) -> DataFrameSchema:
+    """Schéma Pandera d'un historique de taux versionné par date d'entrée en vigueur."""
+    return DataFrameSchema(
+        {
+            "start": Column(
+                pl.Datetime(time_unit="us", time_zone="Europe/Paris"),
+                nullable=False,
+            ),
+            taux_col: Column(pl.Float64, nullable=False),
+        },
+        strict=False,
+    )

--- a/electricore/core/orchestrations/contexte_mensuel.py
+++ b/electricore/core/orchestrations/contexte_mensuel.py
@@ -38,7 +38,7 @@ _MAPPING_CATEGORIE_COLONNE: dict[str, str] = {
 }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ContexteMensuel:
     """Bundle immutable des 4 frames dérivés pour produire la facturation d'un mois.
 

--- a/electricore/core/pipelines/taux.py
+++ b/electricore/core/pipelines/taux.py
@@ -10,7 +10,7 @@ configurent uniquement le nom de la colonne de taux et la colonne de date.
 
 import polars as pl
 
-from electricore.core.models.historique_taux import HistoriqueTaux
+from electricore.core.models.historique_taux import historique_taux_schema
 
 
 def ajouter_taux_en_vigueur(
@@ -27,7 +27,7 @@ def ajouter_taux_en_vigueur(
     d'un nouveau taux à `start`, qui remplace le précédent jusqu'à la ligne
     suivante (la dernière s'étend indéfiniment).
     """
-    HistoriqueTaux.to_schema(taux_col).validate(historique)
+    historique_taux_schema(taux_col).validate(historique)
 
     joint = (
         df.sort(date_col)

--- a/electricore/integrations/odoo/config.py
+++ b/electricore/integrations/odoo/config.py
@@ -8,7 +8,7 @@ aux serveurs Odoo dans un style fonctionnel immutable.
 from dataclasses import dataclass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class OdooConfig:
     """
     Configuration immutable pour les connexions Odoo.

--- a/electricore/integrations/odoo/facturation.py
+++ b/electricore/integrations/odoo/facturation.py
@@ -15,7 +15,7 @@ EDN-shaped aujourd'hui ; sert de prototype pour un futur module Odoo libre
 couvrant les fournisseurs alternatifs (cf. CONTEXT.md, ADR-0016).
 """
 
-from typing import NamedTuple
+from dataclasses import dataclass
 
 import polars as pl
 
@@ -28,7 +28,8 @@ from .models.rapport_facturation import RapportFacturationResume
 from .reader import OdooReader
 
 
-class RapportFacturation(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class RapportFacturation:
     """Livrable mensuel de facturation (= les 3 onglets de l'XLSX facturiste).
 
     - `resume` : totaux du mois (1 ligne).

--- a/electricore/integrations/odoo/query.py
+++ b/electricore/integrations/odoo/query.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class OdooQuery:
     """
     Query builder immutable pour chaîner les opérations Odoo + Polars.

--- a/notebooks/surveillance_perimetre.py
+++ b/notebooks/surveillance_perimetre.py
@@ -32,7 +32,7 @@ def _():
 
 @app.cell
 def _():
-    _config = DuckDBConfig()
+    _config = DuckDBConfig.from_env()
     with duckdb_readonly_conn(_config.database_path) as _conn:
         _entrees = _conn.execute("""
             SELECT pdl, ref_situation_contractuelle, MIN(date_evenement)::DATE AS date_entree
@@ -79,7 +79,7 @@ def _(periodes):
 
 @app.cell
 def _():
-    _config = DuckDBConfig()
+    _config = DuckDBConfig.from_env()
     with duckdb_readonly_conn(_config.database_path) as _conn:
         r64_mois = _conn.execute("""
             SELECT DISTINCT pdl, DATE_TRUNC('month', date_releve::DATE)::DATE AS debut_mois

--- a/tests/architecture/test_no_namespace_classes.py
+++ b/tests/architecture/test_no_namespace_classes.py
@@ -1,0 +1,118 @@
+"""
+Guard architectural contre les classes-namespace (ADR-0018).
+
+Toute classe dans `electricore/` doit être justifiée par son état interne.
+Sont acceptées :
+- Classes avec `__init__` custom (état géré manuellement)
+- Classes décorées `@dataclass` (avec ou sans paramètres)
+- Sous-classes des parents de l'allow-list ci-dessous
+
+Allow-list (types qui apportent leur propre machinerie de déclaration) :
+- `pa.DataFrameModel` / `DataFrameModel` (Pandera)
+- `BaseModel` (Pydantic)
+- `StrEnum`, `Enum`, `IntEnum` (stdlib)
+- `NamedTuple` (cas marginal autorisé explicitement)
+- `dict`, `list`, `tuple`, `set` (sous-classes utilitaires)
+
+Toute nouvelle lib apportant son propre type de base doit être ajoutée ici.
+"""
+
+import ast
+from pathlib import Path
+
+_ELECTRICORE_ROOT = Path(__file__).parents[2] / "electricore"
+
+_ALLOW_LIST_SIMPLE = {
+    "DataFrameModel",
+    "BaseModel",
+    "StrEnum",
+    "Enum",
+    "IntEnum",
+    "NamedTuple",
+    "dict",
+    "list",
+    "tuple",
+    "set",
+}
+
+_ALLOW_LIST_ATTRIBUTE = {
+    ("pa", "DataFrameModel"),
+}
+
+
+def _has_custom_init(class_node: ast.ClassDef) -> bool:
+    return any(isinstance(node, ast.FunctionDef) and node.name == "__init__" for node in class_node.body)
+
+
+def _has_dataclass_decorator(class_node: ast.ClassDef) -> bool:
+    for dec in class_node.decorator_list:
+        if isinstance(dec, ast.Name) and dec.id == "dataclass":
+            return True
+        if isinstance(dec, ast.Call):
+            func = dec.func
+            if isinstance(func, ast.Name) and func.id == "dataclass":
+                return True
+            if isinstance(func, ast.Attribute) and func.attr == "dataclass":
+                return True
+    return False
+
+
+def _base_in_allowlist(base: ast.expr) -> bool:
+    if isinstance(base, ast.Name) and base.id in _ALLOW_LIST_SIMPLE:
+        return True
+    if isinstance(base, ast.Attribute):
+        if isinstance(base.value, ast.Name):
+            if (base.value.id, base.attr) in _ALLOW_LIST_ATTRIBUTE:
+                return True
+    return False
+
+
+def _has_allowlisted_parent(class_node: ast.ClassDef) -> bool:
+    return any(_base_in_allowlist(base) for base in class_node.bases)
+
+
+class _ViolationVisitor(ast.NodeVisitor):
+    """Visite l'AST en maintenant la pile des classes pour ignorer les classes imbriquées
+    dans un parent de l'allow-list (ex: class Config dans pa.DataFrameModel)."""
+
+    def __init__(self, source_path: Path) -> None:
+        self.violations: list[str] = []
+        self._source_path = source_path
+        self._class_stack: list[ast.ClassDef] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        inside_allowlisted = any(_has_allowlisted_parent(cls) for cls in self._class_stack)
+        if not inside_allowlisted:
+            if not _has_custom_init(node) and not _has_dataclass_decorator(node) and not _has_allowlisted_parent(node):
+                rel = self._source_path.relative_to(_ELECTRICORE_ROOT.parent)
+                self.violations.append(
+                    f"class {node.name} in {rel}:{node.lineno} violates ADR-0018: "
+                    "no __init__, no @dataclass, no parent in allow-list. "
+                    "Either justify the state (lifecycle/builder/cache/job), "
+                    "use @dataclass(frozen=True, slots=True), or convert to module functions."
+                )
+        self._class_stack.append(node)
+        self.generic_visit(node)
+        self._class_stack.pop()
+
+
+def _collect_violations(source_path: Path) -> list[str]:
+    try:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+    visitor = _ViolationVisitor(source_path)
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def test_no_namespace_classes():
+    """Aucune classe-namespace dans electricore/ (ADR-0018)."""
+    py_files = [p for p in _ELECTRICORE_ROOT.rglob("*.py") if "__pycache__" not in p.parts]
+    assert py_files, "Aucun fichier .py trouvé dans electricore/"
+
+    all_violations: list[str] = []
+    for path in sorted(py_files):
+        all_violations.extend(_collect_violations(path))
+
+    assert not all_violations, "\n" + "\n".join(all_violations)

--- a/tests/core/loaders/test_duckdb_loader.py
+++ b/tests/core/loaders/test_duckdb_loader.py
@@ -23,6 +23,7 @@ from electricore.core.loaders.duckdb import (
     load_releves,
     releves,
 )
+from electricore.core.loaders.duckdb.config import _TABLE_MAPPINGS
 
 # Import des transformations depuis le module interne
 from electricore.core.loaders.duckdb.transforms import (
@@ -34,29 +35,29 @@ from electricore.core.loaders.duckdb.transforms import (
 
 
 class TestDuckDBConfig:
-    """Tests pour la classe DuckDBConfig."""
+    """Tests pour DuckDBConfig et ses factories."""
 
-    def test_config_default_path(self):
-        """Test de la configuration par défaut."""
-        config = DuckDBConfig()
+    def test_from_env_default_path(self):
+        """from_env() sans variable d'env retourne le chemin par défaut."""
+        config = DuckDBConfig.from_env()
         assert config.database_path == Path("electricore/etl/flux_enedis_pipeline.duckdb")
 
-    def test_config_custom_path(self):
-        """Test avec un chemin personnalisé."""
+    def test_from_path_custom_path(self):
+        """from_path() avec un chemin explicite le convertit en Path."""
         custom_path = "/custom/path/db.duckdb"
-        config = DuckDBConfig(custom_path)
+        config = DuckDBConfig.from_path(custom_path)
         assert config.database_path == Path(custom_path)
 
+    def test_from_path_none_falls_back_to_env(self):
+        """from_path(None) équivaut à from_env()."""
+        config = DuckDBConfig.from_path(None)
+        assert config.database_path == DuckDBConfig.from_env().database_path
+
     def test_table_mappings_structure(self):
-        """Test de la structure des mappings de tables."""
-        config = DuckDBConfig()
-
-        # Vérifier que les mappings essentiels existent
-        assert "historique" in config.table_mappings
-        assert "releves" in config.table_mappings
-
-        # Vérifier la structure des mappings
-        hist_mapping = config.table_mappings["historique"]
+        """_TABLE_MAPPINGS documente les tables métier essentielles."""
+        assert "historique" in _TABLE_MAPPINGS
+        assert "releves" in _TABLE_MAPPINGS
+        hist_mapping = _TABLE_MAPPINGS["historique"]
         assert "source_tables" in hist_mapping
         assert "description" in hist_mapping
 


### PR DESCRIPTION
## Summary

- ADR-0018 établit la règle : une classe doit être justifiée par son état interne (lifecycle, builder, cache, job). Tout autre usage devient `@dataclass(frozen=True, slots=True)` ou fonction de module.
- 5 cleanups (#97–#101) éliminent les violations existantes
- 1 guard architectural (#103) empêche les régressions futures via un test AST statique

## Changements

| Issue | Change |
|-------|--------|
| #97 | `HistoriqueTaux` (staticmethod-only) → `historique_taux_schema()` fonction de module |
| #98 | `DuckDBConfig` (`__init__` env+dict statique) → `@dataclass(frozen=True, slots=True)` + factories `from_env()` / `from_path()` |
| #99 | `APIKeyInfo` (`__init__` qui dérive 3 champs) → `@dataclass(frozen=True, slots=True)` + `APIKeyInfo.from_key()` |
| #100 | `RapportFacturation(NamedTuple)` → `@dataclass(frozen=True, slots=True)` (sémantique tuple non exploitée) |
| #101 | `slots=True` sur 8 `@dataclass(frozen=True)` existants (Column, FluxSchema, QueryConfig, DuckDBQuery, ContexteMensuel, OdooConfig, OdooQuery, ETLJob) |
| #103 | `tests/architecture/test_no_namespace_classes.py` — guard AST qui échoue sur toute classe-namespace future |

## Test plan

- [x] `uv run --group test pytest -q` — 446 passed, 35 skipped
- [x] Pre-commit (ruff format + check + secrets) — vert sur tous les commits
- [x] `uv run --group test pytest tests/architecture/ -q` — guard vert

Closes #97
Closes #98
Closes #99
Closes #100
Closes #101
Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)