### PR TITLE
feat(integrations/odoo): extraire les vérifications Odoo via verifier()

### DIFF
--- a/electricore/api/services/check_facturation_service.py
+++ b/electricore/api/services/check_facturation_service.py
@@ -1,6 +1,7 @@
 """
-Vérifications pré-facturation : détecte les anomalies sur les données Odoo
-(et plus tard Enedis, croisé) avant de lancer la campagne mensuelle.
+Vérifications pré-facturation : binding HTTP + sérialisation XLSX.
+
+La logique métier vit dans `integrations.odoo.verification`.
 """
 
 import io
@@ -9,122 +10,29 @@ import polars as pl
 import xlsxwriter
 
 from electricore.api.config import settings
-from electricore.integrations.odoo import OdooReader, query
-
-
-def _odoo_link(model: str, record_id: int) -> str:
-    base = settings.get_odoo_config()["url"].rstrip("/")
-    return f"{base}/web#id={record_id}&model={model}&view_type=form"
-
-
-def _rows_with_links(df: pl.DataFrame, model: str) -> list[dict]:
-    if df.is_empty():
-        return []
-    id_col = f"{model.replace('.', '_')}_id"
-    return [{**row, "url": _odoo_link(model, row[id_col])} for row in df.to_dicts()]
+from electricore.integrations.odoo import OdooReader, enrichir_liens, verifier
 
 
 def verifier_odoo() -> dict:
-    """
-    Vérifie l'état des données Odoo avant facturation.
-
-    Périmètre : tous les sale.order avec state='sale'.
-
-    Returns:
-        dict avec 5 clés :
-        - rsc_manquante : sale.order sans x_ref_situation_contractuelle
-        - cfne_manquante : sale.order sans x_date_cfne
-        - invoicing_state_counts : {state: count} pour x_invoicing_state
-        - factures_draft : factures encore en draft (anomalie après campagne)
-        - lisses_quantite_1 : sale.order lissés avec une ligne énergie (Base/HP/HC) à qty=1
-    """
-    with OdooReader(config=settings.get_odoo_config()) as odoo:
-        rsc_df = query(
-            odoo,
-            "sale.order",
-            domain=[("state", "=", "sale"), ("x_ref_situation_contractuelle", "=", False)],
-            fields=["name", "x_pdl"],
-        ).collect()
-
-        cfne_df = query(
-            odoo,
-            "sale.order",
-            domain=[("state", "=", "sale"), ("x_date_cfne", "=", False)],
-            fields=["name", "x_pdl"],
-        ).collect()
-
-        states_df = query(
-            odoo,
-            "sale.order",
-            domain=[("state", "=", "sale")],
-            fields=["x_invoicing_state"],
-        ).collect()
-
-        factures_df = (
-            query(
-                odoo,
-                "sale.order",
-                domain=[("state", "=", "sale")],
-                fields=["name", "invoice_ids"],
-            )
-            .follow("invoice_ids", domain=[("state", "=", "draft")], fields=["name"])
-            .collect()
-        )
-
-        lisses_qty1_df = (
-            query(
-                odoo,
-                "sale.order",
-                domain=[("state", "=", "sale"), ("x_lisse", "=", True)],
-                fields=["name", "order_line"],
-            )
-            .follow("order_line", domain=[("product_uom_qty", "=", 1)], fields=["product_id", "product_uom_qty"])
-            .follow("product_id", fields=["name", "categ_id"])
-            .enrich("categ_id", fields=["name"])
-            .filter(pl.col("name_product_category").is_in(["Base", "HP", "HC"]))
-            .collect()
-        )
-
-    state_col = pl.col("x_invoicing_state").fill_null("(non défini)")
-    counts = dict(states_df.group_by(state_col.alias("state")).agg(pl.len().alias("n")).sort("state").iter_rows())
-
-    factures_records = []
-    if not factures_df.is_empty():
-        factures_records = [
-            {
-                "sale_order_id": row["sale_order_id"],
-                "sale_order_name": row["name"],
-                "invoice_id": row["invoice_ids"],
-                "invoice_name": row["name_account_move"],
-                "url": _odoo_link("account.move", row["invoice_ids"]),
-            }
-            for row in factures_df.to_dicts()
-        ]
-
-    lisses_qty1_records = []
-    if not lisses_qty1_df.is_empty():
-        grouped = (
-            lisses_qty1_df.group_by(["sale_order_id", "name"])
-            .agg(pl.col("name_product_category").unique().sort().alias("categ_names"))
-            .sort("name")
-        )
-        lisses_qty1_records = [
-            {
-                "sale_order_id": row["sale_order_id"],
-                "sale_order_name": row["name"],
-                "categ_names": row["categ_names"],
-                "url": _odoo_link("sale.order", row["sale_order_id"]),
-            }
-            for row in grouped.to_dicts()
-        ]
-
+    """Vérifie l'état des données Odoo avant facturation et sérialise en dict JSON."""
+    odoo_cfg = settings.get_odoo_config()
+    base_url = odoo_cfg["url"]
+    with OdooReader(config=odoo_cfg) as odoo:
+        r = verifier(odoo)
     return {
-        "rsc_manquante": _rows_with_links(rsc_df, "sale.order"),
-        "cfne_manquante": _rows_with_links(cfne_df, "sale.order"),
-        "invoicing_state_counts": counts,
-        "factures_draft": factures_records,
-        "lisses_quantite_1": lisses_qty1_records,
+        "rsc_manquante": enrichir_liens(r.rsc_manquante, base_url, "sale.order").to_dicts(),
+        "cfne_manquante": enrichir_liens(r.cfne_manquante, base_url, "sale.order").to_dicts(),
+        "invoicing_state_counts": dict(r.invoicing_state_counts.iter_rows()),
+        "factures_draft": enrichir_liens(r.factures_draft, base_url, "account.move").to_dicts(),
+        "lisses_quantite_1": _serialize_lisses(r.lisses_quantite_1, base_url),
     }
+
+
+def _serialize_lisses(df: pl.DataFrame, base_url: str) -> list[dict]:
+    if df.is_empty():
+        return []
+    enriched = enrichir_liens(df, base_url, "sale.order")
+    return [{**row, "categ_names": list(row["categ_names"])} for row in enriched.to_dicts()]
 
 
 def generer_check_odoo_xlsx(result: dict) -> bytes:

--- a/electricore/integrations/odoo/__init__.py
+++ b/electricore/integrations/odoo/__init__.py
@@ -11,8 +11,10 @@ from .helpers import (
     lignes_factures_du_mois,
     query,
 )
+from .liens import enrichir_liens, url_pour_enregistrement
 from .query import OdooQuery
 from .reader import OdooReader
+from .verification import ResultatVerification, verifier
 from .writers import OdooWriter
 
 __all__ = [
@@ -26,4 +28,8 @@ __all__ = [
     "commandes",
     "commandes_lignes",
     "lignes_factures_du_mois",
+    "verifier",
+    "ResultatVerification",
+    "url_pour_enregistrement",
+    "enrichir_liens",
 ]

--- a/electricore/integrations/odoo/liens.py
+++ b/electricore/integrations/odoo/liens.py
@@ -1,0 +1,18 @@
+"""Helpers pour générer des liens vers des enregistrements Odoo."""
+
+import polars as pl
+
+
+def url_pour_enregistrement(base_url: str, model: str, record_id: int) -> str:
+    return f"{base_url.rstrip('/')}/web#id={record_id}&model={model}&view_type=form"
+
+
+def enrichir_liens(df: pl.DataFrame, base_url: str, model: str) -> pl.DataFrame:
+    id_col = f"{model.replace('.', '_')}_id"
+    if df.is_empty():
+        return df.with_columns(pl.lit("").alias("url"))
+    return df.with_columns(
+        pl.col(id_col)
+        .map_elements(lambda rid: url_pour_enregistrement(base_url, model, rid), return_dtype=pl.Utf8)
+        .alias("url")
+    )

--- a/electricore/integrations/odoo/verification.py
+++ b/electricore/integrations/odoo/verification.py
@@ -1,0 +1,105 @@
+"""Vérifications pré-facturation : détecte les anomalies sur les données Odoo."""
+
+from dataclasses import dataclass
+
+import polars as pl
+
+from .helpers import query
+from .reader import OdooReader
+
+
+@dataclass(frozen=True, slots=True)
+class ResultatVerification:
+    rsc_manquante: pl.DataFrame
+    cfne_manquante: pl.DataFrame
+    invoicing_state_counts: pl.DataFrame
+    factures_draft: pl.DataFrame
+    lisses_quantite_1: pl.DataFrame
+
+
+def verifier(odoo: OdooReader) -> ResultatVerification:
+    return ResultatVerification(
+        rsc_manquante=_rsc_manquante(odoo),
+        cfne_manquante=_cfne_manquante(odoo),
+        invoicing_state_counts=_invoicing_state_counts(odoo),
+        factures_draft=_factures_draft(odoo),
+        lisses_quantite_1=_lisses_quantite_1(odoo),
+    )
+
+
+def _rsc_manquante(odoo: OdooReader) -> pl.DataFrame:
+    return query(
+        odoo,
+        "sale.order",
+        domain=[("state", "=", "sale"), ("x_ref_situation_contractuelle", "=", False)],
+        fields=["name", "x_pdl"],
+    ).collect()
+
+
+def _cfne_manquante(odoo: OdooReader) -> pl.DataFrame:
+    return query(
+        odoo,
+        "sale.order",
+        domain=[("state", "=", "sale"), ("x_date_cfne", "=", False)],
+        fields=["name", "x_pdl"],
+    ).collect()
+
+
+def _invoicing_state_counts(odoo: OdooReader) -> pl.DataFrame:
+    raw = query(
+        odoo,
+        "sale.order",
+        domain=[("state", "=", "sale")],
+        fields=["x_invoicing_state"],
+    ).collect()
+    state_col = pl.col("x_invoicing_state").fill_null("(non défini)")
+    return raw.group_by(state_col.alias("state")).agg(pl.len().alias("n")).sort("state")
+
+
+def _factures_draft(odoo: OdooReader) -> pl.DataFrame:
+    raw = (
+        query(
+            odoo,
+            "sale.order",
+            domain=[("state", "=", "sale")],
+            fields=["name", "invoice_ids"],
+        )
+        .follow("invoice_ids", domain=[("state", "=", "draft")], fields=["name"])
+        .collect()
+    )
+    if raw.is_empty():
+        return (
+            raw.rename({"invoice_ids": "account_move_id"})
+            if "invoice_ids" in raw.columns
+            else raw.with_columns(pl.lit(None, dtype=pl.Int64).alias("account_move_id"))
+        )
+    return raw.rename({"invoice_ids": "account_move_id"})
+
+
+def _lisses_quantite_1(odoo: OdooReader) -> pl.DataFrame:
+    raw = (
+        query(
+            odoo,
+            "sale.order",
+            domain=[("state", "=", "sale"), ("x_lisse", "=", True)],
+            fields=["name", "order_line"],
+        )
+        .follow("order_line", domain=[("product_uom_qty", "=", 1)], fields=["product_id", "product_uom_qty"])
+        .follow("product_id", fields=["name", "categ_id"])
+        .enrich("categ_id", fields=["name"])
+        .filter(pl.col("name_product_category").is_in(["Base", "HP", "HC"]))
+        .collect()
+    )
+    if raw.is_empty():
+        return pl.DataFrame(
+            {
+                "sale_order_id": pl.Series([], dtype=pl.Int64),
+                "name": pl.Series([], dtype=pl.Utf8),
+                "categ_names": pl.Series([], dtype=pl.List(pl.Utf8)),
+            }
+        )
+    return (
+        raw.group_by(["sale_order_id", "name"])
+        .agg(pl.col("name_product_category").unique().sort().alias("categ_names"))
+        .sort("name")
+    )

--- a/tests/architecture/test_integrations_odoo_topology.py
+++ b/tests/architecture/test_integrations_odoo_topology.py
@@ -11,7 +11,7 @@ import importlib
 
 import pytest
 
-TYPES = ("OdooConfig", "FieldsCache", "OdooReader", "OdooQuery", "OdooWriter")
+TYPES = ("OdooConfig", "FieldsCache", "OdooReader", "OdooQuery", "OdooWriter", "ResultatVerification")
 
 HELPERS = (
     "query",
@@ -19,6 +19,9 @@ HELPERS = (
     "commandes",
     "commandes_lignes",
     "lignes_factures_du_mois",
+    "verifier",
+    "url_pour_enregistrement",
+    "enrichir_liens",
 )
 
 PANDERA_MODELS = ("FactureOdoo", "LigneFactureOdoo", "CommandeVenteOdoo")

--- a/tests/unit/integrations/odoo/test_liens.py
+++ b/tests/unit/integrations/odoo/test_liens.py
@@ -1,0 +1,44 @@
+"""Tests pour integrations/odoo/liens.py — helpers URL Odoo."""
+
+import polars as pl
+
+from electricore.integrations.odoo.liens import enrichir_liens, url_pour_enregistrement
+
+
+class TestUrlPourEnregistrement:
+    def test_format_standard(self):
+        url = url_pour_enregistrement("https://my.odoo.com", "sale.order", 42)
+        assert url == "https://my.odoo.com/web#id=42&model=sale.order&view_type=form"
+
+    def test_trailing_slash_stripped(self):
+        url = url_pour_enregistrement("https://my.odoo.com/", "sale.order", 1)
+        assert url == "https://my.odoo.com/web#id=1&model=sale.order&view_type=form"
+
+    def test_account_move_model(self):
+        url = url_pour_enregistrement("https://erp.example.com", "account.move", 99)
+        assert url == "https://erp.example.com/web#id=99&model=account.move&view_type=form"
+
+
+class TestEnrichirLiens:
+    def test_ajoute_colonne_url(self):
+        df = pl.DataFrame({"sale_order_id": [1, 2], "name": ["SO1", "SO2"]})
+        result = enrichir_liens(df, "https://my.odoo.com", "sale.order")
+        assert "url" in result.columns
+        assert result["url"][0] == "https://my.odoo.com/web#id=1&model=sale.order&view_type=form"
+        assert result["url"][1] == "https://my.odoo.com/web#id=2&model=sale.order&view_type=form"
+
+    def test_colonnes_originales_preservees(self):
+        df = pl.DataFrame({"sale_order_id": [1], "name": ["SO1"], "x_pdl": ["123"]})
+        result = enrichir_liens(df, "https://my.odoo.com", "sale.order")
+        assert set(result.columns) == {"sale_order_id", "name", "x_pdl", "url"}
+
+    def test_df_vide_retourne_df_avec_colonne_url(self):
+        df = pl.DataFrame({"sale_order_id": pl.Series([], dtype=pl.Int64)})
+        result = enrichir_liens(df, "https://my.odoo.com", "sale.order")
+        assert result.is_empty()
+        assert "url" in result.columns
+
+    def test_account_move_utilise_account_move_id(self):
+        df = pl.DataFrame({"account_move_id": [10], "name": ["INV/001"]})
+        result = enrichir_liens(df, "https://erp.example.com", "account.move")
+        assert result["url"][0] == "https://erp.example.com/web#id=10&model=account.move&view_type=form"

--- a/tests/unit/integrations/odoo/test_verification.py
+++ b/tests/unit/integrations/odoo/test_verification.py
@@ -1,0 +1,162 @@
+"""Tests pour integrations/odoo/verification.py."""
+
+from unittest.mock import MagicMock, patch
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+from electricore.integrations.odoo.verification import (
+    ResultatVerification,
+    _cfne_manquante,
+    _factures_draft,
+    _invoicing_state_counts,
+    _lisses_quantite_1,
+    _rsc_manquante,
+    verifier,
+)
+
+
+def _chain_mock(df: pl.DataFrame) -> MagicMock:
+    """Mock OdooQuery chain dont .collect() retourne df."""
+    m = MagicMock()
+    m.follow.return_value = m
+    m.enrich.return_value = m
+    m.filter.return_value = m
+    m.collect.return_value = df
+    return m
+
+
+MODULE = "electricore.integrations.odoo.verification"
+
+
+class TestRscManquante:
+    @patch(f"{MODULE}.query")
+    def test_retourne_dataframe_depuis_odoo(self, mock_query):
+        odoo = MagicMock()
+        expected = pl.DataFrame({"sale_order_id": [1], "name": ["SO1"], "x_pdl": ["PDL1"]})
+        mock_query.return_value = _chain_mock(expected)
+        result = _rsc_manquante(odoo)
+        assert_frame_equal(result, expected)
+
+
+class TestCfneManquante:
+    @patch(f"{MODULE}.query")
+    def test_retourne_dataframe_depuis_odoo(self, mock_query):
+        odoo = MagicMock()
+        expected = pl.DataFrame({"sale_order_id": [2], "name": ["SO2"], "x_pdl": ["PDL2"]})
+        mock_query.return_value = _chain_mock(expected)
+        result = _cfne_manquante(odoo)
+        assert_frame_equal(result, expected)
+
+
+class TestInvoicingStateCounts:
+    @patch(f"{MODULE}.query")
+    def test_groupe_par_state_et_compte(self, mock_query):
+        odoo = MagicMock()
+        raw = pl.DataFrame({"x_invoicing_state": ["a_facturer", "a_facturer", "facture", None]})
+        mock_query.return_value = _chain_mock(raw)
+        result = _invoicing_state_counts(odoo)
+        assert set(result.columns) == {"state", "n"}
+        totals = dict(result.iter_rows())
+        assert totals["a_facturer"] == 2
+        assert totals["facture"] == 1
+        assert totals["(non défini)"] == 1
+
+    @patch(f"{MODULE}.query")
+    def test_retourne_dataframe_trie(self, mock_query):
+        odoo = MagicMock()
+        raw = pl.DataFrame({"x_invoicing_state": ["z_state", "a_state"]})
+        mock_query.return_value = _chain_mock(raw)
+        result = _invoicing_state_counts(odoo)
+        assert result["state"].to_list() == ["a_state", "z_state"]
+
+
+class TestFacturesDraft:
+    @patch(f"{MODULE}.query")
+    def test_retourne_dataframe_avec_account_move_id(self, mock_query):
+        odoo = MagicMock()
+        raw = pl.DataFrame(
+            {
+                "sale_order_id": [1],
+                "name": ["SO1"],
+                "invoice_ids": [10],
+                "name_account_move": ["INV/001"],
+            }
+        )
+        mock_query.return_value = _chain_mock(raw)
+        result = _factures_draft(odoo)
+        assert "account_move_id" in result.columns
+        assert result["account_move_id"][0] == 10
+
+    @patch(f"{MODULE}.query")
+    def test_df_vide_retourne_colonnes_attendues(self, mock_query):
+        odoo = MagicMock()
+        raw = pl.DataFrame(
+            {
+                "sale_order_id": pl.Series([], dtype=pl.Int64),
+                "name": pl.Series([], dtype=pl.Utf8),
+                "invoice_ids": pl.Series([], dtype=pl.Int64),
+                "name_account_move": pl.Series([], dtype=pl.Utf8),
+            }
+        )
+        mock_query.return_value = _chain_mock(raw)
+        result = _factures_draft(odoo)
+        assert result.is_empty()
+        assert "account_move_id" in result.columns
+
+
+class TestLissesQuantite1:
+    @patch(f"{MODULE}.query")
+    def test_groupe_par_commande_et_agregee_categ_names(self, mock_query):
+        odoo = MagicMock()
+        raw = pl.DataFrame(
+            {
+                "sale_order_id": [1, 1, 2],
+                "name": ["SO1", "SO1", "SO2"],
+                "name_product_category": ["Base", "HP", "HC"],
+            }
+        )
+        mock_query.return_value = _chain_mock(raw)
+        result = _lisses_quantite_1(odoo)
+        assert "categ_names" in result.columns
+        so1 = result.filter(pl.col("sale_order_id") == 1)["categ_names"][0]
+        assert set(so1) == {"Base", "HP"}
+
+    @patch(f"{MODULE}.query")
+    def test_df_vide_retourne_schema_correct(self, mock_query):
+        odoo = MagicMock()
+        raw = pl.DataFrame(
+            {
+                "sale_order_id": pl.Series([], dtype=pl.Int64),
+                "name": pl.Series([], dtype=pl.Utf8),
+                "name_product_category": pl.Series([], dtype=pl.Utf8),
+            }
+        )
+        mock_query.return_value = _chain_mock(raw)
+        result = _lisses_quantite_1(odoo)
+        assert result.is_empty()
+        assert "categ_names" in result.columns
+
+
+class TestVerifier:
+    @patch(f"{MODULE}._lisses_quantite_1")
+    @patch(f"{MODULE}._factures_draft")
+    @patch(f"{MODULE}._invoicing_state_counts")
+    @patch(f"{MODULE}._cfne_manquante")
+    @patch(f"{MODULE}._rsc_manquante")
+    def test_compose_les_5_checks(self, mock_rsc, mock_cfne, mock_counts, mock_draft, mock_lisses):
+        odoo = MagicMock()
+        mock_rsc.return_value = pl.DataFrame({"sale_order_id": [1]})
+        mock_cfne.return_value = pl.DataFrame({"sale_order_id": [2]})
+        mock_counts.return_value = pl.DataFrame({"state": ["a"], "n": [1]})
+        mock_draft.return_value = pl.DataFrame({"account_move_id": [10]})
+        mock_lisses.return_value = pl.DataFrame({"sale_order_id": [3]})
+
+        result = verifier(odoo)
+
+        assert isinstance(result, ResultatVerification)
+        assert result.rsc_manquante["sale_order_id"][0] == 1
+        assert result.cfne_manquante["sale_order_id"][0] == 2
+        assert result.factures_draft["account_move_id"][0] == 10
+        mock_rsc.assert_called_once_with(odoo)
+        mock_cfne.assert_called_once_with(odoo)


### PR DESCRIPTION
## Summary

- Extrait les 5 vérifications Odoo de `check_facturation_service.py` vers `integrations/odoo/verification.py`
- `check_facturation_service.py` réduit à ~55 lignes de binding HTTP + sérialisation XLSX
- Deux nouveaux helpers purs sans dépendance sur `settings` dans `integrations/odoo/liens.py`

## Changements

| Fichier | Nature |
|---------|--------|
| `integrations/odoo/verification.py` (nouveau) | `ResultatVerification` @dataclass + `verifier()` + 5 checks privés |
| `integrations/odoo/liens.py` (nouveau) | `url_pour_enregistrement()` + `enrichir_liens()` |
| `integrations/odoo/__init__.py` | +4 exports publics |
| `api/services/check_facturation_service.py` | Réduit au binding : appelle `verifier()` + `enrichir_liens()` + sérialise |
| `tests/architecture/test_integrations_odoo_topology.py` | +`ResultatVerification` dans TYPES, +3 dans HELPERS |
| `tests/unit/integrations/odoo/test_verification.py` (nouveau) | 9 tests (1/check + composer) |
| `tests/unit/integrations/odoo/test_liens.py` (nouveau) | 7 tests |

## Test plan

- [x] `uv run --group test pytest -q` — 474 passed, 35 skipped
- [x] Pre-commit vert

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)