### PR TITLE
refactor(#110): sortir .collect() des pipeline_* (ADR-0019 règle 5)

### DIFF
--- a/electricore/api/services/taxes_service.py
+++ b/electricore/api/services/taxes_service.py
@@ -60,7 +60,9 @@ def accise_par_contrat_service(odoo: OdooReader, trimestre: str | None = None) -
     """
     from electricore.core.pipelines.accise import pipeline_accise
 
-    detail = pipeline_accise(lignes_factures_taxe(odoo))
+    # pipeline_accise est lazy (ADR-0019) — collect au boundary du service avant
+    # filtre et retour DataFrame (consommé par les sérialiseurs XLSX/Arrow).
+    detail = pipeline_accise(lignes_factures_taxe(odoo)).collect()
     if trimestre is not None:
         detail = detail.filter(pl.col("trimestre") == trimestre)
     return detail

--- a/electricore/core/builds/contexte_mensuel.py
+++ b/electricore/core/builds/contexte_mensuel.py
@@ -54,13 +54,15 @@ class ContexteMensuel:
 
 def _composer(
     historique: pl.LazyFrame, releves: pl.LazyFrame
-) -> tuple[pl.LazyFrame, pl.LazyFrame, pl.LazyFrame, pl.DataFrame]:
+) -> tuple[pl.LazyFrame, pl.LazyFrame, pl.LazyFrame, pl.LazyFrame]:
     """Compose la séquence canonique des pipelines de facturation.
 
     `pipeline_historique` (1 fois) → `pipeline_abonnements` +
     `pipeline_energie` (sur l'historique enrichi) → `pipeline_facturation`
-    (agrégation mensuelle collectée). Retourne les 4 frames dans l'ordre
-    `(historique_enrichi, abonnements, energie, facturation_mensuelle)`.
+    (agrégation mensuelle, toujours lazy). Retourne les 4 LazyFrames dans
+    l'ordre `(historique_enrichi, abonnements, energie, facturation_mensuelle)`.
+    La matérialisation de `facturation_mensuelle` est portée par `charger()`,
+    au boundary du build (ADR-0019).
     """
     historique_enrichi = pipeline_historique(historique)
     abonnements = pipeline_abonnements(historique_enrichi)
@@ -85,7 +87,11 @@ def charger(
         mois: format `YYYY-MM-DD` (premier jour du mois). `None` → dernier mois
             disponible dans `facturation_mensuelle`.
     """
-    historique_enrichi, abonnements, energie, facturation_mensuelle = _composer(historique, releves)
+    historique_enrichi, abonnements, energie, facturation_mensuelle_lf = _composer(historique, releves)
+
+    # Matérialisation au boundary du build (ADR-0019) : pipeline_facturation
+    # reste lazy, le build collecte pour stocker dans le bundle ContexteMensuel.
+    facturation_mensuelle = facturation_mensuelle_lf.collect()
 
     if mois is None:
         debut_mois_expr = pl.col("debut").dt.truncate("1mo").dt.date()

--- a/electricore/core/builds/rapport_taxe.py
+++ b/electricore/core/builds/rapport_taxe.py
@@ -105,7 +105,9 @@ def rapport_accise(lignes_factures: pl.LazyFrame, trimestre: str | None = None) 
         `RapportTaxe(resume, par_taux, detail)` où `detail` est trié
         `(pdl, mois_consommation)`.
     """
-    detail = pipeline_accise(lignes_factures).sort(["pdl", "mois_consommation"])
+    # pipeline_accise retourne déjà un LazyFrame trié (pdl, mois_consommation).
+    # Collect au boundary du build (ADR-0019) pour stocker dans RapportTaxe.
+    detail = pipeline_accise(lignes_factures).collect()
     if trimestre is not None:
         detail = detail.filter(pl.col("trimestre") == trimestre)
 

--- a/electricore/core/models/accise_detail.py
+++ b/electricore/core/models/accise_detail.py
@@ -1,0 +1,27 @@
+"""Schéma Pandera Polars pour le détail Accise TICFE agrégé par PDL × mois.
+
+Sortie de `pipeline_accise` (cf. ADR-0019, issue #110) : une ligne par
+(PDL, mois de consommation), avec énergie consommée, taux en vigueur,
+et montant de l'accise. La colonne `trimestre` permet de filtrer/agréger
+au grain trimestriel pour les déclarations.
+"""
+
+import pandera.polars as pa
+import polars as pl
+
+
+class AcciseDetail(pa.DataFrameModel):
+    """Détail Accise TICFE agrégé par PDL × mois de consommation."""
+
+    pdl: pl.Utf8 = pa.Field(nullable=False)
+    mois_consommation: pl.Utf8 = pa.Field(nullable=False)  # ex: "2025-03"
+    trimestre: pl.Utf8 = pa.Field(nullable=False)  # ex: "2025-T1"
+    order_name: pl.Utf8 = pa.Field(nullable=False)
+    energie_kwh: pl.Float64 = pa.Field(nullable=False, ge=0.0)
+    energie_mwh: pl.Float64 = pa.Field(nullable=False, ge=0.0)
+    taux_accise_eur_mwh: pl.Float64 = pa.Field(nullable=False, ge=0.0)
+    accise_eur: pl.Float64 = pa.Field(nullable=False, ge=0.0)
+
+    class Config:
+        strict = False
+        coerce = True

--- a/electricore/core/models/cta_detail.py
+++ b/electricore/core/models/cta_detail.py
@@ -1,0 +1,26 @@
+"""Schéma Pandera Polars pour le détail CTA agrégé par PDL.
+
+Sortie de `pipeline_cta` (cf. ADR-0019, issue #110) : une ligne par PDL,
+avec sommes mensuelles `turpe_fixe_total` / `cta` et liste des taux distincts
+rencontrés sur la période (changement de taux intra-trimestre détectable
+quand la liste contient plus d'une valeur).
+"""
+
+import pandera.polars as pa
+import polars as pl
+
+
+class CtaDetail(pa.DataFrameModel):
+    """Détail CTA agrégé par PDL pour un trimestre (ou toute la période)."""
+
+    pdl: pl.Utf8 = pa.Field(nullable=False)
+    order_name: pl.Utf8 = pa.Field(nullable=False)
+    turpe_fixe_total: pl.Float64 = pa.Field(nullable=False, ge=0.0)
+    cta: pl.Float64 = pa.Field(nullable=False, ge=0.0)
+    # Liste des taux CTA distincts (en pourcent) rencontrés sur la période,
+    # triée ascendante. `> 1` valeur ⇒ changement de taux intra-période.
+    taux_cta_appliques: pl.List(pl.Float64) = pa.Field(nullable=False)
+
+    class Config:
+        strict = False
+        coerce = True

--- a/electricore/core/pipelines/accise.py
+++ b/electricore/core/pipelines/accise.py
@@ -10,8 +10,11 @@ les taux réglementaires en vigueur selon la période.
 
 from pathlib import Path
 
+import pandera.polars as pa
 import polars as pl
+from pandera.typing.polars import LazyFrame
 
+from electricore.core.models.accise_detail import AcciseDetail
 from electricore.core.pipelines.taux import ajouter_taux_en_vigueur
 
 # =============================================================================
@@ -170,7 +173,8 @@ def ajouter_accise(consommations: pl.LazyFrame, regles: pl.LazyFrame | None = No
     )
 
 
-def pipeline_accise(lignes_factures: pl.LazyFrame, regles: pl.LazyFrame | None = None) -> pl.DataFrame:
+@pa.check_types(lazy=True)
+def pipeline_accise(lignes_factures: pl.LazyFrame, regles: pl.LazyFrame | None = None) -> LazyFrame[AcciseDetail]:
     """
     Pipeline complet de calcul de l'Accise depuis les lignes de factures.
 
@@ -185,7 +189,9 @@ def pipeline_accise(lignes_factures: pl.LazyFrame, regles: pl.LazyFrame | None =
         regles: LazyFrame des règles Accise (optionnel, sera chargé si None)
 
     Returns:
-        DataFrame avec toutes les consommations et leur Accise calculée
+        LazyFrame[AcciseDetail] trié `(pdl, mois_consommation)` avec toutes
+        les consommations et leur Accise calculée. Matérialisation à la charge
+        du caller (typiquement un build ou un service, cf. ADR-0019).
 
     Example:
         >>> from electricore.integrations.odoo import OdooReader, commandes_lignes
@@ -193,7 +199,7 @@ def pipeline_accise(lignes_factures: pl.LazyFrame, regles: pl.LazyFrame | None =
         >>>
         >>> with OdooReader(config) as odoo:
         ...     lignes = commandes_lignes(odoo).collect().lazy()
-        ...     df_accise = pipeline_accise(lignes)
+        ...     df_accise = pipeline_accise(lignes).collect()
     """
     # Étape 1 : Agrégation mensuelle
     consos_mensuelles = agreger_consommations_mensuelles(lignes_factures)
@@ -201,8 +207,8 @@ def pipeline_accise(lignes_factures: pl.LazyFrame, regles: pl.LazyFrame | None =
     # Étape 2 : Calcul de l'Accise
     consos_avec_accise = ajouter_accise(consos_mensuelles, regles)
 
-    # Étape 3 : Collecte et tri
-    return consos_avec_accise.sort(["pdl", "mois_consommation"]).collect()
+    # Étape 3 : Tri (lazy ; le .collect() est à la charge du caller, ADR-0019)
+    return consos_avec_accise.sort(["pdl", "mois_consommation"])
 
 
 # Export des fonctions principales

--- a/electricore/core/pipelines/cta.py
+++ b/electricore/core/pipelines/cta.py
@@ -19,8 +19,11 @@ Formule : cta_eur = turpe_fixe_eur × taux_cta_pct / 100
 
 from pathlib import Path
 
+import pandera.polars as pa
 import polars as pl
+from pandera.typing.polars import LazyFrame
 
+from electricore.core.models.cta_detail import CtaDetail
 from electricore.core.pipelines.facturation import expr_calculer_trimestre
 from electricore.core.pipelines.taux import ajouter_taux_en_vigueur
 
@@ -91,12 +94,13 @@ def ajouter_cta(
 # =============================================================================
 
 
+@pa.check_types(lazy=True)
 def pipeline_cta(
     df_facturation: pl.DataFrame,
     df_pdl: pl.DataFrame,
     trimestre: str | None = None,
     regles: pl.LazyFrame | None = None,
-) -> pl.DataFrame:
+) -> LazyFrame[CtaDetail]:
     """
     Calcule la CTA par PDL sur la période choisie.
 
@@ -113,10 +117,10 @@ def pipeline_cta(
         regles: LazyFrame des règles CTA (optionnel, utile pour les tests).
 
     Returns:
-        DataFrame trié par cta décroissant avec les colonnes :
-        pdl, order_name, turpe_fixe_total, cta, taux_cta_appliques.
-        `taux_cta_appliques` est la liste triée des taux distincts
-        rencontrés dans la période (plus d'une valeur ⇒ changement de taux).
+        LazyFrame[CtaDetail] trié par cta décroissant : une ligne par PDL
+        avec `turpe_fixe_total`, `cta`, et `taux_cta_appliques` (liste triée
+        des taux distincts ; > 1 valeur ⇒ changement de taux intra-période).
+        Matérialisation à la charge du caller (ADR-0019).
     """
     lf_jointure = df_facturation.join(df_pdl.select(["pdl", "order_name"]), on="pdl", how="inner").lazy()
     lf = ajouter_cta(lf_jointure, regles).with_columns(expr_calculer_trimestre().alias("trimestre"))
@@ -135,7 +139,6 @@ def pipeline_cta(
             ]
         )
         .sort("cta", descending=True)
-        .collect()
     )
 
 

--- a/electricore/core/pipelines/facturation.py
+++ b/electricore/core/pipelines/facturation.py
@@ -8,7 +8,7 @@ qui peuvent être composées entre elles pour générer les méta-périodes de f
 
 import pandera.polars as pa
 import polars as pl
-from pandera.typing.polars import DataFrame, LazyFrame
+from pandera.typing.polars import LazyFrame
 
 from electricore.core.models.aggregates import AbonnementMensuel, EnergieMensuel
 from electricore.core.models.periode_abonnement import PeriodeAbonnement
@@ -379,12 +379,12 @@ def joindre_meta_periodes(
 @pa.check_types(lazy=True)
 def pipeline_facturation(
     abonnements_lf: LazyFrame[PeriodeAbonnement], energies_lf: LazyFrame[PeriodeEnergie]
-) -> DataFrame[PeriodeMeta]:
+) -> LazyFrame[PeriodeMeta]:
     """
     Pipeline pur d'agrégation de facturation avec méta-périodes mensuelles - Version Polars.
 
     ⚠️  ATTEND des périodes déjà calculées (abonnements + énergie).
-        Pour l'orchestration complète, utiliser l'orchestration appropriée
+        Pour l'orchestration complète, utiliser le build approprié.
 
     Pipeline d'agrégation pur :
     1. Agrégation mensuelle des abonnements (puissance moyenne pondérée)
@@ -398,7 +398,8 @@ def pipeline_facturation(
         energies_lf: LazyFrame des périodes d'énergie avec TURPE variable
 
     Returns:
-        DataFrame[PeriodeMeta] avec les méta-périodes mensuelles de facturation
+        LazyFrame[PeriodeMeta] avec les méta-périodes mensuelles de facturation.
+        Matérialisation à la charge du caller (typiquement un build, cf. ADR-0019).
     """
     # Étape 1 : Agrégation mensuelle des abonnements
     abo_mensuel_lf = agreger_abonnements_mensuel(abonnements_lf)
@@ -419,8 +420,9 @@ def pipeline_facturation(
         ]
     ).sort(["ref_situation_contractuelle", "debut"])
 
-    # Étape 5 : Collecte et validation Pandera
-    return result_lf.collect()
+    # Validation Pandera au seam (lazy=True dans le décorateur).
+    # Pas de .collect() ici : matérialisation au boundary du caller (ADR-0019).
+    return result_lf
 
 
 # `rapprocher_facturation_mensuelle` a été déplacée vers

--- a/notebooks/demos/marges.py
+++ b/notebooks/demos/marges.py
@@ -220,8 +220,8 @@ def _(df_lignes):
 
 @app.cell
 def _(df_lignes):
-    # Pipeline complet : agrégation + calcul Accise
-    df_accise = pipeline_accise(df_lignes.lazy())
+    # Pipeline complet : agrégation + calcul Accise (lazy depuis ADR-0019, collect ici)
+    df_accise = pipeline_accise(df_lignes.lazy()).collect()
     df_accise
     return (df_accise,)
 

--- a/tests/unit/test_accise.py
+++ b/tests/unit/test_accise.py
@@ -164,14 +164,14 @@ class TestPipelineAccise:
 
     def test_filtre_categories_energie(self, lignes_factures_synthetiques, regles_accise_synthetiques):
         """Les lignes "Abonnements" ne doivent pas contribuer à l'énergie."""
-        result = pipeline_accise(lignes_factures_synthetiques, regles_accise_synthetiques)
+        result = pipeline_accise(lignes_factures_synthetiques, regles_accise_synthetiques).collect()
         row = result.filter(pl.col("pdl") == "A").row(0, named=True)
         # 600 + 400 = 1000 kWh, pas 1000 + 9999
         assert row["energie_kwh"] == 1000.0
 
     def test_agregation_et_accise(self, lignes_factures_synthetiques, regles_accise_synthetiques):
         """1 MWh × 21 €/MWh = 21.00 €."""
-        result = pipeline_accise(lignes_factures_synthetiques, regles_accise_synthetiques)
+        result = pipeline_accise(lignes_factures_synthetiques, regles_accise_synthetiques).collect()
         row = result.filter(pl.col("pdl") == "A").row(0, named=True)
         assert row["mois_consommation"] == "2024-06"
         assert row["energie_mwh"] == 1.0
@@ -203,7 +203,7 @@ class TestPipelineAccise:
             ]
         )
 
-        result = pipeline_accise(lignes, regles_accise_synthetiques)
+        result = pipeline_accise(lignes, regles_accise_synthetiques).collect()
 
         assert len(result) == 1
         row = result.row(0, named=True)

--- a/tests/unit/test_contexte_mensuel.py
+++ b/tests/unit/test_contexte_mensuel.py
@@ -24,20 +24,22 @@ TZ = ZoneInfo("Europe/Paris")
 
 def _make_stub_composition(
     *, debuts_mois: list[datetime]
-) -> tuple[pl.LazyFrame, pl.LazyFrame, pl.LazyFrame, pl.DataFrame]:
-    """Construit le tuple de 4 frames renvoyé par `_composer`.
+) -> tuple[pl.LazyFrame, pl.LazyFrame, pl.LazyFrame, pl.LazyFrame]:
+    """Construit le tuple de 4 LazyFrames renvoyé par `_composer`.
 
     `debuts_mois` peuple `facturation_mensuelle.debut` — c'est l'unique colonne
-    dont `charger()` se sert pour résoudre le mois par défaut.
+    dont `charger()` se sert pour résoudre le mois par défaut. Depuis ADR-0019
+    (#110), `pipeline_facturation` retourne un LazyFrame ; la matérialisation
+    est portée par `charger()` au boundary du build.
     """
-    facturation_df = pl.DataFrame({"debut": debuts_mois}).with_columns(
+    facturation_lf = pl.LazyFrame({"debut": debuts_mois}).with_columns(
         pl.col("debut").dt.replace_time_zone("Europe/Paris")
     )
     return (
         pl.LazyFrame({"sentinel": [1]}),
         pl.LazyFrame({"sentinel": [2]}),
         pl.LazyFrame({"sentinel": [3]}),
-        facturation_df,
+        facturation_lf,
     )
 
 

--- a/tests/unit/test_cta.py
+++ b/tests/unit/test_cta.py
@@ -186,7 +186,7 @@ class TestPipelineCta:
         return pl.DataFrame(rows).with_columns(pl.col("debut").dt.replace_time_zone("Europe/Paris"))
 
     def test_colonnes_sortie(self, df_facturation, df_pdl, regles_cta_synthetiques):
-        result = pipeline_cta(df_facturation, df_pdl, regles=regles_cta_synthetiques)
+        result = pipeline_cta(df_facturation, df_pdl, regles=regles_cta_synthetiques).collect()
         assert set(result.columns) == {
             "pdl",
             "order_name",
@@ -202,7 +202,7 @@ class TestPipelineCta:
             df_pdl,
             trimestre="2026-T1",
             regles=regles_cta_synthetiques,
-        )
+        ).collect()
         row_a = result.filter(pl.col("pdl") == "A")
         assert row_a.height == 1
         assert row_a["turpe_fixe_total"].item() == 300.0
@@ -216,7 +216,7 @@ class TestPipelineCta:
             df_pdl,
             trimestre="2021-T3",
             regles=regles_cta_synthetiques,
-        )
+        ).collect()
         row_b = result.filter(pl.col("pdl") == "B")
         assert row_b.height == 1
         assert row_b["taux_cta_appliques"].item().to_list() == [21.93]
@@ -228,15 +228,15 @@ class TestPipelineCta:
             df_pdl,
             trimestre="2026-T1",
             regles=regles_cta_synthetiques,
-        )
+        ).collect()
         assert "B" not in result["pdl"].to_list()
 
     def test_sans_filtre_tous_trimestres(self, df_facturation, df_pdl, regles_cta_synthetiques):
-        result = pipeline_cta(df_facturation, df_pdl, regles=regles_cta_synthetiques)
+        result = pipeline_cta(df_facturation, df_pdl, regles=regles_cta_synthetiques).collect()
         assert set(result["pdl"].to_list()) == {"A", "B"}
 
     def test_sort_cta_descending(self, df_facturation, df_pdl, regles_cta_synthetiques):
-        result = pipeline_cta(df_facturation, df_pdl, regles=regles_cta_synthetiques)
+        result = pipeline_cta(df_facturation, df_pdl, regles=regles_cta_synthetiques).collect()
         cta_values = result["cta"].to_list()
         assert cta_values == sorted(cta_values, reverse=True)
 
@@ -258,7 +258,7 @@ class TestCasLimites:
             }
         )
         df_pdl = pl.DataFrame({"pdl": ["A"], "order_name": ["SO-A"]})
-        result = pipeline_cta(df_fact, df_pdl, regles=regles_cta_synthetiques)
+        result = pipeline_cta(df_fact, df_pdl, regles=regles_cta_synthetiques).collect()
         assert result.height == 0
 
     def test_pdl_absent_de_df_pdl_exclu(self, regles_cta_synthetiques):
@@ -270,5 +270,5 @@ class TestCasLimites:
             ]
         ).with_columns(pl.col("debut").dt.replace_time_zone("Europe/Paris"))
         df_pdl = pl.DataFrame({"pdl": ["A"], "order_name": ["SO-A"]})
-        result = pipeline_cta(df_fact, df_pdl, regles=regles_cta_synthetiques)
+        result = pipeline_cta(df_fact, df_pdl, regles=regles_cta_synthetiques).collect()
         assert set(result["pdl"].to_list()) == {"A"}

--- a/tests/unit/test_rapport_taxe.py
+++ b/tests/unit/test_rapport_taxe.py
@@ -277,7 +277,7 @@ class TestRapportAcciseBuild:
     def test_returns_rapport_taxe(self, monkeypatch):
         from electricore.core.builds import rapport_taxe as mod
 
-        monkeypatch.setattr(mod, "pipeline_accise", lambda lf: _detail_accise_synthetique())
+        monkeypatch.setattr(mod, "pipeline_accise", lambda lf: _detail_accise_synthetique().lazy())
 
         result = mod.rapport_accise(_lignes_factures_synthetiques())
 
@@ -288,7 +288,7 @@ class TestRapportAcciseBuild:
     def test_detail_sorted_pdl_mois(self, monkeypatch):
         from electricore.core.builds import rapport_taxe as mod
 
-        monkeypatch.setattr(mod, "pipeline_accise", lambda lf: _detail_accise_synthetique())
+        monkeypatch.setattr(mod, "pipeline_accise", lambda lf: _detail_accise_synthetique().lazy())
 
         result = mod.rapport_accise(_lignes_factures_synthetiques())
 
@@ -297,7 +297,7 @@ class TestRapportAcciseBuild:
     def test_trimestre_filter_applied(self, monkeypatch):
         from electricore.core.builds import rapport_taxe as mod
 
-        monkeypatch.setattr(mod, "pipeline_accise", lambda lf: _detail_accise_synthetique())
+        monkeypatch.setattr(mod, "pipeline_accise", lambda lf: _detail_accise_synthetique().lazy())
 
         result = mod.rapport_accise(_lignes_factures_synthetiques(), trimestre="2025-T1")
 
@@ -306,7 +306,7 @@ class TestRapportAcciseBuild:
     def test_par_taux_groups_correctly(self, monkeypatch):
         from electricore.core.builds import rapport_taxe as mod
 
-        monkeypatch.setattr(mod, "pipeline_accise", lambda lf: _detail_accise_synthetique())
+        monkeypatch.setattr(mod, "pipeline_accise", lambda lf: _detail_accise_synthetique().lazy())
 
         result = mod.rapport_accise(_lignes_factures_synthetiques())
 
@@ -315,7 +315,7 @@ class TestRapportAcciseBuild:
     def test_resume_has_trimestre_totals(self, monkeypatch):
         from electricore.core.builds import rapport_taxe as mod
 
-        monkeypatch.setattr(mod, "pipeline_accise", lambda lf: _detail_accise_synthetique())
+        monkeypatch.setattr(mod, "pipeline_accise", lambda lf: _detail_accise_synthetique().lazy())
 
         result = mod.rapport_accise(_lignes_factures_synthetiques())
 


### PR DESCRIPTION
## Summary

Applique la règle 5 de l'[ADR-0019](docs/adr/0019-roles-loaders-pipelines-builds-integrations.md) : un `pipeline_*` retourne un `LazyFrame[Schema]` ; la matérialisation (`.collect()`) est portée par le caller (build, service, ou test). Aligne sur la pratique Polars / dbplyr / Ibis (lazy-in / lazy-out).

3 commits, un par pipeline cible :

- `dceb882` — `pipeline_facturation` → `LazyFrame[PeriodeMeta]`. Le build `contexte_mensuel.charger()` collecte avant stockage dans `ContexteMensuel`.
- `54662e5` — `pipeline_cta` → `LazyFrame[CtaDetail]`. Nouveau schéma Pandera `CtaDetail`. 8 sites de test ajoutent `.collect()`.
- `5203088` — `pipeline_accise` → `LazyFrame[AcciseDetail]`. Nouveau schéma Pandera `AcciseDetail`. 4 callers de production + tests mis à jour.

Hors scope (cas tiers exclus) :
- `taux.py:43` `ajouter_taux_en_vigueur` fait `.collect().item()` pour un check d'orphelins — c'est une **validation**, pas une matérialisation de sortie. Hors scope règle 5.
- Les `.collect()` dans `core/builds/` (rapport_taxe, contexte_mensuel) — légitimes, c'est le rôle d'un build.

## Test plan

- [x] `uv run --group test pytest -q` : 485 passed, 35 skipped
- [x] `uvx pre-commit run` sur tous les fichiers modifiés : Passed
- [ ] Bench perf rapide (AC #110) — à exécuter manuellement avant merge si on veut chiffrer ; Polars devrait être au moins aussi rapide vu qu'on maintient la chaîne lazy plus longtemps
- [ ] Tests d'archi #109 passent sur la branche (à vérifier sur CI)

## Notes

- `pipeline_cta` n'a aucun caller en production (rapport_cta passe par `ajouter_cta` directement). Suppression planifiée via #112 (follow-up bloqué par celle-ci).
- Le décorateur `@pa.check_types(lazy=True)` a été ajouté à `pipeline_cta` et `pipeline_accise` (alignement *Contrat de pipeline* du `core/CONTEXT.md`).

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)