### PR TITLE
refactor(core): donner un module au Cadran (#119)

### DIFF
--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -53,7 +53,7 @@ Sites BT > 36 kVA. Tertiaire et industriel léger ; quatre puissances souscrites
 ## Cadrans temporels
 
 **Cadran** :
-Plage tarifaire temporelle (heures × saison) groupant des périodes au même tarif. Le découpage en cadrans est fixé par le *calendrier distributeur*.
+Plage tarifaire temporelle (heures × saison) groupant des périodes au même tarif. Le découpage en cadrans est fixé par le *calendrier distributeur*. La liste canonique des 7 cadrans, la relation de synthèse (hp ← hph+hpb, hc ← hch+hcb) et les constructeurs de noms de colonnes (`grandeur_cadran_unité`) vivent dans `core/models/cadrans.py`.
 _Éviter_ : créneau, plage tarifaire.
 
 **Base** :

--- a/electricore/core/builds/contexte_mensuel.py
+++ b/electricore/core/builds/contexte_mensuel.py
@@ -23,6 +23,7 @@ import pandera.polars as pa
 import polars as pl
 from pandera.typing.polars import DataFrame
 
+from electricore.core.models.cadrans import col_energie
 from electricore.core.models.lignes_facture import LignesFacture
 from electricore.core.models.lignes_facture_rapprochees import LignesFactureRapprochees
 from electricore.core.pipelines.abonnements import pipeline_abonnements
@@ -30,10 +31,13 @@ from electricore.core.pipelines.energie import pipeline_energie
 from electricore.core.pipelines.facturation import pipeline_facturation
 from electricore.core.pipelines.historique import pipeline_historique
 
+# Les clés sont des *catégories produit* (labels ERP, cf. LignesFacture) —
+# concept distinct des cadrans malgré l'homonymie ; seules les valeurs
+# (noms de colonnes Enedis) viennent de la convention cadran.
 _MAPPING_CATEGORIE_COLONNE: dict[str, str] = {
-    "HP": "energie_hp_kwh",
-    "HC": "energie_hc_kwh",
-    "Base": "energie_base_kwh",
+    "HP": col_energie("hp"),
+    "HC": col_energie("hc"),
+    "Base": col_energie("base"),
     "Abonnements": "nb_jours",
 }
 

--- a/electricore/core/loaders/duckdb/expressions.py
+++ b/electricore/core/loaders/duckdb/expressions.py
@@ -10,20 +10,14 @@ pour construire des pipelines de transformation complexes.
 
 import polars as pl
 
+from electricore.core.models.cadrans import CADRANS, col_index
+
 # =============================================================================
 # CONSTANTES IMMUTABLES
 # =============================================================================
 
 # Colonnes d'index énergétiques (tuple = immutable) - Format: index_cadran_kwh
-INDEX_COLS = (
-    "index_base_kwh",
-    "index_hp_kwh",
-    "index_hc_kwh",
-    "index_hph_kwh",
-    "index_hpb_kwh",
-    "index_hcb_kwh",
-    "index_hch_kwh",
-)
+INDEX_COLS = tuple(col_index(c) for c in CADRANS)
 
 # Colonnes de dates pour chaque type de flux
 DATE_COLS_HISTORIQUE = ("date_evenement", "avant_date_releve", "apres_date_releve")

--- a/electricore/core/models/cadrans.py
+++ b/electricore/core/models/cadrans.py
@@ -1,0 +1,38 @@
+"""Cadrans temporels : liste canonique et convention de nommage des colonnes.
+
+Source unique du concept *Cadran* (cf. CONTEXT.md) côté code : la liste des
+7 cadrans, la relation de synthèse saison haute/basse → cadran principal, et
+les constructeurs de noms de colonnes au format `grandeur_cadran_unité`
+(issue #119).
+
+Importable par pipelines, builds et loaders (ADR-0019). Les expressions
+Polars qui consomment ces noms restent dans `core/pipelines/`.
+"""
+
+# Les 7 cadrans canoniques : Base (tarif unique), HP/HC (heures pleines /
+# creuses), et le découpage 4 cadrans croisant saison (Haute = nov-mars,
+# Basse = avr-oct) et plage horaire — obligatoire en C4, utilisé en Tempo/EJP.
+CADRANS: tuple[str, ...] = ("base", "hp", "hc", "hph", "hch", "hpb", "hcb")
+
+# Relation de synthèse : un cadran principal s'obtient en sommant ses
+# sous-cadrans saisonniers (hp ← hph + hpb, hc ← hch + hcb).
+SOUS_CADRANS: dict[str, tuple[str, str]] = {
+    "hp": ("hph", "hpb"),
+    "hc": ("hch", "hcb"),
+}
+
+
+def _verifier(cadran: str) -> str:
+    if cadran not in CADRANS:
+        raise ValueError(f"Cadran inconnu : {cadran!r} (cadrans canoniques : {', '.join(CADRANS)})")
+    return cadran
+
+
+def col_energie(cadran: str) -> str:
+    """Nom de la colonne d'énergie d'un cadran (ex : `energie_hp_kwh`)."""
+    return f"energie_{_verifier(cadran)}_kwh"
+
+
+def col_index(cadran: str) -> str:
+    """Nom de la colonne d'index d'un cadran (ex : `index_hp_kwh`)."""
+    return f"index_{_verifier(cadran)}_kwh"

--- a/electricore/core/pipelines/energie.py
+++ b/electricore/core/pipelines/energie.py
@@ -10,6 +10,7 @@ import pandera.polars as pa
 import polars as pl
 from pandera.typing.polars import LazyFrame
 
+from electricore.core.models.cadrans import CADRANS, SOUS_CADRANS, col_energie, col_index
 from electricore.core.models.historique import Historique
 from electricore.core.models.periode_energie import PeriodeEnergie
 from electricore.core.models.releve_index import RelevéIndex
@@ -144,28 +145,16 @@ def expr_enrichir_cadrans_principaux() -> list[pl.Expr]:
     Example:
         >>> df.with_columns(expr_enrichir_cadrans_principaux())
     """
-    return [
-        # Étape 1 : Synthèse hc depuis les sous-cadrans hch et hcb
-        pl.sum_horizontal([pl.col("energie_hc_kwh"), pl.col("energie_hch_kwh"), pl.col("energie_hcb_kwh")]).alias(
-            "energie_hc_kwh"
-        ),
-        # Étape 2 : Synthèse hp depuis les sous-cadrans hph et hpb
-        pl.sum_horizontal([pl.col("energie_hp_kwh"), pl.col("energie_hph_kwh"), pl.col("energie_hpb_kwh")]).alias(
-            "energie_hp_kwh"
-        ),
-        # Étape 3 : Synthèse base depuis TOUS les cadrans (évite le problème d'évaluation parallèle)
-        pl.sum_horizontal(
-            [
-                pl.col("energie_base_kwh"),
-                pl.col("energie_hp_kwh"),
-                pl.col("energie_hc_kwh"),
-                pl.col("energie_hph_kwh"),
-                pl.col("energie_hpb_kwh"),
-                pl.col("energie_hch_kwh"),
-                pl.col("energie_hcb_kwh"),
-            ]
-        ).alias("energie_base_kwh"),
+    # Toutes les expressions s'évaluent sur les colonnes d'origine (un seul
+    # with_columns) : base somme les 7 cadrans bruts, pas les synthèses.
+    syntheses_principaux = [
+        pl.sum_horizontal([pl.col(col_energie(principal)), *(pl.col(col_energie(s)) for s in sous)]).alias(
+            col_energie(principal)
+        )
+        for principal, sous in SOUS_CADRANS.items()
     ]
+    synthese_base = pl.sum_horizontal([pl.col(col_energie(c)) for c in CADRANS]).alias(col_energie("base"))
+    return [*syntheses_principaux, synthese_base]
 
 
 def expr_nb_jours() -> pl.Expr:
@@ -498,10 +487,8 @@ def calculer_periodes_energie(lf: pl.LazyFrame) -> LazyFrame[PeriodeEnergie]:
     Example:
         >>> periodes = calculer_periodes_energie(releves_lf).collect()
     """
-    # Cadrans d'index électriques standard
-    cadrans = ["base", "hp", "hc", "hph", "hpb", "hcb", "hch"]
-    # Construire les noms de colonnes complets (index_{cadran}_kwh)
-    colonnes_index = [f"index_{c}_kwh" for c in cadrans]
+    # Colonnes d'index des cadrans canoniques (index_{cadran}_kwh)
+    colonnes_index = [col_index(c) for c in CADRANS]
 
     return (
         lf

--- a/electricore/core/pipelines/historique.py
+++ b/electricore/core/pipelines/historique.py
@@ -14,6 +14,7 @@ import pandera.polars as pa
 import polars as pl
 from pandera.typing.polars import LazyFrame
 
+from electricore.core.models.cadrans import CADRANS, col_index
 from electricore.core.models.historique import Historique
 
 
@@ -152,12 +153,8 @@ def expr_changement_index() -> pl.Expr:
         ...     expr_changement_index().alias("index_change")
         ... )
     """
-    index_cols = ["base", "hp", "hc", "hph", "hch", "hpb", "hcb"]
-
-    # Créer une expression pour chaque colonne d'index
-    changements = [
-        expr_changement_avant_apres(f"avant_index_{col}_kwh", f"apres_index_{col}_kwh") for col in index_cols
-    ]
+    # Créer une expression pour chaque colonne d'index (un cadran = un index)
+    changements = [expr_changement_avant_apres(f"avant_{col_index(c)}", f"apres_{col_index(c)}") for c in CADRANS]
 
     # Retourner True si au moins un changement est détecté
     return pl.any_horizontal(changements)

--- a/electricore/core/pipelines/turpe.py
+++ b/electricore/core/pipelines/turpe.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import polars as pl
 
+from electricore.core.models.cadrans import CADRANS, col_energie
+
 # =============================================================================
 # CHARGEMENT DES RÈGLES TURPE
 # =============================================================================
@@ -216,7 +218,7 @@ def expr_calculer_turpe_cadran(cadran: str) -> pl.Expr:
     Example:
         >>> df.with_columns(expr_calculer_turpe_cadran("base").alias("turpe_base"))
     """
-    energie_col = f"energie_{cadran}_kwh"
+    energie_col = col_energie(cadran)
     tarif_col = f"c_{cadran}"  # Nomenclature CRE officielle
 
     return (
@@ -236,9 +238,7 @@ def expr_calculer_turpe_contributions_cadrans() -> list[pl.Expr]:
     Example:
         >>> df.with_columns(expr_calculer_turpe_contributions_cadrans())
     """
-    cadrans = ["hph", "hch", "hpb", "hcb", "hp", "hc", "base"]
-
-    return [expr_calculer_turpe_cadran(cadran).alias(f"turpe_{cadran}") for cadran in cadrans]
+    return [expr_calculer_turpe_cadran(cadran).alias(f"turpe_{cadran}") for cadran in CADRANS]
 
 
 def expr_sommer_turpe_cadrans() -> pl.Expr:
@@ -253,8 +253,7 @@ def expr_sommer_turpe_cadrans() -> pl.Expr:
     Example:
         >>> df.with_columns(expr_sommer_turpe_cadrans().alias("turpe_variable"))
     """
-    cadrans = ["hph", "hch", "hpb", "hcb", "hp", "hc", "base"]
-    contributions_cols = [f"turpe_{cadran}" for cadran in cadrans]
+    contributions_cols = [f"turpe_{cadran}" for cadran in CADRANS]
 
     return pl.sum_horizontal([pl.col(col) for col in contributions_cols]).round(2)
 
@@ -489,12 +488,11 @@ def debug_turpe_variable(lf: pl.LazyFrame) -> pl.LazyFrame:
         >>> df_debug = debug_turpe_variable(df)
         >>> print(df_debug.collect())
     """
-    cadrans = ["hph", "hch", "hpb", "hcb", "hp", "hc", "base"]
     debug_expressions = []
 
     # Ajouter les détails par cadran
-    for cadran in cadrans:
-        energie_col = f"energie_{cadran}_kwh"
+    for cadran in CADRANS:
+        energie_col = col_energie(cadran)
         tarif_col = f"c_{cadran}"  # Nomenclature CRE officielle
         debug_expressions.extend(
             [

--- a/tests/unit/test_cadrans.py
+++ b/tests/unit/test_cadrans.py
@@ -1,0 +1,39 @@
+"""Tests de contrat du module Cadran (`core/models/cadrans.py`) — issue #119.
+
+Le module porte la liste canonique des cadrans et la convention de nommage
+`grandeur_cadran_unité` (cf. CONTEXT.md, entrée *Cadran*).
+"""
+
+import pytest
+
+from electricore.core.models.cadrans import CADRANS, SOUS_CADRANS, col_energie, col_index
+
+
+class TestCadrans:
+    def test_sept_cadrans_canoniques(self):
+        assert CADRANS == ("base", "hp", "hc", "hph", "hch", "hpb", "hcb")
+
+    def test_sous_cadrans_relation_de_synthese(self):
+        """hp se synthétise depuis hph+hpb, hc depuis hch+hcb (haute/basse saison)."""
+        assert SOUS_CADRANS == {"hp": ("hph", "hpb"), "hc": ("hch", "hcb")}
+
+    def test_sous_cadrans_sont_des_cadrans(self):
+        for principal, sous in SOUS_CADRANS.items():
+            assert principal in CADRANS
+            assert all(s in CADRANS for s in sous)
+
+
+class TestConstructeursDeColonnes:
+    def test_col_energie(self):
+        assert col_energie("hp") == "energie_hp_kwh"
+        assert col_energie("base") == "energie_base_kwh"
+
+    def test_col_index(self):
+        assert col_index("hch") == "index_hch_kwh"
+
+    def test_cadran_inconnu_rejete(self):
+        """Détection de typo : un cadran hors liste canonique lève ValueError."""
+        with pytest.raises(ValueError, match="hpc"):
+            col_energie("hpc")
+        with pytest.raises(ValueError, match="HP"):
+            col_index("HP")  # les cadrans sont en minuscules


### PR DESCRIPTION
## Quoi

Candidat C1 de la revue d'architecture : le concept *Cadran* (CONTEXT.md) obtient son module — `core/models/cadrans.py` porte la liste canonique des 7 cadrans, la relation de synthèse saisonnière et les constructeurs de noms de colonnes `grandeur_cadran_unité` (jusqu'ici de la prose dans CLAUDE.md).

## Avant / après

Avant : la liste re-déclarée en magic strings dans **4 ordres différents** (`turpe.py` ×3, `energie.py`, `historique.py`, `loaders/duckdb/expressions.py`), les f-strings `f"energie_{cadran}_kwh"` dispersées, la synthèse hch+hcb→hc enfouie dans `expr_enrichir_cadrans_principaux`.

Après : une interface de 4 noms (`CADRANS`, `SOUS_CADRANS`, `col_energie`, `col_index`) importée par 6 sites. Un cadran inconnu lève `ValueError` — les typos de colonnes cadran sont détectées au lieu de produire des colonnes fantômes.

## Garde-fous de périmètre

- Le `["Base", "HP", "HC"]` d'accise et les **clés** du mapping de `contexte_mensuel` sont des *catégories produit* (labels ERP) — homonymes mais concept distinct, volontairement hors périmètre (seules les valeurs-colonnes du mapping passent par `col_energie`).
- Les expressions Polars restent dans `core/pipelines/` ; le module ne porte que la convention de forme (rôle `core/models/`, ADR-0019).
- Sémantique de la synthèse inchangée : `base` somme toujours les 7 cadrans bruts dans un seul `with_columns`.

## Tests

`495 passed, 35 skipped`. Nouveau `tests/unit/test_cadrans.py` (liste canonique, relation de synthèse, constructeurs, rejet de typo) ; la suite complète sert de filet au refactor des 6 sites.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)