### PR TITLE
feat(dbt): chemin XML→dict→dbt sur C15, parité golden (#124)

### DIFF
--- a/electricore/etl/dbt/models/flux/flux_c15.sql
+++ b/electricore/etl/dbt/models/flux/flux_c15.sql
@@ -1,0 +1,119 @@
+-- Linéarisation C15 : une ligne par PRM, situation contractuelle + relevés
+-- avant/après pivotés en colonnes (ADR-0020, issue #124 — le flux le plus dur).
+--
+-- Remplace le moteur Python `parser_flux_xml` piloté par `flux.yaml` : la sélection
+-- (data_fields) devient des chemins JSON, l'axe parent XPath `../Code_Qualification`
+-- du DSL disparaît (après unnest, les champs du Donnees_Releve parent sont en scope,
+-- la condition devient un WHERE), le pivot des cadrans devient une agrégation
+-- conditionnelle sur le domaine fermé des cadrans (core/models/cadrans.py).
+--
+-- Accès JSON tolérant (pas de cast struct géant) car le document C15 est profond.
+-- `xml_vers_dict` rend tout conteneur tableau (« conteneur = liste ») → chaque
+-- élément unique est indexé `[0]`.
+
+with flat as (
+    select
+        prm ->> '$.Id_PRM'                                                    as pdl,
+        prm ->> '$.Segment_Clientele'                                         as segment_clientele,
+        prm ->> '$.Num_Depannage'                                             as num_depannage,
+        prm ->> '$.Situation_Contractuelle[0].Titulaire_Contrat[0].Categorie' as categorie,
+        prm ->> '$.Situation_Contractuelle[0].Etat_Contractuel'              as etat_contractuel,
+        prm ->> '$.Situation_Contractuelle[0].Ref_Situation_Contractuelle'   as ref_situation_contractuelle,
+        cast(prm ->> '$.Situation_Contractuelle[0].Structure_Tarifaire[0].Puissance_Souscrite' as double) as puissance_souscrite_kva,
+        prm ->> '$.Situation_Contractuelle[0].Structure_Tarifaire[0].Formule_Tarifaire_Acheminement' as formule_tarifaire_acheminement,
+        prm ->> '$.Dispositif_De_Comptage[0].Compteur[0].Type'              as type_compteur,
+        prm ->> '$.Dispositif_De_Comptage[0].Compteur[0].Num_Serie'         as num_compteur,
+        cast(prm ->> '$.Date_Derniere_Modification_FTA' as date)            as date_derniere_modification_fta,
+        prm ->> '$.Evenement_Declencheur[0].Nature_Evenement'              as evenement_declencheur,
+        prm ->> '$.Evenement_Declencheur[0].Type_Evenement'                as type_evenement,
+        cast(prm ->> '$.Evenement_Declencheur[0].Date_Evenement' as timestamptz) as date_evenement,
+        prm ->> '$.Evenement_Declencheur[0].Ref_Demandeur'                 as ref_demandeur,
+        prm ->> '$.Evenement_Declencheur[0].Id_Affaire'                    as id_affaire
+    from {{ ref('stg_c15') }}
+),
+
+-- Unnest des relevés en deux étages, chacun dans son CTE : isole le double unnest
+-- latéral du WHERE aval. Sans cette césure, l'optimiseur DuckDB pousse le prédicat
+-- JSON sous l'unnest et le caste contre la mauvaise valeur (objet pré-unnest).
+donnees as (
+    select
+        prm ->> '$.Id_PRM' as pdl,
+        t1.donnee
+    from {{ ref('stg_c15') }},
+        unnest(cast(prm -> '$.Evenement_Declencheur[0].Releves[0].Donnees_Releve' as json[])) as t1(donnee)
+),
+
+classes as (
+    select
+        pdl,
+        donnee,
+        t2.classe
+    from donnees,
+        unnest(cast(donnee -> '$.Classe_Temporelle_Distributeur' as json[])) as t2(classe)
+),
+
+-- Extraction en colonnes VARCHAR nommées AVANT tout filtre/cast : le prédicat ne
+-- peut plus se faufiler dans l'unnest.
+extrait as (
+    select
+        pdl,
+        donnee ->> '$.Code_Qualification'          as code_qualif,
+        classe ->> '$.Classe_Mesure'               as classe_mesure,
+        classe ->> '$.Sens_Mesure'                 as sens_mesure,
+        lower(classe ->> '$.Id_Classe_Temporelle') as cadran,
+        classe ->> '$.Valeur'                      as valeur,
+        donnee ->> '$.Date_Releve'                 as date_releve,
+        donnee ->> '$.Nature_Index'                as nature_index,
+        donnee ->> '$.Id_Calendrier_Distributeur'  as id_calendrier_distributeur,
+        donnee ->> '$.Id_Calendrier'               as id_calendrier_fournisseur
+    from classes
+),
+
+releves as (
+    select
+        pdl,
+        case when code_qualif = '1' then 'avant_' else 'apres_' end as prefixe,
+        cadran,
+        cast(valeur as bigint)           as valeur,
+        cast(date_releve as timestamptz) as date_releve,
+        nature_index,
+        id_calendrier_distributeur,
+        id_calendrier_fournisseur
+    -- Code_Qualification : 1 = relevé avant événement, 2 = après. Classe_Mesure = 1
+    -- (énergie) et Sens_Mesure = 0 (soutirage) écartent injection et autres mesures.
+    from extrait
+    where code_qualif in ('1', '2')
+      and classe_mesure = '1'
+      and sens_mesure = '0'
+),
+
+releves_agg as (
+    select
+        pdl,
+        max(case when prefixe = 'avant_' and cadran = 'base' then valeur end) as avant_index_base_kwh,
+        max(case when prefixe = 'avant_' and cadran = 'hp' then valeur end) as avant_index_hp_kwh,
+        max(case when prefixe = 'avant_' and cadran = 'hc' then valeur end) as avant_index_hc_kwh,
+        max(case when prefixe = 'avant_' and cadran = 'hph' then valeur end) as avant_index_hph_kwh,
+        max(case when prefixe = 'avant_' and cadran = 'hpb' then valeur end) as avant_index_hpb_kwh,
+        max(case when prefixe = 'avant_' and cadran = 'hch' then valeur end) as avant_index_hch_kwh,
+        max(case when prefixe = 'avant_' and cadran = 'hcb' then valeur end) as avant_index_hcb_kwh,
+        max(case when prefixe = 'apres_' and cadran = 'base' then valeur end) as apres_index_base_kwh,
+        max(case when prefixe = 'apres_' and cadran = 'hp' then valeur end) as apres_index_hp_kwh,
+        max(case when prefixe = 'apres_' and cadran = 'hc' then valeur end) as apres_index_hc_kwh,
+        max(case when prefixe = 'apres_' and cadran = 'hph' then valeur end) as apres_index_hph_kwh,
+        max(case when prefixe = 'apres_' and cadran = 'hpb' then valeur end) as apres_index_hpb_kwh,
+        max(case when prefixe = 'apres_' and cadran = 'hch' then valeur end) as apres_index_hch_kwh,
+        max(case when prefixe = 'apres_' and cadran = 'hcb' then valeur end) as apres_index_hcb_kwh,
+        max(case when prefixe = 'avant_' then date_releve end)                as avant_date_releve,
+        max(case when prefixe = 'avant_' then nature_index end)               as avant_nature_index,
+        max(case when prefixe = 'avant_' then id_calendrier_distributeur end) as avant_id_calendrier_distributeur,
+        max(case when prefixe = 'avant_' then id_calendrier_fournisseur end)  as avant_id_calendrier_fournisseur,
+        max(case when prefixe = 'apres_' then date_releve end)                as apres_date_releve,
+        max(case when prefixe = 'apres_' then nature_index end)               as apres_nature_index,
+        max(case when prefixe = 'apres_' then id_calendrier_distributeur end) as apres_id_calendrier_distributeur,
+        max(case when prefixe = 'apres_' then id_calendrier_fournisseur end)  as apres_id_calendrier_fournisseur
+    from releves
+    group by pdl
+)
+
+select * from flat left join releves_agg using (pdl)

--- a/electricore/etl/dbt/models/flux/schema.yml
+++ b/electricore/etl/dbt/models/flux/schema.yml
@@ -13,3 +13,16 @@ models:
       - name: date_releve
         description: Date du relevé.
         data_tests: [not_null]
+
+  - name: flux_c15
+    description: >
+      Situation contractuelle C15 : une ligne par PRM, relevés avant/après pivotés
+      en colonnes index_{cadran}_kwh. Parité golden vérifiée
+      (tests/etl/test_dbt_c15_golden.py).
+    columns:
+      - name: pdl
+        description: Point de livraison (14 chiffres).
+        data_tests: [not_null]
+      - name: date_evenement
+        description: Horodatage de l'événement déclencheur (instant, TIMESTAMPTZ).
+        data_tests: [not_null]

--- a/electricore/etl/dbt/models/sources.yml
+++ b/electricore/etl/dbt/models/sources.yml
@@ -17,3 +17,16 @@ sources:
             description: Nom du fichier source (traçabilité).
           - name: modification_date
             description: Date de modification SFTP (clé d'incrémental dlt).
+      - name: raw_c15
+        description: >
+          Flux C15 (situation contractuelle), un document par ligne. Le XML est
+          converti en dict par `etl/parsing/xml.xml_vers_dict` (politique
+          « conteneur = liste ») avant landing — d'où des tableaux JSON même pour
+          les éléments uniques (PRM, Evenement_Declencheur…), indexés `[0]` en SQL.
+        columns:
+          - name: content
+            description: Document JSON intégral (En_Tete_Flux + Contrat + PRM[]).
+          - name: file_name
+            description: Nom du fichier source (traçabilité).
+          - name: modification_date
+            description: Date de modification SFTP (clé d'incrémental dlt).

--- a/electricore/etl/dbt/models/staging/stg_c15.sql
+++ b/electricore/etl/dbt/models/staging/stg_c15.sql
@@ -1,0 +1,17 @@
+-- Éclatement du document C15 : une ligne par PRM.
+--
+-- Contrairement à R64 (struct typé), C15 est un document profond (Adresse,
+-- Alimentation, Dispositif_De_Comptage… des dizaines de feuilles) : un cast struct
+-- exhaustif serait énorme et casserait au moindre champ Enedis inattendu (le cast
+-- DuckDB est strict sur les clés inconnues). On reste donc en accès JSON tolérant
+-- (`->>`/`->`), et `flux_c15` extrait sélectivement ce dont core/ a besoin.
+--
+-- `xml_vers_dict` applique « conteneur = liste » : PRM est toujours un tableau,
+-- même unique → unnest direct.
+
+select
+    file_name,
+    modification_date,
+    p.unnest as prm
+from {{ source('flux_raw', 'raw_c15') }},
+    unnest(cast(content -> '$.PRM' as json[])) as p

--- a/electricore/etl/parsing/xml.py
+++ b/electricore/etl/parsing/xml.py
@@ -66,6 +66,48 @@ class ConfigFluxXml:
         )
 
 
+def xml_vers_dict(xml_bytes: bytes) -> dict:
+    """Convertit un document XML en dict imbriqué, sans connaissance du flux.
+
+    Brique de landing partagée par tous les flux XML (ADR-0020) : le dict est
+    landé en colonne JSON, puis linéarisé par un modèle dbt. La seule règle est
+    structurelle — des balises sœurs de même nom deviennent une liste, une balise
+    unique reste scalaire, une feuille texte devient sa valeur (str).
+
+    Args:
+        xml_bytes: Contenu du fichier XML.
+
+    Returns:
+        Le contenu de l'élément racine en dict (les enfants de la racine,
+        la balise racine elle-même n'étant pas ré-emballée).
+    """
+    return _element_vers_dict(etree.fromstring(xml_bytes))
+
+
+def _element_vers_dict(element: Any) -> Any:
+    enfants = list(element)
+    if not enfants:
+        # Feuille : sa valeur texte (None si vide, pour rester sérialisable).
+        return element.text.strip() if element.text and element.text.strip() else None
+    resultat: dict[str, Any] = {}
+    for enfant in enfants:
+        valeur = _element_vers_dict(enfant)
+        if len(enfant) > 0:
+            # Conteneur = forme répétable → toujours une liste (cast dbt uniforme),
+            # même unique.
+            resultat.setdefault(enfant.tag, []).append(valeur)
+        elif enfant.tag in resultat:
+            # Feuille répétée → liste.
+            existant = resultat[enfant.tag]
+            if isinstance(existant, list):
+                existant.append(valeur)
+            else:
+                resultat[enfant.tag] = [existant, valeur]
+        else:
+            resultat[enfant.tag] = valeur
+    return resultat
+
+
 def match_xml_pattern(xml_name: str, pattern: str | None) -> bool:
     """
     Vérifie si un nom de fichier correspond au pattern (wildcard ou regex).

--- a/tests/etl/test_dbt_c15_golden.py
+++ b/tests/etl/test_dbt_c15_golden.py
@@ -1,0 +1,117 @@
+"""Parité golden du modèle dbt flux_c15 (ADR-0020, issue #124).
+
+C15 est le flux le plus dur : `nested_fields` conditionnels (avant/après via
+Code_Qualification) + pivot des cadrans. On convertit le XML en dict générique
+(`xml_vers_dict`), on le landé en colonne JSON (comme dlt en production), on lance
+dbt, et on compare la table `flux_c15` au golden — modulo traçabilité **et fuseau**.
+
+Le golden a été produit par l'ancien parseur (tout en `str`, offsets `+02:00`
+préservés). Le modèle dbt type les horodatages en instant-correct (TIMESTAMPTZ) :
+la parité compare donc l'**instant**, pas la représentation string (ADR-0020,
+politique timezone tranchée en #124).
+
+Skip si dbt n'est pas installé (`uv sync --extra dbt`).
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import duckdb
+import pytest
+
+pytest.importorskip("dbt.cli.main", reason="dbt absent — uv sync --extra dbt")
+pytest.importorskip("dbt.adapters.duckdb", reason="dbt-duckdb absent — uv sync --extra dbt")
+
+from dbt.cli.main import dbtRunner  # noqa: E402
+
+from electricore.etl.parsing.xml import xml_vers_dict  # noqa: E402
+
+RACINE = Path(__file__).parents[2]
+PROJET_DBT = RACINE / "electricore" / "etl" / "dbt"
+FIXTURE = RACINE / "tests" / "fixtures" / "flux" / "c15_avec_releves.xml"
+GOLDEN = RACINE / "tests" / "fixtures" / "flux" / "golden" / "flux_c15.json"
+
+# Colonnes de traçabilité : ajoutées hors linéarisation, hors périmètre parité.
+TRACABILITE = {"_source_zip", "_flux_type", "_xml_name", "modification_date"}
+
+# Horodatages typés en instant par dbt : comparés sur l'instant, pas la string.
+COLONNES_INSTANT = {"date_evenement", "avant_date_releve", "apres_date_releve"}
+
+
+@pytest.fixture
+def base_avec_brut(tmp_path, monkeypatch):
+    """Convertit + landé la fixture C15 en colonne JSON dans une DuckDB temporaire."""
+    import dlt
+
+    from electricore.etl.raw_landing import lander_documents_bruts
+
+    db_path = tmp_path / "flux.duckdb"
+    document = xml_vers_dict(FIXTURE.read_bytes())
+    pipeline = dlt.pipeline(
+        pipeline_name="test_raw_c15",
+        destination=dlt.destinations.duckdb(str(db_path)),
+        dataset_name="flux_raw",
+    )
+    lander_documents_bruts(
+        pipeline,
+        "raw_c15",
+        [
+            {
+                "file_name": "c15_avec_releves.xml",
+                "modification_date": "2026-01-01T00:00:00",
+                "content": document,
+            }
+        ],
+    )
+    monkeypatch.setenv("DBT_DUCKDB_PATH", str(db_path))
+    return db_path
+
+
+def test_flux_c15_reproduit_le_golden(base_avec_brut):
+    resultat = dbtRunner().invoke(
+        [
+            "build",
+            "--select",
+            "+flux_c15",
+            "--project-dir",
+            str(PROJET_DBT),
+            "--profiles-dir",
+            str(PROJET_DBT),
+            "--target-path",
+            str(base_avec_brut.parent / "target"),
+        ]
+    )
+    # `build` vert = 2 modèles (stg_c15, flux_c15) + 2 data_tests (not_null) passent.
+    assert resultat.success, f"dbt build a échoué : {resultat.exception}"
+    assert len(resultat.result) == 4
+
+    con = duckdb.connect(str(base_avec_brut))
+    cur = con.execute("select * from main.flux_c15")
+    cols = [d[0] for d in cur.description]
+    obtenu = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+    con.close()
+
+    golden = json.loads(GOLDEN.read_text())
+    assert len(obtenu) == len(golden)
+
+    par_pdl = {r["pdl"]: r for r in obtenu}
+    for attendu in golden:
+        ligne = par_pdl[attendu["pdl"]]
+        for k, v in attendu.items():
+            if k in TRACABILITE:
+                continue
+            obt = ligne[k]
+            if k in COLONNES_INSTANT:
+                # Instant-correct : parse les deux côtés en datetime aware et compare.
+                assert _instant(obt) == _instant(v), f"pdl {attendu['pdl']} {k}: {obt!r} != {v!r}"
+            else:
+                # str() absorbe les types (bigint/double/date) : "6.0" == 6.0, "2531" == 2531.
+                assert str(obt) == str(v), f"pdl {attendu['pdl']} colonne {k}: dbt={obt!r} golden={v!r}"
+
+
+def _instant(valeur) -> datetime:
+    """Normalise un horodatage (datetime aware ou string ISO) en instant comparable."""
+    if isinstance(valeur, datetime):
+        return valeur
+    return datetime.fromisoformat(str(valeur))

--- a/tests/etl/test_xml_vers_dict.py
+++ b/tests/etl/test_xml_vers_dict.py
@@ -1,0 +1,26 @@
+"""Convertisseur XML→dict générique (ADR-0020, issue #124).
+
+Seam de landing XML partagé par tous les flux : transforme un document en dict
+imbriqué sans aucune connaissance du flux, prêt à être landé en colonne JSON puis
+linéarisé par un modèle dbt. La seule règle est structurelle.
+"""
+
+from electricore.etl.parsing.xml import xml_vers_dict
+
+
+def test_feuille_scalaire_conteneur_toujours_liste():
+    # Politique structurelle (flux-agnostique) imposée par le cast dbt aval :
+    # une feuille texte → sa valeur (str), scalaire ; un élément à enfants est la
+    # forme *répétable* → toujours une liste, même unique, pour que le cast
+    # `struct(...)[]` soit uniforme quel que soit le nombre d'occurrences.
+    xml = b"""<root>
+        <a>1</a>
+        <b><c>x</c><c>y</c></b>
+        <d><e>z</e></d>
+    </root>"""
+
+    assert xml_vers_dict(xml) == {
+        "a": "1",  # feuille unique → scalaire
+        "b": [{"c": ["x", "y"]}],  # conteneur unique → liste ; feuille répétée → liste
+        "d": [{"e": "z"}],  # conteneur unique → liste de 1
+    }


### PR DESCRIPTION
Deuxième tracer-bullet du prototype dbt (ADR-0020), sur le **flux le plus dur** : `nested_fields` conditionnels (avant/après via `Code_Qualification`) + pivot des cadrans. Suite de #123 (R64).

## Ce que ça apporte

- **`xml_vers_dict`** (`etl/parsing/xml.py`) — convertisseur XML→dict **générique**, zéro connaissance du flux. La sémantique métier (sélection, pivot, axe parent XPath) part dans le SQL dbt, pas en Python.
- **Politique « conteneur = liste »** : un élément à enfants est la forme *répétable* → toujours un tableau, même unique. C'est ce qui rend le cast/unnest dbt uniforme (DuckDB n'auto-emballe pas un objet seul dans un tableau). Coût assumé : les éléments uniques sont indexés `[0]` en SQL.
- **Landing C15** sur le seam raw-landing de #123 — R64 et C15 partagent la même couche brute (`lander_documents_bruts`).
- **`stg_c15` + `flux_c15`** : accès JSON tolérant (pas de cast struct géant, le document C15 est profond et casserait au moindre champ Enedis inattendu). L'axe parent `../Code_Qualification` devient un `WHERE`, le pivot devient une agrégation conditionnelle sur le domaine fermé des cadrans (`core/models/cadrans`).
- **Types issus du XSD C15 v5.2.0** (vérifiés) : `dateTime`→TIMESTAMPTZ, `date`→DATE, `integer`→BIGINT, `decimal`→DOUBLE.
- **Politique timezone tranchée** (ADR-0020, #124) : les horodatages sont typés instant-correct ; la parité golden compare l'**instant**, pas la représentation string (le golden porte les offsets `+02:00` de l'ancien parseur).

## Deux frictions DuckDB résolues (utiles pour #125)

1. **Pushdown sous l'unnest** : double `unnest` latéral + `WHERE` sur l'unnest interne → DuckDB pousse le prédicat JSON sous l'unnest et le caste contre l'objet pré-unnest. Fix : extraire en colonnes VARCHAR nommées **avant** tout filtre/cast.
2. **PIVOT natif** : plan invalide en combinaison double-unnest → remplacé par agrégation conditionnelle (schéma stable, domaine cadrans fermé).

## Acceptance criteria (#124)

- [x] Convertisseur XML→dict générique productionisé, testé isolément (`test_xml_vers_dict.py`)
- [x] Landing XML branché sur le seam raw-landing de #123
- [x] `flux_c15.sql` : champs plats + relevés avant/après pivotés, types XSD
- [x] Parité golden `flux_c15 == golden/flux_c15.json` (modulo traçabilité + tz)
- [x] `dbt build` vert (2 modèles + 2 data_tests) — `test_dbt_c15_golden.py`

Suite : #125 (flux XML restants), puis bascule production conditionnelle.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)