### PR TITLE
fix(dbt+etl): grain par occurrence de PRM + correction index/conso R15 (comparaison réelle)

### DIFF
--- a/electricore/etl/config/flux.yaml
+++ b/electricore/etl/config/flux.yaml
@@ -156,11 +156,21 @@ R15:
         ref_demandeur: 'Donnees_Releve/Ref_Demandeur'
         id_affaire: 'Donnees_Releve/Id_Affaire'
       nested_fields:
+        # Index distributeur uniquement. Chaque cadran porte 2 classes Sens=0 :
+        # Classe_Mesure=1 = index cumulé, Classe_Mesure=2 = énergie de période. Sans
+        # condition, le « dernier-écrit gagne » mélangeait index et conso selon l'ordre
+        # document (~75 % des index R15 faux). Condition ajoutée après comparaison
+        # legacy-vs-dbt sur données réelles (cf. flux_r15.sql).
         - prefix: ''
           child_path: 'Donnees_Releve/Classe_Temporelle_Distributeur'
           id_field: 'Id_Classe_Temporelle'
           value_field: 'Valeur'
-    
+          conditions:
+            - xpath: 'Classe_Mesure'
+              value: '1'
+            - xpath: 'Sens_Mesure'
+              value: '0'
+
     - name: "flux_r15_acc"
       file_regex: "*.xml"  # Même fichiers XML - traitement autoconsommation collective
       row_level: './/PRM'

--- a/electricore/etl/dbt/models/flux/flux_c15.sql
+++ b/electricore/etl/dbt/models/flux/flux_c15.sql
@@ -11,8 +11,14 @@
 -- `xml_vers_dict` rend tout conteneur tableau (« conteneur = liste ») → chaque
 -- élément unique est indexé `[0]`.
 
+-- Grain : une ligne par *occurrence de PRM* (prm_id = fichier + position), pas par
+-- PDL. Un même PDL revient dans plusieurs fichiers C15 (un par événement) ; agréger
+-- les relevés par PDL collerait le relevé le plus récent à tous ses événements. On
+-- scope donc l'agrégation des relevés sur prm_id, porté par le staging.
+
 with flat as (
     select
+        prm_id,
         prm ->> '$.Id_PRM'                                                    as pdl,
         prm ->> '$.Segment_Clientele'                                         as segment_clientele,
         prm ->> '$.Num_Depannage'                                             as num_depannage,
@@ -37,7 +43,7 @@ with flat as (
 -- JSON sous l'unnest et le caste contre la mauvaise valeur (objet pré-unnest).
 donnees as (
     select
-        prm ->> '$.Id_PRM' as pdl,
+        prm_id,
         t1.donnee
     from {{ ref('stg_c15') }},
         unnest(cast(prm -> '$.Evenement_Declencheur[0].Releves[0].Donnees_Releve' as json[])) as t1(donnee)
@@ -45,7 +51,7 @@ donnees as (
 
 classes as (
     select
-        pdl,
+        prm_id,
         donnee,
         t2.classe
     from donnees,
@@ -56,7 +62,7 @@ classes as (
 -- peut plus se faufiler dans l'unnest.
 extrait as (
     select
-        pdl,
+        prm_id,
         donnee ->> '$.Code_Qualification'          as code_qualif,
         classe ->> '$.Classe_Mesure'               as classe_mesure,
         classe ->> '$.Sens_Mesure'                 as sens_mesure,
@@ -71,7 +77,7 @@ extrait as (
 
 releves as (
     select
-        pdl,
+        prm_id,
         case when code_qualif = '1' then 'avant_' else 'apres_' end as prefixe,
         cadran,
         cast(valeur as bigint)           as valeur,
@@ -89,7 +95,7 @@ releves as (
 
 releves_agg as (
     select
-        pdl,
+        prm_id,
         max(case when prefixe = 'avant_' and cadran = 'base' then valeur end) as avant_index_base_kwh,
         max(case when prefixe = 'avant_' and cadran = 'hp' then valeur end) as avant_index_hp_kwh,
         max(case when prefixe = 'avant_' and cadran = 'hc' then valeur end) as avant_index_hc_kwh,
@@ -113,7 +119,7 @@ releves_agg as (
         max(case when prefixe = 'apres_' then id_calendrier_distributeur end) as apres_id_calendrier_distributeur,
         max(case when prefixe = 'apres_' then id_calendrier_fournisseur end)  as apres_id_calendrier_fournisseur
     from releves
-    group by pdl
+    group by prm_id
 )
 
-select * from flat left join releves_agg using (pdl)
+select * exclude (prm_id) from flat left join releves_agg using (prm_id)

--- a/electricore/etl/dbt/models/flux/flux_r15.sql
+++ b/electricore/etl/dbt/models/flux/flux_r15.sql
@@ -5,6 +5,7 @@
 
 with flat as (
     select
+        prm_id,
         prm ->> '$.Id_PRM'                                        as pdl,
         cast(prm ->> '$.Donnees_Releve[0].Date_Releve' as timestamptz) as date_releve,
         prm ->> '$.Donnees_Releve[0].Id_Calendrier'              as id_calendrier,
@@ -18,16 +19,34 @@ with flat as (
 ),
 
 classes as (
-    select
-        prm ->> '$.Id_PRM'                                                  as pdl,
-        'index_' || lower(c.classe ->> '$.Id_Classe_Temporelle') || '_kwh'  as cadran_col,
-        cast(c.classe ->> '$.Valeur' as bigint)                            as valeur
+    select prm_id, c.classe
     from {{ ref('stg_r15') }},
         unnest(cast(prm -> '$.Donnees_Releve[0].Classe_Temporelle_Distributeur' as json[])) as c(classe)
 ),
 
+-- Extraction en colonnes nommées AVANT le filtre (anti-pushdown, cf. flux_c15).
+extrait as (
+    select
+        prm_id,
+        classe ->> '$.Classe_Mesure'                                as classe_mesure,
+        classe ->> '$.Sens_Mesure'                                  as sens_mesure,
+        'index_' || lower(classe ->> '$.Id_Classe_Temporelle') || '_kwh' as cadran_col,
+        cast(classe ->> '$.Valeur' as bigint)                      as valeur
+    from classes
+),
+
+-- Index distributeur uniquement : Classe_Mesure = 1 (énergie) et Sens_Mesure = 0
+-- (soutirage). Le config legacy R15 n'avait PAS cette condition et tombait sur le
+-- bon cadran par accident d'ordre (dernier-écrit) ; on filtre explicitement — le
+-- comportement correct (décision : corriger plutôt que reproduire le legacy bancal).
+filtre as (
+    select prm_id, cadran_col, valeur
+    from extrait
+    where classe_mesure = '1' and sens_mesure = '0'
+),
+
 pivot_cadrans as (
-    pivot classes on cadran_col using first(valeur) group by pdl
+    pivot filtre on cadran_col using first(valeur) group by prm_id
 )
 
-select * from flat left join pivot_cadrans using (pdl)
+select * exclude (prm_id) from flat left join pivot_cadrans using (prm_id)

--- a/electricore/etl/dbt/models/flux/flux_r151.sql
+++ b/electricore/etl/dbt/models/flux/flux_r151.sql
@@ -7,6 +7,7 @@
 
 with flat as (
     select
+        prm_id,
         prm ->> '$.Id_PRM'                                              as pdl,
         cast(prm ->> '$.Donnees_Releve[0].Date_Releve' as date)         as date_releve,
         prm ->> '$.Donnees_Releve[0].Id_Calendrier_Fournisseur'         as id_calendrier_fournisseur,
@@ -18,15 +19,17 @@ with flat as (
 
 classes as (
     select
-        prm ->> '$.Id_PRM'                                                  as pdl,
+        prm_id,
         'index_' || lower(c.classe ->> '$.Id_Classe_Temporelle') || '_kwh'  as cadran_col,
         cast(c.classe ->> '$.Valeur' as bigint)                            as valeur
     from {{ ref('stg_r151') }},
         unnest(cast(prm -> '$.Donnees_Releve[0].Classe_Temporelle_Distributeur' as json[])) as c(classe)
 ),
 
+-- Pivot scopé par prm_id (occurrence de PRM), pas par PDL : un PDL revient à chaque
+-- période, agréger par PDL mélangerait les index de toutes les périodes.
 pivot_cadrans as (
-    pivot classes on cadran_col using first(valeur) group by pdl
+    pivot classes on cadran_col using first(valeur) group by prm_id
 )
 
-select * from flat left join pivot_cadrans using (pdl)
+select * exclude (prm_id) from flat left join pivot_cadrans using (prm_id)

--- a/electricore/etl/dbt/models/flux/flux_r15_acc.sql
+++ b/electricore/etl/dbt/models/flux/flux_r15_acc.sql
@@ -9,6 +9,7 @@
 
 with flat as (
     select
+        prm_id,
         prm ->> '$.Id_PRM'                                        as pdl,
         cast(prm ->> '$.Donnees_Releve[0].Date_Releve' as timestamptz) as date_releve,
         prm ->> '$.Donnees_Releve[0].Id_Calendrier'              as id_calendrier,
@@ -25,14 +26,14 @@ with flat as (
 ),
 
 classes as (
-    select prm ->> '$.Id_PRM' as pdl, c.classe
+    select prm_id, c.classe
     from {{ ref('stg_r15') }},
         unnest(cast(prm -> '$.Donnees_Releve[0].Classe_Temporelle_Distributeur' as json[])) as c(classe)
 ),
 
 extrait as (
     select
-        pdl,
+        prm_id,
         classe ->> '$.Classe_Mesure'               as classe_mesure,
         lower(classe ->> '$.Id_Classe_Temporelle') as cadran,
         classe ->> '$.Valeur'                      as valeur
@@ -41,7 +42,7 @@ extrait as (
 
 ea as (
     select
-        pdl,
+        prm_id,
         case classe_mesure
             when '3' then 'ea_autoproduite_'
             when '4' then 'ea_alloproduite_'
@@ -53,8 +54,9 @@ ea as (
     where classe_mesure in ('3', '4', '5', '6')
 ),
 
+-- Pivot scopé par prm_id, comme flux_r15 (un PDL revient dans plusieurs fichiers).
 pivot_ea as (
-    pivot ea on ea_col using first(valeur) group by pdl
+    pivot ea on ea_col using first(valeur) group by prm_id
 )
 
-select * from flat left join pivot_ea using (pdl)
+select * exclude (prm_id) from flat left join pivot_ea using (prm_id)

--- a/electricore/etl/dbt/models/staging/stg_c15.sql
+++ b/electricore/etl/dbt/models/staging/stg_c15.sql
@@ -9,9 +9,15 @@
 -- `xml_vers_dict` applique « conteneur = liste » : PRM est toujours un tableau,
 -- même unique → unnest direct.
 
+-- prm_id : clé d'occurrence stable (fichier + position du PRM), portée à l'aval pour
+-- scoper l'agrégation des relevés par PRM et non par PDL (un PDL revient dans
+-- plusieurs fichiers). generate_subscripts s'aligne sur unnest.
 select
     file_name,
     modification_date,
-    p.unnest as prm
-from {{ source('flux_raw', 'raw_c15') }},
-    unnest(cast(content -> '$.PRM' as json[])) as p
+    file_name || '#' || generate_subscripts(prms, 1) as prm_id,
+    unnest(prms)                                      as prm
+from (
+    select file_name, modification_date, cast(content -> '$.PRM' as json[]) as prms
+    from {{ source('flux_raw', 'raw_c15') }}
+)

--- a/electricore/etl/dbt/models/staging/stg_r15.sql
+++ b/electricore/etl/dbt/models/staging/stg_r15.sql
@@ -4,10 +4,19 @@
 -- classes ea_*) : même source brute, deux linéarisations. « conteneur = liste »
 -- (xml_vers_dict) → PRM toujours tableau, En_Tete_Flux indexé [0].
 
+-- prm_id : clé d'occurrence stable (fichier + position du PRM) pour scoper les relevés
+-- par PRM et non par PDL (un PDL revient dans de nombreux fichiers R15).
 select
     file_name,
     modification_date,
-    content ->> '$.En_Tete_Flux[0].Unite_Mesure_Index' as unite,
-    p.unnest                                           as prm
-from {{ source('flux_raw', 'raw_r15') }},
-    unnest(cast(content -> '$.PRM' as json[])) as p
+    unite,
+    file_name || '#' || generate_subscripts(prms, 1) as prm_id,
+    unnest(prms)                                      as prm
+from (
+    select
+        file_name,
+        modification_date,
+        content ->> '$.En_Tete_Flux[0].Unite_Mesure_Index' as unite,
+        cast(content -> '$.PRM' as json[])               as prms
+    from {{ source('flux_raw', 'raw_r15') }}
+)

--- a/electricore/etl/dbt/models/staging/stg_r151.sql
+++ b/electricore/etl/dbt/models/staging/stg_r151.sql
@@ -1,9 +1,18 @@
 -- Éclatement R151 : une ligne par PRM, unité portée depuis l'en-tête de flux.
 
+-- prm_id : clé d'occurrence stable (fichier + position du PRM) pour scoper les relevés
+-- par PRM et non par PDL (un PDL revient à chaque période dans les fichiers R151).
 select
     file_name,
     modification_date,
-    content ->> '$.En_Tete_Flux[0].Unite_Mesure_Index' as unite,
-    p.unnest                                           as prm
-from {{ source('flux_raw', 'raw_r151') }},
-    unnest(cast(content -> '$.PRM' as json[])) as p
+    unite,
+    file_name || '#' || generate_subscripts(prms, 1) as prm_id,
+    unnest(prms)                                      as prm
+from (
+    select
+        file_name,
+        modification_date,
+        content ->> '$.En_Tete_Flux[0].Unite_Mesure_Index' as unite,
+        cast(content -> '$.PRM' as json[])               as prms
+    from {{ source('flux_raw', 'raw_r151') }}
+)

--- a/tests/fixtures/flux/golden/flux_r15.json
+++ b/tests/fixtures/flux/golden/flux_r15.json
@@ -6,7 +6,7 @@
     "ref_situation_contractuelle": "554933217",
     "type_compteur": "CCB",
     "motif_releve": "CFNS",
-    "index_base_kwh": "100",
+    "index_base_kwh": "10160",
     "_source_zip": "fixture.zip",
     "_flux_type": "R15",
     "_xml_name": "r15.xml",


### PR DESCRIPTION
Deux bugs trouvés en **comparant legacy vs dbt sur ~4400 XML réels** (`flux_enedis_v2`) — **invisibles aux golden** (une seule occurrence par PDL dans les fixtures). C'est exactement ce que la comparaison devait débusquer.

## 1. Bug de grain (C15, R15, R151, R15_acc)

Un même PDL revient dans plusieurs fichiers (un par événement/période). Les modèles agrégeaient `group by pdl` puis joignaient `using (pdl)` → le relevé le plus récent était collé à **tous** les événements du PDL.

**Fix** : clé d'occurrence `prm_id` (`file_name` + position du PRM via `generate_subscripts`), portée par le staging ; agrégation/jointure scopées sur `prm_id`, exclue de la sortie.

→ **C15 et F12 en parité bit-pour-bit** sur le réel (1171/1171, 2489/2489).

## 2. Bug index/conso R15 (corrigé à la source)

Chaque cadran R15 porte **deux classes Sens=0** : `Classe_Mesure=1` = index cumulé, `Classe_Mesure=2` = énergie de période. Le config legacy R15 **n'a aucune condition** ; le « dernier-écrit gagne » prend CM1 ou CM2 **selon l'ordre document, incohérent par cadran** → **~75 % des index R15 legacy mélangent index et conso**.

**Fix appliqué à la source** : condition `Classe_Mesure=1 / Sens_Mesure=0` ajoutée dans **`flux.yaml`** (corrige le parseur legacy) ET dans le **modèle dbt** (extract-then-filter, anti-pushdown). Legacy et dbt redeviennent cohérents ; golden #121 et golden dbt régénérés à l'identique (10160).

> ⚠️ **Impact prod** : les prochains runs du pipeline legacy R15 stockeront l'index (CM1) au lieu du mélange index/conso. C'est la correction voulue (décision : corriger plutôt que reproduire le bug) — à garder en tête pour la cohérence du warehouse existant (lignes historiques bancales).

Validation : `dbt == legacy` (mêmes conditions) à **99 %** (7220/7301) ; 11 cas de perte = PRM injection pure (légitime).

## Parité sur données réelles après ce PR

| flux | état |
|---|---|
| C15 | ✅ bit-parfait (1171/1171) |
| F12 | ✅ bit-parfait (2489/2489) |
| R15 | ✅ corrigé, 99 % vs legacy-corrigé |
| R151 | ⚠️ résidu 383 — cause distincte (pas de `Classe_Mesure`, piste multi-`Donnees_Releve`) |
| R15_acc | ⚠️ résidu 34 — ordre du pivot `ea_` |
| F15 | ⚠️ gap de comptes — `Element_Valorise` nichés hors du chemin figé |

Suite 519 verte (golden legacy #121 + golden dbt + contrat de types). Résidus R151/R15_acc/F15 = travail de suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)