### PR TITLE
feat(etl): câblage production dbt + validation bascule — parité totale sur le corpus SFTP complet

### DIFF
--- a/electricore/etl/dbt/models/flux/flux_r64.sql
+++ b/electricore/etl/dbt/models/flux/flux_r64.sql
@@ -135,7 +135,7 @@ pivot_cadrans as (
 ),
 
 en_tete as (
-    select distinct mesure_id, id_demande, si_demandeur, code_flux, format
+    select distinct mesure_id, id_demande, si_demandeur, code_flux, format, modification_date
     from {{ ref('stg_r64') }}
 )
 
@@ -155,3 +155,10 @@ select
 from pivot_cadrans
 join meta using (mesure_id)
 join en_tete using (mesure_id)
+-- Les fenêtres R64 se chevauchent : le même relevé (pdl, type, date) arrive dans
+-- plusieurs fichiers. Même contrat que le merge legacy (primary_key pdl/type_releve/
+-- date_releve) : on garde la livraison la plus récente.
+qualify row_number() over (
+    partition by meta.pdl, meta.type_releve, pivot_cadrans.date_releve
+    order by en_tete.modification_date desc, mesure_id desc
+) = 1

--- a/electricore/etl/dbt/models/flux/flux_r64.sql
+++ b/electricore/etl/dbt/models/flux/flux_r64.sql
@@ -1,46 +1,157 @@
--- Linéarisation R64 : une ligne par (PDL, date de relevé), cadrans en colonnes.
+-- Linéarisation R64 : une ligne par (mesure, date de relevé), cadrans en colonnes.
 --
--- Remplace les ~250 lignes Python de `etl/parsing/r64.py` (cf. ADR-0020). La
--- sélection « calendrier distributeur uniquement » (is_valid_calendrier) devient
--- un WHERE ; le pivot wide « 1 mesure × N classes × N dates » devient un PIVOT.
+-- Sémantique = le parser legacy (etl/parsing/r64.py), validée par golden :
+-- - métadonnées (étape, contexte, grandeur, unité) du PREMIER couple
+--   contexte/grandeur valide (grandeurMetier=CONS, grandeurPhysique=EA) ;
+-- - points collectés sur TOUS les couples valides, calendriers distributeur
+--   uniquement, classes SANS idClasseTemporelle ignorées, points iv=0 ;
+-- - pivot par (mesure, date) — pas par PDL (grain occurrence, cf. C15/R15).
+--
+-- Accès JSON tolérant + extraction en colonnes nommées AVANT tout filtre
+-- (anti-pushdown DuckDB, cf. flux_c15).
 
-with points as (
+with contextes as (
     select
-        m.unnest."idPrm"                                                   as pdl,
-        ctx.unnest."etapeMetier"                                           as etape_metier,
-        ctx.unnest."contexteReleve"                                        as contexte_releve,
-        ctx.unnest."typeReleve"                                            as type_releve,
-        g.unnest."grandeurPhysique"                                        as grandeur_physique,
-        g.unnest."grandeurMetier"                                          as grandeur_metier,
-        g.unnest.unite                                                     as unite,
-        s.header."idDemande"                                               as id_demande,
-        s.header."siDemandeur"                                             as si_demandeur,
-        s.header."codeFlux"                                                as code_flux,
-        s.header.format                                                    as format,
-        'index_' || lower(ct.unnest."idClasseTemporelle") || '_kwh'        as cadran_col,
-        v.unnest.d                                                         as date_releve,
-        v.unnest.v                                                         as valeur
-    from {{ ref('stg_r64') }} s,
-        unnest(s.mesures) as m,
-        unnest(m.unnest.contexte) as ctx,
-        unnest(ctx.unnest.grandeur) as g,
-        unnest(g.unnest.calendrier) as cal,
-        unnest(cal.unnest."classeTemporelle") as ct,
-        unnest(ct.unnest.valeur) as v
-    where g.unnest."grandeurMetier" = 'CONS'
-      and g.unnest."grandeurPhysique" = 'EA'
-      -- Seuls les calendriers distributeur entrent dans les tables (is_valid_calendrier).
+        mesure_id,
+        mesure ->> '$.idPrm' as pdl,
+        generate_subscripts(ctxs, 1) as ctx_i,
+        unnest(ctxs)                 as ctx
+    from (
+        select mesure_id, mesure, cast(mesure -> '$.contexte' as json[]) as ctxs
+        from {{ ref('stg_r64') }}
+    )
+),
+
+grandeurs as (
+    select
+        mesure_id,
+        pdl,
+        ctx_i,
+        ctx,
+        generate_subscripts(gs, 1) as g_i,
+        unnest(gs)                 as g
+    from (
+        select mesure_id, pdl, ctx_i, ctx, cast(ctx -> '$.grandeur' as json[]) as gs
+        from contextes
+    )
+),
+
+grandeurs_extraites as (
+    select
+        mesure_id,
+        pdl,
+        ctx_i,
+        g_i,
+        ctx ->> '$.etapeMetier'      as etape_metier,
+        ctx ->> '$.contexteReleve'   as contexte_releve,
+        ctx ->> '$.typeReleve'       as type_releve,
+        g ->> '$.grandeurMetier'     as grandeur_metier,
+        g ->> '$.grandeurPhysique'   as grandeur_physique,
+        g ->> '$.unite'              as unite,
+        g
+    from grandeurs
+),
+
+-- Métadonnées : premier couple contexte/grandeur CONS+EA de chaque mesure.
+meta as (
+    select *
+    from (
+        select
+            mesure_id, pdl, etape_metier, contexte_releve, type_releve,
+            grandeur_metier, grandeur_physique, unite,
+            row_number() over (partition by mesure_id order by ctx_i, g_i) as rang
+        from grandeurs_extraites
+        where grandeur_metier = 'CONS' and grandeur_physique = 'EA'
+    )
+    where rang = 1
+),
+
+calendriers as (
+    select
+        mesure_id,
+        grandeur_metier,
+        grandeur_physique,
+        unnest(cals) as cal
+    from (
+        select mesure_id, grandeur_metier, grandeur_physique, cast(g -> '$.calendrier' as json[]) as cals
+        from grandeurs_extraites
+    )
+),
+
+classes as (
+    select
+        mesure_id,
+        grandeur_metier,
+        grandeur_physique,
+        cal ->> '$.idCalendrier'                  as id_calendrier,
+        lower(cal ->> '$.libelleCalendrier')      as libelle_calendrier,
+        unnest(cast(cal -> '$.classeTemporelle' as json[])) as classe
+    from calendriers
+),
+
+points as (
+    select
+        mesure_id,
+        grandeur_metier,
+        grandeur_physique,
+        id_calendrier,
+        libelle_calendrier,
+        id_classe,
+        p ->> '$.d'              as date_point,
+        p ->> '$.v'              as valeur_point,
+        p ->> '$.iv'             as iv
+    from (
+        select
+            mesure_id, grandeur_metier, grandeur_physique, id_calendrier, libelle_calendrier,
+            classe ->> '$.idClasseTemporelle' as id_classe,
+            cast(classe -> '$.valeur' as json[]) as pts
+        from classes
+    ), unnest(pts) as t(p)
+),
+
+-- Filtres legacy, appliqués sur colonnes nommées (anti-pushdown) :
+-- grandeur CONS/EA, calendrier distributeur, classe identifiée, point valide (iv=0).
+points_valides as (
+    select
+        mesure_id,
+        'index_' || lower(id_classe) || '_kwh' as cadran_col,
+        cast(date_point as timestamp)          as date_releve,
+        cast(valeur_point as bigint)           as valeur
+    from points
+    where grandeur_metier = 'CONS'
+      and grandeur_physique = 'EA'
       and (
-          cal.unnest."idCalendrier" in ('DI000001', 'DI000002', 'DI000003')
-          or lower(cal.unnest."libelleCalendrier") like '%distributeur%'
+          id_calendrier in ('DI000001', 'DI000002', 'DI000003')
+          or libelle_calendrier like '%distributeur%'
       )
-      and v.unnest.iv = 0
-      and v.unnest.d is not null
-      and v.unnest.v is not null
+      and id_classe is not null
+      and iv = '0'
+      and date_point is not null
+      and valeur_point is not null
+),
+
+pivot_cadrans as (
+    pivot points_valides on cadran_col using first(valeur) group by mesure_id, date_releve
+),
+
+en_tete as (
+    select distinct mesure_id, id_demande, si_demandeur, code_flux, format
+    from {{ ref('stg_r64') }}
 )
 
-pivot points
-on cadran_col using first(valeur)
-group by
-    pdl, etape_metier, contexte_releve, type_releve, grandeur_physique,
-    grandeur_metier, unite, id_demande, si_demandeur, code_flux, format, date_releve
+select
+    meta.pdl,
+    meta.etape_metier,
+    meta.contexte_releve,
+    meta.type_releve,
+    meta.grandeur_physique,
+    meta.grandeur_metier,
+    meta.unite,
+    en_tete.id_demande,
+    en_tete.si_demandeur,
+    en_tete.code_flux,
+    en_tete.format,
+    pivot_cadrans.* exclude (mesure_id)
+from pivot_cadrans
+join meta using (mesure_id)
+join en_tete using (mesure_id)

--- a/electricore/etl/dbt/models/staging/stg_r64.sql
+++ b/electricore/etl/dbt/models/staging/stg_r64.sql
@@ -1,38 +1,28 @@
--- Cast du document JSON brut en structs typés.
+-- Éclatement R64 : une ligne par mesure (PDL), métadonnées d'en-tête à plat.
 --
--- Récupère l'ergonomie de read_json (accès `m.unnest.idPrm`) sur une *colonne*
--- JSON landée par dlt — un seul cast par flux, le modèle flux_ aval reste propre
--- (cf. ADR-0020, fork α). Le type est le schéma du flux R64 ; il est dérivable
--- du XSD R6X (Documents/guides_flux/Enedis.SGE.GUI.0503.Flux.R6X) — ici capturé
--- par inférence DuckDB sur un échantillon réel.
+-- Accès JSON tolérant (->>), PAS de cast struct : le corpus réel porte 4 formes
+-- différentes de classeTemporelle (avec/sans codeCadran, avec/sans idClasseTemporelle)
+-- et le cast struct strict de DuckDB casse sur les clés absentes — c'est la limite
+-- « inférence sur échantillon » annoncée par l'ADR-0020, rencontrée au premier run
+-- complet réel. mesure_id (fichier + position) scope l'agrégation aval.
 
 select
     file_name,
     modification_date,
-    cast(content -> '$.header' as struct(
-        "idDemande" varchar, "siDemandeur" varchar, "typeDestinataire" varchar,
-        "idDestinataire" varchar, "codeFlux" varchar, "modePublication" varchar,
-        "idCanalContact" varchar, format varchar, "publicationCrp" varchar
-    )) as header,
-    cast(content -> '$.mesures' as struct(
-        "idPrm" varchar,
-        periode struct("dateDebut" timestamp, "dateFin" timestamp),
-        contexte struct(
-            "etapeMetier" varchar, "contexteReleve" varchar, "typeReleve" varchar,
-            grandeur struct(
-                "grandeurMetier" varchar, "grandeurPhysique" varchar, unite varchar,
-                calendrier struct(
-                    "idCalendrier" varchar, "libelleCalendrier" varchar, "libelleGrille" varchar,
-                    "classeTemporelle" struct(
-                        "idClasseTemporelle" varchar, "libelleClasseTemporelle" varchar,
-                        "codeCadran" varchar,
-                        valeur struct(d timestamp, v bigint, iv bigint)[]
-                    )[]
-                )[],
-                "cadranTotalisateur" struct(
-                    "codeCadran" varchar, valeur struct(d timestamp, v bigint, iv bigint)[]
-                )
-            )[]
-        )[]
-    )[]) as mesures
-from {{ source('flux_raw', 'raw_r64') }}
+    id_demande,
+    si_demandeur,
+    code_flux,
+    format,
+    file_name || '#' || generate_subscripts(mesures, 1) as mesure_id,
+    unnest(mesures)                                      as mesure
+from (
+    select
+        file_name,
+        modification_date,
+        content ->> '$.header.idDemande'     as id_demande,
+        content ->> '$.header.siDemandeur'   as si_demandeur,
+        content ->> '$.header.codeFlux'      as code_flux,
+        content ->> '$.header.format'        as format,
+        cast(content -> '$.mesures' as json[]) as mesures
+    from {{ source('flux_raw', 'raw_r64') }}
+)

--- a/electricore/etl/pipeline_dbt.py
+++ b/electricore/etl/pipeline_dbt.py
@@ -1,0 +1,179 @@
+"""Pipeline de production dbt : SFTP → landing brut JSON → modèles dbt (ADR-0020).
+
+Chemin complet du prototype dbt sur données réelles :
+1. DLT déplace (SFTP, déchiffrement AES, unzip) et dépose chaque document intégral
+   en colonne JSON dans `flux_raw.raw_<flux>` (source `flux_enedis_brut`) ;
+2. `dbt build` matérialise les tables `main.flux_*` (staging + linéarisation + data
+   tests not_null).
+
+Usage :
+    uv run python electricore/etl/pipeline_dbt.py test            # 2 fichiers/flux
+    uv run python electricore/etl/pipeline_dbt.py all             # tout
+    uv run python electricore/etl/pipeline_dbt.py r151 c15        # sélection
+    uv run python electricore/etl/pipeline_dbt.py all --db /tmp/flux_dbt.duckdb
+
+La base par défaut est séparée de la production legacy
+(`flux_enedis_dbt.duckdb` vs `flux_enedis_pipeline.duckdb`) : les deux chemins
+peuvent tourner côte à côte pendant la période de validation.
+"""
+
+# Charger .env avant que DLT lise ses secrets depuis os.environ (SFTP__URL, AES__*).
+import os as _os
+from pathlib import Path as _Path
+
+for _c in [_Path(".env"), _Path(__file__).parents[2] / ".env"]:
+    if _c.exists():
+        with open(_c) as _f:
+            for _l in _f:
+                _l = _l.strip()
+                if _l and not _l.startswith("#") and "=" in _l:
+                    _k, _, _v = _l.partition("=")
+                    _os.environ.setdefault(_k.strip(), _v.strip())
+        break
+
+import argparse
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+import dlt
+import yaml
+
+from electricore.etl.sources.sftp_enedis_brut import flux_enedis_brut
+
+# DLT écrit sur stderr — on laisse faire, on ne lit que stdout
+logging.disable(logging.CRITICAL)
+
+ICI = Path(__file__).parent
+DB_DEFAUT = ICI / "flux_enedis_dbt.duckdb"
+PROJET_DBT = ICI / "dbt"
+
+
+def _out(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def lander_brut(db_path: Path, flux_selection: list[str] | None, max_files: int | None) -> None:
+    """Étape 1 : SFTP → tables raw_<flux> (colonne JSON) dans flux_raw."""
+    config = yaml.safe_load((ICI / "config" / "flux.yaml").read_text())
+    if flux_selection:
+        config = {k: v for k, v in config.items() if k in flux_selection}
+
+    pipeline = dlt.pipeline(
+        pipeline_name=f"flux_brut_{db_path.stem}",
+        destination=dlt.destinations.duckdb(str(db_path)),
+        dataset_name="flux_raw",
+        progress="log",
+    )
+    info = pipeline.run(flux_enedis_brut(config, max_files=max_files))
+    for paquet in info.load_packages:
+        for job in paquet.jobs.get("completed_jobs", []):
+            _out(f"  landé : {job.job_file_info.table_name}")
+
+
+# Modèles dbt servis par chaque table brute (raw_r15 sert deux linéarisations).
+MODELES_PAR_RAW = {
+    "raw_c15": ["flux_c15"],
+    "raw_r15": ["flux_r15", "flux_r15_acc"],
+    "raw_r151": ["flux_r151"],
+    "raw_f12": ["flux_f12_detail"],
+    "raw_f15": ["flux_f15_detail"],
+    "raw_r64": ["flux_r64"],
+}
+
+
+def construire_dbt(db_path: Path) -> bool:
+    """Étape 2 : dbt build (modèles + data tests), restreint aux tables brutes landées.
+
+    La restriction --select évite l'échec sur les sources absentes (sélection
+    partielle de flux, smoke avec max_files tombant sur des zips sans contenu utile
+    comme les R64 de l'ère CSV).
+    """
+    import duckdb
+    from dbt.cli.main import dbtRunner
+
+    con = duckdb.connect(str(db_path), read_only=True)
+    presentes = {t for (t,) in con.execute("select table_name from information_schema.tables").fetchall()}
+    con.close()
+    selection = [f"+{modele}" for raw, modeles in MODELES_PAR_RAW.items() if raw in presentes for modele in modeles]
+    if not selection:
+        _out("  aucune table brute landée — rien à construire")
+        return False
+
+    os.environ["DBT_DUCKDB_PATH"] = str(db_path)
+    resultat = dbtRunner().invoke(
+        [
+            "build",
+            "--select",
+            *selection,
+            "--project-dir",
+            str(PROJET_DBT),
+            "--profiles-dir",
+            str(PROJET_DBT),
+            "--target-path",
+            str(db_path.parent / f".dbt_target_{db_path.stem}"),
+        ]
+    )
+    return bool(resultat.success)
+
+
+def bilan(db_path: Path) -> None:
+    """Comptes par table — brut et matérialisé."""
+    import duckdb
+
+    # Lecture-écriture : dbt vient d'écrire dans le même process, une connexion
+    # read_only aurait une config DuckDB incompatible.
+    con = duckdb.connect(str(db_path))
+    lignes = con.execute(
+        """
+        select table_schema, table_name from information_schema.tables
+        where table_name like 'raw_%' or table_name like 'flux_%'
+        order by table_schema, table_name
+        """
+    ).fetchall()
+    for schema, table in lignes:
+        if table.startswith("_dlt"):
+            continue
+        n = con.execute(f'select count(*) from "{schema}"."{table}"').fetchone()[0]
+        _out(f"  {schema}.{table}: {n}")
+    con.close()
+
+
+def main() -> None:
+    parseur = argparse.ArgumentParser(description="Pipeline dbt : SFTP → brut JSON → modèles dbt")
+    parseur.add_argument("flux", nargs="+", help="'all', 'test' (2 fichiers/flux) ou liste de flux (r151 c15 …)")
+    parseur.add_argument("--db", type=Path, default=DB_DEFAUT, help=f"base DuckDB cible (défaut : {DB_DEFAUT})")
+    parseur.add_argument("--max-files", type=int, default=None, help="limite de fichiers par flux")
+    args = parseur.parse_args()
+
+    selection: list[str] | None
+    max_files = args.max_files
+    if args.flux == ["all"]:
+        selection = None
+    elif args.flux == ["test"]:
+        selection = None
+        max_files = max_files or 2
+    else:
+        selection = [f.upper() for f in args.flux]
+
+    debut = time.time()
+    _out(f"🚀 Landing brut → {args.db}")
+    lander_brut(args.db, selection, max_files)
+    _out(f"⏱️  Landing : {time.time() - debut:.1f}s")
+
+    debut = time.time()
+    _out("🔨 dbt build")
+    if not construire_dbt(args.db):
+        _out("❌ dbt build a échoué")
+        sys.exit(1)
+    _out(f"⏱️  dbt : {time.time() - debut:.1f}s")
+
+    _out("📊 Bilan")
+    bilan(args.db)
+    _out("✅ Terminé")
+
+
+if __name__ == "__main__":
+    main()

--- a/electricore/etl/sources/sftp_enedis_brut.py
+++ b/electricore/etl/sources/sftp_enedis_brut.py
@@ -1,0 +1,90 @@
+"""Source DLT « brut » : dépose les documents Enedis intégraux en colonne JSON (ADR-0020).
+
+Même chaîne de mouvement que la source legacy (`sftp | decrypt | unzip`), mais le
+dernier étage ne linéarise PAS : il convertit le document en dict générique
+(`xml_vers_dict` pour les flux XML, `json.loads` pour R64) et le dépose tel quel dans
+une table `raw_<flux>`. La linéarisation (sélection + pivot + typage) vit ensuite dans
+les modèles dbt (`electricore/etl/dbt/`).
+
+Une table brute par TYPE de flux (raw_r15 sert flux_r15 ET flux_r15_acc), clé primaire
+`file_name` en merge : les re-livraisons Enedis (même XML dans plusieurs zips, contenus
+identiques observés) sont dédoublonnées par construction — le legacy, lui, les
+double-comptait.
+"""
+
+import json
+import logging
+import os
+from collections.abc import Iterator
+
+import dlt
+
+from electricore.etl.parsing.xml import xml_vers_dict
+from electricore.etl.sources.sftp_enedis import create_sftp_resource, mask_password_in_url
+from electricore.etl.transformers.archive import create_unzip_transformer
+from electricore.etl.transformers.crypto import create_decrypt_transformer
+
+logger = logging.getLogger(__name__)
+
+
+def _create_brut_transformer(flux_type: str, est_json: bool):
+    """Transformer final : fichier extrait → document brut (colonne JSON)."""
+
+    @dlt.transformer
+    def vers_document_brut(extracted_file: dict) -> Iterator[dict]:
+        contenu: bytes = extracted_file["extracted_content"]
+        document = json.loads(contenu) if est_json else xml_vers_dict(contenu)
+        yield {
+            "file_name": extracted_file["extracted_file_name"],
+            "modification_date": extracted_file["modification_date"],
+            "_source_zip": extracted_file["source_zip"],
+            "_flux_type": flux_type,
+            "content": document,
+        }
+
+    return vers_document_brut
+
+
+@dlt.source(name="flux_enedis_brut")
+def flux_enedis_brut(flux_config: dict, max_files: int = None):
+    """Source DLT déposant le brut JSON de chaque flux dans `raw_<flux>`.
+
+    Args:
+        flux_config: Sections de flux.yaml (C15, R15, …) — seuls file_pattern et
+            file_regex sont consommés (la sélection xml_configs appartient à dbt).
+        max_files: Limitation par flux (smoke tests).
+    """
+    sftp_url = os.environ.get("SFTP__URL") or dlt.secrets["sftp"]["url"]
+    logger.info("Source URL: %s", mask_password_in_url(sftp_url))
+
+    decrypt_transformer = create_decrypt_transformer()
+
+    for flux_type, config_flux in flux_config.items():
+        file_pattern = config_flux["file_pattern"]
+        table = f"raw_{flux_type.lower()}"
+
+        if "xml_configs" in config_flux:
+            est_json = False
+            # Le file_regex est identique entre les configs d'un même flux (R15 :
+            # flux_r15 et flux_r15_acc lisent les mêmes XML) — on prend la première.
+            file_regex = config_flux["xml_configs"][0].get("file_regex", "*.xml")
+            extension = ".xml"
+        elif "json_configs" in config_flux:
+            est_json = True
+            file_regex = config_flux["json_configs"][0].get("file_regex", "*.json")
+            extension = ".json"
+        else:
+            continue
+
+        sftp_resource = create_sftp_resource(flux_type, table, file_pattern, sftp_url, max_files)
+        unzip_transformer = create_unzip_transformer(extension, file_regex)
+        brut = _create_brut_transformer(flux_type, est_json)
+
+        pipeline_brut = (sftp_resource | decrypt_transformer | unzip_transformer | brut).with_name(table)
+        pipeline_brut.apply_hints(
+            primary_key="file_name",
+            write_disposition="merge",
+            # `json` empêche dlt d'exploser le document en tables filles.
+            columns={"content": {"data_type": "json"}},
+        )
+        yield pipeline_brut

--- a/electricore/etl/tools/comparaison_bases.py
+++ b/electricore/etl/tools/comparaison_bases.py
@@ -1,0 +1,70 @@
+"""Compare deux bases DuckDB table par table, par empreintes canoniques.
+
+Outil de validation de bascule (ADR-0020) : après un run complet des deux pipelines
+sur le même SFTP (legacy → flux_enedis.*, dbt → main.*), compare chaque table flux_*
+en multiset d'empreintes — modulo traçabilité, représentation (instants heure-mur UTC,
+nombres) et exclusions documentées par table.
+
+Verdict du 11/06/2026 (corpus SFTP complet, ~700k lignes par côté) : parité totale
+7/7 tables ; seuls extras legacy = re-livraisons double-comptées (128 R15, 261 F15).
+
+Usage :
+    uv run python -m electricore.etl.tools.comparaison_bases \
+        <db_legacy> <schema_legacy> <db_dbt> <schema_dbt>
+    # ex. /tmp/flux_legacy_full.duckdb flux_enedis /tmp/flux_dbt_full.duckdb main
+"""
+
+import sys
+from collections import Counter
+
+import duckdb
+
+from electricore.etl.tools.comparaison_legacy_dbt import TRACABILITE, canonique
+
+TABLES = ["flux_c15", "flux_r15", "flux_r15_acc", "flux_r151", "flux_f12_detail", "flux_f15_detail", "flux_r64"]
+
+# R64 : les fenêtres de livraison se chevauchent — le même relevé (pdl, type, date,
+# valeurs IDENTIQUES) arrive sous plusieurs id_demande. Le « gagnant » du merge legacy
+# est arbitraire (ordre interne dlt), celui de dbt est déterministe (livraison la plus
+# récente). Vérifié : 27876/27876 divergences portaient uniquement sur id_demande.
+EXCLUSIONS_PAR_TABLE = {"flux_r64": {"id_demande"}}
+
+
+def empreintes(db, schema, table):
+    exclues = EXCLUSIONS_PAR_TABLE.get(table, set())
+    con = duckdb.connect(db, read_only=True)
+    try:
+        cur = con.execute(f'select * from "{schema}"."{table}"')
+    except duckdb.CatalogException:
+        con.close()
+        return None
+    cols = [d[0] for d in cur.description]
+    compte = Counter()
+    while True:
+        rows = cur.fetchmany(50000)
+        if not rows:
+            break
+        for r in rows:
+            compte[
+                frozenset(
+                    (k, canonique(v))
+                    for k, v in zip(cols, r, strict=True)
+                    if k not in TRACABILITE and k not in exclues and not k.startswith("_dlt") and v is not None
+                )
+            ] += 1
+    con.close()
+    return compte
+
+
+db_l, sch_l, db_d, sch_d = sys.argv[1:5]
+for table in TABLES:
+    cl = empreintes(db_l, sch_l, table)
+    cd = empreintes(db_d, sch_d, table)
+    if cl is None or cd is None:
+        print(f"{table}: absente ({'legacy' if cl is None else ''}{'dbt' if cd is None else ''})")
+        continue
+    inter = sum((cl & cd).values())
+    print(
+        f"{table}: legacy={sum(cl.values())} dbt={sum(cd.values())} identiques={inter} "
+        f"seul_legacy={sum((cl - cd).values())} seul_dbt={sum((cd - cl).values())}"
+    )

--- a/electricore/etl/tools/comparaison_legacy_dbt.py
+++ b/electricore/etl/tools/comparaison_legacy_dbt.py
@@ -99,8 +99,7 @@ def canonique(valeur: Any) -> Any:
     if valeur is None:
         return None
     if isinstance(valeur, datetime):
-        instant = valeur.astimezone(UTC) if valeur.tzinfo else valeur
-        return ("dt", instant.isoformat())
+        return ("dt", _heure_mur_utc(valeur))
     if isinstance(valeur, date):
         return ("d", valeur.isoformat())
     texte = str(valeur)
@@ -110,7 +109,7 @@ def canonique(valeur: Any) -> Any:
         pass
     if _RE_DATETIME.match(texte):
         try:
-            return ("dt", datetime.fromisoformat(texte).astimezone(UTC).isoformat())
+            return ("dt", _heure_mur_utc(datetime.fromisoformat(texte)))
         except ValueError:
             pass
     if _RE_DATE.match(texte):
@@ -118,6 +117,20 @@ def canonique(valeur: Any) -> Any:
     # Modulo espaces de bord : xml_vers_dict strip les feuilles, le legacy garde les
     # espaces Enedis (« Composante de relevé résiduel  » a un espace final en source).
     return ("s", texte.strip())
+
+
+def _heure_mur_utc(valeur: datetime) -> str:
+    """Horodatage canonique : heure-mur UTC, sans offset.
+
+    Les aware sont convertis en UTC puis l'offset tombe ; les naïfs restent tels
+    quels. Équivaut « naïf == UTC » — c'est la convention dlt du legacy (les dates
+    R64 sans offset sont stockées comme instants UTC), et pour les sources à offset
+    (C15 +02:00) les deux côtés convergent vers la même heure-mur UTC : la
+    comparaison reste une comparaison d'instants.
+    """
+    if valeur.tzinfo:
+        return valeur.astimezone(UTC).replace(tzinfo=None).isoformat()
+    return valeur.isoformat()
 
 
 def empreinte(record: dict) -> frozenset:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ no_implicit_optional = true         # forbid `x: str = None`
 
 [tool.ruff.lint.per-file-ignores]
 "electricore/etl/pipeline_production.py" = ["E402"]  # sys.path setup before imports
+"electricore/etl/pipeline_dbt.py" = ["E402"]  # chargement .env avant imports (secrets DLT)
 "electricore/etl/sources/sftp_enedis.py" = ["E402"]  # imports after section banner
 "electricore/etl/transformers/archive.py" = ["E402"]  # cross-module import after constants block
 "electricore/etl/tools/debug_single_flux.py" = ["E722"]  # debug-only script, bare except OK


### PR DESCRIPTION
La pièce différée de l'ADR-0020 (câblage production) **+ la validation que tu demandais** : run réel en mode distant des deux chemins sur le même SFTP, bases tmp, comparaison record-par-record.

## Câblage

- **`sources/sftp_enedis_brut.py`** — source DLT « brut » : réutilise la chaîne de mouvement legacy (`sftp | decrypt | unzip`), dernier étage = `xml_vers_dict`/`json.loads` déposé intégralement en colonne JSON dans `raw_<flux>`. Merge sur `file_name` → les re-livraisons Enedis sont dédoublonnées par construction.
- **`pipeline_dbt.py`** — runner 2 étapes (landing DLT → `dbt build` restreint aux tables landées), CLI `test`/`all`/sélection, `--db` pour base jetable. Base par défaut séparée du legacy : cohabitation pendant la validation.

## Deux corrections découvertes par le run complet réel

1. **R64 cast struct → accès JSON tolérant** : le corpus porte 4 formes de `classeTemporelle` (avec/sans `codeCadran`/`idClasseTemporelle`) — la limite « inférence sur échantillon » *annoncée par l'ADR-0020*, rencontrée au premier run. Réécrit sur le motif C15, sémantique legacy répliquée (golden vert).
2. **R64 dédup déterministe** : les fenêtres R64 se chevauchent, même relevé livré N fois. Même contrat que le merge legacy (`pdl, type_releve, date_releve`) mais gagnant **déterministe** (livraison la plus récente) là où dlt choisissait arbitrairement — vérifié : 27 876 doublons aux **valeurs strictement identiques**, seul `id_demande` variait.

## Verdict — corpus SFTP complet, ~700 k lignes par côté

| table | legacy | dbt | identiques | seul legacy | seul dbt |
|---|---|---|---|---|---|
| flux_c15 | 2 204 | 2 204 | **2 204** | 0 | 0 |
| flux_r15 | 17 459 | 17 331 | **17 331** | 128* | 0 |
| flux_r15_acc | 17 459 | 17 331 | **17 331** | 128* | 0 |
| flux_r151 | 274 830 | 274 830 | **274 830** | 0 | 0 |
| flux_f12_detail | 3 976 | 3 976 | **3 976** | 0 | 0 |
| flux_f15_detail | 142 175 | 141 914 | **141 914** | 261* | 0 |
| flux_r64 | 166 525 | 166 525 | **166 525** | 0 | 0 |

\* uniquement les re-livraisons que le legacy double-compte (bug documenté PR #132). **Zéro ligne dbt absente du legacy. Zéro divergence de valeur.**

Perfs : landing 13,5 min (réseau) / `dbt build` **13 s** pour 700 k lignes / 27/27 PASS data tests compris. Outil du verdict pérennisé (`tools/comparaison_bases.py`).

## Reste pour la bascule (hors scope ici)

Déploiement VPS (cron/runner), bascule des loaders core vers la nouvelle base, retrait de `etl/parsing/` + source legacy. La condition ADR-0020 est plus que remplie : parité prouvée sur golden, sur cache local ET sur le corpus SFTP complet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)