### PR TITLE
refactor(config): résolution unique du chemin DuckDB — chemin_base_duckdb()

### DIFF
--- a/docs/adr/0019-roles-loaders-pipelines-builds-integrations.md
+++ b/docs/adr/0019-roles-loaders-pipelines-builds-integrations.md
@@ -124,3 +124,12 @@ La section *Concepts pipeline* de [`electricore/core/CONTEXT.md`](../../electric
 - **`pipeline_cta` reste un *pipeline* malgré sa jointure de 2 sources hétérogènes.** Choix conscient pour ne pas casser les imports et notebooks existants. La justification (« même domaine métier ») est valable mais subjective ; si une autre fonction frôle cette ambiguïté, statuer cas par cas.
 
 - **Le test d'architecture détecte les imports interdits, pas les violations sémantiques** (ex : un fichier de `core/pipelines/` qui ferait du calcul I/O via une lib qui ne s'appelle pas `electricore.loaders`). Couverture imparfaite mais utile.
+
+## Addendum (juin 2026, issue #146)
+
+**`electricore/config/` est le socle transverse de la table ci-dessus** : stdlib-only
+(chargement `.env`, résolution `chemin_base_duckdb()`, config Odoo, CSV de taux),
+importable par tous les rôles — `core/` compris, sans violer [ADR-0016](0016-core-erp-agnostique.md)
+(aucune dépendance ERP ni lib externe). Premier usage : `core/loaders/duckdb/`,
+`api/services/`, le runner ETL et les tools délèguent la résolution du chemin de la
+base DuckDB à `chemin_base_duckdb()` au lieu de porter chacun leur propre défaut.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ Convention dlt : `SECTION__CLÉ` ⇔ `dlt.secrets['section']['clé']` — le fic
 
 | variable | rôle | défaut |
 |---|---|---|
-| `DUCKDB_PATH` | la base DuckDB de production — lue par **trois** consommateurs : loaders core (`core/loaders/duckdb/config.py`), API (`api/services/duckdb_service.py`), runner ETL (`pipeline_dbt.chemin_db_defaut`). En Docker : `/data/flux_enedis_pipeline.duckdb` (volume) | `electricore/etl/flux_enedis_pipeline.duckdb` |
+| `DUCKDB_PATH` | la base DuckDB de production — résolue par **un seul module**, `chemin_base_duckdb()` (`electricore/config/env.py`, `.env` honoré, issue #146), consommé par les loaders core, l'API, le runner ETL et les tools (`reset_incremental_state`). En Docker : `/data/flux_enedis_pipeline.duckdb` (volume) | `electricore/etl/flux_enedis_pipeline.duckdb` (absolu, ancré sur le dépôt — indépendant du CWD) |
 | `DBT_DUCKDB_PATH` | chemin vu par dbt (`etl/dbt/profiles.yml`) — **positionné automatiquement** par le runner et les tests ; ne se règle pas à la main | suit `DUCKDB_PATH` via le runner |
 
 Schémas dans la base : `flux_raw` (brut JSON), `flux_enedis` (tables typées, lues par

--- a/electricore/api/services/duckdb_service.py
+++ b/electricore/api/services/duckdb_service.py
@@ -4,17 +4,15 @@ Fonctions pures pour lire les tables de flux Enedis.
 """
 
 import logging
-import os
 from datetime import UTC, datetime
-from pathlib import Path
 
 import duckdb
 
+from electricore.config import chemin_base_duckdb
 from electricore.core.loaders.duckdb import duckdb_readonly_conn
 
 logger = logging.getLogger(__name__)
 
-DB_PATH = Path(os.getenv("DUCKDB_PATH", "electricore/etl/flux_enedis_pipeline.duckdb"))
 SCHEMA = "flux_enedis"
 
 
@@ -29,19 +27,20 @@ def get_freshness() -> dict:
         - tables: dict {nom_table: estimated_size}, ou {} si inaccessible
         - error: chaîne descriptive si accessible=False
     """
+    db_path = chemin_base_duckdb()
     payload: dict = {"accessible": False, "last_write": None, "tables": {}}
     try:
-        st = DB_PATH.stat()
+        st = db_path.stat()
         payload["last_write"] = datetime.fromtimestamp(st.st_mtime, tz=UTC).isoformat()
     except FileNotFoundError:
-        payload["error"] = f"Fichier DuckDB introuvable: {DB_PATH}"
+        payload["error"] = f"Fichier DuckDB introuvable: {db_path}"
         return payload
     except OSError as exc:
         payload["error"] = f"Erreur accès fichier: {exc}"
         return payload
 
     try:
-        with duckdb_readonly_conn(DB_PATH) as conn:
+        with duckdb_readonly_conn(db_path) as conn:
             rows = conn.execute(
                 "SELECT table_name, estimated_size FROM duckdb_tables() "
                 "WHERE schema_name = ? AND table_name LIKE 'flux_%' "
@@ -65,7 +64,7 @@ def get_table_info(table_name: str) -> dict:
     Returns:
         Dict avec table, count, columns
     """
-    with duckdb_readonly_conn(DB_PATH) as conn:
+    with duckdb_readonly_conn(chemin_base_duckdb()) as conn:
         # Nombre de lignes
         count = conn.execute(f"SELECT COUNT(*) FROM {SCHEMA}.flux_{table_name}").fetchone()[0]
 
@@ -90,7 +89,7 @@ def list_tables() -> list[str]:
     Returns:
         Liste des noms de tables (sans préfixe flux_)
     """
-    with duckdb_readonly_conn(DB_PATH) as conn:
+    with duckdb_readonly_conn(chemin_base_duckdb()) as conn:
         tables = conn.execute(f"""
             SELECT table_name 
             FROM information_schema.tables 

--- a/electricore/config/__init__.py
+++ b/electricore/config/__init__.py
@@ -1,4 +1,4 @@
-from electricore.config.env import charger_env
+from electricore.config.env import charger_env, chemin_base_duckdb
 from electricore.config.odoo import charger_config_odoo
 
-__all__ = ["charger_env", "charger_config_odoo"]
+__all__ = ["charger_env", "charger_config_odoo", "chemin_base_duckdb"]

--- a/electricore/config/env.py
+++ b/electricore/config/env.py
@@ -1,12 +1,17 @@
 """
-Loader partagé pour le fichier .env.
+Loader partagé pour le fichier .env et résolution de l'environnement.
 
 Utilisé par l'API, les notebooks, et l'ETL pour charger les variables
-d'environnement depuis le fichier .env à la racine du projet.
+d'environnement depuis le fichier .env à la racine du projet, et pour
+résoudre le chemin de la base DuckDB de production (issue #146).
 """
 
 import os
+from collections.abc import Mapping
 from pathlib import Path
+
+# Base de prod locale, ancrée sur le package (jamais sur le CWD).
+_DEFAUT_BASE_DUCKDB = Path(__file__).parents[1] / "etl" / "flux_enedis_pipeline.duckdb"
 
 
 def charger_env() -> None:
@@ -34,3 +39,20 @@ def charger_env() -> None:
                             value = value[1:-1]
                         os.environ.setdefault(key.strip(), value)
             break
+
+
+def chemin_base_duckdb(env: Mapping[str, str] | None = None) -> Path:
+    """Résolution unique du chemin de la base DuckDB de production.
+
+    `DUCKDB_PATH` sinon défaut absolu ancré sur le dépôt — indépendant du CWD.
+
+    Args:
+        env: mapping d'environnement explicite (tests, résolution hors process).
+            `None` = environnement réel : `.env` chargé via `charger_env()`
+            puis `os.environ`.
+    """
+    if env is None:
+        charger_env()
+        env = os.environ
+    brut = env.get("DUCKDB_PATH")
+    return Path(brut) if brut else _DEFAUT_BASE_DUCKDB

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -178,6 +178,9 @@ Source et sink ERP. Expose des fonctions qui retournent des `LazyFrame[Schema co
 **Service API** (`api/services/`) :
 Wire-up non-trivial ou stateful entre sources (loaders + integrations) et builds. Lieu où les sources ERP rencontrent les builds core. Routeur reste pur transport.
 
+**Config partagée** (`electricore/config/`) :
+Socle transverse, stdlib-only : chargement `.env` (`charger_env`), résolution du chemin de la base DuckDB (`chemin_base_duckdb`, issue #146), config Odoo, CSV de taux régulés. Importable par **tous** les modules (`core/` compris — compatible ADR-0016 : aucune dépendance ERP ni lib externe). C'est le seul module hors `core/models/` que `core/loaders/` peut importer.
+
 ---
 
 ## Concepts pipeline

--- a/electricore/core/loaders/duckdb/config.py
+++ b/electricore/core/loaders/duckdb/config.py
@@ -6,7 +6,6 @@ pour l'accès aux bases DuckDB dans un style fonctionnel.
 """
 
 import logging
-import os
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -14,6 +13,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import duckdb
+
+from electricore.config import chemin_base_duckdb
 
 logger = logging.getLogger(__name__)
 
@@ -34,8 +35,6 @@ _TABLE_MAPPINGS = {
     },
 }
 
-_DEFAULT_DB_PATH = "electricore/etl/flux_enedis_pipeline.duckdb"
-
 
 @dataclass(frozen=True, slots=True)
 class DuckDBConfig:
@@ -45,7 +44,7 @@ class DuckDBConfig:
 
     @classmethod
     def from_env(cls) -> "DuckDBConfig":
-        return cls(Path(os.getenv("DUCKDB_PATH", _DEFAULT_DB_PATH)))
+        return cls(chemin_base_duckdb())
 
     @classmethod
     def from_path(cls, path: str | Path | None) -> "DuckDBConfig":

--- a/electricore/etl/pipeline_dbt.py
+++ b/electricore/etl/pipeline_dbt.py
@@ -19,18 +19,9 @@ dans `flux_raw`. `--db` permet une base jetable pour les validations.
 """
 
 # Charger .env avant que DLT lise ses secrets depuis os.environ (SFTP__URL, AES__*).
-import os as _os
-from pathlib import Path as _Path
+from electricore.config import charger_env, chemin_base_duckdb
 
-for _c in [_Path(".env"), _Path(__file__).parents[2] / ".env"]:
-    if _c.exists():
-        with open(_c) as _f:
-            for _l in _f:
-                _l = _l.strip()
-                if _l and not _l.startswith("#") and "=" in _l:
-                    _k, _, _v = _l.partition("=")
-                    _os.environ.setdefault(_k.strip(), _v.strip())
-        break
+charger_env()
 
 import argparse
 import logging
@@ -53,9 +44,10 @@ PROJET_DBT = ICI / "dbt"
 
 
 def chemin_db_defaut() -> Path:
-    """Base cible par défaut : DUCKDB_PATH (volume Docker, cf. docker-compose) sinon
-    la base de prod locale — même résolution que l'API et les loaders core."""
-    return Path(os.getenv("DUCKDB_PATH", str(ICI / "flux_enedis_pipeline.duckdb")))
+    """Base cible par défaut : DUCKDB_PATH (.env compris, volume Docker via compose)
+    sinon la base de prod locale — résolution partagée avec l'API et les loaders
+    core (`chemin_base_duckdb`, issue #146)."""
+    return chemin_base_duckdb()
 
 
 def _out(msg: str) -> None:

--- a/electricore/etl/tools/reset_incremental_state.py
+++ b/electricore/etl/tools/reset_incremental_state.py
@@ -6,15 +6,17 @@ DLT stocke l'état dans DEUX endroits :
   1. Fichier local  : ~/.dlt/pipelines/{pipeline}/state.json  (prioritaire au démarrage)
   2. DuckDB         : flux_enedis._dlt_pipeline_state         (restauré au lancement)
 
-Ce script met à jour les deux de manière cohérente.
+Ce script met à jour les deux de manière cohérente. La base visée est résolue
+par `chemin_base_duckdb()` (DUCKDB_PATH, .env compris — issue #146) : le script
+se lance depuis n'importe quel répertoire.
 
-Usage (depuis electricore/etl/) :
+Usage :
     # Reset complet (efface tous les curseurs → retraite tout depuis le début)
-    uv run --extra etl python tools/reset_incremental_state.py --clear
+    uv run --extra etl python electricore/etl/tools/reset_incremental_state.py --clear
 
     # Reset à une date (retraite les fichiers depuis cette date)
-    uv run --extra etl python tools/reset_incremental_state.py 2026-03-17
-    uv run --extra etl python tools/reset_incremental_state.py          # défaut : 2026-03-17
+    uv run --extra etl python electricore/etl/tools/reset_incremental_state.py 2026-03-17
+    uv run --extra etl python electricore/etl/tools/reset_incremental_state.py  # défaut : 2026-03-17
 """
 
 import base64
@@ -26,7 +28,9 @@ from pathlib import Path
 
 import duckdb
 
-DB_PATH = Path("flux_enedis_pipeline.duckdb")
+from electricore.config import chemin_base_duckdb
+
+DB_PATH = chemin_base_duckdb()
 DATASET = "flux_enedis"
 RESET_DATE_DEFAULT = "2026-03-17T00:00:00+00:00"
 

--- a/tests/core/loaders/test_duckdb_loader.py
+++ b/tests/core/loaders/test_duckdb_loader.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, patch
 import polars as pl
 import pytest
 
+from electricore.config import chemin_base_duckdb
 from electricore.core.loaders.duckdb import (
     DuckDBConfig,
     DuckDBQuery,
@@ -37,10 +38,20 @@ from electricore.core.loaders.duckdb.transforms import (
 class TestDuckDBConfig:
     """Tests pour DuckDBConfig et ses factories."""
 
-    def test_from_env_default_path(self):
-        """from_env() sans variable d'env retourne le chemin par défaut."""
-        config = DuckDBConfig.from_env()
-        assert config.database_path == Path("electricore/etl/flux_enedis_pipeline.duckdb")
+    def test_from_env_meme_resolution_que_le_resolveur(self, monkeypatch):
+        """from_env() délègue au résolveur partagé (issue #146) — plus de défaut propre.
+
+        Ordre volontaire : from_env() d'abord — s'il ne déléguait pas, il rendrait
+        son propre défaut avant que le résolveur n'ait chargé le .env.
+        """
+        monkeypatch.delenv("DUCKDB_PATH", raising=False)
+        depuis_config = DuckDBConfig.from_env().database_path
+        assert depuis_config == chemin_base_duckdb()
+
+    def test_from_env_honore_duckdb_path(self, monkeypatch):
+        """DUCKDB_PATH explicite prime, telle quelle."""
+        monkeypatch.setenv("DUCKDB_PATH", "/data/flux.duckdb")
+        assert DuckDBConfig.from_env().database_path == Path("/data/flux.duckdb")
 
     def test_from_path_custom_path(self):
         """from_path() avec un chemin explicite le convertit en Path."""

--- a/tests/etl/test_pipeline_dbt.py
+++ b/tests/etl/test_pipeline_dbt.py
@@ -43,6 +43,20 @@ def test_la_base_par_defaut_honore_duckdb_path(monkeypatch):
     assert chemin_db_defaut().name == "flux_enedis_pipeline.duckdb"
 
 
+def test_la_base_par_defaut_honore_le_dotenv(tmp_path, monkeypatch):
+    """Même résolution que l'API et les loaders core (issue #146) : un DUCKDB_PATH
+    porté par le .env vaut pour le runner aussi, pas seulement pour l'API."""
+    from pathlib import Path
+
+    from electricore.etl.pipeline_dbt import chemin_db_defaut
+
+    monkeypatch.delenv("DUCKDB_PATH", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("DUCKDB_PATH=/data/depuis_dotenv.duckdb\n")
+
+    assert chemin_db_defaut() == Path("/data/depuis_dotenv.duckdb")
+
+
 def test_l_api_subprocess_le_runner_dbt():
     """La bascule #134 : /etl/run lance le chemin dbt, plus le parseur legacy."""
     from electricore.api.services.etl_service import _build_pipeline_command

--- a/tests/etl/test_reset_incremental_state.py
+++ b/tests/etl/test_reset_incremental_state.py
@@ -1,0 +1,24 @@
+"""Le tool de reset des curseurs DLT honore DUCKDB_PATH (issue #146).
+
+`etl/tools/` n'est pas un package : on exécute le module par chemin, comme le
+ferait `uv run python tools/reset_incremental_state.py`.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_CHEMIN_TOOL = Path(__file__).parents[2] / "electricore" / "etl" / "tools" / "reset_incremental_state.py"
+
+
+def _charger_tool():
+    spec = importlib.util.spec_from_file_location("reset_incremental_state", _CHEMIN_TOOL)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_le_tool_honore_duckdb_path(monkeypatch):
+    """DUCKDB_PATH posé → le tool vise cette base, plus un chemin relatif au CWD."""
+    monkeypatch.setenv("DUCKDB_PATH", "/data/autre.duckdb")
+    tool = _charger_tool()
+    assert tool.DB_PATH == Path("/data/autre.duckdb")

--- a/tests/unit/test_chemin_base_duckdb.py
+++ b/tests/unit/test_chemin_base_duckdb.py
@@ -1,0 +1,33 @@
+"""Tests du résolveur unique du chemin de la base DuckDB (issue #146).
+
+Le résolveur est l'unique réponse à « où est la base de production ? » :
+`DUCKDB_PATH` sinon défaut absolu ancré sur le dépôt. Le paramètre `env`
+rend la résolution déterministe en test (le `.env` local peut définir
+`DUCKDB_PATH` sans fausser ces tests) ; `env=None` = environnement réel.
+"""
+
+from pathlib import Path
+
+from electricore.config import chemin_base_duckdb
+
+
+def test_duckdb_path_honore_tel_quel():
+    """DUCKDB_PATH prime sur le défaut ; la valeur est restituée telle quelle (pas de resolve)."""
+    assert chemin_base_duckdb(env={"DUCKDB_PATH": "/data/flux.duckdb"}) == Path("/data/flux.duckdb")
+
+
+def test_env_reel_honore(monkeypatch):
+    """env=None : l'environnement du process est lu (setenv prime sur le .env, jamais écrasé)."""
+    monkeypatch.setenv("DUCKDB_PATH", "/data/process.duckdb")
+    assert chemin_base_duckdb() == Path("/data/process.duckdb")
+
+
+def test_defaut_absolu_et_independant_du_cwd(tmp_path, monkeypatch):
+    """Sans DUCKDB_PATH : défaut absolu ancré dépôt, identique quel que soit le CWD."""
+    depuis_repo = chemin_base_duckdb(env={})
+    monkeypatch.chdir(tmp_path)
+    depuis_ailleurs = chemin_base_duckdb(env={})
+
+    assert depuis_repo.is_absolute()
+    assert depuis_repo == depuis_ailleurs
+    assert depuis_repo.name == "flux_enedis_pipeline.duckdb"

--- a/tests/unit/test_duckdb_service_resolution.py
+++ b/tests/unit/test_duckdb_service_resolution.py
@@ -1,0 +1,19 @@
+"""Le service DuckDB de l'API résout le chemin de la base à l'appel (issue #146).
+
+L'import du module en tête de fichier est volontaire : un chemin figé à
+l'import ignorerait le `DUCKDB_PATH` posé ensuite par le test — c'est
+précisément le comportement corrigé.
+"""
+
+from electricore.api.services import duckdb_service
+
+
+def test_get_freshness_resout_a_l_appel(tmp_path, monkeypatch):
+    """DUCKDB_PATH posé après l'import est honoré ; l'erreur nomme le chemin résolu."""
+    base_absente = tmp_path / "absente.duckdb"
+    monkeypatch.setenv("DUCKDB_PATH", str(base_absente))
+
+    payload = duckdb_service.get_freshness()
+
+    assert payload["accessible"] is False
+    assert str(base_absente) in payload["error"]


### PR DESCRIPTION
## Quoi

Un seul module répond à « où est la base de production ? » : `chemin_base_duckdb()` dans `electricore/config/` — `DUCKDB_PATH` (`.env` compris via `charger_env`) sinon défaut **absolu ancré sur le dépôt**, indépendant du CWD.

Avant : 4 sites résolvaient le chemin avec 3 défauts différents (deux relatifs au CWD, un absolu, un qui ignorait `DUCKDB_PATH`). Le commit `71101cd` avait déjà payé un bug de cette dispersion.

## Les 4 consommateurs délèguent

- **loaders core** : `DuckDBConfig.from_env()` — défaut relatif au CWD supprimé
- **API** : `duckdb_service` résout **à l'appel** (plus de `DB_PATH` figé à l'import) ; l'erreur de `get_freshness()` nomme le chemin résolu
- **runner dbt** : `chemin_db_defaut()` partage enfin la résolution que son docstring promettait, `.env` compris ; le mini-loader `.env` inline (copie de `charger_env` sans strip des guillemets) est remplacé par le loader canonique
- **tools** : `reset_incremental_state` honore `DUCKDB_PATH`, lançable depuis n'importe quel répertoire

## Tests (TDD, 6 cycles RED→GREEN)

Le paramètre `env` du résolveur rend la résolution déterministe en test — un `.env` local définissant `DUCKDB_PATH` ne fausse rien. Le test legacy qui pinnait l'ancien défaut CWD-relatif est remplacé par le nouveau contrat (équivalence avec le résolveur partagé).

Suite complète : **526 passed, 35 skipped** · ruff + pre-commit OK.

## Docs

`docs/configuration.md` (ligne `DUCKDB_PATH`), addendum ADR-0019 et entrée **Config partagée** dans `core/CONTEXT.md` actant l'import `core/` → `electricore.config` (stdlib-only, compatible ADR-0016) — servira aussi au test whitelist de #144.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)