### PR TITLE
refactor(builds): contexte_du_mois() — l'entrée I/O du contexte mensuel

### DIFF
--- a/electricore/api/services/facturation_service.py
+++ b/electricore/api/services/facturation_service.py
@@ -15,17 +15,17 @@ Les 3 fonctions de service correspondent aux 4 endpoints :
 
 import polars as pl
 
-from electricore.core.builds.contexte_mensuel import ContexteMensuel, charger, documents, rapprocher
+from electricore.core.builds.contexte_mensuel import ContexteMensuel, contexte_du_mois, documents, rapprocher
 from electricore.core.builds.rapport_facturation import RapportFacturation
 from electricore.core.builds.rapport_facturation import rapport_facturation as _rapport_facturation_core
-from electricore.core.loaders import c15, f15, releves_harmonises
+from electricore.core.loaders import c15, f15
 from electricore.integrations.odoo.reader import OdooReader
 from electricore.integrations.odoo.sources import lignes_factures_du_mois
 
 
 def _contexte_et_lignes(odoo: OdooReader, mois: str | None) -> tuple[ContexteMensuel, pl.DataFrame]:
-    """Charge le contexte mensuel (loaders DuckDB) et les lignes Odoo du mois résolu."""
-    contexte = charger(c15().lazy(), releves_harmonises().lazy(), mois=mois)
+    """Charge le contexte mensuel (sources par défaut, #145) et les lignes Odoo du mois résolu."""
+    contexte = contexte_du_mois(mois)
     lignes_df = lignes_factures_du_mois(odoo, contexte.mois).collect()
     return contexte, lignes_df
 

--- a/electricore/api/services/taxes_service.py
+++ b/electricore/api/services/taxes_service.py
@@ -18,9 +18,8 @@ Les 4 fonctions de service correspondent aux 6 endpoints :
 
 import polars as pl
 
-from electricore.core.builds.contexte_mensuel import charger
+from electricore.core.builds.contexte_mensuel import contexte_du_mois
 from electricore.core.builds.rapport_taxe import RapportTaxe, rapport_accise, rapport_cta
-from electricore.core.loaders import c15, releves_harmonises
 from electricore.core.models.accise_mensuel import AcciseMensuel
 from electricore.core.models.cta_mensuel import CtaMensuel
 from electricore.core.pipelines.accise import pipeline_accise
@@ -71,7 +70,7 @@ def rapport_cta_service(odoo: OdooReader, trimestre: str | None = None) -> Rappo
     Returns:
         `RapportTaxe(resume, par_taux, detail)` validé.
     """
-    contexte = charger(c15().lazy(), releves_harmonises().lazy(), mois=None)
+    contexte = contexte_du_mois(mois=None)
     return rapport_cta(contexte.facturation_mensuelle, mapping_pdl_order(odoo), trimestre)
 
 
@@ -85,7 +84,7 @@ def cta_par_contrat_service(odoo: OdooReader, trimestre: str | None = None) -> p
     Returns:
         `DataFrame` shape `CtaMensuel` (grain (situation contractuelle, mois) garanti).
     """
-    contexte = charger(c15().lazy(), releves_harmonises().lazy(), mois=None)
+    contexte = contexte_du_mois(mois=None)
     df_mensuel = pipeline_cta(
         contexte.facturation_mensuelle.lazy(),
         mapping_pdl_order(odoo).lazy(),

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -210,7 +210,7 @@ Mois calendaire d'une période (abonnement, énergie, méta-période, taxes), cl
 _Éviter_ : mois_consommation (fusionné), libellé `"mars 2025"` comme clé (trie `août < avril`).
 
 **Contexte mensuel de facturation** :
-Bundle immutable des éléments dérivés une seule fois pour produire la facturation d'un mois donné : `historique_enrichi`, `abonnements`, `energie`, `facturation_mensuelle` (méta-périodes du mois). Construit par `charger()` dans `core/builds/contexte_mensuel.py` (cf. [ADR-0019](../../docs/adr/0019-roles-loaders-pipelines-builds-integrations.md)) ; partagé par les builds qui touchent au même mois (rapprochement, documents de campagne, taxes mensuelles) pour ne déclencher le pipeline `facturation()` qu'une seule fois.
+Bundle immutable des éléments dérivés une seule fois pour produire la facturation d'un mois donné : `historique_enrichi`, `abonnements`, `energie`, `facturation_mensuelle` (méta-périodes du mois). Deux entrées dans `core/builds/contexte_mensuel.py` (cf. [ADR-0019](../../docs/adr/0019-roles-loaders-pipelines-builds-integrations.md)) : `charger(historique, releves, mois)` — composition pure, frames fournis par l'appelant (tests, notebooks, source alternative) — et `contexte_du_mois(mois)` — entrée I/O qui résout les sources par défaut (loaders DuckDB) puis délègue à `charger()` (issue #145, scindage pur/I-O prévu par les « Limites » d'ADR-0019). Partagé par les builds qui touchent au même mois (rapprochement, documents de campagne, taxes mensuelles) pour ne déclencher le pipeline `facturation()` qu'une seule fois.
 _Éviter_ : résultat de facturation (trop vague), contexte tout court (sans qualificatif).
 
 **Rapprochement facturation mensuelle** :

--- a/electricore/core/builds/contexte_mensuel.py
+++ b/electricore/core/builds/contexte_mensuel.py
@@ -2,9 +2,12 @@
 
 Voir `core/CONTEXT.md` (entrée *Contexte mensuel de facturation*).
 
-`charger()` prend `historique` et `relevés` en LazyFrame — les loaders restent
-à la charge de l'appelant (adapter ERP, router API). Le module ne déclenche
-aucune I/O.
+`charger()` prend `historique` et `relevés` en LazyFrame et ne déclenche
+aucune I/O — c'est la composition pure, l'interface des tests (fixtures).
+`contexte_du_mois()` est l'entrée I/O (#145) : elle résout les sources par
+défaut (loaders DuckDB `c15` / `releves_harmonises`) puis délègue à
+`charger()` — application du scindage pur/I-O prévu par les « Limites »
+d'ADR-0019.
 
 `rapprocher()` joint les *lignes de facture* (shape agnostique `LignesFacture`)
 à la facturation Enedis du mois porté par le `ContexteMensuel`, et dérive en
@@ -24,6 +27,7 @@ import pandera.polars as pa
 import polars as pl
 from pandera.typing.polars import DataFrame
 
+from electricore.core.loaders import c15, releves_harmonises
 from electricore.core.models.cadrans import col_energie
 from electricore.core.models.lignes_facture import LignesFacture
 from electricore.core.models.lignes_facture_rapprochees import LignesFactureRapprochees
@@ -135,6 +139,25 @@ def charger(
         energie=energie,
         facturation_mensuelle=facturation_mensuelle,
     )
+
+
+def contexte_du_mois(mois: str | None = None) -> ContexteMensuel:
+    """Entrée I/O du contexte mensuel : sources par défaut puis `charger()` (#145).
+
+    Résout les deux sources canoniques (loaders DuckDB `c15` et
+    `releves_harmonises`) et délègue la composition à `charger()`. Qui dispose
+    déjà de frames (tests, notebooks, autre source) appelle `charger()`
+    directement.
+
+    Args:
+        mois: format `YYYY-MM-DD` (premier jour du mois). `None` → dernier mois
+            disponible.
+
+    Raises:
+        FileNotFoundError: si la base DuckDB est absente (levée par les loaders
+            à l'appel — leur `.lazy()` exécute la lecture immédiatement).
+    """
+    return charger(c15().lazy(), releves_harmonises().lazy(), mois=mois)
 
 
 @pa.check_types(lazy=True)

--- a/tests/integration/test_taxes_service_smoke.py
+++ b/tests/integration/test_taxes_service_smoke.py
@@ -1,8 +1,8 @@
-"""Tests smoke de `cta_par_contrat_service` (ADR-0019, issue #108).
+"""Tests smoke de `cta_par_contrat_service` (ADR-0019, issues #108, #145).
 
 Garantit que le service délègue le chargement de la facturation à
-`core.builds.contexte_mensuel.charger` plutôt que de reconstruire la
-trio `c15 + releves_harmonises + facturation()`.
+`core.builds.contexte_mensuel.contexte_du_mois` (sources par défaut, #145)
+plutôt que de reconstruire le trio `c15 + releves_harmonises + facturation()`.
 
 Depuis #108, la logique de wire-up vit dans `api/services/taxes_service.py`.
 """
@@ -14,11 +14,11 @@ import polars as pl
 from electricore.core.builds.contexte_mensuel import ContexteMensuel
 
 
-def test_cta_par_contrat_service_delegue_a_charger(monkeypatch):
-    """`cta_par_contrat_service` consomme `ContexteMensuel` via `charger()`.
+def test_cta_par_contrat_service_delegue_a_contexte_du_mois(monkeypatch):
+    """`cta_par_contrat_service` consomme `ContexteMensuel` via `contexte_du_mois()`.
 
-    Invariant : le service délègue la composition à `core/builds/contexte_mensuel.py`,
-    sans reconstruire `c15 + releves + facturation()`.
+    Invariant : le service délègue chargement ET composition à
+    `core/builds/contexte_mensuel.py` — un seul nom à patcher (#145).
     """
     import electricore.api.services.taxes_service as svc
 
@@ -44,15 +44,13 @@ def test_cta_par_contrat_service_delegue_a_charger(monkeypatch):
         energie=pl.LazyFrame(),
         facturation_mensuelle=df_facturation,
     )
-    appels_charger: list[tuple] = []
+    appels: list = []
 
-    def _capture_charger(historique, releves, mois=None):
-        appels_charger.append((historique, releves, mois))
+    def _capture_contexte(mois=None):
+        appels.append(mois)
         return contexte_prefab
 
-    monkeypatch.setattr(svc, "charger", _capture_charger)
-    monkeypatch.setattr(svc, "c15", lambda: pl.LazyFrame())
-    monkeypatch.setattr(svc, "releves_harmonises", lambda: pl.LazyFrame())
+    monkeypatch.setattr(svc, "contexte_du_mois", _capture_contexte)
 
     class _QueryMock:
         def __init__(self, df):
@@ -73,7 +71,7 @@ def test_cta_par_contrat_service_delegue_a_charger(monkeypatch):
 
     result = svc.cta_par_contrat_service(odoo=None)
 
-    assert len(appels_charger) == 1, "charger() doit être appelé exactement une fois"
-    assert appels_charger[0][2] is None, "charger() doit être appelé avec mois=None"
+    assert len(appels) == 1, "contexte_du_mois() doit être appelé exactement une fois"
+    assert appels[0] is None, "contexte_du_mois() doit être appelé avec mois=None"
     assert isinstance(result, pl.DataFrame)
     assert "cta_eur" in result.columns

--- a/tests/unit/test_contexte_mensuel.py
+++ b/tests/unit/test_contexte_mensuel.py
@@ -112,3 +112,41 @@ class TestChargerFramesQuiPassent:
         # facturation_mensuelle est une DataFrame (déjà collectée)
         assert isinstance(ctx.facturation_mensuelle, pl.DataFrame)
         assert "debut" in ctx.facturation_mensuelle.columns
+
+
+class TestContexteDuMois:
+    """`contexte_du_mois()` — l'entrée I/O (#145) : loaders DuckDB par défaut, puis `charger()`."""
+
+    def test_cable_les_loaders_et_delegue_a_charger(self, monkeypatch):
+        """c15 → historique, releves_harmonises → relevés (sentinelles : l'inversion échoue)."""
+        import electricore.core.builds.contexte_mensuel as cm
+
+        hist_sentinel = pl.LazyFrame({"source": ["c15"]})
+        rel_sentinel = pl.LazyFrame({"source": ["releves"]})
+
+        class _Query:
+            def __init__(self, lf):
+                self._lf = lf
+
+            def lazy(self):
+                return self._lf
+
+        monkeypatch.setattr(cm, "c15", lambda: _Query(hist_sentinel))
+        monkeypatch.setattr(cm, "releves_harmonises", lambda: _Query(rel_sentinel))
+
+        captures: dict = {}
+        composition = _make_stub_composition(debuts_mois=[datetime(2025, 3, 1)])
+
+        def _composer_capture(historique, releves):
+            captures["historique"] = historique
+            captures["releves"] = releves
+            return composition
+
+        monkeypatch.setattr(cm, "_composer", _composer_capture)
+
+        ctx = cm.contexte_du_mois(mois="2025-03-01")
+
+        assert captures["historique"] is hist_sentinel
+        assert captures["releves"] is rel_sentinel
+        assert isinstance(ctx, ContexteMensuel)
+        assert ctx.mois == "2025-03-01"

--- a/tests/unit/test_facturation_service.py
+++ b/tests/unit/test_facturation_service.py
@@ -47,10 +47,9 @@ def test_documents_facturation_du_mois_returns_fr_sheet_names(monkeypatch):
         energie=pl.LazyFrame(),
         facturation_mensuelle=df_fact_mensuelle,
     )
-    monkeypatch.setattr(facturation_service, "charger", lambda historique, releves, mois=None: contexte_prefab)
-
-    # Les loaders sont évalués côté caller AVANT charger() (topologie #87).
-    monkeypatch.setattr(facturation_service, "releves_harmonises", lambda: pl.LazyFrame())
+    # Un seul nom à patcher depuis #145 (contre charger + c15 + releves_harmonises avant) ;
+    # c15/f15 restent patchés plus bas pour les onglets bruts de documents() (topologie #87).
+    monkeypatch.setattr(facturation_service, "contexte_du_mois", lambda mois=None: contexte_prefab)
 
     df_lignes_odoo = pl.DataFrame(
         {


### PR DESCRIPTION
## Quoi

Issue #145 (candidat 3 de la revue d'architecture), design grillé ce jour. L'incantation `charger(c15().lazy(), releves_harmonises().lazy(), mois=…)` était récitée à 3 endroits — le choix des loaders, l'appel `.lazy()` et leur ordre faisaient partie de l'interface du build.

**Décision : scindage pur/I-O** (le pattern qu'ADR-0019 esquissait déjà dans ses « Limites »), plutôt que des paramètres optionnels sur `charger()` :

- `charger(historique, releves, mois)` — inchangé, composition **pure**, frames in → bundle out, interface des tests. Le docstring du module (« aucune I/O ») redevient exact.
- `contexte_du_mois(mois)` — l'entrée **I/O**, co-localisée : résout les sources canoniques (loaders DuckDB) puis délègue à `charger()`. Signature strictement `mois` (pas de sources surchargeables — qui a des frames appelle `charger()`). Le `FileNotFoundError` base-absente est porté par cette entrée seule : `DuckDBQuery.lazy()` exécute la lecture immédiatement, fait vérifié en séance.

Le nom rejoint la famille `*_du_mois` (« résout le mois cible et lit ce qu'il faut » : `facturation_du_mois`, `lignes_factures_du_mois`) ; la paire devient lisible — `charger(frames)` = pur, `contexte_du_mois(mois)` = I/O.

## Décisions de périmètre

- Les loaders `f15`/`c15` du chemin documents restent explicites au service — topologie #87, non ré-arbitrée ici.
- Pas d'ADR : application littérale de l'échappatoire documentée d'ADR-0019.

## Tests

- Smoke test du câblage par sentinelles distinguables (l'inversion `historique`/`releves` échoue sur identité).
- Gain prédit et constaté : les tests de services patchent **un** nom (`contexte_du_mois`) au lieu de trois (`charger` + `c15` + `releves_harmonises`).
- Suite complète : **532 passed, 35 skipped** · ruff + pre-commit OK.

## Docs

CONTEXT.md — entrée *Contexte mensuel de facturation* : les deux entrées documentées. Docstrings module + fonctions à jour.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)