### PR TITLE
feat(api): check Odoo pré-facturation exporté en XLSX par l'API (#150)

### DIFF
--- a/docs/adr/0022-surface-bot-domaines-hybrides.md
+++ b/docs/adr/0022-surface-bot-domaines-hybrides.md
@@ -1,0 +1,16 @@
+# Surface de commandes du bot par domaines hybrides
+
+La surface du bot Telegram passe de 11 commandes plates (`/etl`, `/status`, `/stats`, `/export`, `/flux`, `/entrees`, `/sorties`, `/taxes`, `/facturation`, `/check`, `/start`) à 5 domaines métier : `/etl` (ingestion), `/flux` (tables brutes Enedis), `/perimetre` (entrées/sorties C15), `/taxes` (accise, CTA), `/facturation` (documents + contrôles pré-facturation). Un domaine invoqué sans argument ouvre un clavier inline — découvrabilité, zéro syntaxe à retenir — ; avec arguments, il agit directement (raccourci power-user, ex : `/taxes accise 2025-T1`). Les actions coûteuses (`resync` : purge de l'état incrémental dlt + re-téléchargement SFTP complet) exigent une confirmation à deux taps. La bascule est big bang, sans alias de compatibilité.
+
+## Alternatives rejetées
+
+- **Surface plate cohérente** (`/etl_run`, `/taxes_accise`…) : autocomplete maximal dans le menu natif, mais le menu grossit linéairement avec chaque fonction.
+- **Hub `/menu` unique** 100 % boutons : zéro syntaxe, mais perd l'autocomplete, le deep-linking par commande et la rapidité power-user.
+- **Alias de transition** des anciennes commandes : code mort garanti pour une allowlist de quelques personnes joignables directement.
+
+## Conséquences
+
+- [ADR-0010](0010-bot-telegram-ui-operationnelle.md) reste valide : le choix Telegram et le statut de contrat de la surface ne changent pas. Le contrat est cassé une seule fois, annoncé dans le chat des opérateurs.
+- Le menu natif (`setMyCommands`) est publié au démarrage et adapté à l'instance : les domaines ERP-dépendants (`/taxes`, `/facturation`) sont masqués quand aucun ERP n'est configuré, et répondent par un message explicite s'ils sont tapés quand même.
+- Chaque instance a son bot, nommé `@<slug>_electricore_bot` ; `/start` annonce l'instance servie.
+- Le mode déprécié `reset` disparaît de la surface ; `rebuild`, `resync` et la sélection de flux arbitraire (déjà supportés par l'API) y entrent.

--- a/electricore/api/routers/facturation.py
+++ b/electricore/api/routers/facturation.py
@@ -9,7 +9,7 @@ from electricore.api.config import settings
 from electricore.api.decorators import arrow_endpoint, xlsx_endpoint
 from electricore.api.security import get_current_api_key
 from electricore.api.serializers import arrow_stream, xlsx_multi_sheet
-from electricore.api.services.check_facturation_service import verifier_odoo
+from electricore.api.services.check_facturation_service import generer_check_odoo_xlsx, verifier_odoo
 from electricore.api.services.facturation_service import (
     documents_facturation_du_mois,
     facturation_du_mois,
@@ -91,6 +91,16 @@ async def check_facturation_odoo(api_key: str = Depends(get_current_api_key)):
         logger.exception("Erreur facturation/check/odoo")
         raise HTTPException(503, f"Erreur lors de la vérification Odoo : {e}")
     return result
+
+
+@xlsx_endpoint(router, "/facturation/check/odoo.xlsx", filename="check_odoo.xlsx", requires_odoo=True)
+def export_check_odoo_xlsx() -> bytes:
+    """Détail complet des vérifications pré-facturation Odoo en XLSX multi-onglets.
+
+    Même contrôle que `/facturation/check/odoo`, sérialisé pour le cas où les
+    anomalies dépassent ce qu'un message texte peut lister (issue #150).
+    """
+    return generer_check_odoo_xlsx(verifier_odoo())
 
 
 @xlsx_endpoint(router, "/facturation/documents.xlsx", filename="facturation{mois}.xlsx", requires_odoo=True)

--- a/electricore/bot/bot.py
+++ b/electricore/bot/bot.py
@@ -440,9 +440,11 @@ async def cmd_check(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.effective_message.reply_markdown(msg, disable_web_page_preview=True)
 
         if xlsx_needed:
-            from electricore.api.services.check_facturation_service import generer_check_odoo_xlsx
-
-            xlsx_bytes = await asyncio.get_event_loop().run_in_executor(None, generer_check_odoo_xlsx, result)
+            try:
+                xlsx_bytes = await client.get_check_odoo_xlsx()
+            except Exception as e:
+                await update.effective_message.reply_text(f"❌ Erreur export détail : {e}")
+                return
             await update.effective_message.reply_document(
                 document=io.BytesIO(xlsx_bytes),
                 filename="check_odoo.xlsx",

--- a/electricore/bot/client.py
+++ b/electricore/bot/client.py
@@ -11,24 +11,28 @@ from electricore.api.config import settings
 class ElectriCoreClient:
     """Client async vers l'API ElectriCore."""
 
-    def __init__(self):
+    def __init__(self, transport: httpx.AsyncBaseTransport | None = None):
         self._base = settings.api_base_url.rstrip("/")
         self._headers = {"X-API-Key": settings.get_valid_api_keys()[0]} if settings.get_valid_api_keys() else {}
+        self._transport = transport
+
+    def _http(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=self._transport)
 
     async def list_tables(self) -> list[str]:
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.get(f"{self._base}/", timeout=10)
             r.raise_for_status()
             return r.json().get("available_tables", [])
 
     async def get_table_info(self, table: str) -> dict:
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.get(f"{self._base}/flux/{table}/info", headers=self._headers, timeout=10)
             r.raise_for_status()
             return r.json()
 
     async def run_etl(self, mode: str) -> dict:
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.post(
                 f"{self._base}/etl/run",
                 json={"mode": mode},
@@ -39,31 +43,31 @@ class ElectriCoreClient:
             return r.json()
 
     async def get_job(self, job_id: str) -> dict:
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.get(f"{self._base}/etl/jobs/{job_id}", headers=self._headers, timeout=10)
             r.raise_for_status()
             return r.json()
 
     async def get_jobs(self, limit: int = 5) -> list[dict]:
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.get(f"{self._base}/etl/jobs", params={"limit": limit}, headers=self._headers, timeout=10)
             r.raise_for_status()
             return r.json()
 
     async def get_entrees_xlsx(self) -> bytes:
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.get(f"{self._base}/flux/c15/entrees.xlsx", headers=self._headers, timeout=120)
             r.raise_for_status()
             return r.content
 
     async def get_sorties_xlsx(self) -> bytes:
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.get(f"{self._base}/flux/c15/sorties.xlsx", headers=self._headers, timeout=120)
             r.raise_for_status()
             return r.content
 
     async def get_xlsx(self, table: str) -> bytes:
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.get(f"{self._base}/flux/{table}.xlsx", headers=self._headers, timeout=120)
             r.raise_for_status()
             return r.content
@@ -72,7 +76,7 @@ class ElectriCoreClient:
         params = {}
         if trimestre:
             params["trimestre"] = trimestre
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.get(
                 f"{self._base}/taxes/accise/rapport.xlsx", headers=self._headers, params=params, timeout=300
             )
@@ -81,14 +85,14 @@ class ElectriCoreClient:
 
     async def get_cta_xlsx(self, trimestre: str | None = None) -> bytes:
         params: dict = {"trimestre": trimestre} if trimestre else {}
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.get(f"{self._base}/taxes/cta/rapport.xlsx", headers=self._headers, params=params, timeout=300)
             r.raise_for_status()
             return r.content
 
     async def get_facturation_xlsx(self, mois: str | None = None) -> bytes:
         params = {"mois": mois} if mois else {}
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.get(f"{self._base}/facturation/rapport.xlsx", headers=self._headers, params=params, timeout=300)
             r.raise_for_status()
             return r.content
@@ -96,7 +100,7 @@ class ElectriCoreClient:
     async def get_facturation_documents_xlsx(self, mois: str | None = None) -> bytes:
         """Livrable XLSX multi-onglets des documents de campagne facturation (cf. #78)."""
         params = {"mois": mois} if mois else {}
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.get(
                 f"{self._base}/facturation/documents.xlsx", headers=self._headers, params=params, timeout=300
             )
@@ -104,7 +108,14 @@ class ElectriCoreClient:
             return r.content
 
     async def check_facturation_odoo(self) -> dict:
-        async with httpx.AsyncClient() as c:
+        async with self._http() as c:
             r = await c.get(f"{self._base}/facturation/check/odoo", headers=self._headers, timeout=300)
             r.raise_for_status()
             return r.json()
+
+    async def get_check_odoo_xlsx(self) -> bytes:
+        """Détail complet du check Odoo en XLSX multi-onglets (issue #150)."""
+        async with self._http() as c:
+            r = await c.get(f"{self._base}/facturation/check/odoo.xlsx", headers=self._headers, timeout=300)
+            r.raise_for_status()
+            return r.content

--- a/tests/architecture/test_bot_topology.py
+++ b/tests/architecture/test_bot_topology.py
@@ -1,0 +1,56 @@
+"""Garde-fou : `electricore/bot/` est un pur client HTTP de l'API.
+
+Le bot traduit des commandes Telegram en appels HTTP et formate les réponses
+([bot/CONTEXT.md](../../electricore/bot/CONTEXT.md), ADR-0009/0010). Il n'importe
+ni la logique métier (`core/`, `integrations/`, `etl/`) ni l'intérieur de l'API
+(`api.services`, `api.routers`) — seule la config partagée (`api.config`) est
+tolérée.
+
+Analyse statique via `ast` : couvre aussi les imports locaux aux fonctions
+(c'est précisément ainsi que la violation #150 s'était glissée).
+"""
+
+import ast
+from pathlib import Path
+
+FORBIDDEN_PREFIXES: tuple[str, ...] = (
+    "electricore.api.services",
+    "electricore.api.routers",
+    "electricore.core",
+    "electricore.integrations",
+    "electricore.etl",
+)
+
+BOT_ROOT = Path(__file__).resolve().parents[2] / "electricore" / "bot"
+
+
+def _collect_absolute_imports(path: Path) -> set[str]:
+    """Retourne les noms de modules importés *absolument* par un fichier .py."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:
+                modules.add(node.module)
+    return modules
+
+
+def _is_forbidden(module: str) -> bool:
+    return any(module == p or module.startswith(p + ".") for p in FORBIDDEN_PREFIXES)
+
+
+def test_bot_est_pur_client_http() -> None:
+    """Aucun fichier sous `electricore/bot/` n'importe métier ou intérieur d'API."""
+    violations: list[tuple[str, str]] = []
+    repo_root = BOT_ROOT.parents[1]
+    for py_file in sorted(BOT_ROOT.rglob("*.py")):
+        for module in _collect_absolute_imports(py_file):
+            if _is_forbidden(module):
+                violations.append((str(py_file.relative_to(repo_root)), module))
+
+    assert not violations, "Imports interdits dans electricore/bot/ (pur client HTTP) :\n" + "\n".join(
+        f"  {path}: {module}" for path, module in violations
+    )

--- a/tests/integration/test_facturation_arrow_endpoint.py
+++ b/tests/integration/test_facturation_arrow_endpoint.py
@@ -1,9 +1,11 @@
 """Tests d'intégration des endpoints `/facturation/*` (issue #64).
 
-3 endpoints : `rapport.xlsx` (facturiste), `detail.xlsx` + `detail.arrow` (technique).
+Endpoints : `rapport.xlsx` (facturiste), `detail.xlsx` + `detail.arrow` (technique),
+`documents.xlsx` (campagne, #78), `check/odoo.xlsx` (détail du check, #150).
 """
 
 import io
+import zipfile
 from contextlib import contextmanager
 
 import polars as pl
@@ -256,3 +258,47 @@ def test_ancien_endpoint_documents_zip_404():
     """L'ancien path `/facturation/documents` (ZIP) est supprimé."""
     response = TestClient(app).get("/facturation/documents")
     assert response.status_code == 404
+
+
+# =============================================================================
+# /facturation/check/odoo.xlsx — détail du check pré-facturation (issue #150)
+# =============================================================================
+
+
+@pytest.fixture
+def resultat_check_odoo() -> dict:
+    """Résultat synthétique de `verifier_odoo` avec une anomalie RSC."""
+    return {
+        "rsc_manquante": [{"id": 1, "name": "S00042", "url": "https://odoo.example/web#id=1"}],
+        "cfne_manquante": [],
+        "invoicing_state_counts": {"up_to_date": 12},
+        "factures_draft": [],
+        "lisses_quantite_1": [],
+    }
+
+
+def test_check_odoo_xlsx_retourne_le_detail_en_xlsx(monkeypatch, resultat_check_odoo):
+    """L'endpoint sert le détail complet du check Odoo en XLSX multi-onglets."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.routers.facturation.verifier_odoo",
+        lambda: resultat_check_odoo,
+    )
+    try:
+        response = TestClient(app).get("/facturation/check/odoo.xlsx")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(XLSX_MIME)
+    assert "check_odoo.xlsx" in response.headers.get("content-disposition", "")
+
+    with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
+        workbook_xml = zf.read("xl/workbook.xml").decode()
+    assert "RSC manquant" in workbook_xml, "l'onglet de l'anomalie RSC doit exister"
+    assert "Invoicing state" in workbook_xml
+
+
+def test_check_odoo_xlsx_refuse_sans_api_key():
+    response = TestClient(app).get("/facturation/check/odoo.xlsx")
+    assert response.status_code == 401

--- a/tests/unit/test_bot_client.py
+++ b/tests/unit/test_bot_client.py
@@ -1,0 +1,44 @@
+"""Tests du client HTTP du bot (`electricore/bot/client.py`).
+
+Boucle complète contre l'app FastAPI réelle via `httpx.ASGITransport` : le bot
+reste pur client HTTP (cf. tests/architecture/test_bot_topology.py), on vérifie
+ici qu'il obtient bien ses livrables par l'API et non par import direct (#150).
+"""
+
+import asyncio
+
+import httpx
+import pytest
+
+from electricore.api.config import settings
+from electricore.api.main import app
+from electricore.api.security import get_current_api_key
+from electricore.bot.client import ElectriCoreClient
+
+
+@pytest.fixture(autouse=True)
+def _mock_odoo_configured(monkeypatch):
+    """Force `settings.is_odoo_configured` à True (sinon les endpoints renvoient 501 en CI)."""
+    monkeypatch.setattr(type(settings), "get_odoo_config", lambda self: {})
+
+
+def test_get_check_odoo_xlsx_obtient_le_detail_via_l_api(monkeypatch):
+    """Le client bot récupère le XLSX du check Odoo par l'endpoint dédié."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.routers.facturation.verifier_odoo",
+        lambda: {
+            "rsc_manquante": [{"id": 1, "name": "S00042", "url": "https://odoo.example/web#id=1"}],
+            "cfne_manquante": [],
+            "invoicing_state_counts": {"up_to_date": 12},
+            "factures_draft": [],
+            "lisses_quantite_1": [],
+        },
+    )
+    bot_client = ElectriCoreClient(transport=httpx.ASGITransport(app=app))
+    try:
+        xlsx_bytes = asyncio.run(bot_client.get_check_odoo_xlsx())
+    finally:
+        app.dependency_overrides.clear()
+
+    assert xlsx_bytes[:4] == b"PK\x03\x04", "XLSX = container ZIP, doit commencer par PK\\x03\\x04"


### PR DESCRIPTION
## Quoi

Première tranche de la refonte bot ([ADR-0022](docs/adr/0022-surface-bot-domaines-hybrides.md), plan #150–#160) : le détail du check Odoo pré-facturation devient un endpoint API, et le bot redevient strictement client HTTP.

- **Nouvel endpoint** `GET /facturation/check/odoo.xlsx` — XLSX multi-onglets du détail du check (même contrôle que `/facturation/check/odoo`), via `xlsx_endpoint` (auth `X-API-Key`, 501 sans Odoo, exécution en executor).
- **Bot** : `cmd_check` obtient le XLSX par le client HTTP (`get_check_odoo_xlsx`) — suppression de l'import direct de `electricore.api.services` qui violait [bot/CONTEXT.md](electricore/bot/CONTEXT.md) et ADR-0009.
- **Testabilité** : transport httpx injectable dans `ElectriCoreClient` (boucle complète client bot → app FastAPI via `ASGITransport`).
- **Garde-fou d'architecture** : `tests/architecture/test_bot_topology.py` — `electricore/bot/` n'importe ni `core/`, `integrations/`, `etl/`, ni `api.services`/`api.routers` (analyse AST, imports locaux aux fonctions compris — c'est ainsi que la violation s'était glissée).

Inclut aussi l'ADR-0022 (commit docs séparé), resté en attente depuis la session de design.

## Note

Quand le détail dépasse la limite d'affichage Telegram, le check tourne désormais deux fois (une pour le résumé JSON, une pour le XLSX) — contrôle read-only, surcoût accepté pour garder le bot sans logique métier.

## Tests

TDD red-green : 4 nouveaux tests (endpoint 200+onglets, contrat 401, topologie bot, boucle client). Suite complète : 536 passed, 35 skipped.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)