### PR TITLE
refactor(bot): squelette du package par domaine, menu natif, /start d'instance (#151)

### DIFF
--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -49,7 +49,7 @@ async def lifespan(app: FastAPI):
         _format_sftp_source(),
     )
     if settings.telegram_bot_token:
-        from electricore.bot.bot import build_application
+        from electricore.bot.app import build_application
 
         _tg_app = build_application(settings.telegram_bot_token)
         await _tg_app.initialize()
@@ -58,7 +58,7 @@ async def lifespan(app: FastAPI):
         logger.info("Bot Telegram démarré.")
     yield
     if _tg_app is not None:
-        from electricore.bot.bot import _background_tasks
+        from electricore.bot.tasks import _background_tasks
 
         for task in list(_background_tasks):
             task.cancel()

--- a/electricore/bot/app.py
+++ b/electricore/bot/app.py
@@ -1,0 +1,34 @@
+"""Assemblage du bot Telegram : application PTB, surface, menu natif (#151).
+
+Point d'entrée unique du bot (consommé par le lifespan de l'API). La surface
+affichée (aide + menu natif) dérive de `handlers.start.COMMANDES`.
+"""
+
+from telegram import BotCommand
+from telegram.ext import Application, CommandHandler
+
+from electricore.bot import bot as v1
+from electricore.bot.handlers import start
+
+
+async def publier_menu(application: Application) -> None:
+    """Publie la surface dans le menu natif Telegram (`setMyCommands`, ADR-0022)."""
+    await application.bot.set_my_commands([BotCommand(c, d) for c, d in start.COMMANDES])
+
+
+def build_application(token: str) -> Application:
+    application = Application.builder().token(token).post_init(publier_menu).build()
+    application.add_handler(CommandHandler("start", start.cmd_start))
+    application.add_handler(CommandHandler("help", start.cmd_help))
+    # Commandes v1 — migrent domaine par domaine (#152–#156, ADR-0022).
+    application.add_handler(CommandHandler("etl", v1.cmd_etl))
+    application.add_handler(CommandHandler("status", v1.cmd_status))
+    application.add_handler(CommandHandler("stats", v1.cmd_stats))
+    application.add_handler(CommandHandler("export", v1.cmd_export))
+    application.add_handler(CommandHandler("flux", v1.cmd_flux))
+    application.add_handler(CommandHandler("entrees", v1.cmd_entrees))
+    application.add_handler(CommandHandler("sorties", v1.cmd_sorties))
+    application.add_handler(CommandHandler("taxes", v1.cmd_taxes))
+    application.add_handler(CommandHandler("facturation", v1.cmd_facturation))
+    application.add_handler(CommandHandler("check", v1.cmd_check))
+    return application

--- a/electricore/bot/auth.py
+++ b/electricore/bot/auth.py
@@ -1,0 +1,26 @@
+"""Contrôle d'accès du bot : allowlist Telegram appliquée par décorateur.
+
+Voir [CONTEXT.md](CONTEXT.md) — allowlist d'IDs numériques via
+`TELEGRAM_ALLOWED_USERS`, pas de rôles ni de granularité (ADR-0010).
+"""
+
+import functools
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from electricore.api.config import settings
+
+
+def require_allowed(handler):
+    """N'exécute le handler que pour un utilisateur de l'allowlist ; sinon `⛔`."""
+
+    @functools.wraps(handler)
+    async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        allowed = settings.get_telegram_allowed_users()
+        if not allowed or update.effective_user.id not in allowed:
+            await update.effective_message.reply_text("⛔ Accès refusé.")
+            return None
+        return await handler(update, context)
+
+    return wrapper

--- a/electricore/bot/bot.py
+++ b/electricore/bot/bot.py
@@ -1,6 +1,9 @@
 """
-Bot Telegram pour ElectriCore.
-Permet de lancer l'ETL, consulter les stats et exporter des données via Telegram.
+Handlers v1 du bot Telegram — en cours de migration par domaine (ADR-0022).
+
+L'assemblage (application, surface, menu natif) vit dans [app.py](app.py) ;
+chaque tranche #152–#156 migre un domaine vers `handlers/` et retire les
+commandes correspondantes d'ici.
 """
 
 import asyncio
@@ -8,41 +11,14 @@ import io
 import logging
 
 from telegram import Update
-from telegram.ext import Application, CommandHandler, ContextTypes
+from telegram.ext import ContextTypes
 
-from electricore.api.config import settings
+from electricore.bot.auth import require_allowed
 from electricore.bot.client import ElectriCoreClient
+from electricore.bot.format import escape
+from electricore.bot.tasks import create_task
 
 logger = logging.getLogger(__name__)
-
-_background_tasks: set[asyncio.Task] = set()
-
-
-def _create_task(coro) -> asyncio.Task:
-    """Crée une tâche en la gardant en référence pour pouvoir l'annuler au shutdown."""
-    task = asyncio.create_task(coro)
-    _background_tasks.add(task)
-    task.add_done_callback(_background_tasks.discard)
-    return task
-
-
-_HELP = r"""
-*ElectriCore Bot* — Commandes disponibles :
-
-/start — Ce message d'aide
-/etl \[mode\] — Lancer l'ingestion ETL \(défaut : all\)
-  Modes : `test`, `r151`, `all`, `reset`
-/status — Statut des 5 derniers jobs ETL
-/stats \[table\] — Stats d'une table flux
-/export \[table\] — Exporter une table en fichier Excel
-/entrees — Exporter les entrées C15 \(PMES, MES, CFNE\)
-/sorties — Exporter les sorties C15 \(RES, CFNS\)
-/flux — Lister les tables disponibles à l'export
-/taxes accise \[trimestre\] — Exporter le calcul Accise TICFE en Excel
-/taxes cta \[trimestre\] — Exporter le calcul CTA en Excel
-/facturation \[YYYY\-MM\-DD\] — Exporter la réconciliation facturation Odoo ↔ Enedis
-/check odoo — Vérifications pré\-facturation côté Odoo \(RSC, CFNE, draft, états\)
-"""
 
 _STATUS_EMOJI = {
     "running": "⏳",
@@ -51,29 +27,8 @@ _STATUS_EMOJI = {
 }
 
 
-def _is_allowed(update: Update) -> bool:
-    allowed = settings.get_telegram_allowed_users()
-    if not allowed:
-        return False
-    return update.effective_user.id in allowed
-
-
-async def _deny(update: Update) -> None:
-    await update.effective_message.reply_text("⛔ Accès refusé.")
-
-
-async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed(update):
-        await _deny(update)
-        return
-    await update.effective_message.reply_markdown_v2(_HELP)
-
-
+@require_allowed
 async def cmd_etl(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed(update):
-        await _deny(update)
-        return
-
     mode = context.args[0] if context.args else "all"
     valid_modes = {"test", "r151", "all", "reset"}
     if mode not in valid_modes:
@@ -104,21 +59,18 @@ async def cmd_etl(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 break
 
         emoji = _STATUS_EMOJI.get(j["status"], "❓")
-        msg = f"{emoji} Pipeline `{mode}` terminé — statut : *{j['status']}*"
+        msg = f"{emoji} Pipeline <code>{escape(mode)}</code> terminé — statut : <b>{escape(j['status'])}</b>"
         if j.get("error"):
-            msg += f"\n\n`{j['error'][:500]}`"
+            msg += f"\n\n<code>{escape(j['error'][:500])}</code>"
         elif j.get("output"):
-            msg += f"\n\n```\n{j['output'][:800]}\n```"
-        await context.bot.send_message(chat_id=chat_id, text=msg, parse_mode="Markdown")
+            msg += f"\n\n<pre>{escape(j['output'][:800])}</pre>"
+        await context.bot.send_message(chat_id=chat_id, text=msg, parse_mode="HTML")
 
-    _create_task(_notify())
+    create_task(_notify())
 
 
+@require_allowed
 async def cmd_status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed(update):
-        await _deny(update)
-        return
-
     client = ElectriCoreClient()
     try:
         jobs = await client.get_jobs(limit=5)
@@ -130,20 +82,17 @@ async def cmd_status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         await update.effective_message.reply_text("Aucun job ETL enregistré.")
         return
 
-    lines = ["*Derniers jobs ETL :*\n"]
+    lines = ["<b>Derniers jobs ETL :</b>\n"]
     for j in jobs:
         emoji = _STATUS_EMOJI.get(j["status"], "❓")
         started = j["started_at"][:16].replace("T", " ")
-        lines.append(f"{emoji} `{j['id'][:8]}…` — *{j['mode']}* — {started}")
+        lines.append(f"{emoji} <code>{j['id'][:8]}…</code> — <b>{escape(j['mode'])}</b> — {started}")
 
-    await update.effective_message.reply_markdown("\n".join(lines))
+    await update.effective_message.reply_html("\n".join(lines))
 
 
+@require_allowed
 async def cmd_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed(update):
-        await _deny(update)
-        return
-
     client = ElectriCoreClient()
 
     if not context.args:
@@ -168,16 +117,13 @@ async def cmd_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     count = info.get("count", "?")
     cols = len(info.get("columns", []))
-    await update.effective_message.reply_markdown(
-        f"📊 *flux_{table}*\n  • Lignes : `{count:,}`\n  • Colonnes : `{cols}`"
+    await update.effective_message.reply_html(
+        f"📊 <b>flux_{escape(table)}</b>\n  • Lignes : <code>{count:,}</code>\n  • Colonnes : <code>{cols}</code>"
     )
 
 
+@require_allowed
 async def cmd_export(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed(update):
-        await _deny(update)
-        return
-
     if not context.args:
         await update.effective_message.reply_text("Usage : /export <table>  (ex: /export r151)")
         return
@@ -199,10 +145,8 @@ async def cmd_export(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     )
 
 
+@require_allowed
 async def cmd_flux(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed(update):
-        await _deny(update)
-        return
     client = ElectriCoreClient()
     try:
         tables = await client.list_tables()
@@ -216,10 +160,8 @@ async def cmd_flux(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.effective_message.reply_text("\n".join(lines))
 
 
+@require_allowed
 async def cmd_entrees(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed(update):
-        await _deny(update)
-        return
     await update.effective_message.reply_text("⏳ Génération de l'export entrées C15…")
     client = ElectriCoreClient()
     try:
@@ -234,10 +176,8 @@ async def cmd_entrees(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     )
 
 
+@require_allowed
 async def cmd_sorties(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed(update):
-        await _deny(update)
-        return
     await update.effective_message.reply_text("⏳ Génération de l'export sorties C15…")
     client = ElectriCoreClient()
     try:
@@ -252,11 +192,8 @@ async def cmd_sorties(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     )
 
 
+@require_allowed
 async def cmd_taxes(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed(update):
-        await _deny(update)
-        return
-
     usage = (
         "Usage :\n"
         "  /taxes accise [trimestre]  — Accise TICFE (ex: /taxes accise 2025-T1)\n"
@@ -307,11 +244,8 @@ async def cmd_taxes(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.effective_message.reply_text(f"❌ Sous-commande inconnue : `{sous_commande}`\n\n{usage}")
 
 
+@require_allowed
 async def cmd_facturation(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed(update):
-        await _deny(update)
-        return
-
     mois = context.args[0] if context.args else None
     periode = f" — {mois}" if mois else " — dernier mois disponible"
     await update.effective_message.reply_text(f"⏳ Génération des documents facturation{periode}…")
@@ -334,14 +268,9 @@ async def cmd_facturation(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 _CHECK_LIMIT = 20  # Au-delà : renvoi en XLSX joint
 
 
-def _md_escape(text: str) -> str:
-    """Échappe les caractères Markdown V1 (mode 'Markdown', pas V2)."""
-    return text.replace("_", r"\_").replace("*", r"\*").replace("`", r"\`").replace("[", r"\[")
-
-
 def _format_check_odoo(result: dict) -> tuple[str, bool]:
-    """Formatte le résultat en Markdown Telegram. Retourne (msg, xlsx_needed)."""
-    lines = ["🔍 *Vérification Odoo*", ""]
+    """Formatte le résultat en HTML Telegram. Retourne (msg, xlsx_needed)."""
+    lines = ["🔍 <b>Vérification Odoo</b>", ""]
     xlsx_needed = False
 
     def _bloc(titre: str, items: list[dict], label_fn, ok_msg: str) -> None:
@@ -350,23 +279,22 @@ def _format_check_odoo(result: dict) -> tuple[str, bool]:
         if n == 0:
             lines.append(f"✅ {ok_msg}")
             return
-        lines.append(f"❌ *{n}* {titre}")
+        lines.append(f"❌ <b>{n}</b> {titre}")
         for r in items[:_CHECK_LIMIT]:
-            label = _md_escape(label_fn(r))
-            lines.append(f"  • [{label}]({r['url']})")
+            lines.append(f'  • <a href="{escape(r["url"])}">{escape(label_fn(r))}</a>')
         if n > _CHECK_LIMIT:
-            lines.append(f"  _… et {n - _CHECK_LIMIT} autres → voir XLSX joint_")
+            lines.append(f"  <i>… et {n - _CHECK_LIMIT} autres → voir XLSX joint</i>")
             xlsx_needed = True
 
     _bloc(
-        "sale.order sans `x_ref_situation_contractuelle`",
+        "sale.order sans <code>x_ref_situation_contractuelle</code>",
         result["rsc_manquante"],
         lambda r: r["name"],
         "Tous les sale.order ont une RSC",
     )
     lines.append("")
     _bloc(
-        "sale.order sans `x_date_cfne`",
+        "sale.order sans <code>x_date_cfne</code>",
         result["cfne_manquante"],
         lambda r: r["name"],
         "Tous les sale.order ont une date CFNE",
@@ -374,12 +302,12 @@ def _format_check_odoo(result: dict) -> tuple[str, bool]:
     lines.append("")
 
     counts = result["invoicing_state_counts"]
-    lines.append("📊 *Répartition x_invoicing_state*")
+    lines.append("📊 <b>Répartition x_invoicing_state</b>")
     if counts:
         for state, n in counts.items():
-            lines.append(f"  • `{state}` : {n}")
+            lines.append(f"  • <code>{escape(state)}</code> : {n}")
     else:
-        lines.append("  _(aucune commande)_")
+        lines.append("  <i>(aucune commande)</i>")
     lines.append("")
 
     _bloc(
@@ -407,16 +335,13 @@ def _format_check_odoo(result: dict) -> tuple[str, bool]:
     )
     if all_ok:
         lines.append("")
-        lines.append("🟢 *OK pour lancer le cycle de facturation*")
+        lines.append("🟢 <b>OK pour lancer le cycle de facturation</b>")
 
     return "\n".join(lines), xlsx_needed
 
 
+@require_allowed
 async def cmd_check(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed(update):
-        await _deny(update)
-        return
-
     usage = (
         "Usage :\n  /check odoo  — Vérifications pré-facturation côté Odoo\n  (sources `enedis` et `croise` à venir)"
     )
@@ -437,7 +362,7 @@ async def cmd_check(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             return
 
         msg, xlsx_needed = _format_check_odoo(result)
-        await update.effective_message.reply_markdown(msg, disable_web_page_preview=True)
+        await update.effective_message.reply_html(msg, disable_web_page_preview=True)
 
         if xlsx_needed:
             try:
@@ -452,19 +377,3 @@ async def cmd_check(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             )
     else:
         await update.effective_message.reply_text(f"❌ Source inconnue : `{source}`\n\n{usage}")
-
-
-def build_application(token: str) -> Application:
-    app = Application.builder().token(token).build()
-    app.add_handler(CommandHandler("start", cmd_start))
-    app.add_handler(CommandHandler("etl", cmd_etl))
-    app.add_handler(CommandHandler("status", cmd_status))
-    app.add_handler(CommandHandler("stats", cmd_stats))
-    app.add_handler(CommandHandler("export", cmd_export))
-    app.add_handler(CommandHandler("flux", cmd_flux))
-    app.add_handler(CommandHandler("entrees", cmd_entrees))
-    app.add_handler(CommandHandler("sorties", cmd_sorties))
-    app.add_handler(CommandHandler("taxes", cmd_taxes))
-    app.add_handler(CommandHandler("facturation", cmd_facturation))
-    app.add_handler(CommandHandler("check", cmd_check))
-    return app

--- a/electricore/bot/format.py
+++ b/electricore/bot/format.py
@@ -1,0 +1,12 @@
+"""Rendu des messages Telegram en HTML (ADR-0022).
+
+Tout le bot rend en `parse_mode=HTML` : seuls `<`, `>` et `&` sont à échapper,
+via `escape()` — fin du mélange Markdown V1/V2 et de ses pièges d'échappement.
+"""
+
+import html
+
+
+def escape(text: object) -> str:
+    """Neutralise `<`, `>` et `&` pour insertion sûre dans un message HTML Telegram."""
+    return html.escape(str(text), quote=False)

--- a/electricore/bot/handlers/__init__.py
+++ b/electricore/bot/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""Handlers du bot, un module par domaine de commande (ADR-0022)."""

--- a/electricore/bot/handlers/start.py
+++ b/electricore/bot/handlers/start.py
@@ -1,0 +1,48 @@
+"""`/start` et `/help` : aide et annonce de l'instance servie (ADR-0022).
+
+`COMMANDES` est la source de vérité de la surface : l'aide ci-dessous et le
+menu natif publié au démarrage ([app.py](../app.py)) en dérivent tous deux.
+Les tranches de migration par domaine (#152–#156) la font évoluer.
+"""
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from electricore.api.config import settings
+from electricore.bot.auth import require_allowed
+from electricore.bot.format import escape
+
+# Surface de commandes : (commande, description menu natif ≤ 256 car.).
+COMMANDES: list[tuple[str, str]] = [
+    ("start", "Aide et instance servie"),
+    ("help", "Aide et instance servie"),
+    ("etl", "Lancer l'ingestion ETL"),
+    ("status", "Statut des derniers jobs ETL"),
+    ("stats", "Stats d'une table flux"),
+    ("export", "Exporter une table en XLSX"),
+    ("flux", "Tables disponibles à l'export"),
+    ("entrees", "Entrées C15 (PMES, MES, CFNE)"),
+    ("sorties", "Sorties C15 (RES, CFNS)"),
+    ("taxes", "Accise TICFE / CTA par trimestre"),
+    ("facturation", "Documents facturation Odoo ↔ Enedis"),
+    ("check", "Vérifications pré-facturation"),
+]
+
+
+def aide_html() -> str:
+    """Aide du bot : instance servie + surface de commandes."""
+    if settings.instance_slug:
+        titre = f"<b>ElectriCore Bot</b> — instance <b>{escape(settings.instance_slug)}</b>"
+    else:
+        titre = "<b>ElectriCore Bot</b>"
+    lignes = [titre, ""]
+    lignes += [f"/{commande} — {escape(description)}" for commande, description in COMMANDES]
+    return "\n".join(lignes)
+
+
+@require_allowed
+async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.effective_message.reply_html(aide_html())
+
+
+cmd_help = cmd_start

--- a/electricore/bot/tasks.py
+++ b/electricore/bot/tasks.py
@@ -1,0 +1,17 @@
+"""Tâches de fond du bot (notifications de fin de job ETL).
+
+Module séparé pour casser le cycle d'import entre `app.py` (assemblage)
+et les handlers qui lancent des tâches.
+"""
+
+import asyncio
+
+_background_tasks: set[asyncio.Task] = set()
+
+
+def create_task(coro) -> asyncio.Task:
+    """Crée une tâche en la gardant en référence pour pouvoir l'annuler au shutdown."""
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task

--- a/tests/unit/test_bot_app.py
+++ b/tests/unit/test_bot_app.py
@@ -1,0 +1,81 @@
+"""Tests de l'assemblage du bot (`electricore/bot/app.py`).
+
+`build_application` enregistre toute la surface (start/help + commandes v1
+non migrées) et publie le menu natif au démarrage (#151, ADR-0022).
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from electricore.api.config import settings
+from electricore.bot.app import build_application, publier_menu
+from electricore.bot.handlers.start import COMMANDES
+
+
+def test_build_application_enregistre_toute_la_surface():
+    tg_app = build_application("123:abc")
+
+    enregistrees: set[str] = set()
+    for handlers in tg_app.handlers.values():
+        for handler in handlers:
+            enregistrees |= set(getattr(handler, "commands", ()))
+
+    attendues = {commande for commande, _ in COMMANDES}
+    assert attendues <= enregistrees, f"commandes sans handler : {attendues - enregistrees}"
+
+
+def test_le_menu_natif_est_branche_au_demarrage():
+    tg_app = build_application("123:abc")
+    assert tg_app.post_init is publier_menu
+
+
+def test_publier_menu_pousse_la_surface_a_telegram():
+    publiees = []
+
+    class FakeBot:
+        async def set_my_commands(self, commands):
+            publiees.extend(commands)
+
+    asyncio.run(publier_menu(SimpleNamespace(bot=FakeBot())))
+
+    assert [(c.command, c.description) for c in publiees] == COMMANDES
+
+
+# =============================================================================
+# Contrat global : l'allowlist protège chaque handler de la surface
+# =============================================================================
+
+
+class FakeMessage:
+    def __init__(self):
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs):
+        self.replies.append(text)
+
+    async def reply_html(self, text: str, **kwargs):
+        self.replies.append(text)
+
+
+def _tous_les_callbacks():
+    tg_app = build_application("123:abc")
+    for handlers in tg_app.handlers.values():
+        for handler in handlers:
+            for commande in getattr(handler, "commands", ()):
+                yield pytest.param(handler.callback, id=commande)
+
+
+@pytest.mark.parametrize("callback", _tous_les_callbacks())
+def test_chaque_handler_refuse_un_user_hors_allowlist(monkeypatch, callback):
+    """Aucun handler de la surface n'est joignable hors allowlist (#151)."""
+    monkeypatch.setattr(type(settings), "get_telegram_allowed_users", lambda self: {42})
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=666),
+        effective_message=FakeMessage(),
+    )
+
+    asyncio.run(callback(update, context=None))
+
+    assert update.effective_message.replies == ["⛔ Accès refusé."]

--- a/tests/unit/test_bot_auth.py
+++ b/tests/unit/test_bot_auth.py
@@ -1,0 +1,74 @@
+"""Tests du contrôle d'accès du bot (`electricore/bot/auth.py`).
+
+L'allowlist Telegram est appliquée par le décorateur `@require_allowed` sur
+chaque handler (#151) — remplace les checks répétés en tête de handler.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from electricore.api.config import settings
+from electricore.bot.auth import require_allowed
+
+
+class FakeMessage:
+    def __init__(self):
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs):
+        self.replies.append(text)
+
+
+def fake_update(user_id: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        effective_user=SimpleNamespace(id=user_id),
+        effective_message=FakeMessage(),
+    )
+
+
+@pytest.fixture
+def allowlist_42(monkeypatch):
+    monkeypatch.setattr(type(settings), "get_telegram_allowed_users", lambda self: {42})
+
+
+def _handler_traceur():
+    appels = []
+
+    @require_allowed
+    async def handler(update, context):
+        appels.append(update.effective_user.id)
+
+    return handler, appels
+
+
+def test_refuse_un_user_hors_allowlist(allowlist_42):
+    handler, appels = _handler_traceur()
+    update = fake_update(user_id=666)
+
+    asyncio.run(handler(update, context=None))
+
+    assert appels == [], "le handler ne doit pas être exécuté"
+    assert update.effective_message.replies == ["⛔ Accès refusé."]
+
+
+def test_execute_pour_un_user_autorise(allowlist_42):
+    handler, appels = _handler_traceur()
+    update = fake_update(user_id=42)
+
+    asyncio.run(handler(update, context=None))
+
+    assert appels == [42]
+    assert update.effective_message.replies == []
+
+
+def test_refuse_tout_le_monde_si_allowlist_vide(monkeypatch):
+    monkeypatch.setattr(type(settings), "get_telegram_allowed_users", lambda self: set())
+    handler, appels = _handler_traceur()
+    update = fake_update(user_id=42)
+
+    asyncio.run(handler(update, context=None))
+
+    assert appels == []
+    assert update.effective_message.replies == ["⛔ Accès refusé."]

--- a/tests/unit/test_bot_check_format.py
+++ b/tests/unit/test_bot_check_format.py
@@ -1,0 +1,42 @@
+"""Tests du rendu HTML du check pré-facturation (`electricore/bot/bot.py`).
+
+Le rendu passe en `parse_mode=HTML` (#151) : liens `<a>`, gras `<b>`,
+échappement centralisé — fin des pièges Markdown sur les noms Odoo.
+"""
+
+from electricore.bot.bot import _format_check_odoo
+
+
+def _resultat(**surcharges) -> dict:
+    base = {
+        "rsc_manquante": [],
+        "cfne_manquante": [],
+        "invoicing_state_counts": {},
+        "factures_draft": [],
+        "lisses_quantite_1": [],
+    }
+    return {**base, **surcharges}
+
+
+def test_les_anomalies_sont_rendues_en_liens_html_echappes():
+    msg, xlsx_needed = _format_check_odoo(
+        _resultat(rsc_manquante=[{"name": "S00042 <bis> & co", "url": "https://odoo.example/web?a=1&b=2"}])
+    )
+
+    assert '<a href="https://odoo.example/web?a=1&amp;b=2">S00042 &lt;bis&gt; &amp; co</a>' in msg
+    assert xlsx_needed is False
+
+
+def test_le_rendu_est_du_html_sans_residus_markdown():
+    msg, _ = _format_check_odoo(_resultat(invoicing_state_counts={"up_to_date": 12}))
+
+    assert "<b>" in msg, "les titres sont en gras HTML"
+    assert "](" not in msg, "plus de liens Markdown"
+    assert "up_to_date" in msg
+
+
+def test_tout_vert_affiche_le_feu_vert():
+    msg, xlsx_needed = _format_check_odoo(_resultat())
+
+    assert "OK pour lancer le cycle de facturation" in msg
+    assert xlsx_needed is False

--- a/tests/unit/test_bot_format.py
+++ b/tests/unit/test_bot_format.py
@@ -1,0 +1,20 @@
+"""Tests du rendu des messages du bot (`electricore/bot/format.py`).
+
+Le bot rend tout en `parse_mode=HTML` (ADR-0022) : seuls `<`, `>` et `&`
+sont à échapper — fin des pièges d'échappement Markdown V1/V2 (#151).
+"""
+
+from electricore.bot.format import escape
+
+
+def test_escape_neutralise_les_caracteres_html():
+    assert escape("a < b & c > d") == "a &lt; b &amp; c &gt; d"
+
+
+def test_escape_laisse_intacts_les_caracteres_pieges_markdown():
+    """Les caractères qui cassaient le Markdown (noms de tables, etc.) passent tels quels."""
+    assert escape("flux_r151 *gras* [lien] `code`") == "flux_r151 *gras* [lien] `code`"
+
+
+def test_escape_accepte_les_non_chaines():
+    assert escape(42) == "42"

--- a/tests/unit/test_bot_handlers_start.py
+++ b/tests/unit/test_bot_handlers_start.py
@@ -1,0 +1,64 @@
+"""Tests de `/start` et `/help` (`electricore/bot/handlers/start.py`).
+
+L'aide annonce l'instance servie (convention `@<slug>_electricore_bot`,
+ADR-0022) et liste la surface de commandes — même source de vérité que le
+menu natif (#151).
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from electricore.api.config import settings
+from electricore.bot.handlers.start import COMMANDES, cmd_start
+
+
+class FakeMessage:
+    def __init__(self):
+        self.html_replies: list[str] = []
+
+    async def reply_html(self, text: str, **kwargs):
+        self.html_replies.append(text)
+
+    async def reply_text(self, text: str, **kwargs):  # refus allowlist
+        self.html_replies.append(text)
+
+
+def fake_update(user_id: int = 42) -> SimpleNamespace:
+    return SimpleNamespace(
+        effective_user=SimpleNamespace(id=user_id),
+        effective_message=FakeMessage(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _instance_edn(monkeypatch):
+    monkeypatch.setattr(type(settings), "get_telegram_allowed_users", lambda self: {42})
+    monkeypatch.setattr(settings, "instance_slug", "edn")
+
+
+def test_start_annonce_l_instance(monkeypatch):
+    update = fake_update()
+    asyncio.run(cmd_start(update, context=None))
+
+    (aide,) = update.effective_message.html_replies
+    assert "edn" in aide, "l'aide doit annoncer l'instance servie"
+
+
+def test_start_liste_la_surface_de_commandes():
+    update = fake_update()
+    asyncio.run(cmd_start(update, context=None))
+
+    (aide,) = update.effective_message.html_replies
+    for commande, _description in COMMANDES:
+        assert f"/{commande}" in aide
+
+
+def test_start_sans_slug_reste_generique(monkeypatch):
+    monkeypatch.setattr(settings, "instance_slug", "")
+    update = fake_update()
+    asyncio.run(cmd_start(update, context=None))
+
+    (aide,) = update.effective_message.html_replies
+    assert "ElectriCore" in aide


### PR DESCRIPTION
## Quoi

Tranche structurelle de la refonte bot ([ADR-0022](docs/adr/0022-surface-bot-domaines-hybrides.md)) : le bot passe d'un module monolithique à un package par domaine. Les commandes v1 restent fonctionnelles — elles migrent domaine par domaine dans #152–#156.

- **`app.py`** — point d'entrée unique (`build_application`), consommé par le lifespan de l'API. Publie le **menu natif** (`setMyCommands`) au démarrage via `post_init`.
- **`handlers/start.py`** — `/start` et `/help` annoncent l'**instance servie** (`instance_slug`, ADR-0015) et listent la surface. `COMMANDES` y est la source de vérité unique : l'aide et le menu natif en dérivent tous deux.
- **`auth.py`** — `@require_allowed` factorise les 11 checks d'allowlist répétés. Un test paramétré parcourt tous les handlers enregistrés et vérifie qu'aucun n'est joignable hors allowlist — le filet qui a permis de retirer les checks internes sans risque.
- **`format.py`** — rendu **HTML partout** (`escape` centralisé, 3 caractères à neutraliser) : fin du mélange Markdown V1/V2, suppression de `_md_escape`, liens du check Odoo en `<a href>` échappés.
- **`tasks.py`** — background tasks extraits de bot.py (casse le cycle d'import app ↔ handlers).
- **`bot.py`** — réduit aux handlers v1 (~80 lignes en moins), docstring de migration.

## Tests

TDD red-green, 27 nouveaux tests : échappement HTML, décorateur allowlist (refus/autorisation/allowlist vide), aide d'instance (avec/sans slug), assemblage de l'application, publication du menu, contrat allowlist global (×12 commandes), rendu HTML du check. Suite complète : **563 passed, 35 skipped**.

## Critères d'acceptation (#151)

- [x] Nouvelle structure de package, point d'entrée unique, commandes v1 fonctionnelles
- [x] Allowlist factorisée en décorateur appliqué à tous les handlers
- [x] Tout le rendu en `parse_mode=HTML` avec échappement centralisé
- [x] Menu natif publié au démarrage
- [x] `/start` et `/help` annoncent l'instance et la surface
- [x] Tests unitaires du décorateur et de l'échappement

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)