### PR TITLE
docs(bot): bascule de surface — README, CHANGELOG, checklist opérateur (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ---
 
+## [Unreleased]
+
+### 🤖 Bot Telegram : surface par domaines hybrides (ADR-0022)
+
+Refonte complète de la surface du bot (issues #150–#160) : 11 commandes plates →
+**5 domaines métier** (`/etl`, `/flux`, `/perimetre`, `/taxes`, `/facturation`).
+Sans argument, un domaine ouvre un **clavier inline** ; avec arguments, raccourci
+power-user. Guide : [electricore/bot/README.md](electricore/bot/README.md).
+
+#### 💥 Breaking
+
+- **Rupture du contrat de commandes, sans alias** (big bang, ADR-0022) :
+  `/status`, `/stats`, `/export`, `/entrees`, `/sorties`, `/check` disparaissent —
+  absorbées respectivement par `/etl statut`, `/flux stats`, `/flux export`,
+  `/perimetre entrees|sorties`, `/facturation check`. L'ancien `/flux` plat et
+  `/facturation [date]` changent de forme (`/flux`, `/facturation documents [date]`).
+- **`/etl reset` retiré** de la surface du bot (déprécié côté runner — `resync`
+  le remplace, derrière une **confirmation à deux taps**).
+
+#### ✨ Nouveau
+
+- **Menu natif Telegram** (`setMyCommands`) publié au démarrage, **adapté à
+  l'instance** : sans ERP configuré, `/taxes` et `/facturation` sont masqués et
+  répondent un message explicite (P2.5, traduction bot d'ADR-0016).
+- **Modes ETL réels exposés** : `rebuild`, `resync`, sélection de flux arbitraire
+  (`/etl r151 c15`) — l'API `POST /etl/run` accepte désormais les listes de flux.
+- **Suivi de job par édition** : le message de lancement s'édite
+  (`⏳ running` → `✅`/`❌` + sortie) au lieu d'un second message.
+- **Alertes proactives** : `TELEGRAM_NOTIFY_CHAT_ID` — alerte 🚨 sur tout job ETL
+  `failed`, y compris ceux du scheduler nocturne.
+- **Fraîcheur des données** : `/flux` stats affiche la dernière date *métier* par
+  table (`GET /flux/{table}/info` expose `derniere_date`).
+- Rendu **HTML partout** (fin du mélange Markdown V1/V2), descriptions des tables
+  dans le menu `/flux`, `/start` annonce l'instance servie
+  (convention `@<slug>_electricore_bot`).
+- API : `GET /facturation/check/odoo.xlsx` (détail du check pré-facturation) —
+  le bot redevient strictement client HTTP (garde-fou d'architecture en CI).
+
+#### 🔧 Interne
+
+- `bot.py` (monolithe) supprimé : package par domaine (`handlers/`), allowlist
+  factorisée en décorateur, fakes Telegram partagés côté tests (+39 tests).
+
+---
+
 ## [2.0.0] - 2026-06-11
 
 ### 🏗️ Ingestion ELT : la linéarisation des flux vit en dbt (ADR-0020 → ADR-0021)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,11 @@ electricore/
 │   ├── security.py            # API key authentication
 │   └── main.py                # FastAPI application
 │
-├── bot/                       # 🤖 Bot Telegram - UI opérationnelle (voir ADR-0010)
-│   ├── bot.py                 # Handlers commandes (/etl, /taxes, /facturation…)
+├── bot/                       # 🤖 Bot Telegram - UI opérationnelle (voir ADR-0010, ADR-0022)
+│   ├── app.py                 # Assemblage : application, menu natif, surveillance
+│   ├── handlers/              # Un module par domaine (/etl, /flux, /perimetre, /taxes, /facturation)
+│   ├── auth.py                # @require_allowed (allowlist), @require_odoo (no-ERP)
+│   ├── surveillance.py        # Alertes proactives (échec de job ETL)
 │   └── client.py              # Client HTTP async vers l'API
 │
 └── config/                    # ⚙️ Tariff rules (TURPE, Accise CSV files)
@@ -328,6 +331,7 @@ uv run --group test pytest --cov=electricore tests/
 - **Configuration (inventaire complet)**: [docs/configuration.md](docs/configuration.md) - Env vars, fichiers versionnés, deploy, outillage
 - **Ingestion (architecture ELT dlt+dbt)**: [docs/ingestion.md](docs/ingestion.md) - Schéma + recettes (ajouter un champ, nouvelle version XSD Enedis, nouveau flux, pièges DuckDB)
 - **API Module**: [electricore/api/README.md](electricore/api/README.md)
+- **Bot Module**: [electricore/bot/README.md](electricore/bot/README.md) - Surface de commandes, alertes, no-ERP (ADR-0022)
 - **DuckDB Integration**: [electricore/core/loaders/DUCKDB_INTEGRATION_GUIDE.md](electricore/core/loaders/DUCKDB_INTEGRATION_GUIDE.md)
 - **Odoo Query Builder**: [docs/odoo-query-builder.md](docs/odoo-query-builder.md)
 - **Date Conventions**: [docs/conventions-dates-enedis.md](docs/conventions-dates-enedis.md)

--- a/README.md
+++ b/README.md
@@ -379,8 +379,9 @@ ODOO_TEST_PASSWORD=mot_de_passe
 # ODOO_PROD_URL / ODOO_PROD_DB / ODOO_PROD_USERNAME / ODOO_PROD_PASSWORD
 
 # === BOT TELEGRAM — optionnel ===
-TELEGRAM_BOT_TOKEN=token_obtenu_via_botfather
-TELEGRAM_ALLOWED_USERS=123456789  # IDs séparés par virgule
+TELEGRAM_BOT_TOKEN=token_obtenu_via_botfather  # convention : @<slug>_electricore_bot
+TELEGRAM_ALLOWED_USERS=123456789   # IDs séparés par virgule
+TELEGRAM_NOTIFY_CHAT_ID=           # chat des alertes (échec ETL) ; vide = désactivé
 ```
 
 ### Commandes essentielles
@@ -485,6 +486,7 @@ uv run --group test pytest --cov=electricore --cov-report=html
 
 - [ETL README](electricore/etl/README.md) - Pipeline extraction & transformation
 - [API README](electricore/api/README.md) - API REST et authentification
+- [Bot README](electricore/bot/README.md) - Bot Telegram : surface de commandes, alertes, no-ERP
 - [Intégration DuckDB](electricore/core/loaders/DUCKDB_INTEGRATION_GUIDE.md) - Query Builder DuckDB
 - [Query Builder Odoo](docs/odoo-query-builder.md) - Intégration Odoo
 - [Conventions Dates](docs/conventions-dates-enedis.md) - Formats temporels Enedis

--- a/electricore/bot/README.md
+++ b/electricore/bot/README.md
@@ -1,0 +1,89 @@
+# Bot Telegram ElectriCore
+
+UI opérationnelle d'ElectriCore ([ADR-0010](../../docs/adr/0010-bot-telegram-ui-operationnelle.md)) :
+pilotage de l'ingestion, exports, taxes et contrôles pré-facturation depuis Telegram.
+Pur client HTTP de l'[API](../api/README.md) — aucune logique métier
+(garde-fou : [tests/architecture/test_bot_topology.py](../../tests/architecture/test_bot_topology.py)).
+
+Vocabulaire : [CONTEXT.md](CONTEXT.md). Décision de surface : [ADR-0022](../../docs/adr/0022-surface-bot-domaines-hybrides.md).
+
+## Surface de commandes
+
+Cinq **domaines** métier + l'aide. Chaque domaine invoqué **sans argument ouvre un
+clavier inline** (découvrable, zéro syntaxe) ; **avec arguments, il agit directement**
+(raccourci power-user). Le menu natif Telegram (☰) est publié au démarrage et
+adapté à l'instance.
+
+| Domaine | Clavier | Raccourcis |
+|---|---|---|
+| `/etl` | All · Test · Rebuild · Flux… · Resync · Statut | `/etl rebuild`, `/etl r151 c15`, `/etl statut` |
+| `/flux` | tables avec descriptions, 📊 stats · 📥 export | `/flux stats c15`, `/flux export r151` |
+| `/perimetre` | 📥 Entrées · 📤 Sorties (C15) | `/perimetre entrees`, `/perimetre sorties` |
+| `/taxes` ⁽ᵉʳᵖ⁾ | Accise · CTA → trimestre (4 derniers + toutes périodes) | `/taxes accise 2025-T1`, `/taxes cta` |
+| `/facturation` ⁽ᵉʳᵖ⁾ | Documents (choix du mois) · Check Odoo | `/facturation documents 2026-05-01`, `/facturation check` |
+| `/start`, `/help` | — | annonce l'instance servie et la surface |
+
+⁽ᵉʳᵖ⁾ masqué du menu et dégradé proprement quand aucun ERP n'est configuré
+(`is_odoo_configured`, cf. ADR-0016).
+
+Comportements notables :
+
+- **`resync` exige une confirmation à deux taps** (purge l'état incrémental dlt et
+  re-télécharge tout le SFTP) — y compris en raccourci texte.
+- **Suivi de job par édition** : le message de lancement ETL s'édite
+  (`⏳ running` → `✅ completed` / `❌ failed` + sortie), pas de second message.
+- **`reset` est retiré** de la surface (déprécié côté runner, alias de `resync`).
+- Les exports partent en **documents XLSX** dans le chat.
+
+## Alertes proactives
+
+Si `TELEGRAM_NOTIFY_CHAT_ID` est défini, le bot surveille les jobs ETL via l'API
+et pousse une alerte 🚨 quand un job passe à `failed` — **y compris ceux lancés
+par le scheduler** (supercronic). Pas d'alerte sur l'historique antérieur au
+démarrage, pas de doublon. Vide = désactivé.
+
+## Configuration
+
+| variable | rôle |
+|---|---|
+| `TELEGRAM_BOT_TOKEN` | token BotFather ; vide = bot non démarré |
+| `TELEGRAM_ALLOWED_USERS` | allowlist d'IDs Telegram (virgules) — obligatoire |
+| `TELEGRAM_NOTIFY_CHAT_ID` | chat des alertes proactives ; vide = désactivé |
+| `API_BASE_URL` | URL de l'API appelée par le bot (défaut `http://localhost:8001`) |
+| `INSTANCE_SLUG` | slug de l'instance, annoncé par `/start` (ADR-0015) |
+
+Convention de nommage : un bot par instance, `@<slug>_electricore_bot`
+(ex. `@edn_electricore_bot`).
+
+Le bot démarre dans le **process de l'API** (lifespan FastAPI) dès que
+`TELEGRAM_BOT_TOKEN` est défini — en local :
+
+```bash
+uv run uvicorn electricore.api.main:app --port 8001
+```
+
+(le port doit correspondre à `API_BASE_URL`, sinon les commandes échouent en
+« connexion refusée »).
+
+## Architecture
+
+```
+bot/
+├── app.py             # assemblage : build_application, menu natif, surveillance
+├── auth.py            # @require_allowed (allowlist), @require_odoo (no-ERP)
+├── client.py          # client HTTP async vers l'API (X-API-Key)
+├── format.py          # rendu HTML (escape) — parse_mode=HTML partout
+├── surveillance.py    # alertes proactives (polling /etl/jobs)
+├── tasks.py           # tâches de fond (annulées au shutdown)
+└── handlers/          # un module par domaine de commande
+    ├── start.py       # /start, /help — COMMANDES = source de vérité de la surface
+    ├── etl.py
+    ├── flux.py
+    ├── perimetre.py
+    ├── taxes.py
+    └── facturation.py
+```
+
+Un seul poller Telegram par token : pour tester en local avec le token de prod,
+arrêter d'abord le conteneur `api` de la prod (`docker compose stop api`) — ou
+utiliser un bot de dev dédié.


### PR DESCRIPTION
## Quoi

Partie repo de la bascule #160 (la dernière tranche de la refonte bot, ADR-0022) :

- **[electricore/bot/README.md](electricore/bot/README.md)** (nouveau) — la surface par domaines (tableau claviers/raccourcis), resync à deux taps, suivi par édition, alertes proactives, no-ERP, configuration complète, architecture du package, piège du poller unique.
- **CHANGELOG `[Unreleased]`** — section 💥 Breaking (rupture du contrat de commandes **sans alias**, mapping ancienne → nouvelle commande, `reset` retiré) + ✨ nouveautés. Le numéro de version reste à trancher au moment de la release (rupture du contrat *utilisateur bot* — majeure ou mineure selon ta lecture SemVer, sachant que v2.0.0 vient de sortir).
- **CLAUDE.md / README racine** — structure `bot/` réelle (le monolithe `bot.py` n'existe plus), lien vers le README bot, `TELEGRAM_NOTIFY_CHAT_ID` dans l'exemple `.env`.

Suite complète : **637 passed, 35 skipped**.

## ✅ Checklist opérateur (ta partie — à cocher avant de fermer #160)

- [x] Renommer le(s) bot(s) dans BotFather : `@<slug>_electricore_bot` (`/setname`, username via `/setusername`)
- [x] Ajouter `TELEGRAM_NOTIFY_CHAT_ID` au `.env` du VPS (ID du groupe d'alertes — le bot doit être membre du groupe)
- [x] Déployer la release, vérifier que le menu ☰ se met à jour (`setMyCommands` au démarrage)
- [x] Poster l'annonce dans le chat des opérateurs (texte prêt ci-dessous)
- [x] Fermer #160

## 📣 Annonce prête à coller dans Telegram

```
🤖 Le bot fait peau neuve — les commandes changent (sans alias) :

Tapez une commande SANS argument pour avoir des boutons. Les raccourcis texte marchent toujours pour les habitués.

• /etl — ingestion : All/Test/Rebuild/Resync/Statut (remplace aussi /status)
• /flux — tables brutes : stats + exports (remplace /stats et /export)
• /perimetre — entrées/sorties C15 (remplace /entrees et /sorties)
• /taxes — accise & CTA, choix du trimestre par boutons
• /facturation — documents par mois + check Odoo (remplace /check)

Nouveau :
• resync demande confirmation (re-téléchargement complet ~10 min)
• le suivi ETL se met à jour dans le même message
• 🚨 alertes automatiques ici quand un ETL nocturne échoue
• /flux affiche la date des dernières données reçues

/help pour tout revoir. Le menu ☰ liste tout.
```

Refs #160 — fermeture manuelle de l'issue une fois la checklist opérateur cochée (le merge ne la ferme pas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

