### PR TITLE
fix(bot): check Odoo — colonnes réelles + fin du ⏳ figé (incident 2026-06-12)

### DIFF
--- a/electricore/bot/handlers/facturation.py
+++ b/electricore/bot/handlers/facturation.py
@@ -6,6 +6,7 @@ les anomalies dépassent la limite d'affichage. Absorbe /facturation et /check v
 """
 
 import io
+import logging
 from datetime import date
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
@@ -15,8 +16,11 @@ from electricore.bot.auth import require_allowed, require_odoo
 from electricore.bot.client import ElectriCoreClient
 from electricore.bot.format import escape
 
+logger = logging.getLogger(__name__)
+
 _TITRE_MENU = "<b>Facturation</b> — choisis une action :"
 _USAGE = "Usage :\n  /facturation documents [YYYY-MM-DD]\n  /facturation check"
+_TELEGRAM_MSG_MAX = 4096  # limite dure de l'API Telegram par message
 
 
 def derniers_mois(aujourd_hui: date, n: int = 4) -> list[str]:
@@ -100,7 +104,7 @@ def _format_check_odoo(result: dict) -> tuple[str, bool]:
     _bloc(
         "factures encore en draft",
         result["factures_draft"],
-        lambda r: f"{r['sale_order_name']}{r['invoice_name']}",
+        lambda r: f"{r['name']} — {r['name_account_move']}",
         "Aucune facture en draft",
     )
     lines.append("")
@@ -108,7 +112,7 @@ def _format_check_odoo(result: dict) -> tuple[str, bool]:
     _bloc(
         "contrats lissés avec ligne énergie à qty=1",
         result.get("lisses_quantite_1", []),
-        lambda r: f"{r['sale_order_name']} ({', '.join(r['categ_names'])})",
+        lambda r: f"{r['name']} ({', '.join(r['categ_names'])})",
         "Aucun contrat lissé avec qty=1 sur Base/HP/HC",
     )
 
@@ -124,7 +128,20 @@ def _format_check_odoo(result: dict) -> tuple[str, bool]:
         lines.append("")
         lines.append("🟢 <b>OK pour lancer le cycle de facturation</b>")
 
-    return "\n".join(lines), xlsx_needed
+    msg = "\n".join(lines)
+    if len(msg) > _TELEGRAM_MSG_MAX:
+        # Tronquer aux frontières de lignes (chaque ligne est du HTML bien formé)
+        # et renvoyer vers le XLSX — sinon l'édition Telegram échoue (>4096 car.).
+        tronque: list[str] = []
+        budget = _TELEGRAM_MSG_MAX - 100
+        for ligne in lines:
+            if sum(len(li) + 1 for li in tronque) + len(ligne) > budget:
+                break
+            tronque.append(ligne)
+        msg = "\n".join(tronque) + "\n\n<i>… résumé tronqué — détail complet dans le XLSX joint</i>"
+        xlsx_needed = True
+
+    return msg, xlsx_needed
 
 
 async def _envoyer_documents(bot, chat_id: int, message_id: int, mois: str | None) -> None:
@@ -169,10 +186,22 @@ async def _executer_check(bot, chat_id: int, message_id: int) -> None:
         )
         return
 
-    msg, xlsx_needed = _format_check_odoo(result)
-    await bot.edit_message_text(
-        msg, chat_id=chat_id, message_id=message_id, parse_mode="HTML", disable_web_page_preview=True
-    )
+    try:
+        msg, xlsx_needed = _format_check_odoo(result)
+        await bot.edit_message_text(
+            msg, chat_id=chat_id, message_id=message_id, parse_mode="HTML", disable_web_page_preview=True
+        )
+    except Exception as e:
+        # Sans ce filet, une erreur de formatage/édition laissait le ⏳ figé
+        # et l'exception n'était visible que dans les logs (incident 2026-06-12).
+        logger.exception("Erreur de rendu du check Odoo")
+        await bot.edit_message_text(
+            f"❌ Erreur de rendu du check : <code>{escape(e)}</code>",
+            chat_id=chat_id,
+            message_id=message_id,
+            parse_mode="HTML",
+        )
+        return
     if xlsx_needed:
         try:
             xlsx_bytes = await client.get_check_odoo_xlsx()

--- a/tests/unit/test_bot_check_format.py
+++ b/tests/unit/test_bot_check_format.py
@@ -40,3 +40,39 @@ def test_tout_vert_affiche_le_feu_vert():
 
     assert "OK pour lancer le cycle de facturation" in msg
     assert xlsx_needed is False
+
+
+def test_factures_draft_rendues_avec_les_colonnes_reelles():
+    """Régression prod 2026-06-12 : KeyError sale_order_name — les colonnes
+    réelles du check sont `name` (commande) et `name_account_move` (facture)."""
+    msg, _ = _format_check_odoo(
+        _resultat(
+            factures_draft=[
+                {"name": "S00042", "account_move_id": 7, "name_account_move": "INV/2026/0001", "url": "https://o/7"}
+            ]
+        )
+    )
+
+    assert "S00042" in msg and "INV/2026/0001" in msg
+
+
+def test_lisses_rendus_avec_les_colonnes_reelles():
+    """Même famille : les lissés portent `name` + `categ_names`, pas `sale_order_name`."""
+    msg, _ = _format_check_odoo(
+        _resultat(lisses_quantite_1=[{"name": "S00043", "categ_names": ["Base", "HP"], "url": "https://o/8"}])
+    )
+
+    assert "S00043" in msg and "Base, HP" in msg
+
+
+def test_message_trop_long_bascule_sur_le_xlsx():
+    """Un résumé qui dépasserait la limite Telegram (4096) est raccourci et
+    renvoie vers le XLSX de détail au lieu de faire échouer l'édition."""
+    nombreuses = [
+        {"name": f"S{i:05}", "url": f"https://odoo.example/web#id={i}&model=sale.order&view_type=form"}
+        for i in range(20)
+    ]
+    msg, xlsx_needed = _format_check_odoo(_resultat(rsc_manquante=list(nombreuses), cfne_manquante=list(nombreuses)))
+
+    assert len(msg) <= 4096
+    assert xlsx_needed is True

--- a/tests/unit/test_bot_handlers_facturation.py
+++ b/tests/unit/test_bot_handlers_facturation.py
@@ -139,6 +139,22 @@ def test_callback_check_avec_depassement_joint_le_xlsx(monkeypatch):
     assert kwargs["filename"] == "check_odoo.xlsx"
 
 
+def test_check_au_payload_inattendu_affiche_l_erreur_au_lieu_de_figer(monkeypatch):
+    """Régression prod 2026-06-12 : une exception de formatage laissait le
+    message figé sur ⏳ — elle doit s'afficher dans Telegram."""
+    fake = FakeClient(check={**_CHECK_VIDE, "factures_draft": [{"colonne": "inattendue"}]})
+    monkeypatch.setattr(handlers_facturation, "ElectriCoreClient", lambda: fake)
+    monkeypatch.setattr(
+        handlers_facturation, "_format_check_odoo", lambda result: (_ for _ in ()).throw(KeyError("boom"))
+    )
+    update = update_callback("facturation:check")
+    bot = FakeBot()
+
+    asyncio.run(handlers_facturation.on_callback(update, contexte(bot=bot)))
+
+    assert "❌" in bot.edits[-1][2], "l'erreur doit remplacer le ⏳, pas le laisser figé"
+
+
 def test_raccourci_documents_avec_mois(client):
     update = update_commande()
     bot = FakeBot()


### PR DESCRIPTION
## Incident

En prod v2.1.0 : `/facturation` → Check Odoo → le message reste figé sur « ⏳ Vérifications côté Odoo… ». L'API répondait 200 ; la stacktrace (logs conteneur) montrait un `KeyError` dans `_format_check_odoo`, bloc « factures encore en draft ».

## Cause

Les lambdas des blocs **factures draft** et **lissés** demandaient `sale_order_name`/`invoice_name`, alors que le check produit `name`/`name_account_move` (convention du query builder) et `name`/`categ_names`. Bug **hérité du bot v1 verbatim** — latent car ces blocs ne s'exécutent que si des anomalies existent, et les fixtures de test ne les peuplaient jamais. La campagne de facturation en cours (factures draft présentes) l'a réveillé.

Aggravant : dans `_executer_check`, seul l'appel API était protégé — une exception de formatage/édition partait dans les logs et laissait le ⏳ pour toujours.

## Fix (TDD, 4 tests de régression)

- **Lambdas alignés** sur les colonnes réelles, testés avec les payloads réels des deux blocs.
- **Filet anti-⏳** : toute erreur de formatage/édition s'affiche en `❌ …` dans Telegram (+ `logger.exception`).
- **Garde 4096** : un résumé qui dépasserait la limite Telegram (le HTML des liens est verbeux) est tronqué aux frontières de lignes et bascule automatiquement sur le XLSX de détail — c'était le crash suivant en embuscade.

Suite complète : **641 passed, 35 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)