### PR TITLE
refactor(api): check Odoo — feuilles projetées depuis ResultatVerification (5 onglets fixes)

### DIFF
--- a/electricore/api/routers/facturation.py
+++ b/electricore/api/routers/facturation.py
@@ -9,7 +9,7 @@ from electricore.api.config import settings
 from electricore.api.decorators import arrow_endpoint, xlsx_endpoint
 from electricore.api.security import get_current_api_key
 from electricore.api.serializers import arrow_stream, xlsx_multi_sheet
-from electricore.api.services.check_facturation_service import generer_check_odoo_xlsx, verifier_odoo
+from electricore.api.services.check_facturation_service import check_odoo_xlsx, verifier_odoo
 from electricore.api.services.facturation_service import (
     documents_facturation_du_mois,
     facturation_du_mois,
@@ -99,8 +99,9 @@ def export_check_odoo_xlsx() -> bytes:
 
     Même contrôle que `/facturation/check/odoo`, sérialisé pour le cas où les
     anomalies dépassent ce qu'un message texte peut lister (issue #150).
+    Forme stable : 5 onglets, vides quand rien à signaler (issue #173).
     """
-    return generer_check_odoo_xlsx(verifier_odoo())
+    return check_odoo_xlsx()
 
 
 @xlsx_endpoint(router, "/facturation/documents.xlsx", filename="facturation{mois}.xlsx", requires_odoo=True)

--- a/electricore/api/services/check_facturation_service.py
+++ b/electricore/api/services/check_facturation_service.py
@@ -1,16 +1,17 @@
 """
-Vérifications pré-facturation : binding HTTP + sérialisation XLSX.
+Vérifications pré-facturation : binding HTTP + forme du livrable XLSX.
 
-La logique métier vit dans `integrations.odoo.verification`.
+La logique métier vit dans `integrations.odoo.verification`. La projection
+`feuilles_check_odoo` vit ici — les données sont intrinsèquement Odoo, donc
+ni core-able (ADR-0016) ni assemblables en `integrations/` (ADR-0019, règle 3 :
+source-only). Voir l'entrée « Feuilles » de core/CONTEXT.md (issue #173).
 """
 
-import io
-
 import polars as pl
-import xlsxwriter
 
 from electricore.api.config import settings
-from electricore.integrations.odoo import OdooReader, enrichir_liens, verifier
+from electricore.api.serializers import xlsx_multi_sheet
+from electricore.integrations.odoo import OdooReader, ResultatVerification, enrichir_liens, verifier
 
 
 def verifier_odoo() -> dict:
@@ -35,26 +36,27 @@ def _serialize_lisses(df: pl.DataFrame, base_url: str) -> list[dict]:
     return [{**row, "categ_names": list(row["categ_names"])} for row in enriched.to_dicts()]
 
 
-def generer_check_odoo_xlsx(result: dict) -> bytes:
-    """XLSX multi-onglets pour les checks dépassant la limite Telegram."""
-    buf = io.BytesIO()
-    wb = xlsxwriter.Workbook(buf, {"remove_timezone": True})
+def feuilles_check_odoo(r: ResultatVerification, base_url: str) -> dict[str, pl.DataFrame]:
+    """Projette le résultat de vérification en feuilles XLSX — 5 onglets fixes.
 
-    if result["rsc_manquante"]:
-        pl.DataFrame(result["rsc_manquante"]).write_excel(workbook=wb, worksheet="RSC manquant")
-    if result["cfne_manquante"]:
-        pl.DataFrame(result["cfne_manquante"]).write_excel(workbook=wb, worksheet="CFNE manquant")
-    if result["factures_draft"]:
-        pl.DataFrame(result["factures_draft"]).write_excel(workbook=wb, worksheet="Factures draft")
-    if result.get("lisses_quantite_1"):
-        df = pl.DataFrame(result["lisses_quantite_1"])
-        if "categ_names" in df.columns and df["categ_names"].dtype == pl.List(pl.Utf8):
-            df = df.with_columns(pl.col("categ_names").list.join(", "))
-        df.write_excel(workbook=wb, worksheet="Lissés qty=1")
+    Un onglet vide dit explicitement « rien à signaler » : la forme du livrable
+    est stable quelles que soient les anomalies présentes.
+    """
+    lisses = enrichir_liens(r.lisses_quantite_1, base_url, "sale.order")
+    if "categ_names" in lisses.columns and lisses["categ_names"].dtype == pl.List(pl.Utf8):
+        lisses = lisses.with_columns(pl.col("categ_names").list.join(", "))
+    return {
+        "RSC manquant": enrichir_liens(r.rsc_manquante, base_url, "sale.order"),
+        "CFNE manquant": enrichir_liens(r.cfne_manquante, base_url, "sale.order"),
+        "Factures draft": enrichir_liens(r.factures_draft, base_url, "account.move"),
+        "Lissés qty=1": lisses,
+        "Invoicing state": r.invoicing_state_counts.rename({"state": "x_invoicing_state"}),
+    }
 
-    counts_rows = [{"x_invoicing_state": k, "n": v} for k, v in result["invoicing_state_counts"].items()]
-    if counts_rows:
-        pl.DataFrame(counts_rows).write_excel(workbook=wb, worksheet="Invoicing state")
 
-    wb.close()
-    return buf.getvalue()
+def check_odoo_xlsx() -> bytes:
+    """XLSX multi-onglets du check : verifier → feuilles → xlsx_multi_sheet."""
+    odoo_cfg = settings.get_odoo_config()
+    with OdooReader(config=odoo_cfg) as odoo:
+        r = verifier(odoo)
+    return xlsx_multi_sheet(feuilles_check_odoo(r, odoo_cfg["url"]))

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -245,9 +245,10 @@ Export structuré destiné à un consommateur métier (facturiste, audit). Un li
 _Éviter_ : export (trop générique), fichier.
 
 **Feuilles** :
-Onglets d'un *Livrable* XLSX, matérialisés par un `dict[str, DataFrame]` consommable par `xlsx_multi_sheet`. Les clés du dict sont les libellés d'onglets affichés à l'utilisateur (FR : `Résumé`, `Par taux`, `Détail`, `F15 complet`, `Changements puissance`…). Deux formes de production coexistent :
+Onglets d'un *Livrable* XLSX, matérialisés par un `dict[str, DataFrame]` consommable par `xlsx_multi_sheet`. Les clés du dict sont les libellés d'onglets affichés à l'utilisateur (FR : `Résumé`, `Par taux`, `Détail`, `F15 complet`, `Changements puissance`…). Trois formes de production coexistent :
 
 - **À partir d'un `Rapport*`** : `feuilles_rapport_*(r) -> dict[str, DataFrame]` co-localisée avec le `rapport_*` correspondant (cas Accise, CTA, facturation rapport).
 - **Directement par un build** : `documents(ctx, lignes, f15, c15) -> tuple[dict[str, DataFrame], str]` dans `core/builds/contexte_mensuel.py` (cas `/facturation/documents.xlsx` — pas de dataclass intermédiaire, la forme du livrable est directement assemblée par le build ; le wire-up `documents_facturation_du_mois(odoo, mois)` vit en `api/services/facturation_service.py`, #144).
+- **Livrable ERP-spécifique, côté service** : quand les données sont intrinsèquement ERP (cas check Odoo — `sale.order`, champs `x_*`), la projection ne peut ni descendre en `core/builds/` (ADR-0016) ni vivre en `integrations/` (ADR-0019 règle 3, lecture stricte : source-only) ; elle vit en `api/services/`, à côté de la sérialisation (`feuilles_check_odoo` dans `check_facturation_service.py`, issue #173). Forme stable : les onglets sont fixes, vides quand rien à signaler.
 
 _Éviter_ : onglets (anglicisme), sheets.

--- a/tests/integration/test_facturation_arrow_endpoint.py
+++ b/tests/integration/test_facturation_arrow_endpoint.py
@@ -16,6 +16,7 @@ from polars.testing import assert_frame_equal
 from electricore.api.config import settings
 from electricore.api.main import app
 from electricore.api.security import get_current_api_key
+from electricore.integrations.odoo import ResultatVerification
 
 ARROW_IPC = "application/vnd.apache.arrow.stream"
 XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
@@ -266,24 +267,35 @@ def test_ancien_endpoint_documents_zip_404():
 
 
 @pytest.fixture
-def resultat_check_odoo() -> dict:
-    """Résultat synthétique de `verifier_odoo` avec une anomalie RSC."""
-    return {
-        "rsc_manquante": [{"id": 1, "name": "S00042", "url": "https://odoo.example/web#id=1"}],
-        "cfne_manquante": [],
-        "invoicing_state_counts": {"up_to_date": 12},
-        "factures_draft": [],
-        "lisses_quantite_1": [],
-    }
+def resultat_check_odoo() -> ResultatVerification:
+    """Résultat synthétique de `verifier` avec une anomalie RSC."""
+    return ResultatVerification(
+        rsc_manquante=pl.DataFrame({"sale_order_id": [1], "name": ["S00042"], "x_pdl": ["14000000000000"]}),
+        cfne_manquante=pl.DataFrame(schema={"sale_order_id": pl.Int64, "name": pl.Utf8, "x_pdl": pl.Utf8}),
+        invoicing_state_counts=pl.DataFrame({"state": ["up_to_date"], "n": [12]}),
+        factures_draft=pl.DataFrame(schema={"account_move_id": pl.Int64, "name": pl.Utf8}),
+        lisses_quantite_1=pl.DataFrame(
+            schema={"sale_order_id": pl.Int64, "name": pl.Utf8, "categ_names": pl.List(pl.Utf8)}
+        ),
+    )
 
 
-def test_check_odoo_xlsx_retourne_le_detail_en_xlsx(monkeypatch, resultat_check_odoo):
+@pytest.fixture
+def _mock_check_service(monkeypatch, resultat_check_odoo):
+    """Court-circuite l'I/O Odoo du service check : le chemin feuilles → xlsx reste réel (#173)."""
+
+    @contextmanager
+    def _fake_reader(config):
+        yield None
+
+    monkeypatch.setattr(type(settings), "get_odoo_config", lambda self: {"url": "https://odoo.example"})
+    monkeypatch.setattr("electricore.api.services.check_facturation_service.OdooReader", _fake_reader)
+    monkeypatch.setattr("electricore.api.services.check_facturation_service.verifier", lambda odoo: resultat_check_odoo)
+
+
+def test_check_odoo_xlsx_retourne_le_detail_en_xlsx(_mock_check_service):
     """L'endpoint sert le détail complet du check Odoo en XLSX multi-onglets."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
-    monkeypatch.setattr(
-        "electricore.api.routers.facturation.verifier_odoo",
-        lambda: resultat_check_odoo,
-    )
     try:
         response = TestClient(app).get("/facturation/check/odoo.xlsx")
     finally:
@@ -295,8 +307,8 @@ def test_check_odoo_xlsx_retourne_le_detail_en_xlsx(monkeypatch, resultat_check_
 
     with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
         workbook_xml = zf.read("xl/workbook.xml").decode()
-    assert "RSC manquant" in workbook_xml, "l'onglet de l'anomalie RSC doit exister"
-    assert "Invoicing state" in workbook_xml
+    for onglet in ("RSC manquant", "CFNE manquant", "Factures draft", "Lissés qty=1", "Invoicing state"):
+        assert onglet in workbook_xml, f"forme stable (#173) : l'onglet {onglet} doit exister même vide"
 
 
 def test_check_odoo_xlsx_refuse_sans_api_key():

--- a/tests/unit/test_bot_client.py
+++ b/tests/unit/test_bot_client.py
@@ -6,14 +6,17 @@ ici qu'il obtient bien ses livrables par l'API et non par import direct (#150).
 """
 
 import asyncio
+from contextlib import contextmanager
 
 import httpx
+import polars as pl
 import pytest
 
 from electricore.api.config import settings
 from electricore.api.main import app
 from electricore.api.security import get_current_api_key
 from electricore.bot.client import ElectriCoreClient
+from electricore.integrations.odoo import ResultatVerification
 
 
 @pytest.fixture(autouse=True)
@@ -25,16 +28,23 @@ def _mock_odoo_configured(monkeypatch):
 def test_get_check_odoo_xlsx_obtient_le_detail_via_l_api(monkeypatch):
     """Le client bot récupère le XLSX du check Odoo par l'endpoint dédié."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
-    monkeypatch.setattr(
-        "electricore.api.routers.facturation.verifier_odoo",
-        lambda: {
-            "rsc_manquante": [{"id": 1, "name": "S00042", "url": "https://odoo.example/web#id=1"}],
-            "cfne_manquante": [],
-            "invoicing_state_counts": {"up_to_date": 12},
-            "factures_draft": [],
-            "lisses_quantite_1": [],
-        },
+
+    @contextmanager
+    def _fake_reader(config):
+        yield None
+
+    resultat = ResultatVerification(
+        rsc_manquante=pl.DataFrame({"sale_order_id": [1], "name": ["S00042"], "x_pdl": ["14000000000000"]}),
+        cfne_manquante=pl.DataFrame(schema={"sale_order_id": pl.Int64, "name": pl.Utf8, "x_pdl": pl.Utf8}),
+        invoicing_state_counts=pl.DataFrame({"state": ["up_to_date"], "n": [12]}),
+        factures_draft=pl.DataFrame(schema={"account_move_id": pl.Int64, "name": pl.Utf8}),
+        lisses_quantite_1=pl.DataFrame(
+            schema={"sale_order_id": pl.Int64, "name": pl.Utf8, "categ_names": pl.List(pl.Utf8)}
+        ),
     )
+    monkeypatch.setattr(type(settings), "get_odoo_config", lambda self: {"url": "https://odoo.example"})
+    monkeypatch.setattr("electricore.api.services.check_facturation_service.OdooReader", _fake_reader)
+    monkeypatch.setattr("electricore.api.services.check_facturation_service.verifier", lambda odoo: resultat)
     bot_client = ElectriCoreClient(transport=httpx.ASGITransport(app=app))
     try:
         xlsx_bytes = asyncio.run(bot_client.get_check_odoo_xlsx())

--- a/tests/unit/test_feuilles_check_odoo.py
+++ b/tests/unit/test_feuilles_check_odoo.py
@@ -1,0 +1,70 @@
+"""Tests unitaires de `feuilles_check_odoo` (issue #173).
+
+La projection suit le pattern Feuilles (core/CONTEXT.md) et se teste sur
+DataFrames directs — sans round-trip dict JSON. Forme stable : 5 onglets fixes,
+vides quand rien à signaler.
+"""
+
+import polars as pl
+
+from electricore.api.serializers import xlsx_multi_sheet
+from electricore.api.services.check_facturation_service import feuilles_check_odoo
+from electricore.integrations.odoo import ResultatVerification
+
+BASE_URL = "https://odoo.example"
+
+ONGLETS = ("RSC manquant", "CFNE manquant", "Factures draft", "Lissés qty=1", "Invoicing state")
+
+
+def _resultat(**overrides) -> ResultatVerification:
+    defaults = dict(
+        rsc_manquante=pl.DataFrame(schema={"sale_order_id": pl.Int64, "name": pl.Utf8, "x_pdl": pl.Utf8}),
+        cfne_manquante=pl.DataFrame(schema={"sale_order_id": pl.Int64, "name": pl.Utf8, "x_pdl": pl.Utf8}),
+        invoicing_state_counts=pl.DataFrame(schema={"state": pl.Utf8, "n": pl.UInt32}),
+        factures_draft=pl.DataFrame(schema={"account_move_id": pl.Int64, "name": pl.Utf8}),
+        lisses_quantite_1=pl.DataFrame(
+            schema={"sale_order_id": pl.Int64, "name": pl.Utf8, "categ_names": pl.List(pl.Utf8)}
+        ),
+    )
+    return ResultatVerification(**{**defaults, **overrides})
+
+
+def test_forme_stable_5_onglets_meme_sans_anomalie():
+    feuilles = feuilles_check_odoo(_resultat(), BASE_URL)
+    assert tuple(feuilles.keys()) == ONGLETS
+
+
+def test_liens_odoo_sur_les_anomalies():
+    r = _resultat(rsc_manquante=pl.DataFrame({"sale_order_id": [7], "name": ["S00042"], "x_pdl": ["14000000000000"]}))
+    feuilles = feuilles_check_odoo(r, BASE_URL)
+    assert feuilles["RSC manquant"]["url"].to_list() == [
+        "https://odoo.example/web#id=7&model=sale.order&view_type=form"
+    ]
+
+
+def test_factures_draft_liees_au_account_move():
+    r = _resultat(factures_draft=pl.DataFrame({"account_move_id": [42], "name": ["S00007"]}))
+    feuilles = feuilles_check_odoo(r, BASE_URL)
+    assert feuilles["Factures draft"]["url"].to_list() == [
+        "https://odoo.example/web#id=42&model=account.move&view_type=form"
+    ]
+
+
+def test_categ_names_aplati_en_texte():
+    r = _resultat(
+        lisses_quantite_1=pl.DataFrame({"sale_order_id": [3], "name": ["S00007"], "categ_names": [["Base", "HP"]]})
+    )
+    feuilles = feuilles_check_odoo(r, BASE_URL)
+    assert feuilles["Lissés qty=1"]["categ_names"].to_list() == ["Base, HP"]
+
+
+def test_invoicing_state_renomme_pour_le_livrable():
+    r = _resultat(invoicing_state_counts=pl.DataFrame({"state": ["up_to_date"], "n": [12]}))
+    feuilles = feuilles_check_odoo(r, BASE_URL)
+    assert feuilles["Invoicing state"].columns == ["x_invoicing_state", "n"]
+
+
+def test_xlsx_serialisable_meme_sans_anomalie():
+    """Les onglets vides doivent rester écrivables par xlsx_multi_sheet."""
+    xlsx = xlsx_multi_sheet(feuilles_check_odoo(_resultat(), BASE_URL))
+    assert xlsx[:4] == b"PK\x03\x04"


### PR DESCRIPTION
## Quoi

Le livrable XLSX du check pré-facturation rejoint le pattern **Feuilles** (core/CONTEXT.md) :

- `feuilles_check_odoo(r: ResultatVerification, base_url) -> dict[str, DataFrame]` dans `check_facturation_service.py` — projection directe, plus de round-trip dict JSON (cas `categ_names` compris) ;
- sérialisation déléguée à `api/serializers.xlsx_multi_sheet` — la boucle xlsxwriter inline disparaît ;
- **5 onglets fixes** : un onglet vide dit « rien à signaler », la forme du livrable est stable ;
- chemin JSON (`verifier_odoo`, contrat du bot) inchangé ;
- entrée « Feuilles » de core/CONTEXT.md affûtée (3ᵉ forme : livrable ERP-spécifique côté `api/services/`, décision de grilling — ADR-0016 + lecture stricte d'ADR-0019 règle 3).

## Tests

- Nouveaux unitaires `test_feuilles_check_odoo.py` : forme stable, liens sale.order/account.move, aplatissement `categ_names`, renommage `x_invoicing_state`, sérialisation des onglets vides.
- Tests existants adaptés au nouveau seam : ils patchent `verifier` côté service et exercent le vrai chemin feuilles → xlsx (assertion renforcée : les 5 onglets présents même vides).
- Suite complète : 647 passed, 35 skipped.

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)