### PR TITLE
refactor(bot): module Livraison — squelette d'envoi unifié (4 copies → 1) + primitives HTTP du client

### DIFF
--- a/electricore/bot/CONTEXT.md
+++ b/electricore/bot/CONTEXT.md
@@ -27,7 +27,11 @@ Chat Telegram destinataire des alertes proactives du bot (échec d'un job ETL, y
 Liste d'identifiants numériques Telegram autorisés à utiliser le bot, configurée via `TELEGRAM_ALLOWED_USERS`. Tout autre utilisateur reçoit `⛔ Accès refusé`. Pas de rôles ni de granularité.
 
 **Client API** :
-Wrapper `httpx.AsyncClient` ([client.py](client.py)) qui factorise les appels HTTP vers l'API : injection automatique de la clé `X-API-Key`, gestion des timeouts (10 s pour les requêtes courtes, 300 s pour les exports lourds).
+Wrapper `httpx.AsyncClient` ([client.py](client.py)) qui factorise les appels HTTP vers l'API : injection automatique de la clé `X-API-Key`, gestion des timeouts (10 s pour les requêtes courtes, 120 s pour les exports de tables, 300 s pour les livrables calculés). Le squelette httpx vit dans les primitives `_get_json` / `_get_bytes` / `_post_json` ; les méthodes publiques ne déclarent que chemin et budget de timeout.
+
+**Livraison** :
+Remise d'un *livrable* (cf. [core/CONTEXT.md](../core/CONTEXT.md)) dans le chat, avec suivi de progression (⏳ pendant le calcul, 📥 à l'envoi) et filet d'erreur (❌ édité sur le message de suivi — aucun chemin ne laisse le ⏳ figé). Deux primitives composables dans [livraison.py](livraison.py) : `etape()` (suivi + filet, retourne `None` quand l'échec est déjà signalé) et `envoyer_document()` (étape + document + confirmation). Tous les domaines passent par là ; le format des messages de suivi vit en un seul endroit (issue #174).
+_Éviter_ : envoi (ne dit ni le suivi ni le filet), remise (collision avec le rabais commercial).
 
 **Instance** :
 Déploiement complet de la stack pour un opérateur donné (voir [ADR-0015](../../docs/adr/0015-deploiement-multi-instance.md)). Chaque instance a son propre bot Telegram, nommé `@<slug>_electricore_bot` ; `/start` annonce l'instance servie.

--- a/electricore/bot/client.py
+++ b/electricore/bot/client.py
@@ -1,11 +1,20 @@
 """
 Client HTTP async pour l'API ElectriCore.
 Utilisé par le bot Telegram pour appeler les endpoints REST.
+
+Le squelette httpx (ouverture du client, clé API, `raise_for_status`) vit dans
+les primitives `_get_json` / `_get_bytes` / `_post_json` (#174) ; les méthodes
+publiques ne déclarent que le chemin et le budget de timeout.
 """
 
 import httpx
 
 from electricore.api.config import settings
+
+# Budgets de timeout par profil d'endpoint (secondes)
+TIMEOUT_COURT = 10  # JSON légers : statuts, listes, infos de table
+TIMEOUT_EXPORT = 120  # exports XLSX de tables flux
+TIMEOUT_LOURD = 300  # livrables calculés : taxes, facturation, check Odoo
 
 
 class ElectriCoreClient:
@@ -19,103 +28,69 @@ class ElectriCoreClient:
     def _http(self) -> httpx.AsyncClient:
         return httpx.AsyncClient(transport=self._transport)
 
-    async def list_tables(self) -> list[str]:
+    async def _get(self, path: str, *, timeout: float, params: dict | None = None) -> httpx.Response:
         async with self._http() as c:
-            r = await c.get(f"{self._base}/", timeout=10)
+            r = await c.get(f"{self._base}{path}", headers=self._headers, params=params, timeout=timeout)
             r.raise_for_status()
-            return r.json().get("available_tables", [])
+            return r
+
+    async def _get_json(self, path: str, *, timeout: float = TIMEOUT_COURT, params: dict | None = None):
+        return (await self._get(path, timeout=timeout, params=params)).json()
+
+    async def _get_bytes(self, path: str, *, timeout: float = TIMEOUT_EXPORT, params: dict | None = None) -> bytes:
+        return (await self._get(path, timeout=timeout, params=params)).content
+
+    async def _post_json(self, path: str, *, json: dict, timeout: float = TIMEOUT_COURT):
+        async with self._http() as c:
+            r = await c.post(f"{self._base}{path}", json=json, headers=self._headers, timeout=timeout)
+            r.raise_for_status()
+            return r.json()
+
+    async def list_tables(self) -> list[str]:
+        data = await self._get_json("/")
+        return data.get("available_tables", [])
 
     async def get_table_info(self, table: str) -> dict:
-        async with self._http() as c:
-            r = await c.get(f"{self._base}/flux/{table}/info", headers=self._headers, timeout=10)
-            r.raise_for_status()
-            return r.json()
+        return await self._get_json(f"/flux/{table}/info")
 
     async def run_etl(self, mode: str) -> dict:
-        async with self._http() as c:
-            r = await c.post(
-                f"{self._base}/etl/run",
-                json={"mode": mode},
-                headers=self._headers,
-                timeout=10,
-            )
-            r.raise_for_status()
-            return r.json()
+        return await self._post_json("/etl/run", json={"mode": mode})
 
     async def get_job(self, job_id: str) -> dict:
-        async with self._http() as c:
-            r = await c.get(f"{self._base}/etl/jobs/{job_id}", headers=self._headers, timeout=10)
-            r.raise_for_status()
-            return r.json()
+        return await self._get_json(f"/etl/jobs/{job_id}")
 
     async def get_jobs(self, limit: int = 5) -> list[dict]:
-        async with self._http() as c:
-            r = await c.get(f"{self._base}/etl/jobs", params={"limit": limit}, headers=self._headers, timeout=10)
-            r.raise_for_status()
-            return r.json()
+        return await self._get_json("/etl/jobs", params={"limit": limit})
 
     async def get_entrees_xlsx(self) -> bytes:
-        async with self._http() as c:
-            r = await c.get(f"{self._base}/flux/c15/entrees.xlsx", headers=self._headers, timeout=120)
-            r.raise_for_status()
-            return r.content
+        return await self._get_bytes("/flux/c15/entrees.xlsx")
 
     async def get_sorties_xlsx(self) -> bytes:
-        async with self._http() as c:
-            r = await c.get(f"{self._base}/flux/c15/sorties.xlsx", headers=self._headers, timeout=120)
-            r.raise_for_status()
-            return r.content
+        return await self._get_bytes("/flux/c15/sorties.xlsx")
 
     async def get_xlsx(self, table: str) -> bytes:
-        async with self._http() as c:
-            r = await c.get(f"{self._base}/flux/{table}.xlsx", headers=self._headers, timeout=120)
-            r.raise_for_status()
-            return r.content
+        return await self._get_bytes(f"/flux/{table}.xlsx")
 
     async def get_accise_xlsx(self, trimestre: str | None = None) -> bytes:
-        params = {}
-        if trimestre:
-            params["trimestre"] = trimestre
-        async with self._http() as c:
-            r = await c.get(
-                f"{self._base}/taxes/accise/rapport.xlsx", headers=self._headers, params=params, timeout=300
-            )
-            r.raise_for_status()
-            return r.content
+        params = {"trimestre": trimestre} if trimestre else None
+        return await self._get_bytes("/taxes/accise/rapport.xlsx", params=params, timeout=TIMEOUT_LOURD)
 
     async def get_cta_xlsx(self, trimestre: str | None = None) -> bytes:
-        params: dict = {"trimestre": trimestre} if trimestre else {}
-        async with self._http() as c:
-            r = await c.get(f"{self._base}/taxes/cta/rapport.xlsx", headers=self._headers, params=params, timeout=300)
-            r.raise_for_status()
-            return r.content
+        params = {"trimestre": trimestre} if trimestre else None
+        return await self._get_bytes("/taxes/cta/rapport.xlsx", params=params, timeout=TIMEOUT_LOURD)
 
     async def get_facturation_xlsx(self, mois: str | None = None) -> bytes:
-        params = {"mois": mois} if mois else {}
-        async with self._http() as c:
-            r = await c.get(f"{self._base}/facturation/rapport.xlsx", headers=self._headers, params=params, timeout=300)
-            r.raise_for_status()
-            return r.content
+        params = {"mois": mois} if mois else None
+        return await self._get_bytes("/facturation/rapport.xlsx", params=params, timeout=TIMEOUT_LOURD)
 
     async def get_facturation_documents_xlsx(self, mois: str | None = None) -> bytes:
         """Livrable XLSX multi-onglets des documents de campagne facturation (cf. #78)."""
-        params = {"mois": mois} if mois else {}
-        async with self._http() as c:
-            r = await c.get(
-                f"{self._base}/facturation/documents.xlsx", headers=self._headers, params=params, timeout=300
-            )
-            r.raise_for_status()
-            return r.content
+        params = {"mois": mois} if mois else None
+        return await self._get_bytes("/facturation/documents.xlsx", params=params, timeout=TIMEOUT_LOURD)
 
     async def check_facturation_odoo(self) -> dict:
-        async with self._http() as c:
-            r = await c.get(f"{self._base}/facturation/check/odoo", headers=self._headers, timeout=300)
-            r.raise_for_status()
-            return r.json()
+        return await self._get_json("/facturation/check/odoo", timeout=TIMEOUT_LOURD)
 
     async def get_check_odoo_xlsx(self) -> bytes:
         """Détail complet du check Odoo en XLSX multi-onglets (issue #150)."""
-        async with self._http() as c:
-            r = await c.get(f"{self._base}/facturation/check/odoo.xlsx", headers=self._headers, timeout=300)
-            r.raise_for_status()
-            return r.content
+        return await self._get_bytes("/facturation/check/odoo.xlsx", timeout=TIMEOUT_LOURD)

--- a/electricore/bot/handlers/facturation.py
+++ b/electricore/bot/handlers/facturation.py
@@ -15,6 +15,7 @@ from telegram.ext import ContextTypes
 from electricore.bot.auth import require_allowed, require_odoo
 from electricore.bot.client import ElectriCoreClient
 from electricore.bot.format import escape
+from electricore.bot.livraison import envoyer_document, etape
 
 logger = logging.getLogger(__name__)
 
@@ -146,44 +147,29 @@ def _format_check_odoo(result: dict) -> tuple[str, bool]:
 
 async def _envoyer_documents(bot, chat_id: int, message_id: int, mois: str | None) -> None:
     periode = mois[:7] if mois else "dernier mois disponible"
-    await bot.edit_message_text(
-        f"⏳ Génération des documents facturation — {escape(periode)}…",
-        chat_id=chat_id,
-        message_id=message_id,
-        parse_mode="HTML",
-    )
     client = ElectriCoreClient()
-    try:
-        xlsx_bytes = await client.get_facturation_documents_xlsx(mois)
-    except Exception as e:
-        await bot.edit_message_text(
-            f"❌ Erreur : <code>{escape(e)}</code>", chat_id=chat_id, message_id=message_id, parse_mode="HTML"
-        )
-        return
     suffixe = f"_{mois[:7]}" if mois else ""
-    filename = f"facturation{suffixe}.xlsx"
-    await bot.send_document(
-        chat_id=chat_id,
-        document=io.BytesIO(xlsx_bytes),
-        filename=filename,
+    await envoyer_document(
+        bot,
+        chat_id,
+        message_id,
+        attente=f"Génération des documents facturation — {escape(periode)}",
+        fetch=lambda: client.get_facturation_documents_xlsx(mois),
+        filename=f"facturation{suffixe}.xlsx",
         caption=f"Documents facturation Odoo ↔ Enedis — {periode} (6 onglets)",
-    )
-    await bot.edit_message_text(
-        f"📥 <code>{filename}</code> envoyé.", chat_id=chat_id, message_id=message_id, parse_mode="HTML"
     )
 
 
 async def _executer_check(bot, chat_id: int, message_id: int) -> None:
-    await bot.edit_message_text(
-        "⏳ Vérifications côté Odoo…", chat_id=chat_id, message_id=message_id, parse_mode="HTML"
-    )
     client = ElectriCoreClient()
-    try:
-        result = await client.check_facturation_odoo()
-    except Exception as e:
-        await bot.edit_message_text(
-            f"❌ Erreur : <code>{escape(e)}</code>", chat_id=chat_id, message_id=message_id, parse_mode="HTML"
-        )
+    result = await etape(
+        bot,
+        chat_id,
+        message_id,
+        attente="Vérifications côté Odoo",
+        action=client.check_facturation_odoo,
+    )
+    if result is None:
         return
 
     try:

--- a/electricore/bot/handlers/flux.py
+++ b/electricore/bot/handlers/flux.py
@@ -5,14 +5,13 @@ Stats / Export. Raccourcis : `/flux stats <table>`, `/flux export <table>`.
 Remplace les commandes v1 `/stats`, `/export` et l'ancien `/flux` plat.
 """
 
-import io
-
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
 
 from electricore.bot.auth import require_allowed
 from electricore.bot.client import ElectriCoreClient
 from electricore.bot.format import escape
+from electricore.bot.livraison import envoyer_document
 
 _TITRE_MENU = "<b>Tables flux Enedis</b> — stats ou export :"
 
@@ -68,35 +67,17 @@ async def _texte_stats(client: ElectriCoreClient, table: str) -> str:
 
 async def _envoyer_export(bot, chat_id: int, message_id: int, client: ElectriCoreClient, table: str) -> None:
     """Génère l'export, l'envoie en document et confirme sur le message du clavier."""
-    await bot.edit_message_text(
-        f"⏳ Génération de l'export <code>{escape(table)}</code>…",
-        chat_id=chat_id,
-        message_id=message_id,
-        parse_mode="HTML",
-    )
-    try:
-        xlsx_bytes = await client.get_xlsx(table)
-    except Exception as e:
-        await bot.edit_message_text(
-            f"❌ Erreur pour <code>{escape(table)}</code> : <code>{escape(e)}</code>",
-            chat_id=chat_id,
-            message_id=message_id,
-            parse_mode="HTML",
-            reply_markup=clavier_retour(),
-        )
-        return
-    await bot.send_document(
-        chat_id=chat_id,
-        document=io.BytesIO(xlsx_bytes),
+    await envoyer_document(
+        bot,
+        chat_id,
+        message_id,
+        attente=f"Génération de l'export <code>{escape(table)}</code>",
+        fetch=lambda: client.get_xlsx(table),
         filename=f"flux_{table}.xlsx",
         caption=f"Export flux_{table}",
-    )
-    await bot.edit_message_text(
-        f"📥 <code>flux_{escape(table)}.xlsx</code> envoyé.",
-        chat_id=chat_id,
-        message_id=message_id,
-        parse_mode="HTML",
-        reply_markup=clavier_retour(),
+        libelle_erreur=f"Erreur pour <code>{escape(table)}</code>",
+        clavier_erreur=clavier_retour(),
+        clavier_confirmation=clavier_retour(),
     )
 
 

--- a/electricore/bot/handlers/taxes.py
+++ b/electricore/bot/handlers/taxes.py
@@ -5,7 +5,6 @@ ou raccourcis texte v1 inchangés : `/taxes accise [trimestre]`, `/taxes cta
 [trimestre]`.
 """
 
-import io
 from datetime import date
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
@@ -14,6 +13,7 @@ from telegram.ext import ContextTypes
 from electricore.bot.auth import require_allowed, require_odoo
 from electricore.bot.client import ElectriCoreClient
 from electricore.bot.format import escape
+from electricore.bot.livraison import envoyer_document
 
 _TITRE_MENU = "<b>Taxes</b> — choisis un calcul :"
 _USAGE = "Usage :\n  /taxes accise [trimestre]  (ex: /taxes accise 2025-T1)\n  /taxes cta [trimestre]"
@@ -56,30 +56,20 @@ def clavier_trimestres(taxe: str) -> InlineKeyboardMarkup:
 async def _envoyer_rapport(bot, chat_id: int, message_id: int, taxe: str, trimestre: str | None) -> None:
     libelle = _LIBELLES[taxe]
     periode = trimestre or "toutes périodes"
-    await bot.edit_message_text(
-        f"⏳ Calcul {libelle} — {escape(periode)}…", chat_id=chat_id, message_id=message_id, parse_mode="HTML"
-    )
     client = ElectriCoreClient()
-    try:
-        if taxe == "accise":
-            xlsx_bytes = await client.get_accise_xlsx(trimestre)
-        else:
-            xlsx_bytes = await client.get_cta_xlsx(trimestre)
-    except Exception as e:
-        await bot.edit_message_text(
-            f"❌ Erreur {libelle} : <code>{escape(e)}</code>",
-            chat_id=chat_id,
-            message_id=message_id,
-            parse_mode="HTML",
-        )
-        return
-    suffixe = f"_{trimestre}" if trimestre else ""
-    filename = f"{taxe}{suffixe}.xlsx"
-    await bot.send_document(
-        chat_id=chat_id, document=io.BytesIO(xlsx_bytes), filename=filename, caption=f"{libelle} — {periode}"
+    fetch = (
+        (lambda: client.get_accise_xlsx(trimestre)) if taxe == "accise" else (lambda: client.get_cta_xlsx(trimestre))
     )
-    await bot.edit_message_text(
-        f"📥 <code>{filename}</code> envoyé.", chat_id=chat_id, message_id=message_id, parse_mode="HTML"
+    suffixe = f"_{trimestre}" if trimestre else ""
+    await envoyer_document(
+        bot,
+        chat_id,
+        message_id,
+        attente=f"Calcul {libelle} — {escape(periode)}",
+        fetch=fetch,
+        filename=f"{taxe}{suffixe}.xlsx",
+        caption=f"{libelle} — {periode}",
+        libelle_erreur=f"Erreur {libelle}",
     )
 
 

--- a/electricore/bot/livraison.py
+++ b/electricore/bot/livraison.py
@@ -1,0 +1,111 @@
+"""Livraison : remise d'un livrable dans le chat (#174, voir CONTEXT.md).
+
+Le squelette « éditer ⏳ → exécuter → éditer ❌ en cas d'échec → envoyer le
+document → confirmer 📥 » vivait en quatre copies dans les handlers ; le filet
+d'erreur posé après l'incident du ⏳ figé (72a1ed2) ne couvrait qu'une copie.
+Deux primitives composables le portent désormais pour tous les domaines :
+
+- `etape()` : suivi de progression + filet d'erreur — retourne le résultat de
+  l'action, ou `None` si l'échec a déjà été signalé dans le chat ;
+- `envoyer_document()` : étape + `send_document` + confirmation 📥, l'envoi
+  lui-même restant sous le filet.
+"""
+
+import io
+import logging
+from collections.abc import Awaitable, Callable
+
+from telegram import InlineKeyboardMarkup
+
+from electricore.bot.format import escape
+
+logger = logging.getLogger(__name__)
+
+
+async def _signaler_echec(
+    bot,
+    chat_id: int,
+    message_id: int,
+    libelle_erreur: str,
+    e: Exception,
+    clavier_erreur: InlineKeyboardMarkup | None,
+) -> None:
+    kwargs = {"reply_markup": clavier_erreur} if clavier_erreur else {}
+    await bot.edit_message_text(
+        f"❌ {libelle_erreur} : <code>{escape(e)}</code>",
+        chat_id=chat_id,
+        message_id=message_id,
+        parse_mode="HTML",
+        **kwargs,
+    )
+
+
+async def etape[T](
+    bot,
+    chat_id: int,
+    message_id: int,
+    *,
+    attente: str,
+    action: Callable[[], Awaitable[T]],
+    libelle_erreur: str = "Erreur",
+    clavier_erreur: InlineKeyboardMarkup | None = None,
+) -> T | None:
+    """Exécute une action en éditant le message de suivi : ⏳ avant, ❌ si échec.
+
+    Retourne `None` quand l'échec est déjà signalé dans le chat — le caller
+    s'arrête là (`if resultat is None: return`), il n'a rien à rapporter.
+    `attente` et `libelle_erreur` sont des fragments HTML déjà échappés.
+    """
+    await bot.edit_message_text(f"⏳ {attente}…", chat_id=chat_id, message_id=message_id, parse_mode="HTML")
+    try:
+        return await action()
+    except Exception as e:
+        logger.exception("Échec d'étape : %s", libelle_erreur)
+        await _signaler_echec(bot, chat_id, message_id, libelle_erreur, e, clavier_erreur)
+        return None
+
+
+async def envoyer_document(
+    bot,
+    chat_id: int,
+    message_id: int,
+    *,
+    attente: str,
+    fetch: Callable[[], Awaitable[bytes]],
+    filename: str,
+    caption: str,
+    libelle_erreur: str = "Erreur",
+    clavier_erreur: InlineKeyboardMarkup | None = None,
+    clavier_confirmation: InlineKeyboardMarkup | None = None,
+) -> bool:
+    """Livre un document : étape suivie, envoi, confirmation 📥.
+
+    Retourne `True` si le document a été livré. L'envoi et la confirmation
+    restent sous le filet — aucun chemin ne laisse le ⏳ figé.
+    """
+    contenu = await etape(
+        bot,
+        chat_id,
+        message_id,
+        attente=attente,
+        action=fetch,
+        libelle_erreur=libelle_erreur,
+        clavier_erreur=clavier_erreur,
+    )
+    if contenu is None:
+        return False
+    try:
+        await bot.send_document(chat_id=chat_id, document=io.BytesIO(contenu), filename=filename, caption=caption)
+        kwargs = {"reply_markup": clavier_confirmation} if clavier_confirmation else {}
+        await bot.edit_message_text(
+            f"📥 <code>{escape(filename)}</code> envoyé.",
+            chat_id=chat_id,
+            message_id=message_id,
+            parse_mode="HTML",
+            **kwargs,
+        )
+    except Exception as e:
+        logger.exception("Échec de livraison : %s", filename)
+        await _signaler_echec(bot, chat_id, message_id, libelle_erreur, e, clavier_erreur)
+        return False
+    return True

--- a/tests/unit/test_bot_livraison.py
+++ b/tests/unit/test_bot_livraison.py
@@ -1,0 +1,138 @@
+"""Tests du module Livraison (`electricore/bot/livraison.py`) — #174.
+
+Le squelette « ⏳ → action → ❌/📥 » est testé ici une seule fois ; les tests
+des handlers ne couvrent plus que leur contenu métier.
+"""
+
+import asyncio
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+from electricore.bot.livraison import envoyer_document, etape
+from tests.unit.telegram_fakes import FakeBot
+
+CLAVIER = InlineKeyboardMarkup([[InlineKeyboardButton("← Retour", callback_data="x:menu")]])
+
+
+# =============================================================================
+# etape — suivi de progression + filet d'erreur
+# =============================================================================
+
+
+def test_etape_edite_l_attente_puis_retourne_le_resultat():
+    bot = FakeBot()
+
+    async def action():
+        return 42
+
+    resultat = asyncio.run(etape(bot, 1, 100, attente="Calcul en cours", action=action))
+
+    assert resultat == 42
+    assert len(bot.edits) == 1
+    _, _, texte, _ = bot.edits[0]
+    assert texte == "⏳ Calcul en cours…"
+
+
+def test_etape_signale_l_echec_et_retourne_none():
+    bot = FakeBot()
+
+    async def action():
+        raise RuntimeError("boom")
+
+    resultat = asyncio.run(etape(bot, 1, 100, attente="Calcul", action=action, libelle_erreur="Erreur Accise"))
+
+    assert resultat is None
+    _, _, texte, kwargs = bot.edits[-1]
+    assert texte == "❌ Erreur Accise : <code>boom</code>"
+    assert "reply_markup" not in kwargs
+
+
+def test_etape_pose_le_clavier_d_erreur_quand_fourni():
+    bot = FakeBot()
+
+    async def action():
+        raise RuntimeError("boom")
+
+    asyncio.run(etape(bot, 1, 100, attente="x", action=action, clavier_erreur=CLAVIER))
+
+    _, _, _, kwargs = bot.edits[-1]
+    assert kwargs["reply_markup"] is CLAVIER
+
+
+# =============================================================================
+# envoyer_document — étape + document + confirmation
+# =============================================================================
+
+
+def test_envoyer_document_livre_puis_confirme():
+    bot = FakeBot()
+
+    async def fetch():
+        return b"PK\x03\x04fake"
+
+    livre = asyncio.run(
+        envoyer_document(bot, 1, 100, attente="Génération", fetch=fetch, filename="accise.xlsx", caption="Accise")
+    )
+
+    assert livre is True
+    [(chat_id, kwargs)] = bot.documents
+    assert chat_id == 1
+    assert kwargs["filename"] == "accise.xlsx"
+    assert kwargs["caption"] == "Accise"
+    assert kwargs["document"].read() == b"PK\x03\x04fake"
+    _, _, texte, _ = bot.edits[-1]
+    assert texte == "📥 <code>accise.xlsx</code> envoyé."
+
+
+def test_envoyer_document_echec_du_fetch_aucun_document():
+    bot = FakeBot()
+
+    async def fetch():
+        raise RuntimeError("API 503")
+
+    livre = asyncio.run(
+        envoyer_document(bot, 1, 100, attente="Génération", fetch=fetch, filename="f.xlsx", caption="c")
+    )
+
+    assert livre is False
+    assert bot.documents == []
+    _, _, texte, _ = bot.edits[-1]
+    assert texte == "❌ Erreur : <code>API 503</code>"
+
+
+def test_envoyer_document_echec_d_envoi_ne_laisse_pas_le_sablier_fige():
+    """Filet de l'incident « ⏳ figé » : même un échec APRÈS le fetch édite le suivi."""
+    bot = FakeBot()
+
+    async def fetch():
+        return b"ok"
+
+    async def send_document_qui_explose(chat_id, **kwargs):
+        raise RuntimeError("Request Entity Too Large")
+
+    bot.send_document = send_document_qui_explose
+
+    livre = asyncio.run(
+        envoyer_document(bot, 1, 100, attente="Génération", fetch=fetch, filename="f.xlsx", caption="c")
+    )
+
+    assert livre is False
+    _, _, texte, _ = bot.edits[-1]
+    assert texte.startswith("❌"), "le message de suivi doit signaler l'échec, pas rester sur ⏳"
+
+
+def test_envoyer_document_clavier_de_confirmation():
+    bot = FakeBot()
+
+    async def fetch():
+        return b"ok"
+
+    asyncio.run(
+        envoyer_document(
+            bot, 1, 100, attente="x", fetch=fetch, filename="f.xlsx", caption="c", clavier_confirmation=CLAVIER
+        )
+    )
+
+    _, _, texte, kwargs = bot.edits[-1]
+    assert texte == "📥 <code>f.xlsx</code> envoyé."
+    assert kwargs["reply_markup"] is CLAVIER


### PR DESCRIPTION
## Quoi

Deepening de la livraison de documents du bot (revue d'architecture, candidats 2+3) :

**`bot/livraison.py`** (nouveau) — deux primitives composables :
- `etape()` : édite ⏳, exécute l'action, filet ❌ — retourne `T | None` (`None` = échec déjà signalé dans le chat) ;
- `envoyer_document()` : étape + `send_document` + confirmation 📥, **l'envoi restant sous le filet** — aucun chemin ne laisse le ⏳ figé (le filet de l'incident 72a1ed2 ne couvrait qu'une copie sur quatre).

Migration des 4 copies : `taxes._envoyer_rapport`, `flux._envoyer_export`, `facturation._envoyer_documents` (via `envoyer_document`) et `facturation._executer_check` (compose `etape`). Le format des messages de suivi vit en un seul endroit ; **les messages visibles sont inchangés** — preuve : les tests handlers passent sans modification.

**`bot/client.py`** — le squelette httpx (ouverture client, clé API, `raise_for_status`) est absorbé par `_get_json` / `_get_bytes` / `_post_json` ; timeouts en constantes nommées (`TIMEOUT_COURT/EXPORT/LOURD`) ; **interface des 13 méthodes inchangée** (`test_client.py` et `test_bot_client.py` passent tels quels).

**`bot/CONTEXT.md`** — terme **Livraison** ajouté (décision de grilling) ; entrée Client API mise à jour.

Décisions de design figées en issue : contrat d'erreur `T | None`, messages uniformisés portés par la primitive, `derniers_trimestres`/`derniers_mois` laissés tels quels (deletion test défavorable).

## Tests

- Nouveau `tests/unit/test_bot_livraison.py` : le squelette testé une fois — progression, filet sur fetch, **filet sur l'envoi lui-même** (régression incident ⏳ figé), claviers optionnels, confirmation.
- Tests handlers, client et no-ERP existants : verts sans modification.
- Suite complète : 648 passed, 35 skipped.

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)