### PR TITLE
refactor(pipelines): formules de période partagées dans periodes.py

### DIFF
--- a/docs/adr/0023-periodisations-separees-abonnement-energie.md
+++ b/docs/adr/0023-periodisations-separees-abonnement-energie.md
@@ -1,0 +1,50 @@
+# Périodisations séparées abonnement / énergie
+
+## Contexte
+
+Les pipelines `abonnements` et `energie` découpent chacun une ligne de temps en périodes,
+avec des mécanismes en miroir : l'abonnement porte la période par sa borne de *début*
+(attributs contractuels lus à l'événement, `fin = shift(-1)`), l'énergie par sa borne de
+*fin* (`energie = index − index.shift(1)`). Vue du code seul, cette symétrie suggère un
+périodiseur unique « ruptures → périodes » dont les deux pipelines seraient des
+adaptateurs de contenu — la suggestion a été formulée lors de la revue d'architecture
+de juin 2026, et le sera à nouveau par toute revue future si la raison du rejet n'est
+pas écrite.
+
+## Décision
+
+**Les deux périodisations restent séparées, chacune sur sa propre ligne de temps.**
+Le partage entre pipelines se limite aux *formules* transverses (nb_jours, `mois_annee`,
+libellés français, validité de période) — pas aux découpages.
+
+## Raison
+
+L'unification suppose « même ligne de temps, contenus différents ». C'est faux au niveau
+des données Enedis :
+
+- **Enedis ne fournit pas de relevé d'index pour les événements sans impact comptage.**
+  Un MCT qui ne change que la puissance souscrite crée une rupture d'abonnement (part
+  fixe) *sans index à cette borne* — la ligne de temps énergie ne peut pas porter cette
+  rupture. Les ruptures d'abonnement ne sont donc pas un sous-ensemble alignable des
+  bornes d'énergie.
+- **Combler exigerait de stocker l'intégralité des relevés quotidiens R64**, pour aller
+  chercher l'index à chaque date de MCT. Écarté : l'usage se concentre sur les relevés
+  du 1ᵉʳ du mois, le volume ne se justifie pas.
+- **Enedis lui-même facture les deux séparément** : l'abonnement à échoir, l'énergie à
+  échue. Les deux grains ne coïncident pas non plus côté facturation réseau.
+
+### Alternatives écartées
+
+- **Périodiseur unique `decouper(timeline, over, colonnes_fin)`** — en plus du problème
+  de données ci-dessus, le paramétrage des colonnes-de-fin rend l'interface plus large
+  que les deux implémentations réunies (module shallow).
+- **Récupérer les index aux dates MCT depuis R64** — voir le point volume ci-dessus.
+
+## Conséquences
+
+- Toute proposition de fusion des découpages doit d'abord lever la contrainte de
+  données (relevés aux événements hors comptage), pas seulement la symétrie du code.
+- Le partage de formules entre les pipelines de périodes est légitime et souhaitable
+  (la duplication de `expr_nb_jours` et le formatage de dates en 3 sites — dont un
+  `strftime("%d %B %Y")` en facturation qui sort les mois en anglais — relèvent de ce
+  partage, pas de l'unification des découpages).

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -197,10 +197,10 @@ _Éviter_ : portefeuille (terme commercial), parc.
 Période continue entre deux événements contractuels où la configuration (FTA, puissance, calendrier) ne change pas. Unité de calcul du TURPE fixe.
 
 **Rupture de période** :
-Événement contractuel (MES, MCT, RES) qui découpe une période d'abonnement en deux.
+Événement contractuel (MES, MCT, RES) qui découpe une période d'abonnement en deux. Toute rupture d'abonnement n'est **pas** une rupture d'énergie : Enedis ne fournit un relevé d'index qu'aux événements impactant le comptage (un MCT puissance seule n'en a pas) — les deux lignes de temps ne sont pas synchronisables (cf. [ADR-0023](../../docs/adr/0023-periodisations-separees-abonnement-energie.md)).
 
 **Période d'énergie** :
-Intervalle entre deux relevés d'index, support du calcul de consommation et du TURPE variable.
+Intervalle entre deux relevés d'index, support du calcul de consommation et du TURPE variable. Sa ligne de temps (relevés) est distincte de celle des abonnements (événements contractuels) et le reste délibérément — Enedis facture d'ailleurs séparément l'abonnement (à échoir) et l'énergie (à échue) (cf. [ADR-0023](../../docs/adr/0023-periodisations-separees-abonnement-energie.md)).
 
 **Méta-période mensuelle** :
 Agrégation d'abonnements + périodes d'énergie sur un mois calendaire, unité de la facturation client mensuelle. Grain : une ligne par **(situation contractuelle, mois)** — pas par PDL : un PDL qui change de RSC en cours de mois porte deux méta-périodes ce mois-là (le TURPE fixe est facturé par situation).

--- a/electricore/core/pipelines/abonnements.py
+++ b/electricore/core/pipelines/abonnements.py
@@ -13,6 +13,14 @@ from pandera.typing.polars import LazyFrame
 from electricore.core.models.historique import Historique
 from electricore.core.models.periode_abonnement import PeriodeAbonnement
 
+# Formules partagées entre pipelines de périodes (issue #178, ADR-0023)
+from electricore.core.pipelines.periodes import (
+    expr_date_formatee_fr,
+    expr_fin_lisible,
+    expr_mois_annee,
+    expr_nb_jours,
+)
+
 # =============================================================================
 # EXPRESSIONS PURES ATOMIQUES
 # =============================================================================
@@ -35,77 +43,6 @@ def expr_bornes_periode(over: str = "ref_situation_contractuelle") -> list[pl.Ex
         >>> df.with_columns(expr_bornes_periode())
     """
     return [pl.col("date_evenement").alias("debut"), pl.col("date_evenement").shift(-1).over(over).alias("fin")]
-
-
-def expr_nb_jours() -> pl.Expr:
-    """
-    Calcule le nombre de jours entre les bornes de période.
-
-    Cette expression calcule la différence en jours entre fin et debut,
-    en normalisant les timestamps pour éviter les problèmes d'heures.
-
-    Returns:
-        Expression Polars retournant le nombre de jours
-
-    Example:
-        >>> df.with_columns(expr_nb_jours().alias("nb_jours"))
-    """
-    return (pl.col("fin").dt.date() - pl.col("debut").dt.date()).dt.total_days().cast(pl.Int32)
-
-
-def expr_date_formatee_fr(col: str) -> pl.Expr:
-    """
-    Formate une colonne de date en libellé français « 1 mars 2025 ».
-
-    Réservé aux champs d'affichage (`debut_lisible`, `fin_lisible`) — les clés
-    de calcul utilisent le format `YYYY-MM` (issue #115). Copie unique partagée
-    par les pipelines abonnements et énergie.
-
-    Args:
-        col: Nom de la colonne à formater
-
-    Returns:
-        Expression Polars retournant la date formatée
-
-    Example:
-        >>> df.with_columns(expr_date_formatee_fr("debut").alias("debut_lisible"))
-    """
-    # Dictionnaire de correspondance anglais -> français
-    mois_mapping = {
-        "January": "janvier",
-        "February": "février",
-        "March": "mars",
-        "April": "avril",
-        "May": "mai",
-        "June": "juin",
-        "July": "juillet",
-        "August": "août",
-        "September": "septembre",
-        "October": "octobre",
-        "November": "novembre",
-        "December": "décembre",
-    }
-
-    expr = pl.col(col).dt.strftime("%d %B %Y")
-    for en_mois, fr_mois in mois_mapping.items():
-        expr = expr.str.replace_all(en_mois, fr_mois)
-    return expr
-
-
-def expr_fin_lisible() -> pl.Expr:
-    """
-    Formate la date de fin avec gestion du cas "en cours".
-
-    Cette expression formate la fin en français ou retourne "en cours"
-    si la date de fin est nulle.
-
-    Returns:
-        Expression Polars retournant la fin formatée
-
-    Example:
-        >>> df.with_columns(expr_fin_lisible().alias("fin_lisible"))
-    """
-    return pl.when(pl.col("fin").is_null()).then(pl.lit("en cours")).otherwise(expr_date_formatee_fr("fin"))
 
 
 def expr_periode_valide() -> pl.Expr:
@@ -173,7 +110,7 @@ def calculer_periodes_abonnement(lf: pl.LazyFrame) -> pl.LazyFrame:
                 expr_date_formatee_fr("debut").alias("debut_lisible"),
                 expr_fin_lisible().alias("fin_lisible"),
                 # Clé calculable YYYY-MM, triable (issue #115)
-                pl.col("debut").dt.strftime("%Y-%m").alias("mois_annee"),
+                expr_mois_annee(),
             ]
         )
         # 5. Filtrage des périodes valides

--- a/electricore/core/pipelines/energie.py
+++ b/electricore/core/pipelines/energie.py
@@ -15,8 +15,8 @@ from electricore.core.models.historique import Historique
 from electricore.core.models.periode_energie import PeriodeEnergie
 from electricore.core.models.releve_index import RelevéIndex
 
-# Formatage français des champs d'affichage (copie unique, cf. abonnements)
-from electricore.core.pipelines.abonnements import expr_date_formatee_fr
+# Formules partagées entre pipelines de périodes (issue #178, ADR-0023)
+from electricore.core.pipelines.periodes import expr_date_formatee_fr, expr_mois_annee, expr_nb_jours
 
 # Import du calcul TURPE variable
 from electricore.core.pipelines.turpe import ajouter_turpe_variable
@@ -155,19 +155,6 @@ def expr_enrichir_cadrans_principaux() -> list[pl.Expr]:
     ]
     synthese_base = pl.sum_horizontal([pl.col(col_energie(c)) for c in CADRANS]).alias(col_energie("base"))
     return [*syntheses_principaux, synthese_base]
-
-
-def expr_nb_jours() -> pl.Expr:
-    """
-    Expression pour calculer le nombre de jours d'une période.
-
-    Returns:
-        Expression Polars pour calculer nb_jours
-
-    Example:
-        >>> lf = lf.with_columns(expr_nb_jours())
-    """
-    return (pl.col("fin").dt.date() - pl.col("debut").dt.date()).dt.total_days().cast(pl.Int32).alias("nb_jours")
 
 
 def expr_filtrer_periodes_valides() -> pl.Expr:
@@ -500,7 +487,7 @@ def calculer_periodes_energie(lf: pl.LazyFrame) -> LazyFrame[PeriodeEnergie]:
             [*expr_bornes_depuis_shift(over="ref_situation_contractuelle"), *expr_arrondir_index_kwh(colonnes_index)]
         )
         # Étape 2 : Calcul énergies + nb_jours (énergies dépendent d'étape 1, nb_jours indépendant)
-        .with_columns([*expr_calculer_energies_tous_cadrans(colonnes_index), expr_nb_jours()])
+        .with_columns([*expr_calculer_energies_tous_cadrans(colonnes_index), expr_nb_jours().alias("nb_jours")])
         # Étape 3 : Flag de complétude des données
         .with_columns([expr_data_complete().alias("data_complete")])
         # Filtrage des périodes valides
@@ -511,7 +498,7 @@ def calculer_periodes_energie(lf: pl.LazyFrame) -> LazyFrame[PeriodeEnergie]:
                 expr_date_formatee_fr("debut").alias("debut_lisible"),
                 expr_date_formatee_fr("fin").alias("fin_lisible"),
                 # Clé calculable YYYY-MM, triable (issue #115)
-                pl.col("debut").dt.strftime("%Y-%m").alias("mois_annee"),
+                expr_mois_annee(),
                 *expr_enrichir_cadrans_principaux(),
             ]
         )

--- a/electricore/core/pipelines/facturation.py
+++ b/electricore/core/pipelines/facturation.py
@@ -16,6 +16,7 @@ from electricore.core.models.periode_energie import PeriodeEnergie
 
 # Import des modèles Pandera
 from electricore.core.models.periode_meta import PeriodeMeta
+from electricore.core.pipelines.periodes import expr_date_formatee_fr, expr_nb_jours
 
 # =============================================================================
 # EXPRESSIONS ATOMIQUES POUR CALCULS D'AGRÉGATION
@@ -215,14 +216,12 @@ def agreger_energies_mensuel(periodes: LazyFrame[PeriodeEnergie]) -> LazyFrame[E
 
     # Calculer nb_jours si pas présent
     if "nb_jours" not in schema_cols:
-        periodes = periodes.with_columns(
-            [((pl.col("fin").dt.date() - pl.col("debut").dt.date()).dt.total_days().cast(pl.Int32)).alias("nb_jours")]
-        )
+        periodes = periodes.with_columns([expr_nb_jours().alias("nb_jours")])
     else:
         periodes = periodes.with_columns(
             [
                 pl.when(pl.col("nb_jours").is_null())
-                .then((pl.col("fin").dt.date() - pl.col("debut").dt.date()).dt.total_days().cast(pl.Int32))
+                .then(expr_nb_jours())
                 .otherwise(pl.col("nb_jours"))
                 .alias("nb_jours")
             ]
@@ -252,9 +251,7 @@ def agreger_energies_mensuel(periodes: LazyFrame[PeriodeEnergie]) -> LazyFrame[E
         .with_columns(
             [
                 # Calculer le nombre de jours total du mois
-                ((pl.col("fin").dt.date() - pl.col("debut").dt.date()).dt.total_days().cast(pl.Int32)).alias(
-                    "nb_jours_total_mois"
-                ),
+                expr_nb_jours().alias("nb_jours_total_mois"),
             ]
         )
         .with_columns(
@@ -336,7 +333,7 @@ def joindre_meta_periodes(
             [
                 # Recalculer nb_jours si manquant
                 pl.when(pl.col("nb_jours").is_null())
-                .then((pl.col("fin").dt.date() - pl.col("debut").dt.date()).dt.total_days().cast(pl.Int32))
+                .then(expr_nb_jours())
                 .otherwise(pl.col("nb_jours"))
                 .alias("nb_jours"),
                 # Flag de changement global
@@ -413,10 +410,9 @@ def pipeline_facturation(
     # Étape 4 : Formatage final et tri
     result_lf = meta_periodes_lf.with_columns(
         [
-            # Formatage des dates lisibles (réutiliser les expressions existantes)
-            # TODO: Implémenter expr_date_formatee_fr pour Polars
-            pl.col("debut").dt.strftime("%d %B %Y").alias("debut_lisible"),
-            pl.col("fin").dt.strftime("%d %B %Y").alias("fin_lisible"),
+            # Dates lisibles en français, même convention que les sous-périodes (issue #178)
+            expr_date_formatee_fr("debut").alias("debut_lisible"),
+            expr_date_formatee_fr("fin").alias("fin_lisible"),
         ]
     ).sort(["ref_situation_contractuelle", "debut"])
 

--- a/electricore/core/pipelines/periodes.py
+++ b/electricore/core/pipelines/periodes.py
@@ -1,0 +1,99 @@
+"""
+Expressions partagées entre les pipelines de périodes (abonnements, énergie, facturation).
+
+Ce module porte les *formules* transverses aux périodes — pas les découpages :
+les périodisations abonnement et énergie restent séparées, chacune sur sa
+propre ligne de temps (cf. ADR-0023). Les filtres de validité restent locaux
+à chaque pipeline (duals miroir, conséquence directe de cette séparation).
+"""
+
+import polars as pl
+
+
+def expr_nb_jours() -> pl.Expr:
+    """
+    Calcule le nombre de jours entre les bornes `debut` et `fin` d'une période.
+
+    La formule canonique — différence des dates civiles, heures normalisées —
+    partagée par tous les pipelines de périodes (issue #178). Le check Pandera
+    `verifier_nb_jours_coherent` du modèle garde sa propre copie : c'est un
+    contrat qui valide le pipeline, l'indépendance est voulue.
+
+    Returns:
+        Expression Polars retournant le nombre de jours (Int32, non aliasée)
+
+    Example:
+        >>> df.with_columns(expr_nb_jours().alias("nb_jours"))
+    """
+    return (pl.col("fin").dt.date() - pl.col("debut").dt.date()).dt.total_days().cast(pl.Int32)
+
+
+def expr_mois_annee() -> pl.Expr:
+    """
+    Clé calculable du mois d'une période : `"YYYY-MM"` depuis `debut` (issue #115).
+
+    Triable chronologiquement, garantie `str_matches` dans les schémas Pandera.
+    Les libellés français restent portés par `debut_lisible` / `fin_lisible`.
+
+    Returns:
+        Expression Polars aliasée `mois_annee`
+
+    Example:
+        >>> df.with_columns(expr_mois_annee())
+    """
+    return pl.col("debut").dt.strftime("%Y-%m").alias("mois_annee")
+
+
+def expr_date_formatee_fr(col: str) -> pl.Expr:
+    """
+    Formate une colonne de date en libellé français « 01 mars 2025 ».
+
+    Réservé aux champs d'affichage (`debut_lisible`, `fin_lisible`) — les clés
+    de calcul utilisent le format `YYYY-MM` (issue #115). Copie unique partagée
+    par les pipelines abonnements, énergie et facturation (issue #178).
+
+    Args:
+        col: Nom de la colonne à formater
+
+    Returns:
+        Expression Polars retournant la date formatée
+
+    Example:
+        >>> df.with_columns(expr_date_formatee_fr("debut").alias("debut_lisible"))
+    """
+    # Dictionnaire de correspondance anglais -> français
+    mois_mapping = {
+        "January": "janvier",
+        "February": "février",
+        "March": "mars",
+        "April": "avril",
+        "May": "mai",
+        "June": "juin",
+        "July": "juillet",
+        "August": "août",
+        "September": "septembre",
+        "October": "octobre",
+        "November": "novembre",
+        "December": "décembre",
+    }
+
+    expr = pl.col(col).dt.strftime("%d %B %Y")
+    for en_mois, fr_mois in mois_mapping.items():
+        expr = expr.str.replace_all(en_mois, fr_mois)
+    return expr
+
+
+def expr_fin_lisible() -> pl.Expr:
+    """
+    Formate la date de fin avec gestion du cas « en cours ».
+
+    Cette expression formate la fin en français ou retourne « en cours »
+    si la date de fin est nulle (période ouverte).
+
+    Returns:
+        Expression Polars retournant la fin formatée
+
+    Example:
+        >>> df.with_columns(expr_fin_lisible().alias("fin_lisible"))
+    """
+    return pl.when(pl.col("fin").is_null()).then(pl.lit("en cours")).otherwise(expr_date_formatee_fr("fin"))

--- a/tests/architecture/test_imports_par_role.py
+++ b/tests/architecture/test_imports_par_role.py
@@ -1,6 +1,6 @@
-"""Garde-fous des règles d'import par rôle (ADR-0019, issues #109, #144).
+"""Garde-fous des règles d'import par rôle (ADR-0019, issues #109, #144 ; ADR-0023, issue #178).
 
-Quatre règles enforced par analyse statique (`ast`) :
+Cinq règles enforced par analyse statique (`ast`) :
 
 1. `core/pipelines/**` : n'importe pas `core.loaders`, `core.builds`,
    `integrations.*`, `api.*`. (Transformations pures.)
@@ -17,9 +17,14 @@ Quatre règles enforced par analyse statique (`ast`) :
    inverse de `test_core_purity`). Un import `core.builds` / `core.pipelines` /
    `core.writers` depuis une intégration échoue ici (#144).
 
-Pour chaque violation : fichier, ligne, import/annotation fautif + message ADR-0019.
+5. `core/pipelines/abonnements.py` ↔ `core/pipelines/energie.py` : aucun import
+   dans aucun sens (ADR-0023, #178). Les périodisations sont indépendantes ;
+   les formules partagées vivent dans `core/pipelines/periodes.py`.
 
-Voir [ADR-0019](../../docs/adr/0019-roles-loaders-pipelines-builds-integrations.md).
+Pour chaque violation : fichier, ligne, import/annotation fautif + message ADR.
+
+Voir [ADR-0019](../../docs/adr/0019-roles-loaders-pipelines-builds-integrations.md)
+et [ADR-0023](../../docs/adr/0023-periodisations-separees-abonnement-energie.md).
 """
 
 import ast
@@ -196,6 +201,41 @@ INTEGRATIONS_CORE_WHITELIST = (
     "electricore.core.models",
     "electricore.core.loaders",
 )
+
+
+def _imports_resolus_pipelines(path: Path) -> list[tuple[int, str]]:
+    """Imports du fichier, relatifs résolus contre le package `core.pipelines`."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    result: list[tuple[int, str]] = list(_absolute_imports(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
+            result.append((node.lineno, f"electricore.core.pipelines.{node.module}"))
+    return result
+
+
+def test_periodisations_independantes() -> None:
+    """Règle 5 ADR-0023 (#178) : abonnements et energie ne s'importent pas l'un l'autre.
+
+    Les deux périodisations opèrent sur des lignes de temps distinctes (Enedis ne
+    fournit pas de relevé aux événements hors comptage) ; les formules partagées
+    (nb_jours, mois_annee, libellés) vivent dans `core/pipelines/periodes.py`.
+    """
+    paire = {
+        PIPELINES_ROOT / "abonnements.py": "electricore.core.pipelines.energie",
+        PIPELINES_ROOT / "energie.py": "electricore.core.pipelines.abonnements",
+    }
+    violations: list[str] = []
+    for py_file, interdit in paire.items():
+        for lineno, module in _imports_resolus_pipelines(py_file):
+            if module == interdit or module.startswith(interdit + "."):
+                violations.append(_fmt(py_file, lineno, f"import interdit: {module}"))
+
+    assert not violations, (
+        "Violations règle 5 ADR-0023 (périodisations indépendantes) :\n"
+        + "\n".join(violations)
+        + "\nLes formules partagées vivent dans core/pipelines/periodes.py.\n"
+        + "Voir docs/adr/0023-periodisations-separees-abonnement-energie.md"
+    )
 
 
 def test_integrations_core_imports_whitelist() -> None:

--- a/tests/unit/test_expressions_abonnements.py
+++ b/tests/unit/test_expressions_abonnements.py
@@ -8,12 +8,10 @@ import pytest
 from electricore.core.pipelines.abonnements import (
     calculer_periodes_abonnement,
     expr_bornes_periode,
-    expr_date_formatee_fr,
-    expr_fin_lisible,
-    expr_nb_jours,
     expr_periode_valide,
     generer_periodes_abonnement,
 )
+from electricore.core.pipelines.periodes import expr_nb_jours
 
 
 @pytest.fixture
@@ -70,50 +68,8 @@ def test_expr_bornes_periode():
     assert result["fin"].to_list() == fins_attendues
 
 
-def test_expr_nb_jours():
-    """Teste le calcul du nombre de jours."""
-    df = pl.DataFrame(
-        {
-            "debut": [datetime(2024, 1, 1), datetime(2024, 2, 1), datetime(2024, 3, 1)],
-            "fin": [datetime(2024, 1, 31), datetime(2024, 2, 29), None],  # 2024 est bissextile
-        }
-    ).lazy()
-
-    result = df.with_columns(expr_nb_jours().alias("nb_jours")).collect()
-
-    expected = [30, 28, None]  # 31-1, 29-1, null pour None
-    assert result["nb_jours"].to_list() == expected
-
-
-def test_expr_date_formatee_fr():
-    """Teste le formatage français des champs d'affichage (« 15 mars 2024 »)."""
-    df = pl.DataFrame(
-        {
-            "ma_date": [datetime(2024, 3, 15), datetime(2024, 12, 25)],
-        }
-    ).lazy()
-
-    result = df.with_columns(expr_date_formatee_fr("ma_date").alias("date_fr")).collect()
-
-    assert result["date_fr"].to_list() == ["15 mars 2024", "25 décembre 2024"]
-
-
-def test_expr_fin_lisible():
-    """Teste le formatage de la fin avec gestion des nulls."""
-    df = pl.DataFrame(
-        {
-            "fin": [datetime(2024, 3, 31), None],
-        }
-    ).lazy()
-
-    result = df.with_columns(expr_fin_lisible().alias("fin_lisible")).collect()
-
-    fins_lisibles = result["fin_lisible"].to_list()
-
-    # Le premier doit contenir "31" (date formatée)
-    assert "31" in fins_lisibles[0]
-    # Le second doit être "en cours"
-    assert fins_lisibles[1] == "en cours"
+# Les tests de expr_nb_jours / expr_date_formatee_fr / expr_fin_lisible vivent
+# dans test_expressions_periodes.py (formules partagées, issue #178).
 
 
 def test_expr_periode_valide():

--- a/tests/unit/test_expressions_facturation.py
+++ b/tests/unit/test_expressions_facturation.py
@@ -414,6 +414,61 @@ class TestJointureMetaPeriodes:
         assert pdl2["energie_base_kwh"][0] == 0.0  # Fill null
 
 
+class TestDatesLisiblesFrancaises:
+    """Issue #178 : les méta-périodes portent des dates lisibles en français.
+
+    Les sous-périodes (abonnements, énergie) formatent leurs libellés via
+    `expr_date_formatee_fr` (« 01 mars 2025 ») ; les méta-périodes doivent
+    suivre la même convention — pas le `%B` anglais de chrono (« 01 March 2025 »).
+    """
+
+    def test_meta_periodes_dates_lisibles_en_francais(self):
+        from zoneinfo import ZoneInfo
+
+        from electricore.core.pipelines.facturation import pipeline_facturation
+
+        paris = ZoneInfo("Europe/Paris")
+
+        abonnements = pl.LazyFrame(
+            {
+                "ref_situation_contractuelle": ["RSC1"],
+                "pdl": ["PDL1"],
+                "mois_annee": ["2025-03"],
+                "debut_lisible": ["01 mars 2025"],
+                "fin_lisible": ["31 mars 2025"],
+                "formule_tarifaire_acheminement": ["BTINFCU4"],
+                "puissance_souscrite_kva": [6.0],
+                "nb_jours": [30],
+                "debut": [datetime(2025, 3, 1, tzinfo=paris)],
+                "fin": [datetime(2025, 3, 31, tzinfo=paris)],
+                "turpe_fixe_eur": [50.0],
+            }
+        )
+
+        energies = pl.LazyFrame(
+            {
+                "ref_situation_contractuelle": ["RSC1"],
+                "pdl": ["PDL1"],
+                "mois_annee": ["2025-03"],
+                "debut": [datetime(2025, 3, 1, tzinfo=paris)],
+                "fin": [datetime(2025, 3, 31, tzinfo=paris)],
+                "source_avant": ["flux_C15"],
+                "source_apres": ["flux_R151"],
+                "data_complete": [True],
+                "energie_base_kwh": [1000.0],
+                "energie_hp_kwh": [500.0],
+                "energie_hc_kwh": [300.0],
+                "turpe_variable_eur": [25.0],
+            }
+        )
+
+        meta = pipeline_facturation(abonnements, energies).collect()
+
+        assert len(meta) == 1
+        assert meta["debut_lisible"][0] == "01 mars 2025"
+        assert meta["fin_lisible"][0] == "31 mars 2025"
+
+
 class TestTriChronologique:
     """La motivation de l'issue #115 : mois_annee est triable chronologiquement.
 

--- a/tests/unit/test_expressions_periodes.py
+++ b/tests/unit/test_expressions_periodes.py
@@ -1,0 +1,71 @@
+"""Tests unitaires des formules partagées entre pipelines de périodes (issue #178).
+
+Le module `core/pipelines/periodes.py` porte les *formules* transverses
+(nb_jours, mois_annee, libellés français) — pas les découpages, qui restent
+propres à chaque périodisation (ADR-0023).
+"""
+
+from datetime import datetime
+
+import polars as pl
+
+from electricore.core.pipelines.periodes import (
+    expr_date_formatee_fr,
+    expr_fin_lisible,
+    expr_mois_annee,
+    expr_nb_jours,
+)
+
+
+def test_expr_nb_jours():
+    """La formule canonique : différence des dates civiles, null si fin absente."""
+    df = pl.DataFrame(
+        {
+            "debut": [datetime(2024, 1, 1), datetime(2024, 2, 1), datetime(2024, 3, 1)],
+            "fin": [datetime(2024, 1, 31), datetime(2024, 2, 29), None],  # 2024 est bissextile
+        }
+    ).lazy()
+
+    result = df.with_columns(expr_nb_jours().alias("nb_jours")).collect()
+
+    expected = [30, 28, None]  # 31-1, 29-1, null pour None
+    assert result["nb_jours"].to_list() == expected
+
+
+def test_expr_mois_annee():
+    """Clé `YYYY-MM` depuis debut, triable chronologiquement (issue #115)."""
+    df = pl.DataFrame(
+        {
+            "debut": [datetime(2024, 12, 1), datetime(2025, 4, 15)],
+        }
+    ).lazy()
+
+    result = df.with_columns(expr_mois_annee()).collect()
+
+    assert result["mois_annee"].to_list() == ["2024-12", "2025-04"]
+
+
+def test_expr_date_formatee_fr():
+    """Formatage français des champs d'affichage (« 15 mars 2024 »)."""
+    df = pl.DataFrame(
+        {
+            "ma_date": [datetime(2024, 3, 15), datetime(2024, 12, 25)],
+        }
+    ).lazy()
+
+    result = df.with_columns(expr_date_formatee_fr("ma_date").alias("date_fr")).collect()
+
+    assert result["date_fr"].to_list() == ["15 mars 2024", "25 décembre 2024"]
+
+
+def test_expr_fin_lisible():
+    """Formatage de la fin avec gestion du cas « en cours »."""
+    df = pl.DataFrame(
+        {
+            "fin": [datetime(2024, 3, 31), None],
+        }
+    ).lazy()
+
+    result = df.with_columns(expr_fin_lisible().alias("fin_lisible")).collect()
+
+    assert result["fin_lisible"].to_list() == ["31 mars 2024", "en cours"]

--- a/tests/unit/test_pipeline_energie.py
+++ b/tests/unit/test_pipeline_energie.py
@@ -406,39 +406,8 @@ def test_expr_calculer_energie_cadran():
     assert result["energie_base_kwh"].to_list() == energies_attendues
 
 
-def test_expr_date_formatee_fr():
-    """Teste le formatage des dates en français."""
-    df = pl.DataFrame(
-        {
-            "ma_date": [datetime(2024, 3, 15), datetime(2024, 12, 25)],
-        }
-    ).lazy()
-
-    from electricore.core.pipelines.energie import expr_date_formatee_fr
-
-    result = df.with_columns(expr_date_formatee_fr("ma_date").alias("date_fr")).collect()
-
-    # Vérifier que les dates contiennent les éléments français
-    dates_fr = result["date_fr"].to_list()
-    assert "15" in dates_fr[0] and "mars" in dates_fr[0] and "2024" in dates_fr[0]
-    assert "25" in dates_fr[1] and "décembre" in dates_fr[1] and "2024" in dates_fr[1]
-
-
-def test_expr_nb_jours():
-    """Teste le calcul du nombre de jours."""
-    df = pl.DataFrame(
-        {
-            "debut": [datetime(2024, 1, 1), datetime(2024, 2, 1)],
-            "fin": [datetime(2024, 1, 15), datetime(2024, 2, 29)],
-        }
-    ).lazy()
-
-    from electricore.core.pipelines.energie import expr_nb_jours
-
-    result = df.with_columns(expr_nb_jours()).collect()
-
-    # Vérifier le calcul des jours
-    assert result["nb_jours"].to_list() == [14, 28]
+# Les tests de expr_date_formatee_fr / expr_nb_jours vivent dans
+# test_expressions_periodes.py (formules partagées, issue #178).
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Résumé

Implémente le design arrêté en revue d'architecture (cf. ADR-0023) : les *formules* transverses aux périodes sont partagées, les *découpages* restent séparés.

- **`core/pipelines/periodes.py`** (nouveau) : `expr_nb_jours` (formule unique — dédupliquée de 5 sites), `expr_mois_annee`, `expr_date_formatee_fr`, `expr_fin_lisible`.
- **Fin de l'import croisé** `energie → abonnements`, verrouillé par la règle 5 des tests d'architecture (`test_periodisations_independantes`, ADR-0023) — imports relatifs compris.
- **Bug mois-anglais corrigé** : `pipeline_facturation` formatait `debut_lisible`/`fin_lisible` avec `strftime("%d %B %Y")` (mois en anglais via chrono) ; les méta-périodes suivent maintenant la même convention française que les sous-périodes, avec test.
- **ADR-0023** + retouches `CONTEXT.md` (entrées *Rupture de période* / *Période d'énergie*) : la raison structurelle du non-fusionnement des périodisations est consignée.

## Méthode

TDD vertical : tracer bullet RED→GREEN sur les dates françaises via l'interface publique `pipeline_facturation`, puis test structurel RED→GREEN sur l'indépendance des périodisations, puis refactor de déduplication sous filet vert. Les checks Pandera des modèles gardent leur propre copie de la formule `nb_jours` (contrat qui valide le pipeline, indépendance voulue).

## Tests

- `642 passed, 35 skipped` (suite complète)
- Nouveau : `tests/unit/test_expressions_periodes.py` (formules au seam), `TestDatesLisiblesFrancaises` (facturation), règle 5 architecture.
- ruff format + check : OK (pre-commit).

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)