### PR TITLE
refactor(pipelines): exprs_meta_periode — le bundle d'assemblage rejoint periodes.py

### DIFF
--- a/electricore/core/pipelines/abonnements.py
+++ b/electricore/core/pipelines/abonnements.py
@@ -13,13 +13,8 @@ from pandera.typing.polars import LazyFrame
 from electricore.core.models.historique import Historique
 from electricore.core.models.periode_abonnement import PeriodeAbonnement
 
-# Formules partagées entre pipelines de périodes (issue #178, ADR-0023)
-from electricore.core.pipelines.periodes import (
-    expr_date_formatee_fr,
-    expr_fin_lisible,
-    expr_mois_annee,
-    expr_nb_jours,
-)
+# Méta-colonnes de période partagées (issue #178, ADR-0023)
+from electricore.core.pipelines.periodes import exprs_meta_periode
 
 # =============================================================================
 # EXPRESSIONS PURES ATOMIQUES
@@ -101,18 +96,8 @@ def calculer_periodes_abonnement(lf: pl.LazyFrame) -> pl.LazyFrame:
         .sort(["ref_situation_contractuelle", "date_evenement"])
         # 2. Calcul des bornes de période avec window functions
         .with_columns(expr_bornes_periode())
-        # 3-4. Calcul des colonnes dérivées qui dépendent des bornes
-        .with_columns(
-            [
-                # Durée en jours (dépend de debut/fin)
-                expr_nb_jours().alias("nb_jours"),
-                # Formatage des dates en français (champs d'affichage)
-                expr_date_formatee_fr("debut").alias("debut_lisible"),
-                expr_fin_lisible().alias("fin_lisible"),
-                # Clé calculable YYYY-MM, triable (issue #115)
-                expr_mois_annee(),
-            ]
-        )
+        # 3-4. Méta-colonnes dérivées des bornes (bundle partagé, cf. periodes.py)
+        .with_columns(exprs_meta_periode())
         # 5. Filtrage des périodes valides
         .filter(expr_periode_valide())
         # 6. Sélection des colonnes finales
@@ -181,43 +166,3 @@ def pipeline_abonnements(historique: LazyFrame[Historique]) -> LazyFrame[Periode
     from .turpe import ajouter_turpe_fixe
 
     return historique.pipe(generer_periodes_abonnement).pipe(ajouter_turpe_fixe)
-
-
-# =============================================================================
-# FONCTIONS DE VALIDATION ET SÉLECTION
-# =============================================================================
-
-
-def selectionner_colonnes_abonnement(lf: pl.LazyFrame) -> pl.LazyFrame:
-    """
-    Sélectionne et réordonne les colonnes finales pour les périodes d'abonnement.
-
-    Cette fonction assure un ordre cohérent des colonnes dans la sortie finale.
-
-    Args:
-        lf: LazyFrame avec toutes les colonnes calculées
-
-    Returns:
-        LazyFrame avec les colonnes dans l'ordre final
-    """
-    colonnes_finales = [
-        "ref_situation_contractuelle",
-        "pdl",
-        "mois_annee",
-        "debut_lisible",
-        "fin_lisible",
-        "formule_tarifaire_acheminement",
-        "puissance_souscrite_kva",
-        "nb_jours",
-        "debut",
-        "fin",
-        # Colonnes TURPE (optionnelles)
-        "turpe_fixe_journalier_eur",
-        "turpe_fixe_eur",
-    ]
-
-    # Sélectionner uniquement les colonnes qui existent
-    available_columns = lf.collect_schema().names()
-    columns_to_select = [col for col in colonnes_finales if col in available_columns]
-
-    return lf.select(columns_to_select)

--- a/electricore/core/pipelines/energie.py
+++ b/electricore/core/pipelines/energie.py
@@ -15,8 +15,8 @@ from electricore.core.models.historique import Historique
 from electricore.core.models.periode_energie import PeriodeEnergie
 from electricore.core.models.releve_index import RelevéIndex
 
-# Formules partagées entre pipelines de périodes (issue #178, ADR-0023)
-from electricore.core.pipelines.periodes import expr_date_formatee_fr, expr_mois_annee, expr_nb_jours
+# Méta-colonnes de période partagées (issue #178, ADR-0023)
+from electricore.core.pipelines.periodes import exprs_meta_periode
 
 # Import du calcul TURPE variable
 from electricore.core.pipelines.turpe import ajouter_turpe_variable
@@ -462,8 +462,7 @@ def calculer_periodes_energie(lf: pl.LazyFrame) -> LazyFrame[PeriodeEnergie]:
     4. Calcul vectorisé des énergies tous cadrans
     5. Calcul des flags de qualité
     6. Filtrage des périodes valides
-    7. Formatage des dates en français
-    8. Enrichissement hiérarchique des cadrans
+    7. Enrichissement hiérarchique des cadrans
 
     Args:
         lf: LazyFrame contenant les relevés d'index chronologiques
@@ -486,22 +485,14 @@ def calculer_periodes_energie(lf: pl.LazyFrame) -> LazyFrame[PeriodeEnergie]:
         .with_columns(
             [*expr_bornes_depuis_shift(over="ref_situation_contractuelle"), *expr_arrondir_index_kwh(colonnes_index)]
         )
-        # Étape 2 : Calcul énergies + nb_jours (énergies dépendent d'étape 1, nb_jours indépendant)
-        .with_columns([*expr_calculer_energies_tous_cadrans(colonnes_index), expr_nb_jours().alias("nb_jours")])
+        # Étape 2 : Calcul énergies + méta-colonnes de période (bundle partagé, cf. periodes.py)
+        .with_columns([*expr_calculer_energies_tous_cadrans(colonnes_index), *exprs_meta_periode()])
         # Étape 3 : Flag de complétude des données
         .with_columns([expr_data_complete().alias("data_complete")])
         # Filtrage des périodes valides
         .filter(expr_filtrer_periodes_valides())
         # post traitement
-        .with_columns(
-            [
-                expr_date_formatee_fr("debut").alias("debut_lisible"),
-                expr_date_formatee_fr("fin").alias("fin_lisible"),
-                # Clé calculable YYYY-MM, triable (issue #115)
-                expr_mois_annee(),
-                *expr_enrichir_cadrans_principaux(),
-            ]
-        )
+        .with_columns([*expr_enrichir_cadrans_principaux()])
         # Note: La sélection finale des colonnes se fait après l'ajout du TURPE dans pipeline_energie
     )
 

--- a/electricore/core/pipelines/periodes.py
+++ b/electricore/core/pipelines/periodes.py
@@ -97,3 +97,29 @@ def expr_fin_lisible() -> pl.Expr:
         >>> df.with_columns(expr_fin_lisible().alias("fin_lisible"))
     """
     return pl.when(pl.col("fin").is_null()).then(pl.lit("en cours")).otherwise(expr_date_formatee_fr("fin"))
+
+
+def exprs_meta_periode() -> list[pl.Expr]:
+    """
+    Bundle canonique des méta-colonnes d'une période : `nb_jours`,
+    `debut_lisible`, `fin_lisible`, `mois_annee`.
+
+    C'est le *contrat d'assemblage* partagé par les périodisations
+    (abonnements, énergie) : les quatre colonnes ne dérivent que des bornes
+    `debut`/`fin`, le bundle s'applique donc dès que les bornes existent,
+    avant tout filtre de validité. `fin_lisible` passe par
+    `expr_fin_lisible` : une fin nulle (période ouverte) s'affiche
+    « en cours » au lieu de null.
+
+    Returns:
+        Liste d'expressions Polars aliasées, à éclater dans un with_columns
+
+    Example:
+        >>> df.with_columns(exprs_meta_periode())
+    """
+    return [
+        expr_nb_jours().alias("nb_jours"),
+        expr_date_formatee_fr("debut").alias("debut_lisible"),
+        expr_fin_lisible().alias("fin_lisible"),
+        expr_mois_annee(),
+    ]

--- a/tests/unit/test_expressions_periodes.py
+++ b/tests/unit/test_expressions_periodes.py
@@ -14,6 +14,7 @@ from electricore.core.pipelines.periodes import (
     expr_fin_lisible,
     expr_mois_annee,
     expr_nb_jours,
+    exprs_meta_periode,
 )
 
 
@@ -69,3 +70,26 @@ def test_expr_fin_lisible():
     result = df.with_columns(expr_fin_lisible().alias("fin_lisible")).collect()
 
     assert result["fin_lisible"].to_list() == ["31 mars 2024", "en cours"]
+
+
+def test_exprs_meta_periode():
+    """Le bundle d'assemblage : les 4 méta-colonnes depuis les seules bornes.
+
+    C'est le contrat partagé par les périodisations abonnements et énergie —
+    y compris le cas « période ouverte » (fin nulle → nb_jours null,
+    fin_lisible « en cours »).
+    """
+    df = pl.DataFrame(
+        {
+            "debut": [datetime(2025, 3, 1), datetime(2025, 4, 15)],
+            "fin": [datetime(2025, 4, 1), None],
+        }
+    ).lazy()
+
+    result = df.with_columns(exprs_meta_periode()).collect()
+
+    assert result.columns == ["debut", "fin", "nb_jours", "debut_lisible", "fin_lisible", "mois_annee"]
+    assert result["nb_jours"].to_list() == [31, None]
+    assert result["debut_lisible"].to_list() == ["01 mars 2025", "15 avril 2025"]
+    assert result["fin_lisible"].to_list() == ["01 avril 2025", "en cours"]
+    assert result["mois_annee"].to_list() == ["2025-03", "2025-04"]


### PR DESCRIPTION
Complète #178 (suite de #182) — proposition issue de la revue d'architecture du 12 juin.

## Quoi

Les *formules* de période sont partagées depuis #182, mais l'**assemblage** des 4 méta-colonnes (`nb_jours`, `debut_lisible`, `fin_lisible`, `mois_annee`) restait dupliqué en miroir dans `abonnements.py` et `energie.py`. Le bundle `exprs_meta_periode()` devient le contrat d'assemblage, dans les limites d'ADR-0023 : toujours des formules, **pas** de découpage commun.

- `periodes.py` : `exprs_meta_periode()` — ne dérive que des bornes `debut`/`fin`, s'applique avant les filtres de validité ; `fin_lisible` passe par `expr_fin_lisible` (une fin nulle s'affiche « en cours », inerte côté énergie où `fin = date_releve`, jamais nulle).
- `abonnements.py` : consomme le bundle ; **suppression de `selectionner_colonnes_abonnement`** — zéro appelant (code + tests), corps sans copie ailleurs (test de suppression sur le corps, pas le nom).
- `energie.py` : consomme le bundle — les lisibles se calculent désormais avant le filtre de validité (pur ligne à ligne, sortie identique).

## Hors périmètre (à terme)

Le travail profond sur `pipeline_energie` reste tracé : #180 (chronologie des relevés) et #179 (horizon de facturation).

## Validation

Suite complète : 658 passed, 35 skipped. ruff format + check OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)