### PR TITLE
test(property): socle PBT — stratégies Pandera→parametric + invariants TURPE (#194)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -43,9 +43,23 @@ Les données énergétiques Enedis ont des **dépendances complexes** :
 - **Validation** : Schémas entrée/sortie respectés
 - **Pas besoin** de données parfaitement cohérentes
 
-#### Niveau 4 : Hypothesis pour invariants simples (1% de l'effort)
-- **Usage** : Propriétés mathématiques simples uniquement
-- **Exemple** : `BASE = HP + HC`
+#### Niveau 4 : Property-based testing pour invariants simples (1% de l'effort)
+- **Usage** : Propriétés mathématiques simples sur entrées *plates* générées
+- **Implémentation** : [tests/property/](property/) — stratégies dérivées des schémas Pandera
+  via `strategie_depuis_schema` ([tests/property/strategies.py](property/strategies.py)),
+  construit sur `polars.testing.parametric` (issue #194)
+- **Exemples** : TURPE fixe/variable — contributions ≥ 0, tarifs nuls → contribution nulle,
+  préservation des lignes par la jointure, validité temporelle des règles
+- **Profil CI** : `max_examples=25`, pas de deadline (enregistré dans [conftest.py](conftest.py)) ;
+  lancement : `uv run --group test pytest -m hypothesis`
+
+**🚧 Garde-fou (leçon de 2025)** : les stratégies restent **plates** — colonnes indépendantes,
+contraintes simples (bornes `ge`/`le`, regex) dérivées des schémas Pandera, surcharges
+ponctuelles par test. Dès qu'une stratégie exige des séquences d'événements C15 cohérentes
+(MES → vie du contrat → RES) ou des dépendances entre colonnes (debut < fin), **on s'arrête** :
+c'est le territoire des fixtures + snapshots (Niveau 1). La tentative de 2025 (commit `cea13af`,
+supprimé) réinventait ~500 lignes de stratégies à la main pour générer des données métier
+cohérentes — plus complexe que les pipelines testés. Ne pas recommencer.
 
 ## Cas métier critiques couverts
 
@@ -89,8 +103,11 @@ tests/
 │   └── cas_metier.py                # ✅ Fixtures pytest (2 implémentées)
 ├── unit/
 │   ├── test_expressions_*.py        # Tests unitaires expressions Polars
-│   ├── test_*_parametrized.py       # 🆕 Tests paramétrés
-│   └── test_invariants.py           # Tests Hypothesis simples
+│   └── test_*_parametrized.py       # 🆕 Tests paramétrés
+├── property/                        # 🆕 Property-based tests (Niveau 4, issue #194)
+│   ├── strategies.py                # Helper : schéma Pandera → stratégie parametric
+│   ├── test_strategies.py           # Balle traçante du socle
+│   └── test_turpe_invariants.py     # Invariants TURPE fixe + variable
 ├── integration/
 │   ├── test_pipelines_snapshot.py   # 🆕 Tests snapshot avec Syrupy
 │   └── test_pipeline.py             # Tests avec fixtures
@@ -222,22 +239,27 @@ def test_expr_changement_cases(valeurs, expected_changements, description):
 
 Voir [tests/unit/test_expressions_perimetre_parametrized.py](unit/test_expressions_perimetre_parametrized.py) et [tests/unit/test_turpe_parametrized.py](unit/test_turpe_parametrized.py).
 
-### Test d'invariant simple
+### Test d'invariant property-based (Niveau 4)
 ```python
-@given(
-    hp=st.floats(min_value=0, max_value=10000, allow_nan=False),
-    hc=st.floats(min_value=0, max_value=10000, allow_nan=False)
-)
-def test_invariant_base_equals_hp_plus_hc(hp, hc):
-    """BASE doit toujours égaler HP + HC"""
-    df = pl.DataFrame({"HP": [hp], "HC": [hc]})
-    
-    result = df.with_columns(
-        (pl.col("HP") + pl.col("HC")).alias("BASE")
-    )
-    
-    assert abs(result["BASE"][0] - (hp + hc)) < 1e-10
+from tests.property.strategies import strategie_depuis_schema
+
+@pytest.mark.hypothesis
+@given(periodes=strategie_depuis_schema(
+    PeriodeAbonnement,
+    colonnes=["pdl", "formule_tarifaire_acheminement", "puissance_souscrite_kva", "nb_jours", "debut"],
+    surcharges={  # uniquement ce que le schéma ne sait pas
+        "formule_tarifaire_acheminement": st.sampled_from(FTAS_REELLES),
+        "nb_jours": st.integers(1, 366),
+    },
+))
+def test_turpe_fixe_contributions_positives(periodes):
+    """Puissances ≥ 0 → TURPE fixe ≥ 0 (les tarifs réels sont positifs)."""
+    result = ajouter_turpe_fixe(periodes.lazy(), REGLES.lazy()).collect()
+    assert (result["turpe_fixe_eur"] >= 0).all()
 ```
+
+Dtypes, nullabilité, bornes (`ge=0`) et regex viennent du schéma Pandera — pas de
+quatrième copie du savoir de typage. Voir [tests/property/](property/).
 
 ## Processus d'anonymisation
 
@@ -365,25 +387,17 @@ pytest -vv --showlocals
 
 ---
 
-## Historique : Stratégies Hypothesis (conservées pour référence)
+## Historique : la tentative Hypothesis de 2025 (abandonnée)
 
-*Cette section documente l'approche précédente basée sur la génération complexe avec Hypothesis, conservée pour référence.*
+La première tentative de property-based testing (commit `cea13af`, supprimé par `052c99f`)
+maintenait ~500 lignes de stratégies manuelles (`electricore/core/testing/strategies_polars.py`,
+module supprimé) pour générer des données métier cohérentes : PDL à 14 chiffres, calendriers
+distributeur, séquences temporelles. La génération était devenue plus complexe que les
+pipelines testés — c'est l'anti-pattern documenté en tête de ce fichier.
 
-### Stratégies disponibles (usage limité recommandé)
-
-#### RelevéIndex (simplifié)
-```python
-from electricore.core.testing.strategies_polars import releve_index_strategy
-
-# Pour tests d'invariants uniquement
-df = releve_index_strategy(min_size=5, max_size=10).example()
-```
-
-#### Données générées
-- **PDL** : 14 chiffres numériques
-- **Dates** : 2024-2025 avec timezone Europe/Paris  
-- **Valeurs d'énergie** : 0-99999 avec 3 décimales
-- **Calendriers** : DI000001 (BASE), DI000002 (HP/HC), DI000003 (Tempo)
+La reprise de 2026 (issue #194, [tests/property/](property/)) repose sur
+`polars.testing.parametric` (inexistant pour nous à l'époque) et dérive les stratégies
+des schémas Pandera au lieu de les écrire à la main.
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,19 @@ from pathlib import Path
 import duckdb
 import polars as pl
 import pytest
+from hypothesis import HealthCheck, settings
+
+# =========================================================================
+# PROFIL HYPOTHESIS - CI bornée, pas de deadline flaky (issue #194)
+# =========================================================================
+
+settings.register_profile(
+    "ci",
+    max_examples=25,
+    deadline=None,  # pas de deadline : durée d'un exemple variable selon la machine CI
+    suppress_health_check=[HealthCheck.too_slow],
+)
+settings.load_profile("ci")
 
 # =========================================================================
 # FIXTURES - DONNÉES DE TEST MINIMALES

--- a/tests/property/strategies.py
+++ b/tests/property/strategies.py
@@ -1,0 +1,119 @@
+"""
+Socle property-based testing : stratégies dérivées des schémas Pandera (issue #194).
+
+pandera-polars ne sait pas synthétiser de données (`Model.strategy()` lève
+`NotImplementedError` — suivi upstream : https://github.com/unionai-oss/pandera/issues/1661,
+dormant depuis 2024). En attendant, ce module dérive des colonnes
+`polars.testing.parametric` depuis un `DataFrameModel` via `to_schema()` :
+noms, dtypes, nullabilité et bornes simples (ge/le). Source de vérité unique :
+les schémas Pandera — aucune redéfinition manuelle du savoir de typage.
+
+Garde-fou (anti-pattern 2025, cf. tests/README.md) : les stratégies restent
+*plates* — colonnes indépendantes, contraintes simples. Les checks dataframe
+multi-colonnes (ex: debut < fin) ne sont PAS satisfaits par génération ;
+dès qu'un test exige une cohérence métier séquentielle, c'est le territoire
+des fixtures + snapshots.
+"""
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import hypothesis.strategies as st
+import polars as pl
+from polars.testing.parametric import column, dataframes
+
+# Bornes par défaut : garder l'arithmétique des pipelines stable (pas d'overflow,
+# pas de perte de précision float qui rendrait les invariants indécidables)
+_FLOAT_MIN, _FLOAT_MAX = -1e6, 1e6
+_INT_MIN, _INT_MAX = -10_000, 10_000
+_DATE_MIN, _DATE_MAX = dt.datetime(2020, 1, 1), dt.datetime(2030, 12, 31)
+
+
+def _bornes_depuis_checks(checks) -> dict:
+    """Extrait les bornes simples (ge/le/in_range) et regex des checks Pandera."""
+    bornes = {}
+    for check in checks:
+        stats = getattr(check, "statistics", None) or {}
+        if "min_value" in stats and stats["min_value"] is not None:
+            bornes["min_value"] = stats["min_value"]
+        if "max_value" in stats and stats["max_value"] is not None:
+            bornes["max_value"] = stats["max_value"]
+        if "pattern" in stats and stats["pattern"] is not None:
+            bornes["pattern"] = stats["pattern"]
+    return bornes
+
+
+def _strategie_valeurs(dtype: pl.DataType, checks) -> st.SearchStrategy:
+    """Stratégie de valeurs pour un dtype Polars, bornée par les checks Pandera."""
+    bornes = _bornes_depuis_checks(checks)
+
+    if dtype == pl.Float64:
+        return st.floats(
+            min_value=float(bornes.get("min_value", _FLOAT_MIN)),
+            max_value=float(bornes.get("max_value", _FLOAT_MAX)),
+            allow_nan=False,
+            allow_infinity=False,
+            width=64,
+        )
+    if dtype in (pl.Int8, pl.Int16, pl.Int32, pl.Int64):
+        return st.integers(
+            min_value=int(bornes.get("min_value", _INT_MIN)),
+            max_value=int(bornes.get("max_value", _INT_MAX)),
+        )
+    if dtype == pl.Boolean:
+        return st.booleans()
+    if isinstance(dtype, pl.Datetime):
+        timezones = st.just(ZoneInfo(dtype.time_zone)) if dtype.time_zone else st.none()
+        return st.datetimes(
+            min_value=_DATE_MIN,
+            max_value=_DATE_MAX,
+            timezones=timezones,
+            allow_imaginary=False,  # pas d'heures inexistantes (trou DST)
+        )
+    if dtype == pl.Date:
+        return st.dates(min_value=_DATE_MIN.date(), max_value=_DATE_MAX.date())
+    if dtype == pl.Utf8:
+        if "pattern" in bornes:
+            # fullmatch : sans lui, `$` tolère un '\n' final que str_matches refuse
+            return st.from_regex(bornes["pattern"], fullmatch=True)
+        return st.text(alphabet="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", min_size=1, max_size=14)
+
+    raise NotImplementedError(f"Dtype non supporté par le socle property-based : {dtype}")
+
+
+def strategie_depuis_schema(
+    modele,
+    colonnes: list[str] | None = None,
+    surcharges: dict[str, st.SearchStrategy] | None = None,
+    min_size: int = 1,
+    max_size: int = 10,
+    lazy: bool = False,
+) -> st.SearchStrategy:
+    """
+    Dérive une stratégie `polars.testing.parametric.dataframes` d'un DataFrameModel Pandera.
+
+    Args:
+        modele: classe DataFrameModel Pandera (ex: PeriodeAbonnement)
+        colonnes: sous-ensemble de colonnes à générer (défaut : toutes celles du schéma)
+        surcharges: stratégies de valeurs par colonne, prioritaires sur la dérivation —
+            réservées aux contraintes propres au test (ex: FTA existant dans les règles),
+            jamais à redéclarer ce que le schéma sait déjà
+        min_size / max_size: nombre de lignes générées
+        lazy: produire des LazyFrames au lieu de DataFrames
+
+    Returns:
+        Stratégie hypothesis générant des DataFrames conformes au schéma
+        (dtypes, nullabilité, bornes simples ge/le, regex str_matches)
+    """
+    schema = modele.to_schema()
+    surcharges = surcharges or {}
+    noms = colonnes if colonnes is not None else list(schema.columns)
+
+    cols = []
+    for nom in noms:
+        col_pa = schema.columns[nom]
+        dtype = col_pa.dtype.type
+        strategie = surcharges[nom] if nom in surcharges else _strategie_valeurs(dtype, col_pa.checks)
+        cols.append(column(name=nom, dtype=dtype, strategy=strategie, allow_null=col_pa.nullable))
+
+    return dataframes(cols=cols, min_size=min_size, max_size=max_size, lazy=lazy, allow_chunks=False)

--- a/tests/property/test_strategies.py
+++ b/tests/property/test_strategies.py
@@ -1,0 +1,25 @@
+"""
+Tests du socle property-based : dérivation de stratégies depuis les schémas Pandera.
+
+Le helper `strategie_depuis_schema` est la source de vérité unique : il dérive
+colonnes, dtypes, nullabilité et bornes simples depuis un DataFrameModel Pandera,
+sans redéfinition manuelle (issue #194, garde-fou anti-2025).
+"""
+
+import polars as pl
+import pytest
+from hypothesis import given
+
+from electricore.core.models.periode_abonnement import PeriodeAbonnement
+from tests.property.strategies import strategie_depuis_schema
+
+
+@pytest.mark.hypothesis
+@given(df=strategie_depuis_schema(PeriodeAbonnement, max_size=10))
+def test_frames_generes_valident_le_schema_pandera(df: pl.DataFrame):
+    """Les frames générés depuis PeriodeAbonnement passent la validation Pandera.
+
+    C'est la balle traçante du socle : dtypes, nullabilité, bornes (ge=0)
+    et regex (mois_annee) dérivés du schéma produisent des données valides.
+    """
+    PeriodeAbonnement.validate(df, lazy=True)

--- a/tests/property/test_turpe_invariants.py
+++ b/tests/property/test_turpe_invariants.py
@@ -1,0 +1,217 @@
+"""
+Property tests des invariants TURPE (issue #194).
+
+Entrées générées depuis les schémas Pandera (socle `strategies.py`),
+vraies règles versionnées (CSV) comme fixture. Invariants :
+- puissances/énergies positives → contributions ≥ 0 ;
+- tarifs nuls → contribution nulle ;
+- préservation des lignes (aucune période perdue ni dupliquée par la jointure) ;
+- validité temporelle (aucune règle appliquée hors de sa fenêtre).
+"""
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import hypothesis.strategies as st
+import polars as pl
+import pytest
+from hypothesis import given
+
+from electricore.core.models.periode_abonnement import PeriodeAbonnement
+from electricore.core.models.periode_energie import PeriodeEnergie
+from electricore.core.pipelines.turpe import (
+    ajouter_turpe_fixe,
+    ajouter_turpe_variable,
+    load_turpe_rules,
+)
+from tests.property.strategies import strategie_depuis_schema
+
+TZ_PARIS = ZoneInfo("Europe/Paris")
+
+# Vraies règles versionnées — fixture de module (hypothesis interdit les fixtures function-scoped)
+REGLES = load_turpe_rules().collect()
+
+FTAS = REGLES["Formule_Tarifaire_Acheminement"].unique().sort().to_list()
+
+_COLONNES_TARIFS = [
+    "cg", "cc", "b",
+    "b_hph", "b_hch", "b_hpb", "b_hcb",
+    "c_hph", "c_hch", "c_hpb", "c_hcb",
+    "c_hp", "c_hc", "c_base",
+    "cmdps",
+]  # fmt: skip
+
+
+def _regles_synthetiques(start: dt.datetime, end: dt.datetime | None, **tarifs: float) -> pl.DataFrame:
+    """Une règle TURPE contrôlée (FTA 'BTTEST'), même schéma que load_turpe_rules."""
+    data = {"Formule_Tarifaire_Acheminement": ["BTTEST"], "start": [start], "end": [end]}
+    data.update({col: [tarifs.get(col)] for col in _COLONNES_TARIFS})
+    return pl.DataFrame(
+        data,
+        schema_overrides={
+            "start": pl.Datetime("us", "Europe/Paris"),
+            "end": pl.Datetime("us", "Europe/Paris"),
+            **{col: pl.Float64 for col in _COLONNES_TARIFS},
+        },
+    )
+
+
+# FTA dont les règles portent un coefficient C5 (b) — le calcul fixe C5 exige b non-null
+FTAS_C5 = REGLES.filter(pl.col("b").is_not_null())["Formule_Tarifaire_Acheminement"].unique().sort().to_list()
+
+# Après le start le plus récent, chaque FTA a exactement une fenêtre applicable
+# (toutes les grilles actuelles sont ouvertes, end=null)
+_DEBUT_MIN = REGLES["start"].max().replace(tzinfo=None) + dt.timedelta(days=1)
+
+
+def _periodes_abonnement(max_size: int = 10) -> st.SearchStrategy[pl.DataFrame]:
+    """Périodes d'abonnement générées depuis le schéma Pandera.
+
+    Les surcharges portent uniquement les contraintes que le schéma ne connaît pas :
+    FTA existant dans les règles, puissance C5 plausible, durée ≥ 1 jour,
+    début dans la fenêtre des grilles actuelles.
+    """
+    return strategie_depuis_schema(
+        PeriodeAbonnement,
+        colonnes=[
+            "ref_situation_contractuelle",
+            "pdl",
+            "formule_tarifaire_acheminement",
+            "puissance_souscrite_kva",
+            "nb_jours",
+            "debut",
+        ],
+        surcharges={
+            "formule_tarifaire_acheminement": st.sampled_from(FTAS_C5),
+            "puissance_souscrite_kva": st.floats(0.0, 36.0, allow_nan=False),
+            "nb_jours": st.integers(1, 366),
+            "debut": st.datetimes(
+                _DEBUT_MIN,
+                dt.datetime(2030, 12, 31),
+                timezones=st.just(TZ_PARIS),
+                allow_imaginary=False,
+            ),
+        },
+        max_size=max_size,
+    )
+
+
+@pytest.mark.hypothesis
+@given(periodes=_periodes_abonnement())
+def test_turpe_fixe_contributions_positives(periodes: pl.DataFrame):
+    """Puissances ≥ 0 et durées ≥ 1 jour → TURPE fixe ≥ 0 (les tarifs réels sont positifs)."""
+    result = ajouter_turpe_fixe(periodes.lazy(), REGLES.lazy()).collect()
+
+    assert result["turpe_fixe_eur"].null_count() == 0
+    assert (result["turpe_fixe_eur"] >= 0).all()
+
+
+@pytest.mark.hypothesis
+@given(periodes=_periodes_abonnement())
+def test_turpe_fixe_preserve_les_lignes(periodes: pl.DataFrame):
+    """La jointure aux règles ne perd ni ne duplique aucune période."""
+    avec_index = periodes.with_row_index("ligne")
+
+    result = ajouter_turpe_fixe(avec_index.lazy(), REGLES.lazy()).collect()
+
+    assert sorted(result["ligne"].to_list()) == list(range(periodes.height))
+
+
+@pytest.mark.hypothesis
+@given(
+    periodes=strategie_depuis_schema(
+        PeriodeAbonnement,
+        colonnes=["pdl", "formule_tarifaire_acheminement", "puissance_souscrite_kva", "nb_jours", "debut"],
+        surcharges={
+            "formule_tarifaire_acheminement": st.just("BTTEST"),
+            "puissance_souscrite_kva": st.floats(0.0, 36.0, allow_nan=False),
+            "nb_jours": st.integers(1, 366),
+            "debut": st.datetimes(
+                dt.datetime(2020, 1, 1),
+                dt.datetime(2030, 12, 31),
+                timezones=st.just(TZ_PARIS),
+                allow_imaginary=False,
+            ),
+        },
+    )
+)
+def test_turpe_fixe_aucune_regle_hors_fenetre(periodes: pl.DataFrame):
+    """Validité temporelle : une règle ne s'applique qu'aux périodes dont le début est dans [start, end)."""
+    fenetre = _regles_synthetiques(
+        start=dt.datetime(2024, 1, 1, tzinfo=TZ_PARIS),
+        end=dt.datetime(2025, 1, 1, tzinfo=TZ_PARIS),
+        cg=1.0, cc=1.0, b=1.0,
+    )  # fmt: skip
+    avec_index = periodes.with_row_index("ligne")
+
+    result = ajouter_turpe_fixe(avec_index.lazy(), fenetre.lazy()).collect()
+
+    attendues = avec_index.filter((pl.col("debut") >= fenetre["start"][0]) & (pl.col("debut") < fenetre["end"][0]))
+    assert sorted(result["ligne"].to_list()) == sorted(attendues["ligne"].to_list())
+
+
+# =============================================================================
+# TURPE VARIABLE
+# =============================================================================
+
+_COLONNES_ENERGIE = [
+    "energie_base_kwh", "energie_hp_kwh", "energie_hc_kwh",
+    "energie_hph_kwh", "energie_hpb_kwh", "energie_hch_kwh", "energie_hcb_kwh",
+]  # fmt: skip
+
+
+def _periodes_energie(fta: st.SearchStrategy[str], debut_min: dt.datetime) -> st.SearchStrategy[pl.DataFrame]:
+    """Périodes d'énergie générées depuis le schéma Pandera, énergies positives."""
+    return strategie_depuis_schema(
+        PeriodeEnergie,
+        colonnes=["pdl", "formule_tarifaire_acheminement", "debut", *_COLONNES_ENERGIE],
+        surcharges={
+            "formule_tarifaire_acheminement": fta,
+            "debut": st.datetimes(
+                debut_min,
+                dt.datetime(2030, 12, 31),
+                timezones=st.just(TZ_PARIS),
+                allow_imaginary=False,
+            ),
+            # prémisse de l'invariant : énergies positives (les nulls injectés par
+            # la nullabilité du schéma restent possibles → contribution 0)
+            **{col: st.floats(0.0, 1e6, allow_nan=False) for col in _COLONNES_ENERGIE},
+        },
+    )
+
+
+@pytest.mark.hypothesis
+@given(periodes=_periodes_energie(st.sampled_from(FTAS), _DEBUT_MIN))
+def test_turpe_variable_contributions_positives(periodes: pl.DataFrame):
+    """Énergies ≥ 0 → TURPE variable ≥ 0 (les tarifs réels sont positifs)."""
+    result = ajouter_turpe_variable(periodes.lazy(), REGLES.lazy()).collect()
+
+    assert result["turpe_variable_eur"].null_count() == 0
+    assert (result["turpe_variable_eur"] >= 0).all()
+
+
+@pytest.mark.hypothesis
+@given(periodes=_periodes_energie(st.just("BTTEST"), dt.datetime(2024, 1, 2)))
+def test_turpe_variable_tarifs_nuls_contribution_nulle(periodes: pl.DataFrame):
+    """Tous les tarifs à zéro → contribution nulle, quelles que soient les énergies."""
+    tarifs_nuls = _regles_synthetiques(
+        start=dt.datetime(2024, 1, 1, tzinfo=TZ_PARIS),
+        end=None,
+        **{col: 0.0 for col in ["c_hph", "c_hch", "c_hpb", "c_hcb", "c_hp", "c_hc", "c_base"]},
+    )
+
+    result = ajouter_turpe_variable(periodes.lazy(), tarifs_nuls.lazy()).collect()
+
+    assert (result["turpe_variable_eur"] == 0.0).all()
+    assert result["turpe_variable_eur"].null_count() == 0
+
+
+@pytest.mark.hypothesis
+@given(periodes=_periodes_energie(st.sampled_from(FTAS), _DEBUT_MIN))
+def test_turpe_variable_preserve_les_lignes(periodes: pl.DataFrame):
+    """La jointure aux règles ne perd ni ne duplique aucune période d'énergie."""
+    avec_index = periodes.with_row_index("ligne")
+
+    result = ajouter_turpe_variable(avec_index.lazy(), REGLES.lazy()).collect()
+
+    assert sorted(result["ligne"].to_list()) == list(range(periodes.height))


### PR DESCRIPTION
## Contexte

Issue #194 : réactivation du property-based testing, reconstruit sur `polars.testing.parametric` (la tentative de 2025 — `cea13af`, supprimée — réinventait ~500 lignes de stratégies à la main).

## Contenu

- **Helper `strategie_depuis_schema`** ([tests/property/strategies.py](../blob/feat/194-pbt-socle-turpe/tests/property/strategies.py)) : dérive les colonnes `polars.testing.parametric` d'un `DataFrameModel` Pandera via `to_schema()` — noms, dtypes, nullabilité, bornes simples (`ge`/`le`), regex `str_matches`. Surcharges ponctuelles par test pour ce que le schéma ne sait pas (FTA réelles, durées ≥ 1 jour). Commentaire pointant l'issue upstream unionai-oss/pandera#1661.
- **Profil hypothesis CI** (conftest.py) : `max_examples=25`, `deadline=None` — durée bornée, pas de flakiness. Le marker `hypothesis` (déclaré, orphelin jusqu'ici) porte enfin 7 tests.
- **Invariants TURPE** (`ajouter_turpe_fixe` + `ajouter_turpe_variable`, vraies règles CSV comme fixture) :
  - puissances/énergies positives → contributions ≥ 0 (et jamais null) ;
  - tarifs nuls → contribution nulle ;
  - préservation des lignes : la jointure aux règles ne perd ni ne duplique aucune période (vérifié par row index) ;
  - validité temporelle : règle synthétique à fenêtre `[2024-01-01, 2025-01-01)` — seules les périodes dont le début tombe dans la fenêtre ressortent.
- **README des tests** : Niveau 4 réel, garde-fou anti-2025 écrit noir sur blanc (stratégies plates uniquement ; séquences C15 cohérentes = fixtures + snapshots), section historique corrigée (le module `strategies_polars` n'existe plus).

## Vérifications

- `uv run --group test pytest -m hypothesis` : 7 passed en ~2 s
- Suite complète : 678 passed, 35 skipped
- ruff format + check : OK

## Notes de balle traçante

- `st.from_regex` sans `fullmatch` génère des `\n` finaux que `$` tolère mais que `str_matches` Polars refuse — corrigé dans le helper.
- Les invariants "fixe" se limitent aux FTA C5 (`b` non-null) : pour une FTA C4, le pipeline rend `turpe_fixe_eur` null si les 4 puissances C4 sont absentes — comportement existant, hors scope du socle.

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)