### PR TITLE
feat(taxes): millésime des taux régulés — reference CSV, dérivation core, API, bot (#185)

### DIFF
--- a/electricore/api/models.py
+++ b/electricore/api/models.py
@@ -3,7 +3,7 @@ Modèles de données pour l'API ElectriCore.
 Définit les structures de données Pydantic pour les réponses API.
 """
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -98,6 +98,19 @@ class IngestionJobResponse(BaseModel):
     finished_at: datetime | None = Field(None, description="Horodatage de fin")
     error: str | None = Field(None, description="Message d'erreur si failed")
     output: str | None = Field(None, description="Sortie stdout/stderr du pipeline")
+
+
+# Modèles taxes
+
+
+class MillesimeResponse(BaseModel):
+    """Millésime d'un registre de taux régulés (ADR-0024) : dernière ligne entrée en vigueur."""
+
+    taxe: str = Field(..., description="Registre : TURPE | Accise | CTA")
+    date_vigueur: date = Field(..., description="Date d'entrée en vigueur de la dernière ligne")
+    reference: str = Field(..., description="Référence réglementaire (texte fondateur + lien public)")
+    valeur: float | None = Field(None, description="Taux scalaire si la taxe en a un (None pour une grille)")
+    unite: str | None = Field(None, description="Unité du taux scalaire (€/MWh, %)")
 
 
 # Modèles pour les requêtes (si nécessaire pour des POST/PUT futurs)

--- a/electricore/api/routers/taxes.py
+++ b/electricore/api/routers/taxes.py
@@ -1,8 +1,12 @@
 """Router des endpoints taxes énergétiques : Accise TICFE et CTA (issue #82)."""
 
-from fastapi import APIRouter, Query
+from dataclasses import asdict
+
+from fastapi import APIRouter, Depends, Query
 
 from electricore.api.decorators import arrow_endpoint, xlsx_endpoint
+from electricore.api.models import MillesimeResponse
+from electricore.api.security import get_current_api_key
 from electricore.api.serializers import arrow_stream, xlsx_multi_sheet
 from electricore.api.services.taxes_service import (
     accise_par_contrat_service,
@@ -11,9 +15,25 @@ from electricore.api.services.taxes_service import (
     rapport_cta_service,
 )
 from electricore.core.builds.rapport_taxe import feuilles_rapport_taxe
+from electricore.core.millesimes import millesimes
 from electricore.integrations.odoo.decorators import with_odoo
 
 router = APIRouter(tags=["taxes"])
+
+
+# =============================================================================
+# Millésimes des taux régulés (#185, ADR-0024)
+# =============================================================================
+
+
+@router.get("/taxes/millesimes", response_model=list[MillesimeResponse])
+def get_millesimes(api_key: str = Depends(get_current_api_key)) -> list[MillesimeResponse]:
+    """Millésimes des trois registres de taux régulés (TURPE, Accise, CTA).
+
+    Dérivés des CSV versionnés — dit ce que cette instance « sait » de la
+    réglementation. Sans dépendance Odoo : disponible sur une instance no-ERP.
+    """
+    return [MillesimeResponse(**asdict(m)) for m in millesimes()]
 
 
 # =============================================================================

--- a/electricore/bot/client.py
+++ b/electricore/bot/client.py
@@ -105,6 +105,10 @@ class ElectriCoreClient:
         params = {"trimestre": trimestre} if trimestre else None
         return await self._get_bytes("/taxes/cta/rapport.xlsx", params=params, timeout=TIMEOUT_LOURD)
 
+    async def get_millesimes(self) -> list[dict]:
+        """Millésimes des taux régulés (TURPE, Accise, CTA) — #185, ADR-0024."""
+        return await self._get_json("/taxes/millesimes")
+
     async def get_facturation_xlsx(self, mois: str | None = None) -> bytes:
         params = {"mois": mois} if mois else None
         return await self._get_bytes("/facturation/rapport.xlsx", params=params, timeout=TIMEOUT_LOURD)

--- a/electricore/bot/handlers/taxes.py
+++ b/electricore/bot/handlers/taxes.py
@@ -16,7 +16,9 @@ from electricore.bot.format import escape
 from electricore.bot.livraison import envoyer_document
 
 _TITRE_MENU = "<b>Taxes</b> — choisis un calcul :"
-_USAGE = "Usage :\n  /taxes accise [trimestre]  (ex: /taxes accise 2025-T1)\n  /taxes cta [trimestre]"
+_USAGE = (
+    "Usage :\n  /taxes accise [trimestre]  (ex: /taxes accise 2025-T1)\n  /taxes cta [trimestre]\n  /taxes millesimes"
+)
 
 _LIBELLES = {"accise": "Accise TICFE", "cta": "CTA"}
 
@@ -39,9 +41,24 @@ def clavier_principal() -> InlineKeyboardMarkup:
             [
                 InlineKeyboardButton("🧾 Accise", callback_data="taxes:choix:accise"),
                 InlineKeyboardButton("📊 CTA", callback_data="taxes:choix:cta"),
-            ]
+            ],
+            [InlineKeyboardButton("📜 Millésimes", callback_data="taxes:millesimes")],
         ]
     )
+
+
+def formater_millesimes(millesimes: list[dict]) -> str:
+    """Texte HTML des millésimes — ce que cette instance « sait » de la réglementation (ADR-0024)."""
+    lignes = ["<b>Millésimes des taux régulés</b>"]
+    for m in millesimes:
+        if m["valeur"] is not None:
+            entete = (
+                f"• <b>{escape(m['taxe'])}</b> — {m['valeur']:g} {escape(m['unite'])} depuis le {m['date_vigueur']}"
+            )
+        else:
+            entete = f"• <b>{escape(m['taxe'])}</b> — grille du {m['date_vigueur']}"
+        lignes.append(f"{entete}\n  réf. {escape(m['reference'])}")
+    return "\n".join(lignes)
 
 
 def clavier_trimestres(taxe: str) -> InlineKeyboardMarkup:
@@ -81,6 +98,10 @@ async def cmd_taxes(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
     taxe = context.args[0].lower()
+    if taxe == "millesimes":
+        texte = formater_millesimes(await ElectriCoreClient().get_millesimes())
+        await update.effective_message.reply_html(texte, disable_web_page_preview=True)
+        return
     if taxe not in _LIBELLES:
         await update.effective_message.reply_text(_USAGE)
         return
@@ -100,6 +121,16 @@ async def on_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     if data == "taxes:menu":
         await context.bot.edit_message_text(
             _TITRE_MENU, chat_id=chat_id, message_id=message_id, parse_mode="HTML", reply_markup=clavier_principal()
+        )
+    elif data == "taxes:millesimes":
+        texte = formater_millesimes(await ElectriCoreClient().get_millesimes())
+        await context.bot.edit_message_text(
+            texte,
+            chat_id=chat_id,
+            message_id=message_id,
+            parse_mode="HTML",
+            disable_web_page_preview=True,
+            reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("← Retour", callback_data="taxes:menu")]]),
         )
     elif data.startswith("taxes:choix:"):
         taxe = data.removeprefix("taxes:choix:")

--- a/electricore/config/accise_rules.csv
+++ b/electricore/config/accise_rules.csv
@@ -1,4 +1,4 @@
-start,taux_accise_eur_mwh
-2024-01-02,21
-2025-02-01,33.7
-2025-08-01,29.98
+start,taux_accise_eur_mwh,reference
+2024-01-02,21,Arrêté du 25 janvier 2024 (art. 92 de la LF 2024 n° 2023-1322 — tarif ménages 21 €/MWh) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000049059983
+2025-02-01,33.7,LF 2025 n° 2025-127 du 14 février 2025 (tarif ménages 33.70 €/MWh au 1er février 2025) — https://www.impots.gouv.fr/actualite/consommation-denergie-tarifs-normaux-des-accises-en-2025
+2025-08-01,29.98,Tarif ménages 25.09 €/MWh + majoration ZNI 4.89 €/MWh (art. L312-37-1 CIBS) au 1er août 2025 — https://www.impots.gouv.fr/actualite/consommation-denergie-tarifs-normaux-des-accises-en-2025

--- a/electricore/config/cta_rules.csv
+++ b/electricore/config/cta_rules.csv
@@ -1,4 +1,4 @@
-start,taux_cta_pct
-2020-01-01,27.04
-2021-08-01,21.93
-2026-02-01,15.00
+start,taux_cta_pct,reference
+2020-01-01,27.04,Arrêté du 26 avril 2013 (taux distribution 27.04 % — abrogé au 1er août 2021) — https://www.cnieg.fr/accueil/entreprise/cta/informations-cta.html
+2021-08-01,21.93,Arrêté du 20 juillet 2021 (taux distribution 21.93 %) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043847483
+2026-02-01,15.00,Arrêté du 28 janvier 2026 modifiant l'arrêté du 20 juillet 2021 (taux distribution 15 %) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000053417026

--- a/electricore/config/turpe_rules.csv
+++ b/electricore/config/turpe_rules.csv
@@ -1,39 +1,39 @@
-Formule_Tarifaire_Acheminement,start,end,cg,cc,b,b_hph,b_hch,b_hpb,b_hcb,c_hph,c_hch,c_hpb,c_hcb,c_hp,c_hc,c_base,cmdps
-BTINFCU4,2023-08-01,2024-11-01,15.48,19.92,9,,,,,6.67,4.56,1.43,0.88,0,0,0,
-BTINFCUST,2023-08-01,2024-11-01,15.48,19.92,9.96,,,,,0,0,0,0,0,0,4.37,
-BTINFMU4,2023-08-01,2024-11-01,15.48,19.92,10.56,,,,,6.12,4.24,1.39,0.87,0,0,0,
-BTINFMUDT,2023-08-01,2024-11-01,15.48,19.92,12.24,,,,,0,0,0,0,4.47,3.16,0,
-BTINFLU,2023-08-01,2024-11-01,15.48,19.92,81.24,,,,,0,0,0,0,0,0,1.1,
-BTINFCU4ACCAUTO,2023-08-01,2024-11-01,12.19,19.92,9,,,,,1.64,1.29,0.77,0.37,0,0,0,
-BTINFCU4ACCALLO,2023-08-01,2024-11-01,12.19,19.92,9,,,,,7.23,4.42,2.29,0.86,0,0,0,
-BTINFMU4ACCAUTO,2023-08-01,2024-11-01,12.19,19.92,10.68,,,,,1.64,1.29,0.77,0.37,0,0,0,
-BTINFMU4ACCALLO,2023-08-01,2024-11-01,12.19,19.92,10.68,,,,,6.6,4.23,2.22,0.86,0,0,0,
-BTINFCU4,2024-11-01,2025-02-01,16.2,20.88,9.36,,,,,6.96,4.76,1.48,0.92,0,0,0,
-BTINFCUST,2024-11-01,2025-02-01,16.2,20.88,10.44,,,,,0,0,0,0,0,0,4.58,
-BTINFMU4,2024-11-01,2025-02-01,16.2,20.88,11.04,,,,,6.39,4.43,1.46,0.91,0,0,0,
-BTINFMUDT,2024-11-01,2025-02-01,16.2,20.88,12.72,,,,,0,0,0,0,4.68,3.31,0,
-BTINFLU,2024-11-01,2025-02-01,16.2,20.88,84.96,,,,,0,0,0,0,0,0,1.15,
-BTINFCU4ACCAUTO,2024-11-01,2025-02-01,12.77,20.88,9.36,,,,,1.72,1.34,0.81,0.39,0,0,0,
-BTINFCU4ACCALLO,2024-11-01,2025-02-01,12.77,20.88,9.36,,,,,7.56,4.62,2.39,0.9,0,0,0,
-BTINFMU4ACCAUTO,2024-11-01,2025-02-01,12.77,20.88,11.16,,,,,1.72,1.34,0.81,0.39,0,0,0,
-BTINFMU4ACCALLO,2024-11-01,2025-02-01,12.77,20.88,11.16,,,,,6.88,4.41,2.32,0.9,0,0,0,
-BTINFCU4,2025-02-01,2025-08-01,16.92,22.44,10.08,,,,,7.50,5.13,1.60,1,0,0,0,
-BTINFCUST,2025-02-01,2025-08-01,16.92,22.44,11.28,,,,,0,0,0,0,0,0,4.93,
-BTINFMU4,2025-02-01,2025-08-01,16.92,22.44,11.88,,,,,6.89,4.77,1.57,0.98,0,0,0,
-BTINFMUDT,2025-02-01,2025-08-01,16.92,22.44,13.80,,,,,0,0,0,0,5.04,3.57,0,
-BTINFLU,2025-02-01,2025-08-01,16.92,22.44,91.44,,,,,0,0,0,0,0,0,1.24,
-BTINFCU4ACCAUTO,2025-02-01,2025-08-01,21.60,22.44,10.08,,,,,1.86,1.44,0.87,0.42,0,0,0,
-BTINFCU4ACCALLO,2025-02-01,2025-08-01,21.60,22.44,10.08,,,,,8.14,4.98,2.57,0.97,0,0,0,
-BTINFMU4ACCAUTO,2025-02-01,2025-08-01,21.60,22.44,12.00,,,,,1.86,1.44,0.87,0.42,0,0,0,
-BTINFMU4ACCALLO,2025-02-01,2025-08-01,21.60,22.44,12.00,,,,,7.41,4.75,2.50,0.97,0,0,0,
-BTINFCU4,2025-08-01,,16.8,22,10.11,,,,,7.49,3.97,1.66,1.16,0,0,0,
-BTINFCUST,2025-08-01,,16.8,22,11.07,,,,,0,0,0,0,0,0,4.84,
-BTINFMU4,2025-08-01,,16.8,22,12.12,,,,,7,3.73,1.61,1.11,0,0,0,
-BTINFCU4ACCAUTO,2025-08-01,,21.27,22,10.11,,,,,2.86,1.28,0.76,0.49,0,0,0,
-BTINFCU4ACCALLO,2025-08-01,,21.27,22,10.11,,,,,7.52,4.03,1.73,1.21,0,0,0,
-BTINFMU4ACCAUTO,2025-08-01,,21.27,22,12.12,,,,,2.60,1.23,0.75,0.49,0,0,0,
-BTINFMU4ACCALLO,2025-08-01,,21.27,22,12.12,,,,,7.04,3.76,1.61,1.15,0,0,0,
-BTINFMUDT,2025-08-01,,16.8,22,13.49,,,,,0,0,0,0,4.94,3.5,0,
-BTINFLU,2025-08-01,,16.8,22,93.13,,,,,0,0,0,0,0,0,1.25,
-BTSUPCU,2025-08-01,,217.8,283.27,,17.61,15.96,14.56,11.98,6.91,4.21,2.13,1.52,0,0,0,12.41
-BTSUPLU,2025-08-01,,217.8,283.27,,30.16,21.18,16.64,12.37,5.69,3.47,2.01,1.49,0,0,0,12.41
+Formule_Tarifaire_Acheminement,start,end,cg,cc,b,b_hph,b_hch,b_hpb,b_hcb,c_hph,c_hch,c_hpb,c_hcb,c_hp,c_hc,c_base,cmdps,reference
+BTINFCU4,2023-08-01,2024-11-01,15.48,19.92,9,,,,,6.67,4.56,1.43,0.88,0,0,0,,Délibération CRE n° 2023-137 du 31 mai 2023 (évolution grille HTA-BT au 1er août 2023) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047916180
+BTINFCUST,2023-08-01,2024-11-01,15.48,19.92,9.96,,,,,0,0,0,0,0,0,4.37,,Délibération CRE n° 2023-137 du 31 mai 2023 (évolution grille HTA-BT au 1er août 2023) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047916180
+BTINFMU4,2023-08-01,2024-11-01,15.48,19.92,10.56,,,,,6.12,4.24,1.39,0.87,0,0,0,,Délibération CRE n° 2023-137 du 31 mai 2023 (évolution grille HTA-BT au 1er août 2023) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047916180
+BTINFMUDT,2023-08-01,2024-11-01,15.48,19.92,12.24,,,,,0,0,0,0,4.47,3.16,0,,Délibération CRE n° 2023-137 du 31 mai 2023 (évolution grille HTA-BT au 1er août 2023) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047916180
+BTINFLU,2023-08-01,2024-11-01,15.48,19.92,81.24,,,,,0,0,0,0,0,0,1.1,,Délibération CRE n° 2023-137 du 31 mai 2023 (évolution grille HTA-BT au 1er août 2023) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047916180
+BTINFCU4ACCAUTO,2023-08-01,2024-11-01,12.19,19.92,9,,,,,1.64,1.29,0.77,0.37,0,0,0,,Délibération CRE n° 2023-137 du 31 mai 2023 (évolution grille HTA-BT au 1er août 2023) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047916180
+BTINFCU4ACCALLO,2023-08-01,2024-11-01,12.19,19.92,9,,,,,7.23,4.42,2.29,0.86,0,0,0,,Délibération CRE n° 2023-137 du 31 mai 2023 (évolution grille HTA-BT au 1er août 2023) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047916180
+BTINFMU4ACCAUTO,2023-08-01,2024-11-01,12.19,19.92,10.68,,,,,1.64,1.29,0.77,0.37,0,0,0,,Délibération CRE n° 2023-137 du 31 mai 2023 (évolution grille HTA-BT au 1er août 2023) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047916180
+BTINFMU4ACCALLO,2023-08-01,2024-11-01,12.19,19.92,10.68,,,,,6.6,4.23,2.22,0.86,0,0,0,,Délibération CRE n° 2023-137 du 31 mai 2023 (évolution grille HTA-BT au 1er août 2023) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047916180
+BTINFCU4,2024-11-01,2025-02-01,16.2,20.88,9.36,,,,,6.96,4.76,1.48,0.92,0,0,0,,Délibération CRE n° 2024-122 du 26 juin 2024 (évolution grille HTA-BT reportée au 1er novembre 2024) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050259478
+BTINFCUST,2024-11-01,2025-02-01,16.2,20.88,10.44,,,,,0,0,0,0,0,0,4.58,,Délibération CRE n° 2024-122 du 26 juin 2024 (évolution grille HTA-BT reportée au 1er novembre 2024) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050259478
+BTINFMU4,2024-11-01,2025-02-01,16.2,20.88,11.04,,,,,6.39,4.43,1.46,0.91,0,0,0,,Délibération CRE n° 2024-122 du 26 juin 2024 (évolution grille HTA-BT reportée au 1er novembre 2024) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050259478
+BTINFMUDT,2024-11-01,2025-02-01,16.2,20.88,12.72,,,,,0,0,0,0,4.68,3.31,0,,Délibération CRE n° 2024-122 du 26 juin 2024 (évolution grille HTA-BT reportée au 1er novembre 2024) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050259478
+BTINFLU,2024-11-01,2025-02-01,16.2,20.88,84.96,,,,,0,0,0,0,0,0,1.15,,Délibération CRE n° 2024-122 du 26 juin 2024 (évolution grille HTA-BT reportée au 1er novembre 2024) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050259478
+BTINFCU4ACCAUTO,2024-11-01,2025-02-01,12.77,20.88,9.36,,,,,1.72,1.34,0.81,0.39,0,0,0,,Délibération CRE n° 2024-122 du 26 juin 2024 (évolution grille HTA-BT reportée au 1er novembre 2024) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050259478
+BTINFCU4ACCALLO,2024-11-01,2025-02-01,12.77,20.88,9.36,,,,,7.56,4.62,2.39,0.9,0,0,0,,Délibération CRE n° 2024-122 du 26 juin 2024 (évolution grille HTA-BT reportée au 1er novembre 2024) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050259478
+BTINFMU4ACCAUTO,2024-11-01,2025-02-01,12.77,20.88,11.16,,,,,1.72,1.34,0.81,0.39,0,0,0,,Délibération CRE n° 2024-122 du 26 juin 2024 (évolution grille HTA-BT reportée au 1er novembre 2024) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050259478
+BTINFMU4ACCALLO,2024-11-01,2025-02-01,12.77,20.88,11.16,,,,,6.88,4.41,2.32,0.9,0,0,0,,Délibération CRE n° 2024-122 du 26 juin 2024 (évolution grille HTA-BT reportée au 1er novembre 2024) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050259478
+BTINFCU4,2025-02-01,2025-08-01,16.92,22.44,10.08,,,,,7.50,5.13,1.60,1,0,0,0,,Délibération CRE n° 2025-08 du 15 janvier 2025 (évolution exceptionnelle du TURPE 6 HTA-BT au 1er février 2025) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051023199
+BTINFCUST,2025-02-01,2025-08-01,16.92,22.44,11.28,,,,,0,0,0,0,0,0,4.93,,Délibération CRE n° 2025-08 du 15 janvier 2025 (évolution exceptionnelle du TURPE 6 HTA-BT au 1er février 2025) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051023199
+BTINFMU4,2025-02-01,2025-08-01,16.92,22.44,11.88,,,,,6.89,4.77,1.57,0.98,0,0,0,,Délibération CRE n° 2025-08 du 15 janvier 2025 (évolution exceptionnelle du TURPE 6 HTA-BT au 1er février 2025) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051023199
+BTINFMUDT,2025-02-01,2025-08-01,16.92,22.44,13.80,,,,,0,0,0,0,5.04,3.57,0,,Délibération CRE n° 2025-08 du 15 janvier 2025 (évolution exceptionnelle du TURPE 6 HTA-BT au 1er février 2025) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051023199
+BTINFLU,2025-02-01,2025-08-01,16.92,22.44,91.44,,,,,0,0,0,0,0,0,1.24,,Délibération CRE n° 2025-08 du 15 janvier 2025 (évolution exceptionnelle du TURPE 6 HTA-BT au 1er février 2025) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051023199
+BTINFCU4ACCAUTO,2025-02-01,2025-08-01,21.60,22.44,10.08,,,,,1.86,1.44,0.87,0.42,0,0,0,,Délibération CRE n° 2025-08 du 15 janvier 2025 (évolution exceptionnelle du TURPE 6 HTA-BT au 1er février 2025) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051023199
+BTINFCU4ACCALLO,2025-02-01,2025-08-01,21.60,22.44,10.08,,,,,8.14,4.98,2.57,0.97,0,0,0,,Délibération CRE n° 2025-08 du 15 janvier 2025 (évolution exceptionnelle du TURPE 6 HTA-BT au 1er février 2025) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051023199
+BTINFMU4ACCAUTO,2025-02-01,2025-08-01,21.60,22.44,12.00,,,,,1.86,1.44,0.87,0.42,0,0,0,,Délibération CRE n° 2025-08 du 15 janvier 2025 (évolution exceptionnelle du TURPE 6 HTA-BT au 1er février 2025) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051023199
+BTINFMU4ACCALLO,2025-02-01,2025-08-01,21.60,22.44,12.00,,,,,7.41,4.75,2.50,0.97,0,0,0,,Délibération CRE n° 2025-08 du 15 janvier 2025 (évolution exceptionnelle du TURPE 6 HTA-BT au 1er février 2025) — https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051023199
+BTINFCU4,2025-08-01,,16.8,22,10.11,,,,,7.49,3.97,1.66,1.16,0,0,0,,Délibération CRE n° 2025-40 du 6 février 2025 (TURPE 7 HTA-BT au 1er août 2025) — https://www.cre.fr/actualites/nos-lettres-dinformation/la-cre-publie-ses-decisions-finales-sur-le-tarif-dutilisation-des-reseaux-publics-delectricite-turpe-7.html
+BTINFCUST,2025-08-01,,16.8,22,11.07,,,,,0,0,0,0,0,0,4.84,,Délibération CRE n° 2025-40 du 6 février 2025 (TURPE 7 HTA-BT au 1er août 2025) — https://www.cre.fr/actualites/nos-lettres-dinformation/la-cre-publie-ses-decisions-finales-sur-le-tarif-dutilisation-des-reseaux-publics-delectricite-turpe-7.html
+BTINFMU4,2025-08-01,,16.8,22,12.12,,,,,7,3.73,1.61,1.11,0,0,0,,Délibération CRE n° 2025-40 du 6 février 2025 (TURPE 7 HTA-BT au 1er août 2025) — https://www.cre.fr/actualites/nos-lettres-dinformation/la-cre-publie-ses-decisions-finales-sur-le-tarif-dutilisation-des-reseaux-publics-delectricite-turpe-7.html
+BTINFCU4ACCAUTO,2025-08-01,,21.27,22,10.11,,,,,2.86,1.28,0.76,0.49,0,0,0,,Délibération CRE n° 2025-40 du 6 février 2025 (TURPE 7 HTA-BT au 1er août 2025) — https://www.cre.fr/actualites/nos-lettres-dinformation/la-cre-publie-ses-decisions-finales-sur-le-tarif-dutilisation-des-reseaux-publics-delectricite-turpe-7.html
+BTINFCU4ACCALLO,2025-08-01,,21.27,22,10.11,,,,,7.52,4.03,1.73,1.21,0,0,0,,Délibération CRE n° 2025-40 du 6 février 2025 (TURPE 7 HTA-BT au 1er août 2025) — https://www.cre.fr/actualites/nos-lettres-dinformation/la-cre-publie-ses-decisions-finales-sur-le-tarif-dutilisation-des-reseaux-publics-delectricite-turpe-7.html
+BTINFMU4ACCAUTO,2025-08-01,,21.27,22,12.12,,,,,2.60,1.23,0.75,0.49,0,0,0,,Délibération CRE n° 2025-40 du 6 février 2025 (TURPE 7 HTA-BT au 1er août 2025) — https://www.cre.fr/actualites/nos-lettres-dinformation/la-cre-publie-ses-decisions-finales-sur-le-tarif-dutilisation-des-reseaux-publics-delectricite-turpe-7.html
+BTINFMU4ACCALLO,2025-08-01,,21.27,22,12.12,,,,,7.04,3.76,1.61,1.15,0,0,0,,Délibération CRE n° 2025-40 du 6 février 2025 (TURPE 7 HTA-BT au 1er août 2025) — https://www.cre.fr/actualites/nos-lettres-dinformation/la-cre-publie-ses-decisions-finales-sur-le-tarif-dutilisation-des-reseaux-publics-delectricite-turpe-7.html
+BTINFMUDT,2025-08-01,,16.8,22,13.49,,,,,0,0,0,0,4.94,3.5,0,,Délibération CRE n° 2025-40 du 6 février 2025 (TURPE 7 HTA-BT au 1er août 2025) — https://www.cre.fr/actualites/nos-lettres-dinformation/la-cre-publie-ses-decisions-finales-sur-le-tarif-dutilisation-des-reseaux-publics-delectricite-turpe-7.html
+BTINFLU,2025-08-01,,16.8,22,93.13,,,,,0,0,0,0,0,0,1.25,,Délibération CRE n° 2025-40 du 6 février 2025 (TURPE 7 HTA-BT au 1er août 2025) — https://www.cre.fr/actualites/nos-lettres-dinformation/la-cre-publie-ses-decisions-finales-sur-le-tarif-dutilisation-des-reseaux-publics-delectricite-turpe-7.html
+BTSUPCU,2025-08-01,,217.8,283.27,,17.61,15.96,14.56,11.98,6.91,4.21,2.13,1.52,0,0,0,12.41,Délibération CRE n° 2025-40 du 6 février 2025 (TURPE 7 HTA-BT au 1er août 2025) — https://www.cre.fr/actualites/nos-lettres-dinformation/la-cre-publie-ses-decisions-finales-sur-le-tarif-dutilisation-des-reseaux-publics-delectricite-turpe-7.html
+BTSUPLU,2025-08-01,,217.8,283.27,,30.16,21.18,16.64,12.37,5.69,3.47,2.01,1.49,0,0,0,12.41,Délibération CRE n° 2025-40 du 6 février 2025 (TURPE 7 HTA-BT au 1er août 2025) — https://www.cre.fr/actualites/nos-lettres-dinformation/la-cre-publie-ses-decisions-finales-sur-le-tarif-dutilisation-des-reseaux-publics-delectricite-turpe-7.html

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -108,11 +108,11 @@ Valeur d'un taux réglementé (Accise, CTA, TURPE…) applicable à une date don
 _Éviter_ : barème (gradué par montant, pas par date), grille tarifaire.
 
 **Référence réglementaire** :
-Citation du texte qui fonde un taux régulé (délibération CRE, article de loi de finances). Portée ligne à ligne par la colonne `reference` des fichiers `*_rules.csv` (à introduire — [ADR-0024](../../docs/adr/0024-trois-registres-de-savoir.md)) : chaque changement de taux devient auditable en revue de contribution comme en contrôle a posteriori.
+Citation du texte qui fonde un taux régulé (délibération CRE, article de loi de finances). Portée ligne à ligne par la colonne `reference` des fichiers `*_rules.csv` ([ADR-0024](../../docs/adr/0024-trois-registres-de-savoir.md), #185) : chaque changement de taux devient auditable en revue de contribution comme en contrôle a posteriori.
 _Éviter_ : source (collision avec les sources de données), justificatif.
 
 **Millésime** :
-Dernier changement réglementaire intégré dans un fichier de taux régulés — dérivé, pas déclaré : dernière ligne entrée en vigueur + sa *référence réglementaire*. Dit ce que la lib « sait » de la réglementation ; exposable via API et bot pour vérifier la fraîcheur d'une instance ([ADR-0024](../../docs/adr/0024-trois-registres-de-savoir.md)).
+Dernier changement réglementaire intégré dans un fichier de taux régulés — dérivé, pas déclaré : dernière ligne entrée en vigueur + sa *référence réglementaire*. Dit ce que la lib « sait » de la réglementation ; dérivé par `core/millesimes.py` et exposé via `GET /taxes/millesimes` et `/taxes millesimes` (bot) pour vérifier la fraîcheur d'une instance ([ADR-0024](../../docs/adr/0024-trois-registres-de-savoir.md)).
 _Éviter_ : version (réservé aux releases de la lib), tag (réservé à git).
 
 **Trimestre fiscal** :

--- a/electricore/core/millesimes.py
+++ b/electricore/core/millesimes.py
@@ -1,0 +1,66 @@
+"""
+Millésime des taux régulés (ADR-0024, issue #185).
+
+Le millésime dit ce que la lib « sait » de la réglementation : dernière ligne
+entrée en vigueur d'un fichier de taux + sa référence réglementaire. Dérivé
+des CSV versionnés (`electricore/config/*_rules.csv`), jamais déclaré.
+"""
+
+import datetime as dt
+from dataclasses import dataclass
+
+import polars as pl
+
+from electricore.core.pipelines.accise import load_accise_rules
+from electricore.core.pipelines.cta import load_cta_rules
+from electricore.core.pipelines.turpe import load_turpe_rules
+
+
+@dataclass(frozen=True, slots=True)
+class Millesime:
+    """Dernier changement réglementaire intégré dans un fichier de taux régulés.
+
+    `valeur`/`unite` portent le taux scalaire quand la taxe en a un (Accise en
+    €/MWh, CTA en %) ; None pour une grille multi-colonnes (TURPE).
+    """
+
+    taxe: str
+    date_vigueur: dt.date
+    reference: str
+    valeur: float | None = None
+    unite: str | None = None
+
+
+def deriver_millesime(
+    historique: pl.LazyFrame,
+    *,
+    taxe: str,
+    taux_col: str | None = None,
+    unite: str | None = None,
+) -> Millesime:
+    """Dérive le millésime d'un historique de taux : ligne au `start` le plus récent.
+
+    Args:
+        historique: LazyFrame avec au moins `start` (datetime) et `reference` (str).
+        taxe: libellé du registre ("TURPE", "Accise", "CTA").
+        taux_col: colonne du taux scalaire, si la taxe en a un.
+        unite: unité d'affichage du taux scalaire.
+    """
+    colonnes = ["start", "reference", *([taux_col] if taux_col else [])]
+    derniere = historique.select(colonnes).sort("start").last().collect()
+    return Millesime(
+        taxe=taxe,
+        date_vigueur=derniere["start"][0].date(),
+        reference=derniere["reference"][0],
+        valeur=derniere[taux_col][0] if taux_col else None,
+        unite=unite if taux_col else None,
+    )
+
+
+def millesimes() -> tuple[Millesime, Millesime, Millesime]:
+    """Les millésimes des trois registres de taux régulés : TURPE, Accise, CTA."""
+    return (
+        deriver_millesime(load_turpe_rules(), taxe="TURPE"),
+        deriver_millesime(load_accise_rules(), taxe="Accise", taux_col="taux_accise_eur_mwh", unite="€/MWh"),
+        deriver_millesime(load_cta_rules(), taxe="CTA", taux_col="taux_cta_pct", unite="%"),
+    )

--- a/tests/integration/test_taxes_millesimes_endpoint.py
+++ b/tests/integration/test_taxes_millesimes_endpoint.py
@@ -1,0 +1,44 @@
+"""GET /taxes/millesimes : millésimes des taux régulés (#185, ADR-0024).
+
+Endpoint JSON sans dépendance Odoo — le millésime est un savoir de la lib
+(CSV versionnés), exposable même sur une instance sans ERP.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from electricore.api.main import app
+from electricore.api.security import get_current_api_key
+
+
+@pytest.fixture
+def client_authentifie():
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_millesimes_retourne_les_trois_taxes(client_authentifie):
+    response = client_authentifie.get("/taxes/millesimes")
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert [m["taxe"] for m in data] == ["TURPE", "Accise", "CTA"]
+    for m in data:
+        assert m["reference"], f"{m['taxe']} : référence vide"
+        assert m["date_vigueur"], f"{m['taxe']} : date manquante"
+
+
+def test_millesimes_accise_et_cta_portent_un_taux(client_authentifie):
+    data = client_authentifie.get("/taxes/millesimes").json()
+    par_taxe = {m["taxe"]: m for m in data}
+
+    assert par_taxe["TURPE"]["valeur"] is None  # grille, pas de scalaire
+    assert par_taxe["Accise"]["unite"] == "€/MWh"
+    assert par_taxe["CTA"]["unite"] == "%"
+
+
+def test_millesimes_exige_une_cle_api():
+    response = TestClient(app).get("/taxes/millesimes")
+
+    assert response.status_code in (401, 403)

--- a/tests/unit/test_accise.py
+++ b/tests/unit/test_accise.py
@@ -53,7 +53,7 @@ class TestChargementRegles:
 
     def test_load_accise_rules_colonnes_et_types(self):
         regles = load_accise_rules().collect()
-        assert set(regles.columns) == {"start", "taux_accise_eur_mwh"}
+        assert set(regles.columns) == {"start", "taux_accise_eur_mwh", "reference"}
         assert regles["start"].dtype == pl.Datetime(time_unit="us", time_zone="Europe/Paris")
         assert regles["taux_accise_eur_mwh"].dtype == pl.Float64
 

--- a/tests/unit/test_bot_handlers_taxes.py
+++ b/tests/unit/test_bot_handlers_taxes.py
@@ -34,6 +34,32 @@ class FakeClient:
         self.appels.append(("cta", trimestre))
         return b"PK\x03\x04cta"
 
+    async def get_millesimes(self) -> list[dict]:
+        self.appels.append(("millesimes", None))
+        return [
+            {
+                "taxe": "TURPE",
+                "date_vigueur": "2025-08-01",
+                "reference": "Délibération CRE n° 2025-40 — https://www.cre.fr",
+                "valeur": None,
+                "unite": None,
+            },
+            {
+                "taxe": "Accise",
+                "date_vigueur": "2025-08-01",
+                "reference": "LF 2025 — https://www.impots.gouv.fr",
+                "valeur": 29.98,
+                "unite": "€/MWh",
+            },
+            {
+                "taxe": "CTA",
+                "date_vigueur": "2026-02-01",
+                "reference": "Arrêté du 28 janvier 2026 — https://www.legifrance.gouv.fr",
+                "valeur": 15.0,
+                "unite": "%",
+            },
+        ]
+
 
 @pytest.fixture(autouse=True)
 def _autorise(monkeypatch):
@@ -121,6 +147,44 @@ def test_callback_run_cta_toutes_periodes(client):
     assert client.appels == [("cta", None)]
     ((_, kwargs),) = bot.documents
     assert kwargs["filename"] == "cta.xlsx"
+
+
+# =============================================================================
+# Millésimes des taux régulés (#185, ADR-0024)
+# =============================================================================
+
+
+def test_menu_propose_les_millesimes(client):
+    update = update_commande()
+
+    asyncio.run(handlers_taxes.cmd_taxes(update, contexte()))
+
+    ((_, kwargs),) = update.effective_message.replies
+    assert "taxes:millesimes" in callbacks_du_markup(kwargs)
+
+
+def test_callback_millesimes_affiche_les_trois_registres(client):
+    update = update_callback("taxes:millesimes")
+    bot = FakeBot()
+
+    asyncio.run(handlers_taxes.on_callback(update, contexte(bot=bot)))
+
+    assert client.appels == [("millesimes", None)]
+    (_, _, texte, kwargs) = bot.edits[-1]
+    assert "TURPE" in texte and "Accise" in texte and "CTA" in texte
+    assert "29.98 €/MWh" in texte and "depuis le 2025-08-01" in texte, "démo cible ADR-0024"
+    assert "réf." in texte and "https://www.cre.fr" in texte
+    assert "taxes:menu" in callbacks_du_markup(kwargs), "retour"
+
+
+def test_raccourci_millesimes(client):
+    update = update_commande()
+
+    asyncio.run(handlers_taxes.cmd_taxes(update, contexte(args=["millesimes"])))
+
+    assert client.appels == [("millesimes", None)]
+    ((texte, _),) = update.effective_message.replies
+    assert "CTA" in texte and "15" in texte
 
 
 # =============================================================================

--- a/tests/unit/test_cta.py
+++ b/tests/unit/test_cta.py
@@ -67,7 +67,7 @@ class TestChargementRegles:
 
     def test_load_cta_rules_colonnes_et_types(self):
         regles = load_cta_rules().collect()
-        assert set(regles.columns) == {"start", "taux_cta_pct"}
+        assert set(regles.columns) == {"start", "taux_cta_pct", "reference"}
         assert regles["taux_cta_pct"].dtype == pl.Float64
         assert regles["start"].dtype == pl.Datetime(time_unit="us", time_zone="Europe/Paris")
 

--- a/tests/unit/test_millesimes.py
+++ b/tests/unit/test_millesimes.py
@@ -1,0 +1,80 @@
+"""
+Tests du millésime des taux régulés (issue #185, ADR-0024).
+
+Le millésime est dérivé, jamais déclaré : dernière ligne entrée en vigueur
+d'un fichier de taux + sa référence réglementaire.
+"""
+
+import datetime as dt
+
+import polars as pl
+
+from electricore.core.millesimes import Millesime, deriver_millesime, millesimes
+
+
+def _historique(starts: list[dt.datetime], taux: list[float], references: list[str]) -> pl.LazyFrame:
+    return pl.LazyFrame({"start": starts, "taux_test": taux, "reference": references}).with_columns(
+        pl.col("start").dt.replace_time_zone("Europe/Paris")
+    )
+
+
+class TestDeriverMillesime:
+    def test_derniere_ligne_entree_en_vigueur(self):
+        """Le millésime est la ligne au start le plus récent, avec sa référence."""
+        historique = _historique(
+            [dt.datetime(2024, 1, 1), dt.datetime(2025, 2, 1)],
+            [21.0, 33.7],
+            ["LF 2024", "LF 2025"],
+        )
+
+        m = deriver_millesime(historique, taxe="Accise", taux_col="taux_test", unite="€/MWh")
+
+        assert m == Millesime(
+            taxe="Accise", date_vigueur=dt.date(2025, 2, 1), reference="LF 2025", valeur=33.7, unite="€/MWh"
+        )
+
+    def test_ordre_du_fichier_indifferent(self):
+        """La dérivation se fonde sur start, pas sur l'ordre des lignes."""
+        historique = _historique(
+            [dt.datetime(2026, 2, 1), dt.datetime(2021, 8, 1)],
+            [15.0, 21.93],
+            ["Arrêté 2026", "Arrêté 2021"],
+        )
+
+        m = deriver_millesime(historique, taxe="CTA", taux_col="taux_test", unite="%")
+
+        assert m.date_vigueur == dt.date(2026, 2, 1)
+        assert m.reference == "Arrêté 2026"
+        assert m.valeur == 15.0
+
+    def test_grille_sans_taux_scalaire(self):
+        """Pour une grille (TURPE), pas de valeur scalaire : valeur et unite restent None."""
+        historique = _historique(
+            [dt.datetime(2025, 8, 1), dt.datetime(2025, 8, 1)],
+            [1.0, 2.0],
+            ["Délib TURPE 7", "Délib TURPE 7"],
+        )
+
+        m = deriver_millesime(historique, taxe="TURPE")
+
+        assert m == Millesime(taxe="TURPE", date_vigueur=dt.date(2025, 8, 1), reference="Délib TURPE 7")
+
+
+class TestMillesimesReels:
+    """Smoke : les trois fichiers de taux versionnés portent un millésime exploitable."""
+
+    def test_trois_millesimes(self):
+        result = millesimes()
+
+        assert [m.taxe for m in result] == ["TURPE", "Accise", "CTA"]
+        for m in result:
+            assert m.reference, f"{m.taxe} : référence vide"
+            assert "http" in m.reference, f"{m.taxe} : pas de lien vers le document public"
+            assert m.date_vigueur >= dt.date(2025, 1, 1), f"{m.taxe} : millésime suspect ({m.date_vigueur})"
+
+    def test_accise_et_cta_portent_un_taux(self):
+        turpe, accise, cta = millesimes()
+
+        assert turpe.valeur is None  # grille, pas de scalaire
+        assert accise.unite == "€/MWh" and accise.valeur > 0
+        assert cta.unite == "%" and cta.valeur > 0

--- a/tests/unit/test_turpe.py
+++ b/tests/unit/test_turpe.py
@@ -44,7 +44,7 @@ class TestChargementRegles:
 
         # Vérifications de base
         assert df.shape[0] > 0, "Aucune règle chargée"
-        assert df.shape[1] == 18, f"Nombre de colonnes incorrect: {df.shape[1]}"
+        assert df.shape[1] == 19, f"Nombre de colonnes incorrect: {df.shape[1]}"
 
         # Vérification des colonnes obligatoires
         colonnes_attendues = [
@@ -66,6 +66,7 @@ class TestChargementRegles:
             "c_hc",
             "c_base",
             "cmdps",
+            "reference",
         ]
         for col in colonnes_attendues:
             assert col in df.columns, f"Colonne manquante: {col}"


### PR DESCRIPTION
## Contexte

Issue #185, première suite d'[ADR-0024](https://github.com/Energie-De-Nantes/electricore/blob/main/docs/adr/0024-trois-registres-de-savoir.md) : la tranche de bout en bout CSV → core → API → bot.

## Contenu

- **Colonne `reference`** dans les trois CSV (`turpe_rules`, `accise_rules`, `cta_rules`) : chaque ligne cite son texte fondateur + lien public. Sources :
  - TURPE : délib. CRE [2023-137](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047916180), [2024-122](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050259478), [2025-08](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051023199) (évolution exceptionnelle 1ᵉʳ fév. 2025), [2025-40](https://www.cre.fr/actualites/nos-lettres-dinformation/la-cre-publie-ses-decisions-finales-sur-le-tarif-dutilisation-des-reseaux-publics-delectricite-turpe-7.html) (TURPE 7)
  - Accise : [arrêté du 25 janvier 2024](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000049059983) (21 €/MWh), [tarifs 2025](https://www.impots.gouv.fr/actualite/consommation-denergie-tarifs-normaux-des-accises-en-2025) (33.70 puis 25.09 + majoration ZNI 4.89 = 29.98 €/MWh)
  - CTA : arrêté du 26 avril 2013 (27.04 %), [arrêté du 20 juillet 2021](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043847483) (21.93 %), [arrêté du 28 janvier 2026](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000053417026) (15 %)
- **Dérivation core** (`electricore/core/millesimes.py`) : `deriver_millesime()` pure (dernière ligne au `start` le plus récent + sa référence) + value object `Millesime` `@dataclass(frozen=True, slots=True)` (ADR-0018). Pour le TURPE (grille), pas de taux scalaire : `valeur=None`.
- **API** : `GET /taxes/millesimes` (JSON, clé API). Sans dépendance Odoo — disponible sur une instance no-ERP.
- **Bot** : bouton « 📜 Millésimes » dans le menu `/taxes` + raccourci `/taxes millesimes`. Démo cible ADR-0024 : « Accise — 29.98 €/MWh depuis le 2025-08-01, réf. … ».
- **Pipelines inchangés** : la colonne `reference` est droppée par les `select(colonnes_originales + …)` existants des trois pipelines ; seuls les tests de forme des loaders évoluent (18→19 colonnes TURPE, set de colonnes accise/CTA).
- CONTEXT.md : *Référence réglementaire* (plus « à introduire ») et *Millésime* pointent l'implémentation.

## À vérifier en revue (gouvernance ADR-0024 — l'exactitude juridique se vérifie ici)

- Les références citées ligne à ligne dans les 3 CSV (notamment l'attribution exacte des délibérations TURPE par fenêtre, et la réf. CTA 2013 dont je n'ai pas trouvé de lien Légifrance direct — lien CNIEG en attendant).
- Côté bot, les millésimes restent derrière le gating `@require_odoo` du domaine `/taxes` (comportement no-ERP du bot inchangé) ; l'endpoint API, lui, marche sans ERP. Si on veut le millésime visible sur le bot d'une instance no-ERP, c'est une retouche du gating à décider séparément.

## Vérifications

- Suite complète : 682 passed, 35 skipped ; ruff format + check OK
- Pas de conflit avec la PR #199 (fichiers disjoints)

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)