### PR TITLE
feat(taxes): check de péremption des taux régulés + alerte bot (#186)

### DIFF
--- a/electricore/api/models.py
+++ b/electricore/api/models.py
@@ -113,6 +113,16 @@ class MillesimeResponse(BaseModel):
     unite: str | None = Field(None, description="Unité du taux scalaire (€/MWh, %)")
 
 
+class PeremptionResponse(BaseModel):
+    """Avertissement de péremption d'un taux régulé (#186, ADR-0024) — warning, jamais d'auto-correction."""
+
+    taxe: str = Field(..., description="Registre concerné : TURPE | Accise")
+    attendu_depuis: date = Field(..., description="Jalon du rythme attendu resté sans nouvelle ligne")
+    dernier_start: date = Field(..., description="Dernière entrée en vigueur connue")
+    consigne: str = Field(..., description="Quoi vérifier (délibération CRE, loi de finances)")
+    message: str = Field(..., description="Message prêt à afficher")
+
+
 # Modèles pour les requêtes (si nécessaire pour des POST/PUT futurs)
 
 

--- a/electricore/api/routers/taxes.py
+++ b/electricore/api/routers/taxes.py
@@ -1,11 +1,12 @@
 """Router des endpoints taxes énergétiques : Accise TICFE et CTA (issue #82)."""
 
 from dataclasses import asdict
+from datetime import date
 
 from fastapi import APIRouter, Depends, Query
 
 from electricore.api.decorators import arrow_endpoint, xlsx_endpoint
-from electricore.api.models import MillesimeResponse
+from electricore.api.models import MillesimeResponse, PeremptionResponse
 from electricore.api.security import get_current_api_key
 from electricore.api.serializers import arrow_stream, xlsx_multi_sheet
 from electricore.api.services.taxes_service import (
@@ -16,6 +17,7 @@ from electricore.api.services.taxes_service import (
 )
 from electricore.core.builds.rapport_taxe import feuilles_rapport_taxe
 from electricore.core.millesimes import millesimes
+from electricore.core.peremption import avertissements_peremption
 from electricore.integrations.odoo.decorators import with_odoo
 
 router = APIRouter(tags=["taxes"])
@@ -34,6 +36,16 @@ def get_millesimes(api_key: str = Depends(get_current_api_key)) -> list[Millesim
     réglementation. Sans dépendance Odoo : disponible sur une instance no-ERP.
     """
     return [MillesimeResponse(**asdict(m)) for m in millesimes()]
+
+
+@router.get("/taxes/peremption", response_model=list[PeremptionResponse])
+def get_peremption(api_key: str = Depends(get_current_api_key)) -> list[PeremptionResponse]:
+    """Avertissements de péremption des taux régulés à la date du jour (#186, ADR-0024).
+
+    Rythmes attendus encodés comme heuristiques (TURPE au 1ᵉʳ août, Accise au
+    1ᵉʳ janvier, CTA sans rythme connu). Liste vide = registres présumés à jour.
+    """
+    return [PeremptionResponse(**asdict(a), message=a.message) for a in avertissements_peremption(date.today())]
 
 
 # =============================================================================

--- a/electricore/bot/CONTEXT.md
+++ b/electricore/bot/CONTEXT.md
@@ -21,7 +21,7 @@ Validation explicite en deux taps exigée avant une action coûteuse ou risquée
 Liste des commandes publiée à Telegram au démarrage du bot, adaptée à l'instance : les domaines dépendant d'un ERP (`/taxes`, `/facturation`) sont masqués quand aucun ERP n'est configuré.
 
 **Chat de notification** :
-Chat Telegram destinataire des alertes proactives du bot (échec d'un job d'ingestion, y compris ceux lancés par le scheduler), distinct des réponses aux commandes.
+Chat Telegram destinataire des alertes proactives du bot (échec d'un job d'ingestion, y compris ceux lancés par le scheduler ; taux régulé présumé périmé, #186), distinct des réponses aux commandes.
 
 **Allowlist Telegram** :
 Liste d'identifiants numériques Telegram autorisés à utiliser le bot, configurée via `TELEGRAM_ALLOWED_USERS`. Tout autre utilisateur reçoit `⛔ Accès refusé`. Pas de rôles ni de granularité.

--- a/electricore/bot/README.md
+++ b/electricore/bot/README.md
@@ -42,6 +42,13 @@ et pousse une alerte 🚨 quand un job passe à `failed` — **y compris ceux la
 par le scheduler** (supercronic). Pas d'alerte sur l'historique antérieur au
 démarrage, pas de doublon. Vide = désactivé.
 
+Même canal pour la **péremption des taux régulés** (#186, ADR-0024) : un check
+quotidien compare la dernière entrée en vigueur de chaque fichier de taux aux
+rythmes attendus (heuristiques : TURPE au 1ᵉʳ août, Accise au 1ᵉʳ janvier,
+CTA sans rythme connu) et pousse un ⚠️ par jalon manqué — warning seulement,
+jamais d'auto-correction. Un changement hors calendrier passe sous le radar
+(Limites d'ADR-0024).
+
 ## Configuration
 
 | variable | rôle |
@@ -73,7 +80,7 @@ bot/
 ├── auth.py            # @require_allowed (allowlist), @require_odoo (no-ERP)
 ├── client.py          # client HTTP async vers l'API (X-API-Key)
 ├── format.py          # rendu HTML (escape) — parse_mode=HTML partout
-├── surveillance.py    # alertes proactives (polling /ingestion/jobs)
+├── surveillance.py    # alertes proactives (polling /ingestion/jobs, péremption des taux)
 ├── tasks.py           # tâches de fond (annulées au shutdown)
 └── handlers/          # un module par domaine de commande
     ├── start.py       # /start, /help — COMMANDES = source de vérité de la surface

--- a/electricore/bot/app.py
+++ b/electricore/bot/app.py
@@ -19,10 +19,11 @@ async def publier_menu(application: Application) -> None:
 
 
 async def demarrer(application: Application) -> None:
-    """post_init : menu natif + surveillance proactive des jobs d'ingestion (#157)."""
+    """post_init : menu natif + surveillances proactives — jobs d'ingestion (#157), péremption des taux (#186)."""
     await publier_menu(application)
     if settings.telegram_notify_chat_id:
         create_task(surveillance.boucle_surveillance(application.bot, settings.telegram_notify_chat_id))
+        create_task(surveillance.boucle_peremption(application.bot, settings.telegram_notify_chat_id))
 
 
 def build_application(token: str) -> Application:

--- a/electricore/bot/client.py
+++ b/electricore/bot/client.py
@@ -109,6 +109,10 @@ class ElectriCoreClient:
         """Millésimes des taux régulés (TURPE, Accise, CTA) — #185, ADR-0024."""
         return await self._get_json("/taxes/millesimes")
 
+    async def get_peremption(self) -> list[dict]:
+        """Avertissements de péremption des taux régulés — #186, ADR-0024."""
+        return await self._get_json("/taxes/peremption")
+
     async def get_facturation_xlsx(self, mois: str | None = None) -> bytes:
         params = {"mois": mois} if mois else None
         return await self._get_bytes("/facturation/rapport.xlsx", params=params, timeout=TIMEOUT_LOURD)

--- a/electricore/bot/surveillance.py
+++ b/electricore/bot/surveillance.py
@@ -18,6 +18,7 @@ from electricore.bot.format import escape
 logger = logging.getLogger(__name__)
 
 SURVEILLANCE_INTERVAL = 60  # secondes entre deux interrogations
+PEREMPTION_INTERVAL = 24 * 3600  # un check de péremption par jour suffit (rythmes annuels)
 
 
 async def initialiser_vus(client: ElectriCoreClient) -> set[str]:
@@ -60,3 +61,43 @@ async def boucle_surveillance(bot, chat_id: str) -> None:
     while True:
         await asyncio.sleep(SURVEILLANCE_INTERVAL)
         await verifier_jobs(bot, client, vus, chat_id)
+
+
+# =============================================================================
+# Péremption des taux régulés (#186, ADR-0024)
+# =============================================================================
+
+
+async def verifier_peremption(bot, client: ElectriCoreClient, vus: set, chat_id: str) -> None:
+    """Une itération du check : alerte les taux présumés périmés, une fois par jalon manqué.
+
+    Le bot reste pur client HTTP : le check est calculé par l'API
+    (`GET /taxes/peremption`, fonction core pure côté serveur). Warning
+    uniquement, jamais d'auto-correction (ADR-0024).
+    """
+    try:
+        avertissements = await client.get_peremption()
+    except Exception:
+        return  # API indisponible : on retentera au prochain passage
+
+    for a in avertissements:
+        cle = (a["taxe"], a["attendu_depuis"])
+        if cle in vus:
+            continue
+        texte = f"⚠️ Taux régulé présumé périmé : {escape(a['message'])}"
+        try:
+            await bot.send_message(chat_id=chat_id, text=texte, parse_mode="HTML")
+            vus.add(cle)
+        except Exception:
+            logger.exception("Échec d'envoi de l'alerte péremption")  # retentera au prochain passage
+
+
+async def boucle_peremption(bot, chat_id: str) -> None:
+    """Boucle quotidienne du check de péremption (annulée au shutdown via tasks)."""
+    client = ElectriCoreClient()
+    vus: set = set()
+    logger.info("Surveillance péremption des taux régulés active (chat %s)", chat_id)
+    await verifier_peremption(bot, client, vus, chat_id)  # check immédiat au démarrage
+    while True:
+        await asyncio.sleep(PEREMPTION_INTERVAL)
+        await verifier_peremption(bot, client, vus, chat_id)

--- a/electricore/core/peremption.py
+++ b/electricore/core/peremption.py
@@ -1,0 +1,108 @@
+"""
+Check de péremption des taux régulés (issue #186, ADR-0024).
+
+La surveillance réglementaire est déléguée — à un membre non technique de la
+fédération ou à cette alerte automatisée. Les rythmes attendus sont des
+**heuristiques** : un changement hors calendrier passe sous le radar (Limites
+d'ADR-0024). Le check produit des avertissements, jamais d'auto-correction.
+
+Rythmes encodés :
+- TURPE — nouvelle grille effective au 1ᵉʳ août (indexation annuelle CRE) ;
+- Accise — loi de finances, effet au 1ᵉʳ janvier ;
+- CTA — pas de rythme connu, pas de check.
+"""
+
+import datetime as dt
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import polars as pl
+
+
+@dataclass(frozen=True, slots=True)
+class RythmeAttendu:
+    """Heuristique de renouvellement d'un taux régulé : un jalon annuel (mois, jour)."""
+
+    taxe: str
+    mois: int
+    jour: int
+    consigne: str
+
+
+RYTHMES: tuple[RythmeAttendu, ...] = (
+    RythmeAttendu("TURPE", 8, 1, "vérifier la délibération CRE (indexation annuelle au 1ᵉʳ août)"),
+    RythmeAttendu("Accise", 1, 1, "vérifier la loi de finances (effet au 1ᵉʳ janvier)"),
+    # CTA : pas de rythme connu — changements apériodiques par arrêté, pas de check
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AvertissementPeremption:
+    """Un taux présumé périmé : aucune ligne entrée en vigueur depuis le jalon attendu."""
+
+    taxe: str
+    attendu_depuis: dt.date
+    dernier_start: dt.date
+    consigne: str
+
+    @property
+    def message(self) -> str:
+        return (
+            f"aucune ligne {self.taxe} entrée en vigueur depuis le {self.attendu_depuis:%Y-%m-%d} "
+            f"(dernière connue : {self.dernier_start:%Y-%m-%d}) — {self.consigne}"
+        )
+
+
+def dernier_jalon(rythme: RythmeAttendu, a_date: dt.date) -> dt.date:
+    """Dernière échéance du rythme tombée au plus tard à `a_date`."""
+    jalon = dt.date(a_date.year, rythme.mois, rythme.jour)
+    return jalon if jalon <= a_date else dt.date(a_date.year - 1, rythme.mois, rythme.jour)
+
+
+def _derniers_starts_des_csv() -> dict[str, dt.date]:
+    """Dernière entrée en vigueur connue par fichier de taux versionné."""
+    # Import local : éviter le coût des pipelines au chargement du module
+    from electricore.core.pipelines.accise import load_accise_rules
+    from electricore.core.pipelines.cta import load_cta_rules
+    from electricore.core.pipelines.turpe import load_turpe_rules
+
+    def _max_start(lf: pl.LazyFrame) -> dt.date:
+        return lf.select(pl.col("start").max()).collect().item().date()
+
+    return {
+        "TURPE": _max_start(load_turpe_rules()),
+        "Accise": _max_start(load_accise_rules()),
+        "CTA": _max_start(load_cta_rules()),
+    }
+
+
+def avertissements_peremption(
+    a_date: dt.date,
+    derniers_starts: Mapping[str, dt.date] | None = None,
+) -> tuple[AvertissementPeremption, ...]:
+    """Avertissements de péremption à `a_date` : taxes sans ligne depuis leur jalon attendu.
+
+    Args:
+        a_date: date du check.
+        derniers_starts: dernière entrée en vigueur par taxe — dérivée des CSV
+            versionnés si None. Les taxes absentes du mapping sont ignorées.
+    """
+    if derniers_starts is None:
+        derniers_starts = _derniers_starts_des_csv()
+
+    avertissements = []
+    for rythme in RYTHMES:
+        dernier_start = derniers_starts.get(rythme.taxe)
+        if dernier_start is None:
+            continue
+        jalon = dernier_jalon(rythme, a_date)
+        if dernier_start < jalon:
+            avertissements.append(
+                AvertissementPeremption(
+                    taxe=rythme.taxe,
+                    attendu_depuis=jalon,
+                    dernier_start=dernier_start,
+                    consigne=rythme.consigne,
+                )
+            )
+    return tuple(avertissements)

--- a/tests/integration/test_taxes_peremption_endpoint.py
+++ b/tests/integration/test_taxes_peremption_endpoint.py
@@ -1,0 +1,36 @@
+"""GET /taxes/peremption : check de péremption des taux régulés (#186, ADR-0024).
+
+Endpoint JSON sans dépendance Odoo : le check est dérivé des CSV versionnés
+embarqués dans la lib, à la date du jour côté serveur.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from electricore.api.main import app
+from electricore.api.security import get_current_api_key
+
+
+@pytest.fixture
+def client_authentifie():
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_peremption_repond_une_liste_d_avertissements(client_authentifie):
+    response = client_authentifie.get("/taxes/peremption")
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert isinstance(data, list)
+    for a in data:
+        assert a["taxe"] in ("TURPE", "Accise"), "seules les taxes à rythme connu sont vérifiées"
+        assert a["message"] and "vérifier" in a["message"]
+        assert a["attendu_depuis"] and a["dernier_start"]
+
+
+def test_peremption_exige_une_cle_api():
+    response = TestClient(app).get("/taxes/peremption")
+
+    assert response.status_code in (401, 403)

--- a/tests/unit/test_bot_app.py
+++ b/tests/unit/test_bot_app.py
@@ -103,8 +103,9 @@ def test_demarrer_sans_chat_de_notification_ne_surveille_pas(monkeypatch):
     assert _taches_creees_par_demarrer(monkeypatch, chat_id="") == 0
 
 
-def test_demarrer_avec_chat_de_notification_lance_la_surveillance(monkeypatch):
-    assert _taches_creees_par_demarrer(monkeypatch, chat_id="-100123") == 1
+def test_demarrer_avec_chat_de_notification_lance_les_surveillances(monkeypatch):
+    # deux boucles : jobs d'ingestion (#157) + péremption des taux régulés (#186)
+    assert _taches_creees_par_demarrer(monkeypatch, chat_id="-100123") == 2
 
 
 def test_publier_menu_pousse_la_surface_a_telegram(monkeypatch):

--- a/tests/unit/test_bot_surveillance.py
+++ b/tests/unit/test_bot_surveillance.py
@@ -87,3 +87,106 @@ def test_une_erreur_api_n_interrompt_pas_la_surveillance():
     asyncio.run(surveillance.verifier_jobs(bot, ClientCasse(), set(), chat_id="-1"))
 
     assert bot.messages == []
+
+
+# =============================================================================
+# Péremption des taux régulés (#186, ADR-0024)
+# =============================================================================
+
+_AVERT_TURPE = {
+    "taxe": "TURPE",
+    "attendu_depuis": "2026-08-01",
+    "dernier_start": "2025-08-01",
+    "consigne": "vérifier la délibération CRE (indexation annuelle au 1ᵉʳ août)",
+    "message": (
+        "aucune ligne TURPE entrée en vigueur depuis le 2026-08-01 "
+        "(dernière connue : 2025-08-01) — vérifier la délibération CRE (indexation annuelle au 1ᵉʳ août)"
+    ),
+}
+
+
+class FakeClientPeremption:
+    def __init__(self, avertissements):
+        self.avertissements = avertissements
+
+    async def get_peremption(self) -> list[dict]:
+        return self.avertissements
+
+
+def test_un_taux_perime_declenche_une_alerte():
+    bot = FakeBot()
+    client = FakeClientPeremption([_AVERT_TURPE])
+
+    asyncio.run(surveillance.verifier_peremption(bot, client, set(), chat_id="-100123"))
+
+    ((chat_id, texte),) = bot.messages
+    assert chat_id == "-100123"
+    assert "⚠️" in texte and "TURPE" in texte
+    assert "2026-08-01" in texte and "délibération CRE" in texte
+
+
+def test_pas_de_doublon_pour_le_meme_jalon():
+    bot = FakeBot()
+    client = FakeClientPeremption([_AVERT_TURPE])
+    vus: set = set()
+
+    asyncio.run(surveillance.verifier_peremption(bot, client, vus, chat_id="-1"))
+    asyncio.run(surveillance.verifier_peremption(bot, client, vus, chat_id="-1"))
+
+    assert len(bot.messages) == 1
+
+
+def test_un_nouveau_jalon_realerte():
+    """L'année suivante, le même taux toujours périmé est re-signalé (jalon différent)."""
+    bot = FakeBot()
+    client = FakeClientPeremption([_AVERT_TURPE])
+    vus: set = set()
+
+    asyncio.run(surveillance.verifier_peremption(bot, client, vus, chat_id="-1"))
+    client.avertissements = [{**_AVERT_TURPE, "attendu_depuis": "2027-08-01"}]
+    asyncio.run(surveillance.verifier_peremption(bot, client, vus, chat_id="-1"))
+
+    assert len(bot.messages) == 2
+
+
+def test_taux_a_jour_aucune_alerte():
+    bot = FakeBot()
+
+    asyncio.run(surveillance.verifier_peremption(bot, FakeClientPeremption([]), set(), chat_id="-1"))
+
+    assert bot.messages == []
+
+
+def test_une_erreur_api_n_interrompt_pas_le_check_de_peremption():
+    class ClientCasse:
+        async def get_peremption(self):
+            raise ConnectionError("api down")
+
+    bot = FakeBot()
+
+    asyncio.run(surveillance.verifier_peremption(bot, ClientCasse(), set(), chat_id="-1"))
+
+    assert bot.messages == []
+
+
+def test_echec_d_envoi_retentera_au_prochain_passage():
+    class BotCasse(FakeBot):
+        def __init__(self):
+            super().__init__()
+            self.casse = True
+
+        async def send_message(self, chat_id, text: str, **kwargs):
+            if self.casse:
+                raise ConnectionError("telegram down")
+            await super().send_message(chat_id, text, **kwargs)
+
+    bot = BotCasse()
+    client = FakeClientPeremption([_AVERT_TURPE])
+    vus: set = set()
+
+    asyncio.run(surveillance.verifier_peremption(bot, client, vus, chat_id="-1"))
+    assert bot.messages == [] and vus == set(), "échec d'envoi : rien n'est marqué vu"
+
+    bot.casse = False
+    asyncio.run(surveillance.verifier_peremption(bot, client, vus, chat_id="-1"))
+    assert len(bot.messages) == 1

--- a/tests/unit/test_peremption.py
+++ b/tests/unit/test_peremption.py
@@ -1,0 +1,74 @@
+"""
+Tests du check de péremption des taux régulés (issue #186, ADR-0024).
+
+Les rythmes attendus sont des heuristiques (TURPE au 1ᵉʳ août, Accise au
+1ᵉʳ janvier, CTA sans rythme connu) : un warning, jamais d'auto-correction.
+"""
+
+import datetime as dt
+
+from electricore.core.peremption import avertissements_peremption
+
+
+class TestAvertissementsPeremption:
+    def test_a_jour_aucun_avertissement(self):
+        """Chaque taxe à rythme a une ligne postérieure à son dernier jalon → rien à signaler."""
+        avertissements = avertissements_peremption(
+            dt.date(2026, 7, 1),
+            derniers_starts={"TURPE": dt.date(2025, 8, 1), "Accise": dt.date(2026, 1, 1)},
+        )
+
+        assert avertissements == ()
+
+    def test_turpe_en_retard_apres_le_premier_aout(self):
+        """Au 2 août, la grille attendue du 1ᵉʳ août manque → avertissement TURPE."""
+        avertissements = avertissements_peremption(
+            dt.date(2026, 8, 2),
+            derniers_starts={"TURPE": dt.date(2025, 8, 1), "Accise": dt.date(2026, 1, 1)},
+        )
+
+        (a,) = avertissements
+        assert a.taxe == "TURPE"
+        assert a.attendu_depuis == dt.date(2026, 8, 1)
+        assert a.dernier_start == dt.date(2025, 8, 1)
+        assert "délibération CRE" in a.consigne
+
+    def test_accise_en_retard_apres_le_premier_janvier(self):
+        """Loi de finances attendue au 1ᵉʳ janvier : ligne absente → avertissement Accise."""
+        avertissements = avertissements_peremption(
+            dt.date(2026, 6, 13),
+            derniers_starts={"TURPE": dt.date(2025, 8, 1), "Accise": dt.date(2025, 8, 1)},
+        )
+
+        (a,) = avertissements
+        assert a.taxe == "Accise"
+        assert a.attendu_depuis == dt.date(2026, 1, 1)
+        assert "loi de finances" in a.consigne
+
+    def test_cta_sans_rythme_jamais_signalee(self):
+        """Pas de rythme connu pour la CTA : pas de check, même très ancienne."""
+        avertissements = avertissements_peremption(
+            dt.date(2030, 6, 1),
+            derniers_starts={"TURPE": dt.date(2029, 8, 1), "Accise": dt.date(2030, 1, 1), "CTA": dt.date(2020, 1, 1)},
+        )
+
+        assert avertissements == ()
+
+    def test_message_actionnable(self):
+        """Le message dit quoi vérifier, avec les deux dates qui situent le retard."""
+        (a,) = avertissements_peremption(
+            dt.date(2026, 8, 2),
+            derniers_starts={"TURPE": dt.date(2025, 8, 1), "Accise": dt.date(2026, 1, 1)},
+        )
+
+        assert "TURPE" in a.message
+        assert "2026-08-01" in a.message and "2025-08-01" in a.message
+        assert "vérifier" in a.message
+
+
+class TestDerniersStartsReels:
+    def test_les_csv_versionnes_sont_verifiables(self):
+        """Smoke : le check tourne sur les vrais CSV sans exploser, et ne parle que des taxes à rythme."""
+        avertissements = avertissements_peremption(dt.date(2026, 6, 13))
+
+        assert all(a.taxe in ("TURPE", "Accise") for a in avertissements)


### PR DESCRIPTION
## Contexte

Issue #186, deuxième suite d'[ADR-0024](https://github.com/Energie-De-Nantes/electricore/blob/main/docs/adr/0024-trois-registres-de-savoir.md). **PR empilée sur #200** (#185) : elles partagent `routers/taxes.py`, `models.py` et `client.py` — la base sera re-ciblée sur `main` automatiquement au merge de #200.

## Contenu

- **Fonction core pure** `avertissements_peremption(date) -> tuple[AvertissementPeremption, ...]` ([electricore/core/peremption.py](../blob/feat/186-peremption-taux-regules/electricore/core/peremption.py)) : à une date donnée, compare la dernière entrée en vigueur de chaque fichier de taux au dernier jalon de son rythme attendu. Rythmes **heuristiques** : TURPE au 1ᵉʳ août (délibération CRE), Accise au 1ᵉʳ janvier (loi de finances), CTA sans rythme connu → pas de check. Testée : à jour, en retard, taxe sans rythme, message actionnable.
- **`GET /taxes/peremption`** : j'ai d'abord branché le bot en import direct de `core` — le garde-fou `tests/architecture/test_bot_topology.py` l'a refusé (bot = pur client HTTP, ADR-0009). Le check passe donc par l'API, calculé côté serveur à la date du jour.
- **Surveillance bot** : boucle quotidienne (`boucle_peremption`), même canal que les alertes d'échec d'ingestion. Une alerte ⚠️ par (taxe, jalon manqué) ; ré-alerte l'année suivante si toujours périmé ; erreur API silencieuse (retentera) ; échec d'envoi Telegram retenté.
- **Aucune auto-correction ni modification de données** — warning only.

## ⚠️ Au déploiement

Au premier démarrage, l'alerte **Accise** partira réellement : dernière ligne accise au 2025-08-01, jalon attendu 2026-01-01 — le registre accise n'a pas intégré la LF 2026. C'est le comportement voulu (le check fait son travail) ; à traiter par une contribution de taux (cf. #187 / ADR-0024).

## Vérifications

- Suite complète : 696 passed, 35 skipped (dont le garde-fou de topologie bot) ; ruff OK

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)