### PR TITLE
feat(ingestion)!: retirer les alias de transition /etl (#193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@ terme canonique de la doc. Changements cassants et transitions :
 - **Package** : `electricore/etl/` → `electricore/ingestion/` ; CLI :
   `uv run python -m electricore.ingestion <all|test|rebuild|resync|flux…>` ;
 - **Extra** : `uv sync --extra etl` → `uv sync --extra ingestion` (**cassant**) ;
-- **Routes API** : `/etl/run`, `/etl/jobs` → `/ingestion/run`, `/ingestion/jobs` —
-  les anciens chemins répondent encore **une release** (alias hors schéma OpenAPI),
-  mettre à jour la crontab déployée (`deploy/docker/crontab`) ;
-- **Bot** : `/ingestion` remplace `/etl` (qui reste en alias) ;
+- **Routes API** : `/etl/run`, `/etl/jobs` → `/ingestion/run`, `/ingestion/jobs`
+  (**cassant**) ; les alias de transition `/etl/*` sont **retirés** (#193) et
+  répondent désormais `404` — la crontab doit appeler `/ingestion/run`
+  (`deploy/docker/crontab` l'est déjà) ;
+- **Bot** : `/ingestion` remplace `/etl`, **sans alias** (#193) ; les callbacks
+  `etl:*` des claviers postés avant le renommage ne routent plus ;
 - **Compose** : service `etl-scheduler` → `ingestion-scheduler`, conteneur
   `electricore-etl` → `electricore-ingestion` (recréation au prochain pull).
 

--- a/electricore/api/README.md
+++ b/electricore/api/README.md
@@ -75,8 +75,6 @@ API_VERSION="1.0.0"
 - `GET /facturation/...` - Documents mensuels ; `GET /facturation/check/odoo.xlsx` - check pré-facturation
 - `GET /admin/api-keys` - Configuration des clés API
 
-Les routes `/etl/*` restent des alias hors schéma OpenAPI de `/ingestion/*` pour une release (cf. issue #193).
-
 ## 🚀 Exemples d'utilisation
 
 ### Lister les tables disponibles

--- a/electricore/api/routers/ingestion.py
+++ b/electricore/api/routers/ingestion.py
@@ -8,12 +8,8 @@ from electricore.api.services import ingestion_service
 
 router = APIRouter(tags=["ingestion"])
 
-# Alias de transition : les anciens chemins /etl/* répondent encore une release
-# (crontabs déployées), hors schéma OpenAPI. À retirer à la release suivante.
-
 
 @router.post("/ingestion/run", response_model=IngestionJobResponse, status_code=202)
-@router.post("/etl/run", response_model=IngestionJobResponse, status_code=202, include_in_schema=False)
 async def run_ingestion(
     body: IngestionRunRequest,
     api_key: str = Depends(get_current_api_key),
@@ -66,7 +62,6 @@ async def run_ingestion(
 
 
 @router.get("/ingestion/jobs", response_model=list[IngestionJobResponse])
-@router.get("/etl/jobs", response_model=list[IngestionJobResponse], include_in_schema=False)
 async def list_ingestion_jobs(
     limit: int = Query(20, ge=1, le=50, description="Nombre de jobs à retourner"),
     api_key: str = Depends(get_current_api_key),
@@ -92,7 +87,6 @@ async def list_ingestion_jobs(
 
 
 @router.get("/ingestion/jobs/{job_id}", response_model=IngestionJobResponse)
-@router.get("/etl/jobs/{job_id}", response_model=IngestionJobResponse, include_in_schema=False)
 async def get_ingestion_job(
     job_id: str,
     api_key: str = Depends(get_current_api_key),

--- a/electricore/bot/README.md
+++ b/electricore/bot/README.md
@@ -16,7 +16,7 @@ adapté à l'instance.
 
 | Domaine | Clavier | Raccourcis |
 |---|---|---|
-| `/ingestion` (alias `/etl`) | All · Test · Rebuild · Flux… · Resync · Statut | `/ingestion rebuild`, `/ingestion r151 c15`, `/ingestion statut` |
+| `/ingestion` | All · Test · Rebuild · Flux… · Resync · Statut | `/ingestion rebuild`, `/ingestion r151 c15`, `/ingestion statut` |
 | `/flux` | tables avec descriptions, 📊 stats · 📥 export | `/flux stats c15`, `/flux export r151` |
 | `/perimetre` | 📥 Entrées · 📤 Sorties (C15) | `/perimetre entrees`, `/perimetre sorties` |
 | `/taxes` ⁽ᵉʳᵖ⁾ | Accise · CTA → trimestre (4 derniers + toutes périodes) | `/taxes accise 2025-T1`, `/taxes cta` |

--- a/electricore/bot/app.py
+++ b/electricore/bot/app.py
@@ -32,9 +32,7 @@ def build_application(token: str) -> Application:
     application.add_handler(CommandHandler("help", start.cmd_help))
     # Domaine /ingestion (#152, ex-/etl) — clavier inline + raccourcis, absorbe /status.
     application.add_handler(CommandHandler("ingestion", ingestion.cmd_ingestion))
-    # Alias de transition pour la mémoire musculaire des opérateurs.
-    application.add_handler(CommandHandler("etl", ingestion.cmd_ingestion))
-    application.add_handler(CallbackQueryHandler(ingestion.on_callback, pattern="^(ingestion|etl):"))
+    application.add_handler(CallbackQueryHandler(ingestion.on_callback, pattern="^ingestion:"))
     # Domaine /flux (#153) — stats + exports des tables brutes, absorbe /stats et /export.
     application.add_handler(CommandHandler("flux", flux.cmd_flux))
     application.add_handler(CallbackQueryHandler(flux.on_callback, pattern="^flux:"))

--- a/electricore/bot/handlers/ingestion.py
+++ b/electricore/bot/handlers/ingestion.py
@@ -169,11 +169,7 @@ async def on_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     query = update.callback_query
     await query.answer()
     chat_id, message_id = query.message.chat_id, query.message.message_id
-    # Compat transition : les claviers postés avant le renommage portent encore
-    # des callbacks `etl:*` — normalisés ici plutôt que cassés.
     data = query.data
-    if data.startswith("etl:"):
-        data = "ingestion:" + data.removeprefix("etl:")
 
     if data == "ingestion:menu":
         await context.bot.edit_message_text(

--- a/tests/ingestion/test_ingestion.py
+++ b/tests/ingestion/test_ingestion.py
@@ -1,6 +1,6 @@
 """Contrat CLI du runner de production dbt (#134).
 
-L'API (`/etl/run`) subprocess le runner avec un mode : chaque valeur de `ModeIngestion`
+L'API (`/ingestion/run`) subprocess le runner avec un mode : chaque valeur de `ModeIngestion`
 doit être interprétable par `ingestion`, avec la même sémantique que l'ex-runner
 legacy (test = échantillon, all = tout, sélection de flux, reset = re-téléchargement
 complet via drop_sources).
@@ -61,7 +61,7 @@ def test_la_base_par_defaut_honore_le_dotenv(tmp_path, monkeypatch):
 
 
 def test_l_api_subprocess_le_runner_dbt():
-    """La bascule #134 : /etl/run lance le chemin dbt, plus le parseur legacy."""
+    """La bascule #134 : /ingestion/run lance le chemin dbt, plus le parseur legacy."""
     from electricore.api.services.ingestion_service import _build_pipeline_command
 
     commande = _build_pipeline_command("all")

--- a/tests/integration/test_ingestion_run_modes.py
+++ b/tests/integration/test_ingestion_run_modes.py
@@ -1,4 +1,4 @@
-"""Tests du contrat de modes de `POST /etl/run` (#152).
+"""Tests du contrat de modes de `POST /ingestion/run` (#152).
 
 L'API accepte les modes réels du runner (`test`, `all`, `rebuild`, `resync`,
 liste de flux) — pas seulement l'enum historique. Le pipeline subprocess est
@@ -44,3 +44,11 @@ def test_run_normalise_le_mode_dans_le_job():
     response = TestClient(app).post("/ingestion/run", json={"mode": "  R151   c15 "})
     assert response.status_code == 202
     assert response.json()["mode"] == "r151 c15"
+
+
+@pytest.mark.parametrize("chemin", ["/etl/run", "/etl/jobs", "/etl/jobs/abc"])
+def test_anciens_chemins_etl_repondent_404(chemin):
+    """Les alias de transition /etl/* sont retirés (#193) — plus aucune route."""
+    client = TestClient(app)
+    response = client.post(chemin, json={"mode": "test"}) if chemin == "/etl/run" else client.get(chemin)
+    assert response.status_code == 404

--- a/tests/unit/test_bot_app.py
+++ b/tests/unit/test_bot_app.py
@@ -62,7 +62,7 @@ def test_les_callbacks_des_domaines_sont_routes():
         h.pattern for handlers in tg_app.handlers.values() for h in handlers if isinstance(h, CallbackQueryHandler)
     ]
     assert any(p.match("ingestion:menu") for p in patterns)
-    assert any(p.match("etl:menu") for p in patterns), "compat claviers postés avant le renommage"
+    assert not any(p.match("etl:menu") for p in patterns), "alias /etl retiré (#193) : etl:* ne route plus"
     assert any(p.match("flux:menu") for p in patterns)
     assert any(p.match("perimetre:menu") for p in patterns)
     assert any(p.match("taxes:menu") for p in patterns)

--- a/tests/unit/test_bot_handlers_ingestion.py
+++ b/tests/unit/test_bot_handlers_ingestion.py
@@ -51,7 +51,7 @@ def client(monkeypatch) -> FakeClient:
 
 
 # =============================================================================
-# Cycle 2 — /etl sans argument : clavier principal
+# Cycle 2 — /ingestion sans argument : clavier principal
 # =============================================================================
 
 
@@ -106,17 +106,6 @@ def test_callback_run_lance_et_suit_par_edition_du_meme_message(client):
     assert client.lances == ["all"]
     assert update.callback_query.answered
     assert {(c, m) for c, m, _, _ in bot.edits} == {(1, 100)}, "toutes les éditions portent sur le même message"
-    assert "completed" in bot.edits[-1][2]
-
-
-def test_callback_prefixe_etl_legacy_lance_un_run(client):
-    """Compat transition : un bouton `etl:run:*` d'avant le renommage lance bien le job."""
-    update = update_callback("etl:run:all")
-    bot = FakeBot()
-
-    _scenario_callback(update, bot)
-
-    assert client.lances == ["all"]
     assert "completed" in bot.edits[-1][2]
 
 
@@ -288,15 +277,3 @@ def test_statut_sans_aucun_job(monkeypatch):
 
     ((texte, _),) = update.effective_message.replies
     assert "Aucun job" in texte
-
-
-def test_callback_prefixe_etl_legacy_est_normalise(client):
-    """Rétro-compat : les boutons `etl:*` des vieux messages Telegram routent encore."""
-    update = update_callback("etl:flux")
-    bot = FakeBot()
-
-    _scenario_callback(update, bot)
-
-    (_, _, _, kwargs) = bot.edits[-1]
-    callbacks = {btn.callback_data for row in kwargs["reply_markup"].inline_keyboard for btn in row}
-    assert "ingestion:menu" in callbacks, "l'ancien préfixe ouvre le sous-menu, re-câblé en ingestion:*"


### PR DESCRIPTION
## Ce que fait cette PR

Retire les alias de transition `/etl` laissés par le renommage `etl` → `ingestion` (#192). Décision prise au grill release : aucune version stable ne les a embarqués (ils n'ont existé qu'entre PRs sur `main`), et un seul consommateur — nous — touche l'API. On les retire **avant** le tag v3.0.0 plutôt que d'attendre une release de plus.

### Retraits

- **API** : décorateurs `/etl/run`, `/etl/jobs`, `/etl/jobs/{id}` supprimés du router ingestion → `404` (test paramétré).
- **Bot** : `CommandHandler("etl")` supprimé ; pattern callback resserré `^(ingestion|etl):` → `^ingestion:` ; fin de la normalisation `etl:`→`ingestion:` dans `on_callback`.

### Tests

- Les deux tests de rétro-compat `etl:*` (bouton run + normalisation) sont **retirés**.
- Le test de pattern est **inversé** : `etl:menu` ne route plus.
- Ajout d'un test paramétré : `POST /etl/run`, `GET /etl/jobs`, `GET /etl/jobs/{id}` → `404`.

### Docs

- `CHANGELOG.md` : la fenêtre de transition « une release » est annulée — les `/etl/*` répondent 404, `/ingestion` sans alias bot.
- `electricore/api/README.md`, `electricore/bot/README.md` : mention de l'alias retirée.

## Critères d'acceptation (#193)

- [x] `grep -rn '/etl' electricore/` ne retourne plus que des refs historiques (`ex-/etl`)
- [x] Un POST sur `/etl/run` répond 404
- [x] `/etl` dans Telegram ne route plus ; `/ingestion` inchangé
- [x] Suite verte (749 passed, 35 skipped)

## Note déploiement (territoire de Virgile)

La crontab **versionnée** (`deploy/docker/crontab`) appelle déjà `/ingestion/run`. À confirmer sur le VPS au déploiement de v3.0.0 que la crontab live fait de même (sinon l'ingestion planifiée s'arrête en silence).

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)