### PR TITLE
feat(api): endpoint de lecture des méta-périodes (Odoo tire d'electricore)

### DIFF
--- a/docs/adr/0027-endpoint-lecture-meta-periodes-odoo-tire.md
+++ b/docs/adr/0027-endpoint-lecture-meta-periodes-odoo-tire.md
@@ -1,0 +1,121 @@
+# Endpoint de lecture des méta-périodes : Odoo tire d'electricore
+
+## Contexte
+
+Jusqu'ici, la facturation circulait d'electricore **vers** Odoo : les calculs étaient
+rapprochés aux lignes de facture Odoo (`sale.order`, champs `x_*`), puis un opérateur
+poussait les quantités depuis un notebook (`OdooWriter`, sous validation humaine —
+[ADR-0012](0012-api-read-only-odoo.md)).
+
+La migration de l'addon `souscriptions_odoo` vers Odoo 19 (module réécrit
+`souscription.souscription` / `souscription.periode`) **inverse le sens du flux** :
+Odoo devient le système d'écriture et **tire** ses quantités d'electricore par HTTP GET,
+puis construit/upsert ses `souscription.periode`. Côté `souscriptions_odoo`, ce contrat
+est posé par ses ADR-0001 (Odoo = écriture, electricore = lecture), ADR-0002 (deux
+sources de vérité : electricore = physique/réseau, Odoo = comptable) et ADR-0003 (la
+migration Odoo 19 désigne cet endpoint comme **chemin critique** : tant qu'il n'existe
+pas, la bascule métier ne peut pas se faire).
+
+electricore **calcule déjà** la donnée demandée : `ContexteMensuel.facturation_mensuelle`,
+une *méta-période mensuelle* par `(ref_situation_contractuelle, mois)`
+([CONTEXT.md](../../electricore/core/CONTEXT.md), [ADR-0026](0026-facturation-calendaire-pas-moisniversaire.md)).
+Il reste à l'**exposer**.
+
+## Décision
+
+**Ajouter un endpoint de lecture `GET /facturation/meta-periodes`** qui expose les
+méta-périodes mensuelles sous un modèle **electricore-natif** (pas un miroir des modèles
+`souscription.*`), en JSON enveloppé. Décisions structurantes :
+
+- **Une seule opération, en lecture.** GET filtrable (`mois`, `rsc`) et paginé. **Pas de
+  `POST recompute`** : le calcul est déjà *à la volée* depuis DuckDB (`contexte_du_mois`),
+  donc toujours frais ; les corrections de flux remontent par l'**ingestion** (les
+  endpoints `/ingestion/*` existants), pas par un déclencheur de calcul. **Pas de
+  matérialisation** : à <1000 RSC, le pipeline Polars complet par requête est négligeable.
+
+- **Router ERP-agnostique.** L'endpoint expose `core/` directement et **n'importe pas
+  `integrations/odoo`** ([ADR-0016](0016-core-erp-agnostique.md)) — contrairement aux
+  endpoints `/facturation/*` historiques qui lisent les lignes Odoo. Il ne sait rien
+  d'Odoo : c'est un feed neutre, réutilisable par un autre ERP.
+
+- **Charge utile = quantités physiques + réglementé selon qui possède l'assiette.**
+  énergies par *cadran facturé* (`base`/`hp`/`hc`), `nb_jours`, `puissance_moyenne_kva`,
+  `formule_tarifaire_acheminement`. Pour le réglementé, une **règle simple** : *electricore
+  livre le **montant** € quand il possède l'assiette, le **taux** quand Odoo la possède.*
+  → `turpe_fixe_eur`, `turpe_variable_eur` (assiette réseau/mesurée) et `cta_eur` (assiette
+  = `turpe_fixe`, possédée par electricore) en **€ final** ; `taux_accise_eur_mwh` en
+  **taux** (l'assiette accise = le *facturé*, possédé par Odoo). Les **prix fournisseur**
+  (énergie, abonnement) ne sont **jamais** dans la charge utile : Odoo applique ses grilles
+  datées (« référencer, pas recopier »).
+
+- **Accise : electricore livre le taux, Odoo calcule le montant.** L'assiette accise est le
+  *facturé* (= provisions pour un lissé, quantité qui vit côté Odoo ; taux par **catégorie**
+  de consommateur). electricore reste l'**autorité du taux**
+  (`taux_accise_eur_mwh`, taux standard en v1 — [ADR-0024](0024-trois-registres-de-savoir.md))
+  et **n'expose aucun montant d'accise** dans le contrat : pas de figure « physique » à
+  réconcilier côté Odoo, et aucune dépendance à une quantité Odoo (un `accise_eur` correct
+  exigerait le facturé, qu'electricore ne possède pas sur ce chemin pur). L'accise
+  **physique** (énergie mesurée × taux standard) reste *calculable* pour l'analytique
+  interne, hors de ce contrat. Voir l'entrée *Accise physique vs Accise de déclaration* de
+  [CONTEXT.md](../../electricore/core/CONTEXT.md).
+
+- **Périmètre C5.** La méta-période actuelle ne porte qu'une puissance et `base`/`hp`/`hc` —
+  elle ne représente pas un site C4 (4 puissances, 4 cadrans réseau). Le détail 4 cadrans
+  et les 4 puissances **existent déjà** un cran plus haut (`PeriodeEnergie`,
+  `PeriodeAbonnement` — le TURPE C4 est correctement calculé). Les exposer le jour où un
+  C4 entre au périmètre est un **ajout de colonnes versionné**, pas une réécriture.
+
+- **Feed non destructif.** Le retour est un *flux source*, pas une synchro avec
+  suppression : l'upsert Odoo est **insert-or-update sur les brouillons uniquement,
+  jamais delete**, et ne touche jamais une période validée/éditée à la main. electricore
+  **ne peut pas** effacer de donnée Odoo (read-only, [ADR-0012](0012-api-read-only-odoo.md)) ;
+  la garantie est donc portée par l'upsert Odoo, et electricore l'**outille** en
+  publiant un `source_hash` déterministe par ligne (skip-si-inchangé + détection de dérive
+  sous verrou).
+
+- **Évolution additive + `contract_version`.** Le contrat grandit par ajout de colonnes
+  optionnelles ; un lecteur tolérant survit à tout changement additif. Un entier
+  `contract_version` dans l'enveloppe permet à l'addon d'asserter la compat ; on ne passe
+  à un versionnage d'URL (`/v2/…`) que sur rupture réelle.
+
+Le **write-back vers `sale.order`** (notebook + `OdooWriter`) **sort du flux standard de
+facturation** : il reste autorisé pour l'enrichissement ad-hoc et les écritures validées
+à la main, mais n'est plus une étape du chemin de facturation.
+
+## Raison
+
+electricore reste l'autorité du **physique/réseau** (quantités mesurées, coûts réseau,
+taux réglementés) ; Odoo reste l'autorité du **comptable** (prix fournisseur, provisions,
+ce qui est facturé et déclaré). L'endpoint matérialise cette frontière sans la franchir :
+il expose ce qu'electricore *sait*, et laisse à Odoo ce qu'Odoo *possède*. Le sens « pull »
+(plutôt que « push ») met le système d'écriture aux commandes de ses propres écritures —
+aucun service automatique d'electricore ne modifie Odoo.
+
+## Conséquences
+
+- **C'est le long pole de la migration Odoo 19** : tant que l'endpoint n'est pas debout,
+  `souscriptions_odoo` reste sur Odoo 17. À livrer en priorité.
+- **Deux figures d'accise coexistent** et c'est correct : *physique* (mesurée, pour
+  l'analytique et la référence de régularisation) et *de déclaration* (facturée, pour
+  `/taxes/accise/*`). Ne pas laisser l'une se faire passer pour l'autre.
+- **Bord de l'idempotence** : `(debut, fin)` font partie de la clé d'upsert Odoo, mais une
+  correction de date contractuelle (entrée/sortie) **déplace** ces bornes — l'ancienne
+  ligne devient orpheline. L'upsert Odoo doit réconcilier (delete-orphan sur RSC+mois, ou
+  clé `(RSC, mois_annee)` pour les périodes tronquées). À signaler dans le doc de contrat.
+- **Découvertes ouvertes** : (D1) comptage réglementaire exact de l'assiette accise ;
+  (D2) catégories de taux accise — dérivables du flux Enedis, ou saisies côté Odoo ?
+  Tracées en issues `needs-info`.
+
+### Alternatives écartées
+
+- **`POST recompute` ciblé `(RSC, mois)`** (demandé dans le handoff initial) : sans valeur
+  tant que le calcul est à la volée et sans cache — un GET recalcule déjà. N'aurait de sens
+  qu'avec un store matérialisé, lui-même injustifié à cette volumétrie. Réintroduisible
+  trivialement en fine couche au-dessus de l'ingestion si un besoin réel émerge.
+- **Exposer les assiettes accise / CTA** (plutôt que les montants) : confond « assiette »
+  et « quantité ». La CTA est assise sur `turpe_fixe` (qu'electricore possède → montant
+  final). L'accise est assise sur le *facturé*, qui pour un lissé est une quantité Odoo →
+  electricore ne peut pas en faire un montant, il livre le taux.
+- **Continuer le write-back depuis electricore** : recouple electricore au schéma Odoo
+  ([ADR-0016](0016-core-erp-agnostique.md)) et fait d'electricore un écrivain comptable —
+  exactement ce que la frontière des deux sources de vérité refuse.

--- a/docs/contrat-meta-periodes.md
+++ b/docs/contrat-meta-periodes.md
@@ -1,0 +1,163 @@
+# Contrat — endpoint de lecture des méta-périodes
+
+> Contrat d'intégration pour le consommateur (addon `souscriptions_odoo`).
+> Décision et justifications : [ADR-0027](adr/0027-endpoint-lecture-meta-periodes-odoo-tire.md).
+> Vocabulaire : [`electricore/core/CONTEXT.md`](../electricore/core/CONTEXT.md) (entrées *Méta-période mensuelle*, *Accise physique vs Accise de déclaration*).
+
+`GET /facturation/meta-periodes` expose les **méta-périodes mensuelles** d'electricore :
+des quantités physiques et des montants réseau **non valorisés aux prix fournisseur**.
+Odoo **tire** ce flux et construit/upsert ses `souscription.periode`. electricore reste
+**read-only** vis-à-vis d'Odoo ([ADR-0012](adr/0012-api-read-only-odoo.md)) et **n'écrit
+jamais**.
+
+## Requête
+
+```
+GET /facturation/meta-periodes?mois=YYYY-MM-DD&rsc=RSC-A&rsc=RSC-B&limit=500&offset=0
+```
+
+| Param | Défaut | Description |
+|---|---|---|
+| `mois` | dernier mois disponible | Mois cible, format `YYYY-MM-DD` (1er du mois). |
+| `rsc` | — | Filtre, **répétable** : une ou plusieurs `ref_situation_contractuelle`. |
+| `limit` | `500` (max `2000`) | Pagination — nombre de lignes. |
+| `offset` | `0` | Pagination — lignes ignorées. |
+
+**Auth :** header `X-API-Key` (obligatoire ; `401` sinon).
+
+## Réponse (enveloppe JSON)
+
+```json
+{
+  "mois": "2025-03-01",
+  "contract_version": 1,
+  "filters": { "rsc": ["RSC-A"] },
+  "pagination": { "limit": 500, "offset": 0, "returned": 2, "total": 2 },
+  "data": [
+    {
+      "ref_situation_contractuelle": "RSC-A",
+      "pdl": "12345678901234",
+      "mois_annee": "2025-03",
+      "debut": "2025-03-01T00:00:00+01:00",
+      "fin": "2025-04-01T00:00:00+02:00",
+      "nb_jours": 31,
+      "puissance_moyenne_kva": 6.0,
+      "formule_tarifaire_acheminement": "BTINFCUST",
+      "energie_base_kwh": null,
+      "energie_hp_kwh": 312.4,
+      "energie_hc_kwh": 145.2,
+      "turpe_fixe_eur": 9.13,
+      "turpe_variable_eur": 18.40,
+      "cta_eur": 19.18,
+      "taux_accise_eur_mwh": 33.7,
+      "data_complete": true,
+      "coverage_abo": 1.0,
+      "coverage_energie": 1.0,
+      "has_changement": false,
+      "source_hash": "9f2b1c7d4e5a6b08"
+    }
+  ]
+}
+```
+
+### Enveloppe
+
+| Champ | Type | Rôle |
+|---|---|---|
+| `mois` | `str` `YYYY-MM-DD` | Mois effectivement résolu (utile quand la requête omet `mois`). |
+| `contract_version` | `int` | Version du contrat. `1` aujourd'hui. À asserter côté consommateur. |
+| `filters` | `obj \| null` | Écho des filtres appliqués (`rsc`). |
+| `pagination` | `obj` | `limit`, `offset`, `returned` (lignes de cette page), `total` (lignes du mois). |
+| `data` | `array` | Les méta-périodes. |
+
+### Ligne `data` (schéma figé v1)
+
+Grain : **une ligne par `(ref_situation_contractuelle, debut, fin)`** — c'est la clé
+d'upsert recommandée côté Odoo. Pas par PDL : un PDL qui change de RSC en cours de mois
+porte deux lignes.
+
+| Champ | Type | Unité | Null ? | Rôle |
+|---|---|---|---|---|
+| `ref_situation_contractuelle` | `str` | — | non | **Clé d'articulation.** |
+| `pdl` | `str` | — | non | Attribut d'affichage. |
+| `mois_annee` | `str` `YYYY-MM` | — | non | Clé mensuelle calculable/triable. |
+| `debut` | `str` ISO8601 (Europe/Paris) | — | non | Borne de période (clé d'upsert). |
+| `fin` | `str` ISO8601 (Europe/Paris) | — | non | Borne de période (clé d'upsert). |
+| `nb_jours` | `int` | jours | non | Quantité (part fixe). |
+| `puissance_moyenne_kva` | `float` | kVA | non | Quantité (pondérée par les jours). |
+| `formule_tarifaire_acheminement` | `str` | — | non | FTA — informatif (contrôle de cohérence). |
+| `energie_base_kwh` | `float` | kWh | **oui** | Quantité énergie cadran Base (`null` si non applicable). |
+| `energie_hp_kwh` | `float` | kWh | **oui** | Quantité énergie cadran HP. |
+| `energie_hc_kwh` | `float` | kWh | **oui** | Quantité énergie cadran HC. |
+| `turpe_fixe_eur` | `float` | € | non | **Montant final** (réseau). |
+| `turpe_variable_eur` | `float` | € | non | **Montant final** (réseau). |
+| `cta_eur` | `float` | € | non | **Montant final** (assiette = `turpe_fixe_eur`, possédée par electricore). |
+| `taux_accise_eur_mwh` | `float` | €/MWh | non | **Taux** standard en vigueur. *Pas de montant* : Odoo calcule l'accise facturée. |
+| `data_complete` | `bool` | — | non | `false` ⇒ période partielle/estimée. |
+| `coverage_abo` | `float` | [0,1] | non | Couverture temporelle abonnement. |
+| `coverage_energie` | `float` | [0,1] | non | Couverture temporelle énergie. |
+| `has_changement` | `bool` | — | non | Changement (puissance/énergie) en cours de mois. |
+| `source_hash` | `str` (hex) | — | non | Empreinte de contenu de la ligne (cf. *Upsert non destructif*). |
+
+#### Pourquoi un taux pour l'accise mais des montants pour le reste
+
+Règle (ADR-0027) : *electricore livre le **montant** € quand il possède l'assiette, le
+**taux** quand l'ERP la possède.*
+- TURPE, CTA → assiette réseau / `turpe_fixe` (electricore) → **montant €**.
+- Accise → assiette = le **facturé** (= Σ provisions pour un lissé, quantité Odoo) → **taux seul**.
+  Odoo calcule l'**accise facturée** en champ calculé : `taux_accise_eur_mwh × quantité facturée`.
+
+Les **prix fournisseur** (énergie, abonnement) ne sont jamais dans le flux : Odoo applique
+ses grilles datées.
+
+## Invariants
+
+- **Feed = source, pas synchro destructive.** L'upsert Odoo doit être *insert-or-update
+  sur les brouillons uniquement, jamais `delete`*, et **ne jamais toucher** une
+  `souscription.periode` validée/éditée à la main. electricore ne peut pas écraser de
+  donnée Odoo (read-only) ; la garantie est portée par l'upsert.
+- **Évolution additive.** De nouvelles colonnes optionnelles peuvent apparaître sans
+  bump de `contract_version` — un lecteur tolérant (qui ignore les champs inconnus)
+  survit. Renommage/suppression/changement de sémantique ⇒ nouvelle version (`/v2/…`).
+- **Déterminisme.** À état DuckDB constant et version electricore constante, le payload
+  et chaque `source_hash` sont identiques d'un appel à l'autre.
+- **Bord — déplacement des bornes.** `debut`/`fin` font partie de la clé d'upsert, mais
+  une **correction de date contractuelle** (entrée/sortie) les déplace : l'ancienne ligne
+  devient orpheline. L'upsert Odoo doit réconcilier — p.ex. *delete-orphan* sur
+  `(RSC, mois)`, ou clé `(RSC, mois_annee)` pour les périodes tronquées.
+
+## Signalement partiel / estimé
+
+Une `(RSC, mois)` incomplète arrive avec `data_complete = false` et `coverage_* < 1.0`.
+Odoo construit alors la `souscription.periode` comme **brouillon à compléter** par un·e
+facturiste (cf. ADR-0002 souscriptions_odoo : la Période est un brouillon éditable).
+
+## Upsert non destructif (mécanisme `source_hash`)
+
+`source_hash` est une empreinte de contenu de la ligne (sha256 tronqué sur **toutes** les
+colonnes de quantités/montants/complétude). Il outille un upsert qui préserve le travail
+humain :
+
+1. Odoo stocke le `source_hash` reçu sur chaque `souscription.periode`.
+2. Au re-pull : si le `source_hash` entrant **est identique** → la source n'a pas bougé →
+   **ne rien faire** (les éditions manuelles sont préservées sans condition).
+3. Si **différent** et la période est **brouillon** → rafraîchir.
+4. Si **différent** et la période est **verrouillée/éditée** → **ne pas écraser**, mais
+   signaler la dérive au facturiste (la donnée Enedis a bougé depuis l'édition).
+
+## Accise — découvertes ouvertes (côté valorisation ERP)
+
+La valorisation de l'accise *facturée* vit côté Odoo, mais dépend de deux points non
+tranchés (suivis côté electricore) :
+
+- **Assiette accise — comptage réglementaire exact** : [issue #225](https://github.com/Energie-De-Nantes/electricore/issues/225).
+- **Catégories de taux accise** (le taux n'est pas uniforme — dérivable du flux Enedis ou
+  saisi côté ERP ?) : [issue #226](https://github.com/Energie-De-Nantes/electricore/issues/226).
+  Tant que non tranché, l'endpoint livre le **taux standard**.
+
+## Hors périmètre v1
+
+- **C4 / 4 cadrans réseau** : la méta-période v1 est C5 (`base`/`hp`/`hc`, une puissance).
+  Le détail 4 cadrans + 4 puissances existe en amont et sera exposé en **colonnes
+  additionnelles** (sans rupture) le jour où un C4 entre au périmètre.
+- **`accise_eur`** : non exposé (cf. règle taux vs montant ci-dessus).

--- a/electricore/api/CONTEXT.md
+++ b/electricore/api/CONTEXT.md
@@ -5,7 +5,10 @@ Vocabulaire spécifique au service REST qui expose `core` et l'orchestration de 
 ## API
 
 **API** :
-Service REST FastAPI ([electricore/api/](.)) exposant les flux Enedis (`/flux/*`), les déclenchements d'ingestion (`/ingestion/*`), les calculs de taxes (`/taxes/*`), les exports de facturation et vérifications pré-facturation (`/facturation/*`, dont `/facturation/check/odoo.xlsx`).
+Service REST FastAPI ([electricore/api/](.)) exposant les flux Enedis (`/flux/*`), les déclenchements d'ingestion (`/ingestion/*`), les calculs de taxes (`/taxes/*`), les exports de facturation et vérifications pré-facturation (`/facturation/*`, dont `/facturation/check/odoo.xlsx`), et la lecture des méta-périodes mensuelles (`/facturation/meta-periodes`, cf. *Endpoint méta-périodes*).
+
+**Endpoint méta-périodes** :
+`GET /facturation/meta-periodes` — endpoint de lecture par lequel un ERP **tire** les *méta-périodes mensuelles* d'electricore (Odoo construit ses `souscription.periode` à partir de ce flux). JSON enveloppé (`mois` / `contract_version` / `filters` / `pagination` / `data`), ERP-agnostique (zéro `integrations/odoo`, [ADR-0027](../../docs/adr/0027-endpoint-lecture-meta-periodes-odoo-tire.md)). Contrat figé : [docs/contrat-meta-periodes.md](../../docs/contrat-meta-periodes.md). Distinct des autres `/facturation/*` qui, eux, lisent Odoo. Charge utile **non valorisée aux prix fournisseur** : quantités physiques + montants réseau (TURPE, CTA) + *taux* accise.
 
 **Endpoint sécurisé** :
 Endpoint nécessitant la clé `X-API-Key` (header) ou `?api_key=` (query). Tous les endpoints sont sécurisés sauf `/`, `/health`, `/docs`, `/redoc`.

--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -16,6 +16,7 @@ from electricore.api.routers import admin as admin_router
 from electricore.api.routers import facturation as facturation_router
 from electricore.api.routers import flux as flux_router
 from electricore.api.routers import ingestion as ingestion_router
+from electricore.api.routers import meta_periodes as meta_periodes_router
 from electricore.api.routers import taxes as taxes_router
 from electricore.api.services import duckdb_service
 from electricore.config import runtime
@@ -121,6 +122,7 @@ app.include_router(ingestion_router.router)
 app.include_router(flux_router.router)
 app.include_router(taxes_router.router)
 app.include_router(facturation_router.router)
+app.include_router(meta_periodes_router.router)
 
 
 @app.get("/", tags=["public"])

--- a/electricore/api/routers/meta_periodes.py
+++ b/electricore/api/routers/meta_periodes.py
@@ -1,0 +1,50 @@
+"""Router de lecture des méta-périodes mensuelles : Odoo tire d'electricore (ADR-0027).
+
+Endpoint **ERP-agnostique** (zéro `integrations/odoo`, ADR-0016) : il expose un modèle
+electricore-natif (la *méta-période mensuelle*), pas un miroir des modèles `souscription.*`.
+Réponse en JSON enveloppé, même convention que `/flux/{table}` (`mois` / `filters` /
+`pagination` / `data`).
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+
+from electricore.api.security import get_current_api_key
+from electricore.api.services.meta_periodes_service import CONTRAT_VERSION, meta_periodes
+
+router = APIRouter(tags=["facturation"])
+
+
+@router.get("/facturation/meta-periodes")
+async def get_meta_periodes(
+    mois: str | None = Query(
+        None,
+        examples=["2026-05-01"],
+        description="Mois au format YYYY-MM-DD (défaut : dernier mois disponible)",
+    ),
+    rsc: Annotated[
+        list[str] | None,
+        Query(description="Filtrer par référence(s) de situation contractuelle (répétable)"),
+    ] = None,
+    limit: int = Query(500, le=2000, ge=1, description="Nombre maximum de lignes à retourner"),
+    offset: int = Query(0, ge=0, description="Nombre de lignes à ignorer (pagination)"),
+    api_key: str = Depends(get_current_api_key),
+):
+    """Méta-périodes mensuelles `(ref_situation_contractuelle, debut, fin)` en JSON enveloppé.
+
+    **Authentification requise** (`X-API-Key`).
+
+    Charge utile non valorisée aux prix fournisseur : quantités physiques + montants
+    réseau. Odoo construit/upsert ses `souscription.periode` à partir de ce flux.
+    """
+    mois_resolu, df = meta_periodes(mois=mois, rsc=rsc)
+    total = df.height
+    rows = df.slice(offset, limit).to_dicts()
+    return {
+        "mois": mois_resolu,
+        "contract_version": CONTRAT_VERSION,
+        "filters": {"rsc": rsc} if rsc else None,
+        "pagination": {"limit": limit, "offset": offset, "returned": len(rows), "total": total},
+        "data": rows,
+    }

--- a/electricore/api/services/meta_periodes_service.py
+++ b/electricore/api/services/meta_periodes_service.py
@@ -1,0 +1,95 @@
+"""Wire-up de l'endpoint de lecture des méta-périodes (ADR-0027, #227).
+
+Résout le contexte mensuel (loaders DuckDB par défaut via `contexte_du_mois`),
+filtre la facturation mensuelle sur le mois cible (+ RSC optionnelles) et projette
+les colonnes du **contrat v1** (champs déjà portés par `PeriodeMeta`).
+
+Le réglementaire suit la règle ADR-0027 : *montant € quand electricore possède
+l'assiette, taux quand l'ERP la possède.* → `cta_eur` (assiette = `turpe_fixe_eur`,
+possédée par electricore) en € ; `taux_accise_eur_mwh` en taux (assiette accise = le
+facturé, possédé par l'ERP — pas d'`accise_eur` ici). ERP-agnostique : aucun import
+`integrations/odoo` (ADR-0016). L'intégrité (`source_hash`) arrive en #229.
+"""
+
+import hashlib
+
+import polars as pl
+
+from electricore.core.builds.contexte_mensuel import contexte_du_mois
+from electricore.core.pipelines.accise import load_accise_rules
+from electricore.core.pipelines.cta import ajouter_cta
+from electricore.core.pipelines.taux import ajouter_taux_en_vigueur
+
+# Version du contrat exposée dans l'enveloppe (#229). Bump sur rupture (cf. ADR-0027,
+# évolution additive — un ajout de colonne optionnelle ne change pas la version).
+CONTRAT_VERSION = 1
+
+# Colonnes du contrat v1 — sous-ensemble de `PeriodeMeta` + bloc réglementaire (#228).
+COLONNES_CONTRAT: tuple[str, ...] = (
+    "ref_situation_contractuelle",
+    "pdl",
+    "mois_annee",
+    "debut",
+    "fin",
+    "nb_jours",
+    "puissance_moyenne_kva",
+    "formule_tarifaire_acheminement",
+    "energie_base_kwh",
+    "energie_hp_kwh",
+    "energie_hc_kwh",
+    "turpe_fixe_eur",
+    "turpe_variable_eur",
+    "cta_eur",
+    "taux_accise_eur_mwh",
+    "data_complete",
+    "coverage_abo",
+    "coverage_energie",
+    "has_changement",
+)
+
+
+def meta_periodes(mois: str | None = None, rsc: list[str] | None = None) -> tuple[str, pl.DataFrame]:
+    """Méta-périodes du mois cible, projetées sur le contrat v1.
+
+    Args:
+        mois: format `YYYY-MM-DD` (premier jour du mois). `None` → dernier mois
+            disponible.
+        rsc: filtre optionnel sur une liste de `ref_situation_contractuelle`.
+
+    Returns:
+        `(mois_résolu, df)` — le mois effectif (`YYYY-MM-DD`) porté par le contexte,
+        et le DataFrame des méta-périodes du mois, colonnes du contrat v1.
+    """
+    contexte = contexte_du_mois(mois)
+
+    mois_cible = pl.lit(contexte.mois).str.to_date()
+    debut_mois = pl.col("debut").dt.truncate("1mo").dt.date()
+
+    lf = contexte.facturation_mensuelle.lazy().filter(debut_mois == mois_cible)
+    if rsc:
+        lf = lf.filter(pl.col("ref_situation_contractuelle").is_in(rsc))
+
+    # Bloc réglementaire (#228) : CTA en montant € (assiette electricore), accise en
+    # taux seul (assiette ERP). Les deux s'appuient sur `debut` pour le taux en vigueur.
+    lf = ajouter_cta(lf)
+    lf = ajouter_taux_en_vigueur(lf, load_accise_rules(), date_col="debut", taux_col="taux_accise_eur_mwh")
+
+    return contexte.mois, _ajouter_source_hash(lf.select(COLONNES_CONTRAT).collect())
+
+
+def _ajouter_source_hash(df: pl.DataFrame) -> pl.DataFrame:
+    """Ajoute `source_hash` : sha256 (tronqué) de la ligne canonique du contrat (#229).
+
+    Hash de contenu sur **toutes** les colonnes du contrat — déterministe (même état
+    DuckDB → même hash) et robuste aux versions de Polars (repr texte stable, pas le
+    hash interne). Outille l'upsert non destructif côté Odoo : skip-si-inchangé +
+    détection de dérive sous verrou (ADR-0027).
+    """
+    canon = df.select(
+        pl.concat_str(
+            [pl.col(c).cast(pl.Utf8).fill_null("∅") for c in COLONNES_CONTRAT],
+            separator="␟",
+        ).alias("_canon")
+    ).to_series()
+    hashes = [hashlib.sha256(ligne.encode("utf-8")).hexdigest()[:16] for ligne in canon.to_list()]
+    return df.with_columns(pl.Series("source_hash", hashes, dtype=pl.Utf8))

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -100,6 +100,13 @@ Pénalité TURPE spécifique aux sites C4 dépassant leur puissance souscrite, e
 Taxe intérieure sur la consommation finale d'électricité (TICFE), exprimée en €/MWh. Intègre depuis 2022 l'ancienne CSPE.
 _Éviter_ : TICFE (renommée Accise), CSPE (fusionnée dans l'accise).
 
+**Accise physique** vs **Accise de déclaration** (deux assiettes à ne pas confondre) :
+- **Accise physique** : assise sur l'énergie *mesurée* du mois (calculable depuis la *méta-période mensuelle*), au taux standard en vigueur. Vérité physique d'electricore : sert l'analytique et la *référence de régularisation* des lissés. N'est **pas** exposée comme montant dans le contrat de l'endpoint méta-périodes — qui ne livre que le *taux* accise (l'assiette = le facturé appartient à l'ERP).
+- **Accise de déclaration** : assise sur l'énergie *facturée* (le facturé = les *provisions* pour un lissé, quantité qui vit côté ERP), au taux applicable. C'est ce qu'on déclare à l'État (`/taxes/accise/*`) — on déclare ce qu'on a facturé, pas ce qu'on a mesuré. Calculée par `pipeline_accise` depuis les lignes facturées.
+
+electricore est l'**autorité du taux** accise ; la valorisation de l'accise *facturée* (assiette = facturé) peut vivre côté ERP. Le taux n'est pas uniforme : il dépend d'une **catégorie** de consommateur — enhancement ouvert : la catégorie est-elle dérivable du flux Enedis, ou saisie côté ERP ?
+_Éviter_ : parler d'« assiette accise » sans préciser physique ou déclaration (elles divergent dès qu'un contrat est lissé).
+
 **CTA** (Contribution Tarifaire d'Acheminement) :
 Taxe assise sur la part fixe du TURPE (puissance), reversée à la CNIEG pour financer les retraites des industries électriques et gazières.
 
@@ -156,6 +163,17 @@ _Éviter_ : lecture, mesure.
 
 **Énergie** :
 Consommation calculée entre deux relevés (différence d'index), par cadran (`energie_hp_kwh`…). Distincte de l'index. Dite **mesurée** quand des relevés encadrent exactement la période considérée ; **estimée** quand la période n'a pas de relevé à ses bornes et que l'énergie lui est attribuée par interpolation (cas des compteurs non communicants aux bornes calendaires ou réglementaires — la saisonnalité chauffage/clim rend le prorata temporel grossier). La *provision d'énergie* n'est ni l'une ni l'autre : quantité conventionnelle facturée en attente de solde.
+
+**Identité de relevé** (clé métier) :
+Handle stable d'un relevé, dérivé de la lecture *logique* (`pdl`, `date_releve`, source, et le discriminant de la source — `ordre_index` pour les avant/après C15, `type_releve` pour R64). **Pas** la position-fichier (l'`id` d'occurrence dbt `fichier#position` est instable : les fenêtres R64 se chevauchent et la livraison gagnante change à chaque correction) ni un id Enedis natif (absent de R151 *et* de R64, les sources périodiques qui bornent la facturation calendaire ; présent seulement en R15/F15/C15-événements via `Id_Releve`). L'`Id_Releve` natif, quand il existe, est conservé comme *provenance* additionnelle, pas comme clé. Support du lien d'audit entre une *période d'énergie* et les relevés qui l'ont bornée.
+_Éviter_ : id fichier (c'est de la provenance, pas une identité), Id_Releve (natif et partiel — ne couvre pas le cas dominant).
+
+**Nature d'index** :
+Qualité d'une lecture d'index, normalisée (réel / estimé / corrigé) depuis des champs source hétérogènes : `Nature_Index` (R15/C15), `etape_metier` BRUT/CORR/VALID (R64), réel par construction pour les télérelevés périodiques. Mention légale obligatoire sur la facture. Distincte de l'opposition *énergie mesurée / estimée* qui qualifie la période, pas la lecture.
+
+**Traçabilité des index** :
+Conservation, jusqu'à la facture, des relevés effectivement consommés par le calcul d'une période : valeurs d'index en **registres réels** (jamais de cadran synthétisé — on n'additionne pas deux registres cumulés pour fabriquer un « index HP » qu'aucun compteur n'affiche), `date_releve`, *nature d'index*, et *identité de relevé*. Exigence légale : les index doivent figurer sur la facture, dont **Odoo est le système de référence** du « facturé » (le core reste sans état et recalcule ; une correction postérieure relève de la *régularisation*, pas d'une réécriture). Un changement de configuration en cours de mois (MCT) y apparaît sans cas particulier : les relevés intermédiaires utilisés s'ajoutent simplement à la liste.
+_Éviter_ : audit des index (anglicisme mou), historique d'index (collision avec *Historique* contractuel).
 
 **Puissance souscrite** :
 Limite contractuelle en kVA. Un seul champ en C5 (`puissance_souscrite_kva`), quatre en C4 (`puissance_souscrite_hph_kva`…).

--- a/tests/architecture/test_meta_periodes_erp_agnostique.py
+++ b/tests/architecture/test_meta_periodes_erp_agnostique.py
@@ -1,0 +1,45 @@
+"""Garde-fou : l'endpoint méta-périodes est ERP-agnostique (ADR-0027, ADR-0016).
+
+Contrairement aux autres endpoints `/facturation/*` (qui lisent Odoo via `@with_odoo`),
+le router et le service des méta-périodes exposent un modèle **electricore-natif** et
+n'importent **rien** de `electricore.integrations`. Analyse statique via `ast` (couvre
+aussi les imports `TYPE_CHECKING`).
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+API_ROOT = Path(__file__).resolve().parents[2] / "electricore" / "api"
+
+MODULES = [
+    API_ROOT / "routers" / "meta_periodes.py",
+    API_ROOT / "services" / "meta_periodes_service.py",
+]
+
+
+def _absolute_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.add(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            modules.add(node.module)
+    return modules
+
+
+@pytest.mark.parametrize("module", MODULES, ids=lambda p: p.name)
+def test_meta_periodes_n_importe_pas_integrations(module: Path) -> None:
+    """ADR-0027 : ni le router ni le service n'importent `electricore.integrations`."""
+    forbidden = sorted(
+        m
+        for m in _absolute_imports(module)
+        if m == "electricore.integrations" or m.startswith("electricore.integrations.")
+    )
+    assert not forbidden, (
+        f"{module.name} importe {forbidden} — l'endpoint méta-périodes doit rester "
+        "ERP-agnostique (ADR-0027 / ADR-0016)."
+    )

--- a/tests/integration/test_meta_periodes_endpoint.py
+++ b/tests/integration/test_meta_periodes_endpoint.py
@@ -1,0 +1,140 @@
+"""Tests d'intégration de l'endpoint `GET /facturation/meta-periodes` (ADR-0027, #227).
+
+Endpoint de lecture des méta-périodes mensuelles : Odoo tire d'electricore. Le seam
+de test est la fonction de service `meta_periodes` référencée dans le router (même
+patron que `tests/integration/test_facturation_arrow_endpoint.py`) — on court-circuite
+l'I/O DuckDB, le chemin transport + enveloppe reste réel.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+from fastapi.testclient import TestClient
+
+from electricore.api.main import app
+from electricore.api.security import get_current_api_key
+
+PARIS = ZoneInfo("Europe/Paris")
+
+
+@pytest.fixture
+def meta_periodes_synthetiques() -> pl.DataFrame:
+    """Mime la sortie projetée de `meta_periodes` (champs `PeriodeMeta` du contrat v1)."""
+    return pl.DataFrame(
+        {
+            "ref_situation_contractuelle": ["RSC-1", "RSC-2"],
+            "pdl": ["12345678901234", "12345678905678"],
+            "mois_annee": ["2026-05", "2026-05"],
+            "debut": [datetime(2026, 5, 1, tzinfo=PARIS), datetime(2026, 5, 1, tzinfo=PARIS)],
+            "fin": [datetime(2026, 6, 1, tzinfo=PARIS), datetime(2026, 6, 1, tzinfo=PARIS)],
+            "nb_jours": [31, 31],
+            "puissance_moyenne_kva": [6.0, 9.0],
+            "formule_tarifaire_acheminement": ["BTINFCUST", "BTINFCUST"],
+            "energie_base_kwh": [None, 420.0],
+            "energie_hp_kwh": [312.4, None],
+            "energie_hc_kwh": [145.2, None],
+            "turpe_fixe_eur": [9.13, 12.0],
+            "turpe_variable_eur": [18.4, 22.0],
+            "data_complete": [True, False],
+            "coverage_abo": [1.0, 1.0],
+            "coverage_energie": [1.0, 0.5],
+            "has_changement": [False, False],
+        }
+    )
+
+
+def test_meta_periodes_retourne_enveloppe_json(monkeypatch, meta_periodes_synthetiques):
+    """Tracer bullet : GET sert les méta-périodes du mois en JSON enveloppé."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.routers.meta_periodes.meta_periodes",
+        lambda mois=None, rsc=None: ("2026-05-01", meta_periodes_synthetiques),
+    )
+    try:
+        response = TestClient(app).get("/facturation/meta-periodes", params={"mois": "2026-05-01"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    body = response.json()
+
+    # Enveloppe
+    assert body["mois"] == "2026-05-01"
+    assert set(body["pagination"]) >= {"limit", "offset", "returned", "total"}
+    assert body["pagination"]["total"] == 2
+    assert body["pagination"]["returned"] == 2
+
+    # Données
+    assert len(body["data"]) == 2
+    row = body["data"][0]
+    assert row["ref_situation_contractuelle"] == "RSC-1"
+    assert row["energie_hp_kwh"] == 312.4
+    assert row["turpe_fixe_eur"] == 9.13
+    assert row["data_complete"] is True
+
+
+def test_meta_periodes_refuse_sans_api_key():
+    """Endpoint sécurisé : 401 sans clé."""
+    response = TestClient(app).get("/facturation/meta-periodes")
+    assert response.status_code == 401
+
+
+def test_meta_periodes_enveloppe_porte_contract_version(monkeypatch, meta_periodes_synthetiques):
+    """L'enveloppe expose `contract_version` (assertion de compat côté consommateur)."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.routers.meta_periodes.meta_periodes",
+        lambda mois=None, rsc=None: ("2026-05-01", meta_periodes_synthetiques),
+    )
+    try:
+        response = TestClient(app).get("/facturation/meta-periodes")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.json()["contract_version"] == 1
+
+
+def test_meta_periodes_propage_mois_et_rsc(monkeypatch, meta_periodes_synthetiques):
+    """`mois` et les `rsc=` répétés atteignent le service (rsc en liste)."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    appels: list[tuple] = []
+
+    def _capture(mois=None, rsc=None):
+        appels.append((mois, rsc))
+        return "2026-05-01", meta_periodes_synthetiques
+
+    monkeypatch.setattr("electricore.api.routers.meta_periodes.meta_periodes", _capture)
+    try:
+        response = TestClient(app).get(
+            "/facturation/meta-periodes",
+            params={"mois": "2026-05-01", "rsc": ["RSC-1", "RSC-2"]},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert appels == [("2026-05-01", ["RSC-1", "RSC-2"])]
+    assert response.json()["filters"] == {"rsc": ["RSC-1", "RSC-2"]}
+
+
+def test_meta_periodes_pagine(monkeypatch, meta_periodes_synthetiques):
+    """`limit`/`offset` tranchent les lignes ; `total` reste le total non paginé."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.routers.meta_periodes.meta_periodes",
+        lambda mois=None, rsc=None: ("2026-05-01", meta_periodes_synthetiques),
+    )
+    try:
+        response = TestClient(app).get(
+            "/facturation/meta-periodes",
+            params={"limit": 1, "offset": 1},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    body = response.json()
+    assert body["pagination"] == {"limit": 1, "offset": 1, "returned": 1, "total": 2}
+    assert len(body["data"]) == 1
+    assert body["data"][0]["ref_situation_contractuelle"] == "RSC-2"

--- a/tests/integration/test_meta_periodes_service.py
+++ b/tests/integration/test_meta_periodes_service.py
@@ -1,0 +1,112 @@
+"""Tests du service méta-périodes : enrichissement réglementaire (ADR-0027, #228).
+
+Le seam est `contexte_du_mois` (monkeypatché par un `ContexteMensuel` synthétique) ;
+les registres de taux régulés (CTA, Accise) sont les **vrais** CSV versionnés — le
+mois de test est passé (2025-03), donc les taux en vigueur y sont stables.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import polars as pl
+
+from electricore.api.services import meta_periodes_service
+from electricore.core.builds.contexte_mensuel import ContexteMensuel
+
+PARIS = ZoneInfo("Europe/Paris")
+
+
+def _contexte_synthetique() -> ContexteMensuel:
+    """`ContexteMensuel` minimal : seuls `mois` + `facturation_mensuelle` servent au service."""
+    facturation = pl.DataFrame(
+        {
+            "ref_situation_contractuelle": ["RSC-1", "RSC-2"],
+            "pdl": ["12345678901234", "12345678905678"],
+            "mois_annee": ["2025-03", "2025-03"],
+            "debut": [datetime(2025, 3, 1, tzinfo=PARIS), datetime(2025, 3, 1, tzinfo=PARIS)],
+            "fin": [datetime(2025, 4, 1, tzinfo=PARIS), datetime(2025, 4, 1, tzinfo=PARIS)],
+            "nb_jours": [31, 31],
+            "puissance_moyenne_kva": [6.0, 9.0],
+            "formule_tarifaire_acheminement": ["BTINFCUST", "BTINFCUST"],
+            "energie_base_kwh": [None, 420.0],
+            "energie_hp_kwh": [312.4, None],
+            "energie_hc_kwh": [145.2, None],
+            "turpe_fixe_eur": [10.0, 0.0],
+            "turpe_variable_eur": [18.4, 22.0],
+            "data_complete": [True, False],
+            "coverage_abo": [1.0, 1.0],
+            "coverage_energie": [1.0, 0.5],
+            "has_changement": [False, False],
+        }
+    )
+    vide = pl.LazyFrame()
+    return ContexteMensuel(
+        mois="2025-03-01",
+        historique_enrichi=vide,
+        abonnements=vide,
+        energie=vide,
+        facturation_mensuelle=facturation,
+    )
+
+
+def test_meta_periodes_ajoute_cta_eur_et_taux_accise(monkeypatch):
+    """Le service enrichit le payload avec `cta_eur` (€) et `taux_accise_eur_mwh` (taux)."""
+    monkeypatch.setattr(meta_periodes_service, "contexte_du_mois", lambda mois=None: _contexte_synthetique())
+
+    mois, df = meta_periodes_service.meta_periodes("2025-03-01")
+
+    assert mois == "2025-03-01"
+    assert "cta_eur" in df.columns
+    assert "taux_accise_eur_mwh" in df.columns
+
+    # Pas d'accise_eur : electricore livre le taux, pas le montant (ADR-0027).
+    assert "accise_eur" not in df.columns
+
+    lignes = df.sort("ref_situation_contractuelle")
+    # CTA = turpe_fixe × taux/100 : nul quand turpe_fixe = 0, positif sinon.
+    assert lignes["cta_eur"][0] > 0.0  # RSC-1, turpe_fixe = 10
+    assert lignes["cta_eur"][1] == 0.0  # RSC-2, turpe_fixe = 0
+    # Taux accise standard en vigueur : positif et uniforme sur le mois.
+    assert lignes["taux_accise_eur_mwh"][0] > 0.0
+    assert lignes["taux_accise_eur_mwh"][0] == lignes["taux_accise_eur_mwh"][1]
+
+
+def test_meta_periodes_source_hash_deterministe_et_distinct(monkeypatch):
+    """`source_hash` : présent, déterministe (même état → même hash), distinct par contenu."""
+    monkeypatch.setattr(meta_periodes_service, "contexte_du_mois", lambda mois=None: _contexte_synthetique())
+
+    _, df1 = meta_periodes_service.meta_periodes("2025-03-01")
+    _, df2 = meta_periodes_service.meta_periodes("2025-03-01")
+
+    assert "source_hash" in df1.columns
+    h1 = df1.sort("ref_situation_contractuelle")["source_hash"].to_list()
+    h2 = df2.sort("ref_situation_contractuelle")["source_hash"].to_list()
+    assert h1 == h2  # déterministe
+    assert len(set(h1)) == 2  # deux lignes de contenu différent → deux hash
+
+
+def test_meta_periodes_source_hash_change_si_quantite_change(monkeypatch):
+    """Toute modification d'une quantité du payload change le `source_hash` de la ligne."""
+    monkeypatch.setattr(meta_periodes_service, "contexte_du_mois", lambda mois=None: _contexte_synthetique())
+    _, avant = meta_periodes_service.meta_periodes("2025-03-01")
+    h_avant = avant.sort("ref_situation_contractuelle")["source_hash"][0]
+
+    base = _contexte_synthetique()
+    fm_modifie = base.facturation_mensuelle.with_columns(
+        pl.when(pl.col("ref_situation_contractuelle") == "RSC-1")
+        .then(pl.lit(999.0))
+        .otherwise(pl.col("energie_hp_kwh"))
+        .alias("energie_hp_kwh")
+    )
+    ctx_modifie = ContexteMensuel(
+        mois="2025-03-01",
+        historique_enrichi=base.historique_enrichi,
+        abonnements=base.abonnements,
+        energie=base.energie,
+        facturation_mensuelle=fm_modifie,
+    )
+    monkeypatch.setattr(meta_periodes_service, "contexte_du_mois", lambda mois=None: ctx_modifie)
+    _, apres = meta_periodes_service.meta_periodes("2025-03-01")
+    h_apres = apres.sort("ref_situation_contractuelle")["source_hash"][0]
+
+    assert h_avant != h_apres


### PR DESCRIPTION
Implémente l'**endpoint de lecture des méta-périodes** : Odoo **tire** ses quantités d'electricore (HTTP GET) au lieu du write-back notebook. C'est le *chemin critique* de la migration Odoo 19 côté `souscriptions_odoo`.

Décision et justifications : **[ADR-0027](../blob/feat/api-meta-periodes-endpoint/docs/adr/0027-endpoint-lecture-meta-periodes-odoo-tire.md)**. Contrat figé : **[docs/contrat-meta-periodes.md](../blob/feat/api-meta-periodes-endpoint/docs/contrat-meta-periodes.md)**.

## Ce qui est livré

`GET /facturation/meta-periodes` — router **ERP-agnostique** (zéro `integrations/odoo`, ADR-0016), JSON enveloppé (`mois` / `contract_version` / `filters` / `pagination` / `data`), filtres `mois` + `rsc`, pagination, `X-API-Key`. Calcul à la volée (`contexte_du_mois`, <1000 RSC, pur Polars).

**Charge utile** (non valorisée aux prix fournisseur) :
- quantités physiques : énergies `base`/`hp`/`hc`, `nb_jours`, `puissance_moyenne_kva`, FTA ;
- montants réseau finaux : `turpe_fixe_eur`, `turpe_variable_eur`, `cta_eur` ;
- `taux_accise_eur_mwh` — **taux seul** (l'accise *facturée* est calculée côté ERP : assiette = le facturé ; règle ADR-0027 « montant € si electricore possède l'assiette, taux sinon ») ;
- `source_hash` (sha256 de contenu, déterministe) pour l'**upsert non destructif** côté Odoo.

## Slices (TDD)

- Closes #227
- Closes #228
- Closes #229
- Closes #230

## Tests

759 passed, 35 skipped, lint clean. 11 tests dédiés (endpoint : enveloppe, 401, propagation `mois`/`rsc`, pagination, `contract_version` ; service : enrichissement CTA/taux, déterminisme + sensibilité du `source_hash` ; architecture : garde-fou ERP-agnostique).

## Hors périmètre / parqué

- **C4 / 4 cadrans** : v1 est C5 ; le détail existe en amont, ajout versionné le jour venu.
- **Accise — découvertes ouvertes** : #225 (comptage de l'assiette), #226 (catégories de taux) — `needs-info`, non fermées par cette PR.
- **E2E staging** : « un dev Odoo construit des `souscription.periode` depuis l'endpoint » reste à valider sur une base de staging (le seam de test suit le patron maison : monkeypatch du service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)