### PR TITLE
fix(deploy): strip stale validation-error block from .env when validation passes (#224)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -194,6 +194,7 @@ main() {
         fi
         if errs=$(validate_env_file "$ENV_FILE" "$OPT_SLUG"); then
             log_ok ".env valide"
+            strip_validation_error_block "$ENV_FILE"
             chmod 600 "$ENV_FILE"
             break
         fi

--- a/deploy/lib/env_validate.sh
+++ b/deploy/lib/env_validate.sh
@@ -69,6 +69,25 @@ validate_env_file() {
     return 0
 }
 
+# strip_validation_error_block <env_file>
+# Supprime le bloc d'erreurs (marqueurs VALIDATION-ERROR-BLOCK-BEGIN/END et
+# son contenu) du .env, quand la validation vient de réussir. Idempotent :
+# no-op si aucun bloc n'est présent. Les clés et séparateurs # === sont préservés.
+strip_validation_error_block() {
+    local env_file="$1"
+    local start='# >>>VALIDATION-ERROR-BLOCK-BEGIN<<<'
+    local end='# >>>VALIDATION-ERROR-BLOCK-END<<<'
+    # Vérifie si le bloc est présent avant de réécrire le fichier
+    grep -qF "$start" "$env_file" 2>/dev/null || return 0
+    local owner; owner=$(stat -c '%u:%g' "$env_file" 2>/dev/null || echo "")
+    local tmp; tmp=$(mktemp)
+    # Supprime le bloc (début inclus, fin incluse) et la ligne vide qui le suit
+    sed "/${start}/,/${end}/d" "$env_file" | sed '/./,$!d' > "$tmp"
+    mv "$tmp" "$env_file"
+    [[ -n "$owner" ]] && chown "$owner" "$env_file" 2>/dev/null || true
+    chmod 600 "$env_file"
+}
+
 # prepend_errors_to_env <env_file> <errors_text>
 # Réécrit le .env avec un bloc d'erreurs en tête (commenté), pour guider la
 # ré-édition de l'utilisateur.

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -181,6 +181,28 @@ grep -q "^INSTANCE_SLUG=edn$" "$tmp_env" && ok "prepend: INSTANCE_SLUG survit au
 rm -f "$tmp_env"
 
 echo
+echo "→ env_validate.sh / strip_validation_error_block"
+# Cas 1 : bloc présent + validate_env_file OK → bloc supprimé
+tmp_env=$(mktemp); cp "${FIXTURES_DIR}/env-valid" "$tmp_env"
+prepend_errors_to_env "$tmp_env" "erreur temporaire"
+grep -q "VALIDATION-ERROR-BLOCK-BEGIN" "$tmp_env" || { ko "setup: bloc absent avant strip"; rm -f "$tmp_env"; }
+strip_validation_error_block "$tmp_env"
+grep -q "VALIDATION-ERROR-BLOCK-BEGIN" "$tmp_env" && ko "strip: bloc toujours présent après strip" || ok "strip: bloc absent après strip"
+# Cas 2 : idempotent — aucun bloc → no-op, fichier inchangé
+cp "${FIXTURES_DIR}/env-valid" "$tmp_env"
+checksum_before=$(md5sum "$tmp_env" | awk '{print $1}')
+strip_validation_error_block "$tmp_env"
+checksum_after=$(md5sum "$tmp_env" | awk '{print $1}')
+assert_eq "$checksum_after" "$checksum_before" "strip: no-op si aucun bloc présent"
+# Cas 3 : les vraies données survivent au strip
+cp "${FIXTURES_DIR}/env-valid" "$tmp_env"
+prepend_errors_to_env "$tmp_env" "erreur x"
+strip_validation_error_block "$tmp_env"
+grep -q "^INSTANCE_SLUG=edn$" "$tmp_env" && ok "strip: INSTANCE_SLUG survit" || ko "strip: INSTANCE_SLUG effacé"
+grep -q "^API_KEY=" "$tmp_env" && ok "strip: API_KEY survit" || ko "strip: API_KEY effacé"
+rm -f "$tmp_env"
+
+echo
 if [[ "$FAIL" -eq 0 ]]; then
     printf "\033[32m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
     exit 0


### PR DESCRIPTION
## Bug

After the classic fail → fix → success cycle in the `.env` editor loop,
the `# >>>VALIDATION-ERROR-BLOCK-BEGIN<<<` … `# >>>VALIDATION-ERROR-BLOCK-END<<<`
block inserted by `prepend_errors_to_env` was never removed from the `.env`
once validation succeeded. The operator was left with a `.env` that falsely
claimed keys were still invalid, even though the stack was about to come up fine.

## Fix

Added `strip_validation_error_block()` to `deploy/lib/env_validate.sh`.
It reuses the same exact markers as `prepend_errors_to_env`, is idempotent
(no-op and no file rewrite when no block is present), and preserves all real
keys plus `# ===` section separators.

Called on the SUCCESS branch of the editor loop in `deploy/install.sh`
(one line, before the `chmod 600`). The failure branch (`prepend_errors_to_env`)
is unchanged.

## Tests (`deploy/tests/unit.sh`)

Three new assertions in the `strip_validation_error_block` section:
1. Block present + valid env → block absent after strip
2. No block present → file byte-for-byte identical (md5sum check, true no-op)
3. Real keys (`INSTANCE_SLUG`, `API_KEY`) survive the strip

All 74 unit tests pass. Pre-push hook (ruff + gitleaks + pytest) passed.

Closes #224