### PR TITLE
feat(core): bascule de la chronologie sur le modèle de relevés canonique + journal (#244, #233)

### DIFF
--- a/electricore/core/builds/contexte_mensuel.py
+++ b/electricore/core/builds/contexte_mensuel.py
@@ -33,7 +33,7 @@ from electricore.core.models.cadrans import col_energie
 from electricore.core.models.lignes_facture import LignesFacture
 from electricore.core.models.lignes_facture_rapprochees import LignesFactureRapprochees
 from electricore.core.pipelines.abonnements import pipeline_abonnements
-from electricore.core.pipelines.energie import pipeline_energie
+from electricore.core.pipelines.energie import chronologie_releves, pipeline_energie
 from electricore.core.pipelines.facturation import pipeline_facturation
 from electricore.core.pipelines.historique import horizon_par_defaut, pipeline_historique
 
@@ -85,12 +85,17 @@ class ContexteMensuel:
     historique_enrichi: pl.LazyFrame
     abonnements: pl.LazyFrame
     energie: pl.LazyFrame
+    # Journal des relevés effectivement consommés par le calcul d'énergie (#233,
+    # ADR-0029) : un relevé par (RSC, date, ordre_index), registres réels d'index +
+    # `releve_id` + `nature_index`, conservé pour la traçabilité jusqu'à la facture.
+    # Un changement de config en cours de mois (MCT) y figure sans cas particulier.
+    releves_utilises: pl.LazyFrame
     facturation_mensuelle: pl.DataFrame
 
 
 def _composer(
     historique: pl.LazyFrame, releves: pl.LazyFrame, horizon: dt.datetime
-) -> tuple[pl.LazyFrame, pl.LazyFrame, pl.LazyFrame, pl.LazyFrame]:
+) -> tuple[pl.LazyFrame, pl.LazyFrame, pl.LazyFrame, pl.LazyFrame, pl.LazyFrame]:
     """Compose la séquence canonique des pipelines de facturation.
 
     `pipeline_historique` (1 fois, borné par `horizon`) → `pipeline_abonnements` +
@@ -110,8 +115,15 @@ def _composer(
     # conformité à `RelevéIndex` est garantie à l'exécution par le décorateur
     # Pandera de `pipeline_energie`.
     energie = pipeline_energie(historique_enrichi, releves)  # type: ignore[arg-type]
+    # Journal des relevés utilisés (#233, ADR-0029) : ré-assemble la chronologie sur
+    # les mêmes entrées que `pipeline_energie` (historique impacté + relevés canoniques)
+    # et la conserve dans le bundle. Calcul indépendant — les énergies restent intactes.
+    releves_utilises = chronologie_releves(
+        historique_enrichi.filter(pl.col("impacte_energie")),
+        releves,  # type: ignore[arg-type]
+    )
     facturation_mensuelle = pipeline_facturation(abonnements, energie)
-    return historique_enrichi, abonnements, energie, facturation_mensuelle
+    return historique_enrichi, abonnements, energie, releves_utilises, facturation_mensuelle
 
 
 def charger(
@@ -136,7 +148,9 @@ def charger(
     if horizon is None:
         horizon = horizon_par_defaut()
 
-    historique_enrichi, abonnements, energie, facturation_mensuelle_lf = _composer(historique, releves, horizon)
+    historique_enrichi, abonnements, energie, releves_utilises, facturation_mensuelle_lf = _composer(
+        historique, releves, horizon
+    )
 
     # Matérialisation au boundary du build (ADR-0019) : pipeline_facturation
     # reste lazy, le build collecte pour stocker dans le bundle ContexteMensuel.
@@ -151,6 +165,7 @@ def charger(
         historique_enrichi=historique_enrichi,
         abonnements=abonnements,
         energie=energie,
+        releves_utilises=releves_utilises,
         facturation_mensuelle=facturation_mensuelle,
     )
 

--- a/electricore/core/builds/contexte_mensuel.py
+++ b/electricore/core/builds/contexte_mensuel.py
@@ -28,7 +28,7 @@ import pandera.polars as pa
 import polars as pl
 from pandera.typing.polars import DataFrame
 
-from electricore.core.loaders import c15, releves_harmonises
+from electricore.core.loaders import c15, releves_canoniques
 from electricore.core.models.cadrans import col_energie
 from electricore.core.models.lignes_facture import LignesFacture
 from electricore.core.models.lignes_facture_rapprochees import LignesFactureRapprochees
@@ -173,7 +173,7 @@ def contexte_du_mois(mois: str | None = None, horizon: dt.datetime | None = None
         FileNotFoundError: si la base DuckDB est absente (levée par les loaders
             à l'appel — leur `.lazy()` exécute la lecture immédiatement).
     """
-    return charger(c15().lazy(), releves_harmonises().lazy(), mois=mois, horizon=horizon)
+    return charger(c15().lazy(), releves_canoniques().lazy(), mois=mois, horizon=horizon)
 
 
 @pa.check_types(lazy=True)

--- a/electricore/core/builds/contexte_mensuel.py
+++ b/electricore/core/builds/contexte_mensuel.py
@@ -119,7 +119,7 @@ def _composer(
     # les mêmes entrées que `pipeline_energie` (historique impacté + relevés canoniques)
     # et la conserve dans le bundle. Calcul indépendant — les énergies restent intactes.
     releves_utilises = chronologie_releves(
-        historique_enrichi.filter(pl.col("impacte_energie")),
+        historique_enrichi.filter(pl.col("impacte_energie")),  # type: ignore[arg-type]
         releves,  # type: ignore[arg-type]
     )
     facturation_mensuelle = pipeline_facturation(abonnements, energie)

--- a/electricore/core/loaders/duckdb/helpers.py
+++ b/electricore/core/loaders/duckdb/helpers.py
@@ -206,7 +206,22 @@ def releves_canoniques(database_path: str | Path | None = None) -> DuckDBQuery:
         >>> r64_only = releves_canoniques().filter({"source": "flux_R64"}).collect()
     """
     union_schema = FluxSchema(flux_name="RELEVES_CANONIQUES", table="", columns=())
-    config = QueryConfig(schema=union_schema, transform=lambda lf: lf, validator=None)
+    # Les index sont matérialisés en BIGINT par dbt ; l'aval (chronologie / énergie)
+    # attend des Float64. Cast au boundary loader, comme l'ex-`releves_harmonises`.
+    index_cols = (
+        "index_base_kwh",
+        "index_hp_kwh",
+        "index_hc_kwh",
+        "index_hph_kwh",
+        "index_hpb_kwh",
+        "index_hch_kwh",
+        "index_hcb_kwh",
+    )
+    config = QueryConfig(
+        schema=union_schema,
+        transform=lambda lf: lf.with_columns([pl.col(c).cast(pl.Float64, strict=False) for c in index_cols]),
+        validator=None,
+    )
     return DuckDBQuery(config=config, database_path=database_path, base_sql="SELECT * FROM flux_enedis.releves")
 
 

--- a/electricore/core/models/chronologie_releves.py
+++ b/electricore/core/models/chronologie_releves.py
@@ -49,6 +49,13 @@ class ChronologieReleves(pa.DataFrameModel):
     # Source gagnante (table de priorité explicite C15 > R64 > R151).
     source: pl.Utf8 = pa.Field(nullable=False, isin=SOURCES_CHRONOLOGIE)
 
+    # 🆔 Identité (ADR-0028/0029, #244) portée jusqu'au journal (#233). Mintée au seam
+    # dbt pour toutes les sources. Nullable : un relevé interrogé absent (releve_manquant)
+    # n'en porte pas.
+    releve_id: pl.Utf8 | None = pa.Field(nullable=True)
+    # Nature canonique (réel/estimé/corrigé) ; nullable pour la même raison.
+    nature_index: pl.Utf8 | None = pa.Field(nullable=True, isin=["réel", "estimé", "corrigé"])
+
     # 🏢 Référence calendrier distributeur (utile au contrôle des cadrans attendus)
     id_calendrier_distributeur: pl.Utf8 | None = pa.Field(nullable=True)
 

--- a/electricore/core/pipelines/energie.py
+++ b/electricore/core/pipelines/energie.py
@@ -448,10 +448,18 @@ def _assembler_chronologie(evenements: pl.LazyFrame, releves: pl.LazyFrame) -> p
     evt_contractuels = evenements.filter(pl.col("evenement_declencheur") != "FACTURATION")
     evt_facturation = evenements.filter(pl.col("evenement_declencheur") == "FACTURATION")
 
-    # 2. Extraire les relevés des événements contractuels
-    rel_evenements = extraire_releves_evenements(evt_contractuels)
+    # 2. Relevés contractuels C15 : depuis le modèle canonique `releves` (dépivotés +
+    #    releve_id minté au seam dbt, ADR-0029), restreints aux événements qui impactent
+    #    l'énergie. L'historique est déjà filtré `impacte_energie` en amont du pipeline ;
+    #    le semi-join garantit la parité avec l'ex-extraction historique.
+    cles_impacte = evt_contractuels.select(["pdl", pl.col("date_evenement").alias("date_releve")]).unique()
+    rel_evenements = releves.filter(pl.col("source") == "flux_C15").join(
+        cles_impacte, on=["pdl", "date_releve"], how="semi"
+    )
 
-    # 3. Pour FACTURATION : construire requête et interroger les relevés existants
+    # 3. Pour FACTURATION : interroger les relevés PÉRIODIQUES (tout sauf C15) aux dates
+    #    de facturation. La priorité inter-sources est arbitrée au dédoublonnage ci-dessous.
+    rel_periodiques = releves.filter(pl.col("source") != "flux_C15")
     requete_facturation = evt_facturation.select(
         [
             "pdl",
@@ -461,7 +469,7 @@ def _assembler_chronologie(evenements: pl.LazyFrame, releves: pl.LazyFrame) -> p
         ]
     )
 
-    rel_facturation = interroger_releves(requete_facturation, releves)
+    rel_facturation = interroger_releves(requete_facturation, rel_periodiques)
 
     # 4. Combiner les deux sources de relevés
     return (

--- a/tests/integration/test_meta_periodes_service.py
+++ b/tests/integration/test_meta_periodes_service.py
@@ -45,6 +45,7 @@ def _contexte_synthetique() -> ContexteMensuel:
         historique_enrichi=vide,
         abonnements=vide,
         energie=vide,
+        releves_utilises=vide,
         facturation_mensuelle=facturation,
     )
 
@@ -103,6 +104,7 @@ def test_meta_periodes_source_hash_change_si_quantite_change(monkeypatch):
         historique_enrichi=base.historique_enrichi,
         abonnements=base.abonnements,
         energie=base.energie,
+        releves_utilises=base.releves_utilises,
         facturation_mensuelle=fm_modifie,
     )
     monkeypatch.setattr(meta_periodes_service, "contexte_du_mois", lambda mois=None: ctx_modifie)

--- a/tests/integration/test_taxes_service_smoke.py
+++ b/tests/integration/test_taxes_service_smoke.py
@@ -42,6 +42,7 @@ def test_cta_par_contrat_service_delegue_a_contexte_du_mois(monkeypatch):
         historique_enrichi=pl.LazyFrame(),
         abonnements=pl.LazyFrame(),
         energie=pl.LazyFrame(),
+        releves_utilises=pl.LazyFrame(),
         facturation_mensuelle=df_facturation,
     )
     appels: list = []

--- a/tests/property/test_abonnements_energie_invariants.py
+++ b/tests/property/test_abonnements_energie_invariants.py
@@ -199,25 +199,33 @@ def _historique_energie(jours: list[dt.date], hp: list[float], hc: list[float]) 
 
 
 def _releves_r151(jours: list[dt.date], hp: list[float], hc: list[float]) -> pl.LazyFrame:
-    """Relevés R151 aux dates intermédiaires (celles des événements FACTURATION)."""
-    interieurs = list(range(1, len(jours) - 1))
+    """Relevés canoniques (ADR-0029) : relevés C15 aux bornes de vie (après MES, avant
+    RES) + R151 aux dates intermédiaires (FACTURATION). Les relevés C15 viennent désormais
+    du modèle canonique, plus de l'historique."""
+    n = len(jours)
+    interieurs = list(range(1, n - 1))
+    # MES après (ordre True) à la 1ʳᵉ borne, R151 (ordre False) au milieu, RES avant
+    # (ordre False) à la dernière borne.
+    idxs = [0, *interieurs, n - 1]
+    sources = ["flux_C15", *["flux_R151"] * len(interieurs), "flux_C15"]
+    ordres = [True, *[False] * len(interieurs), False]
     data = {
-        "pdl": [_PDL] * len(interieurs),
-        "ref_situation_contractuelle": [_RSC] * len(interieurs),
-        "formule_tarifaire_acheminement": [_FTA] * len(interieurs),
-        "date_releve": [_ts(jours[i]) for i in interieurs],
-        "source": ["flux_R151"] * len(interieurs),
-        "unite": ["kWh"] * len(interieurs),
-        "precision": ["kWh"] * len(interieurs),
-        "ordre_index": [False] * len(interieurs),
-        "id_calendrier_distributeur": ["DI000002"] * len(interieurs),
-        "index_base_kwh": [None] * len(interieurs),
-        "index_hp_kwh": [hp[i] for i in interieurs],
-        "index_hc_kwh": [hc[i] for i in interieurs],
-        "index_hch_kwh": [None] * len(interieurs),
-        "index_hph_kwh": [None] * len(interieurs),
-        "index_hpb_kwh": [None] * len(interieurs),
-        "index_hcb_kwh": [None] * len(interieurs),
+        "pdl": [_PDL] * len(idxs),
+        "ref_situation_contractuelle": [_RSC] * len(idxs),
+        "formule_tarifaire_acheminement": [_FTA] * len(idxs),
+        "date_releve": [_ts(jours[i]) for i in idxs],
+        "source": sources,
+        "unite": ["kWh"] * len(idxs),
+        "precision": ["kWh"] * len(idxs),
+        "ordre_index": ordres,
+        "id_calendrier_distributeur": ["DI000002"] * len(idxs),
+        "index_base_kwh": [None] * len(idxs),
+        "index_hp_kwh": [hp[i] for i in idxs],
+        "index_hc_kwh": [hc[i] for i in idxs],
+        "index_hch_kwh": [None] * len(idxs),
+        "index_hph_kwh": [None] * len(idxs),
+        "index_hpb_kwh": [None] * len(idxs),
+        "index_hcb_kwh": [None] * len(idxs),
     }
     return pl.DataFrame(
         data,

--- a/tests/unit/test_chronologie_releves.py
+++ b/tests/unit/test_chronologie_releves.py
@@ -150,7 +150,16 @@ def test_priorite_c15_bat_periodique():
             _evenement("PDL001", "REF001", datetime(2024, 1, 15), "FACTURATION"),
         ]
     )
-    releves = _releves([_releve("PDL001", datetime(2024, 1, 15), "flux_R151", 9999.0, ref="REF001")])
+    # C15 (avant/après) et R151 au même jour : C15 vient désormais du modèle canonique
+    # `releves` (ADR-0029), aux côtés du périodique. L'événement reste dans l'historique
+    # pour le semi-join d'impact.
+    releves = _releves(
+        [
+            _releve("PDL001", datetime(2024, 1, 15), "flux_C15", 1000.0, ref="REF001", ordre_index=False),
+            _releve("PDL001", datetime(2024, 1, 15), "flux_C15", 1500.0, ref="REF001", ordre_index=True),
+            _releve("PDL001", datetime(2024, 1, 15), "flux_R151", 9999.0, ref="REF001"),
+        ]
+    )
 
     result = _assembler_chronologie(historique, releves).collect()
     a_la_date = result.filter(pl.col("date_releve") == datetime(2024, 1, 15, tzinfo=PARIS))
@@ -262,7 +271,13 @@ def test_ordre_index_booleen_avant_apres():
             _evenement("PDL001", "REF001", datetime(2024, 2, 1), "FACTURATION"),
         ]
     )
-    releves = _releves([_releve("PDL001", datetime(2024, 2, 1), "flux_R151", 2000.0, ref="REF001")])
+    releves = _releves(
+        [
+            _releve("PDL001", datetime(2024, 1, 15), "flux_C15", 1000.0, ref="REF001", ordre_index=False),
+            _releve("PDL001", datetime(2024, 1, 15), "flux_C15", 1500.0, ref="REF001", ordre_index=True),
+            _releve("PDL001", datetime(2024, 2, 1), "flux_R151", 2000.0, ref="REF001"),
+        ]
+    )
 
     result = _assembler_chronologie(historique, releves).collect()
     assert result.schema["ordre_index"] == pl.Boolean

--- a/tests/unit/test_contexte_mensuel.py
+++ b/tests/unit/test_contexte_mensuel.py
@@ -158,7 +158,7 @@ class TestContexteDuMois:
     """`contexte_du_mois()` — l'entrée I/O (#145) : loaders DuckDB par défaut, puis `charger()`."""
 
     def test_cable_les_loaders_et_delegue_a_charger(self, monkeypatch):
-        """c15 → historique, releves_harmonises → relevés (sentinelles : l'inversion échoue)."""
+        """c15 → historique, releves_canoniques → relevés (sentinelles : l'inversion échoue)."""
         import electricore.core.builds.contexte_mensuel as cm
 
         hist_sentinel = pl.LazyFrame({"source": ["c15"]})
@@ -172,7 +172,7 @@ class TestContexteDuMois:
                 return self._lf
 
         monkeypatch.setattr(cm, "c15", lambda: _Query(hist_sentinel))
-        monkeypatch.setattr(cm, "releves_harmonises", lambda: _Query(rel_sentinel))
+        monkeypatch.setattr(cm, "releves_canoniques", lambda: _Query(rel_sentinel))
 
         captures: dict = {}
         composition = _make_stub_composition(debuts_mois=[datetime(2025, 3, 1)])

--- a/tests/unit/test_contexte_mensuel.py
+++ b/tests/unit/test_contexte_mensuel.py
@@ -24,8 +24,8 @@ TZ = ZoneInfo("Europe/Paris")
 
 def _make_stub_composition(
     *, debuts_mois: list[datetime]
-) -> tuple[pl.LazyFrame, pl.LazyFrame, pl.LazyFrame, pl.LazyFrame]:
-    """Construit le tuple de 4 LazyFrames renvoyé par `_composer`.
+) -> tuple[pl.LazyFrame, pl.LazyFrame, pl.LazyFrame, pl.LazyFrame, pl.LazyFrame]:
+    """Construit le tuple de 5 LazyFrames renvoyé par `_composer`.
 
     `debuts_mois` peuple `facturation_mensuelle.debut` — c'est l'unique colonne
     dont `charger()` se sert pour résoudre le mois par défaut. Depuis ADR-0019
@@ -36,9 +36,10 @@ def _make_stub_composition(
         pl.col("debut").dt.replace_time_zone("Europe/Paris")
     )
     return (
-        pl.LazyFrame({"sentinel": [1]}),
-        pl.LazyFrame({"sentinel": [2]}),
-        pl.LazyFrame({"sentinel": [3]}),
+        pl.LazyFrame({"sentinel": [1]}),  # historique_enrichi
+        pl.LazyFrame({"sentinel": [2]}),  # abonnements
+        pl.LazyFrame({"sentinel": [3]}),  # energie
+        pl.LazyFrame({"sentinel": [4]}),  # releves_utilises (journal #233)
         facturation_lf,
     )
 
@@ -109,6 +110,8 @@ class TestChargerFramesQuiPassent:
         assert ctx.historique_enrichi.collect()["sentinel"].item() == 1
         assert ctx.abonnements.collect()["sentinel"].item() == 2
         assert ctx.energie.collect()["sentinel"].item() == 3
+        # releves_utilises : le journal des relevés consommés (#233) est exposé.
+        assert ctx.releves_utilises.collect()["sentinel"].item() == 4
         # facturation_mensuelle est une DataFrame (déjà collectée)
         assert isinstance(ctx.facturation_mensuelle, pl.DataFrame)
         assert "debut" in ctx.facturation_mensuelle.columns

--- a/tests/unit/test_documents.py
+++ b/tests/unit/test_documents.py
@@ -51,6 +51,7 @@ def _ctx(mois: str = "2025-01-01") -> ContexteMensuel:
         historique_enrichi=historique,
         abonnements=pl.LazyFrame(),
         energie=pl.LazyFrame(),
+        releves_utilises=pl.LazyFrame(),
         facturation_mensuelle=fact,
     )
 
@@ -189,6 +190,7 @@ class TestChangementsPuissance:
             historique_enrichi=ctx.historique_enrichi,
             abonnements=ctx.abonnements,
             energie=ctx.energie,
+            releves_utilises=ctx.releves_utilises,
             facturation_mensuelle=fact_avec_memo,
         )
 

--- a/tests/unit/test_facturation_service.py
+++ b/tests/unit/test_facturation_service.py
@@ -45,6 +45,7 @@ def test_documents_facturation_du_mois_returns_fr_sheet_names(monkeypatch):
         ),
         abonnements=pl.LazyFrame(),
         energie=pl.LazyFrame(),
+        releves_utilises=pl.LazyFrame(),
         facturation_mensuelle=df_fact_mensuelle,
     )
     # Un seul nom à patcher depuis #145 (contre charger + c15 + releves_harmonises avant) ;

--- a/tests/unit/test_pipeline_energie.py
+++ b/tests/unit/test_pipeline_energie.py
@@ -185,14 +185,17 @@ class TestReconstituerChronologieRelevesPolars:
         )
 
         # Base de relevés R151 (seulement PDL001)
+        # Relevés canoniques (ADR-0029) : C15 (avant/après du MES) + périodique R151.
         releves = pl.LazyFrame(
             {
-                "pdl": ["PDL001"],
-                "date_releve": [datetime(2024, 2, 1)],
-                "source": ["flux_R151"],
-                "index_base_kwh": [2000.0],
-                "ordre_index": [0],
-                "id_calendrier_distributeur": ["DI000001"],
+                "pdl": ["PDL001", "PDL001", "PDL001"],
+                "date_releve": [datetime(2024, 1, 15), datetime(2024, 1, 15), datetime(2024, 2, 1)],
+                "source": ["flux_C15", "flux_C15", "flux_R151"],
+                "index_base_kwh": [1000.0, 1500.0, 2000.0],
+                "index_hp_kwh": [500.0, 750.0, None],
+                "ordre_index": [False, True, False],
+                "ref_situation_contractuelle": ["REF001", "REF001", None],
+                "id_calendrier_distributeur": ["DI000001", "DI000001", "DI000001"],
             }
         )
 
@@ -238,15 +241,16 @@ class TestReconstituerChronologieRelevesPolars:
             ]
         )
 
-        # Relevé R151 à la même date
+        # C15 (avant/après) + R151 au même jour : C15 doit gagner (ADR-0029).
         releves = pl.LazyFrame(
             {
-                "pdl": ["PDL001"],
-                "date_releve": [datetime(2024, 1, 15)],
-                "source": ["flux_R151"],
-                "index_base_kwh": [9999.0],  # Valeur différente pour détecter le conflit
-                "ordre_index": [0],
-                "id_calendrier_distributeur": ["DI000001"],
+                "pdl": ["PDL001", "PDL001", "PDL001"],
+                "date_releve": [datetime(2024, 1, 15), datetime(2024, 1, 15), datetime(2024, 1, 15)],
+                "source": ["flux_C15", "flux_C15", "flux_R151"],
+                "index_base_kwh": [1000.0, 1500.0, 9999.0],  # 9999 = conflit R151 à écarter
+                "ordre_index": [False, True, False],
+                "ref_situation_contractuelle": ["REF001", "REF001", "REF001"],
+                "id_calendrier_distributeur": ["DI000001", "DI000001", "DI000001"],
             }
         )
 

--- a/tests/unit/test_rapport_facturation.py
+++ b/tests/unit/test_rapport_facturation.py
@@ -70,6 +70,7 @@ def _ctx(fact: pl.DataFrame, mois: str = "2025-03-01") -> ContexteMensuel:
         historique_enrichi=historique,
         abonnements=pl.LazyFrame(),
         energie=pl.LazyFrame(),
+        releves_utilises=pl.LazyFrame(),
         facturation_mensuelle=fact,
     )
 

--- a/tests/unit/test_rapprochement_facturation.py
+++ b/tests/unit/test_rapprochement_facturation.py
@@ -114,6 +114,7 @@ def _ctx(
         historique_enrichi=historique,
         abonnements=pl.LazyFrame(),
         energie=pl.LazyFrame(),
+        releves_utilises=pl.LazyFrame(),
         facturation_mensuelle=fact_mensuelle,
     )
 


### PR DESCRIPTION
Suite de la refonte relevés ([ADR-0029](../blob/main/docs/adr/0029-modele-releves-canonique-dbt-assemble-coeur-arbitre.md)) : le cœur **consomme** désormais le modèle de relevés canonique `releves` (la fondation dbt a été mergée en #245). Les deux dernières slices.

## Ce que ça fait

**#244 — bascule cœur (`376133c`)**
- La *Chronologie des relevés* (#180) lit le modèle dbt `releves` via `releves_canoniques()` : les relevés **C15 viennent de `releves`** (`source=flux_C15`, `releve_id` minté au seam dbt), restreints aux événements impactant l'énergie par semi-join ; les **périodiques** (R151/R64) sont interrogés aux dates de facturation.
- `ChronologieReleves` porte `releve_id` + `nature_index` (traçabilité de bout en bout).
- `contexte_mensuel` câblé sur `releves_canoniques` ; index castés Float64 au loader.
- **Parité énergie** : gate des tests unitaires energie/chronologie (21) + property tests verts ; **suite complète verte sous `TZ=UTC`** (784).

**#233 — journal (`<ce commit>`)**
- `ContexteMensuel.releves_utilises` : journal des relevés effectivement consommés (registres réels + `releve_id` + `nature_index`), conservé pour la traçabilité. Un MCT en cours de mois y figure sans cas particulier. Assemblage indépendant → énergies intactes.

## Garde de parité

Les tests unitaires energie/chronologie (assertions d'énergies sur fixtures conformes) sont le gate retenu ([décision : snapshots integration stale, à réparer séparément]). Vérifié aussi sous `TZ=UTC` pour le déterminisme.

## Suites / reste

- ⚠️ **Dead-code à retirer** (suivi séparé) : `extraire_releves_evenements` + les loaders `releves` / `releves_harmonises` sont désormais inutilisés par le chemin énergie mais conservés (consommateurs notebooks/API à auditer avant suppression — ADR-0029 prévoit leur disparition).
- 🧹 `core/CONTEXT.md` : entrées *Chronologie des relevés* / *Contexte mensuel* (désormais 5 frames) à rafraîchir.
- 🧪 Harnais snapshot `test_pipelines_snapshot.py` à réparer (stale, pré-existant).

Closes #244
Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)