### PR TITLE
fix(ingestion): build dbt sur données réelles — OOM flux_r64, nature null, wiring releves

### DIFF
--- a/electricore/ingestion/dbt/macros/identite_releve.sql
+++ b/electricore/ingestion/dbt/macros/identite_releve.sql
@@ -28,15 +28,15 @@
 --
 -- Chaque source porte sa propre nomenclature ; on la projette sur le vocabulaire
 -- canonique unique consommé par l'aval (RelevéIndex / ChronologieReleves) :
--- - R15/C15 `Nature_Index` : REEL → réel, ESTIME → estimé (autres → estimé par défaut
---   prudent, jamais réel par erreur) ;
+-- - R15/C15 `Nature_Index` : REEL → réel, ESTIME → estimé (autres ET absent/NULL →
+--   estimé par défaut prudent, jamais réel par erreur — sur données réelles certains
+--   relevés R15 n'ont pas de Nature_Index) ;
 -- - R64 `etapeMetier` : BRUT/VALID → réel, CORR → corrigé ;
 -- - R151 (télérelevé périodique) : pas de Nature_Index → réel par défaut.
 {% macro nature_depuis_nature_index(nature_index) %}
     case
         when upper({{ nature_index }}) = 'REEL' then 'réel'
         when upper({{ nature_index }}) = 'ESTIME' then 'estimé'
-        when {{ nature_index }} is null then null
         else 'estimé'
     end
 {% endmacro %}

--- a/electricore/ingestion/dbt/profiles.yml
+++ b/electricore/ingestion/dbt/profiles.yml
@@ -9,3 +9,10 @@ electricore_flux:
       # Schéma cible = celui que lisent les loaders core (mêmes noms de tables que
       # l'ex-chemin legacy → bascule transparente pour l'aval, ADR-0020/#134).
       schema: flux_enedis
+      # Mémoire : sur gros corpus réels (R64, modèle `releves`), les tris/fenêtres
+      # (dedup `qualify`, forward-fill RSC) saturaient la RAM (OOM à ~6 GiB). Ne pas
+      # préserver l'ordre d'insertion laisse DuckDB déverser sur disque — l'ordre des
+      # lignes matérialisées n'a aucune importance (les loaders trient, golden = match
+      # modulo ordre). Cf. https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads
+      settings:
+        preserve_insertion_order: false

--- a/electricore/ingestion/runner.py
+++ b/electricore/ingestion/runner.py
@@ -143,6 +143,12 @@ def construire_dbt(db_path: Path) -> bool:
     presentes = {t for (t,) in con.execute("select table_name from information_schema.tables").fetchall()}
     con.close()
     selection = [f"+{modele}" for raw, modeles in MODELES_PAR_RAW.items() if raw in presentes for modele in modeles]
+    # Le modèle de relevés canonique `releves` (mart, ADR-0029) est un DESCENDANT des
+    # flux : les `+flux_*` (ancêtres) ne l'atteignent pas. On l'ajoute explicitement dès
+    # que ses trois sources sont matérialisables (C15 + périodiques R151/R64) — sinon un
+    # arm d'union pointerait un flux non construit. Ses ancêtres sont déjà dans `selection`.
+    if {"raw_c15", "raw_r151", "raw_r64"} <= presentes:
+        selection.append("releves")
     if not selection:
         _out("  aucune table brute landée — rien à construire")
         return False
@@ -161,7 +167,21 @@ def construire_dbt(db_path: Path) -> bool:
                 str(db_path.parent / f".dbt_target_{db_path.stem}"),
             ]
         )
-    return bool(resultat.success)
+    success = bool(resultat.success)
+    if not success:
+        # Surfacer les nœuds en échec : sinon le runner masque l'erreur dbt réelle
+        # (OOM, data test, SQL) et le diagnostic exige de relancer dbt à la main.
+        try:
+            res = getattr(resultat, "result", None)
+            for noeud in getattr(res, "results", res) or []:
+                statut = str(getattr(noeud, "status", "")).lower()
+                if "error" in statut or "fail" in statut:
+                    nom = getattr(getattr(noeud, "node", None), "name", "?")
+                    msg = " ".join(str(getattr(noeud, "message", "")).split())
+                    _out(f"  ✗ {nom} [{statut}] — {msg}")
+        except Exception:  # noqa: BLE001 — le diagnostic ne doit jamais masquer l'échec
+            pass
+    return success
 
 
 def bilan(db_path: Path) -> None:


### PR DESCRIPTION
Le rebuild **rc3 sur données réelles** a échoué — trois défauts que les fixtures (trop étroites) ne couvraient pas. Diagnostic via `dbt build` dans le conteneur de prod.

## Corrections

1. **`flux_r64` — Out of Memory (~6 GiB)** : le tri de la fenêtre `qualify` (dedup des fenêtres R64 chevauchantes, ajouté en #232) saturait la RAM sur le corpus réel. → `preserve_insertion_order: false` dans le profil dbt : DuckDB déverse sur disque. L'ordre des lignes matérialisées n'a aucune importance (les loaders trient, golden = match modulo ordre).

2. **`flux_r15.nature_index` not_null échouait (9 lignes)** : des relevés R15 réels n'ont pas de `Nature_Index` → la macro renvoyait `NULL`. Désormais absent/`NULL` → `estimé` (défaut prudent, ADR-0028 « jamais réel par erreur »).

3. **Mart `releves` jamais construit par le runner** : descendant des flux, il n'était pas atteint par les `+flux_*` (ancêtres) de `MODELES_PAR_RAW`. → ajouté à la sélection dbt quand C15+R151+R64 sont présents. Sans ça, `flux_enedis.releves` n'existe pas et la facturation échoue (`releves_canoniques()`).

Bonus : `construire_dbt` **surface désormais les nœuds dbt en échec** (le runner masquait l'erreur réelle — d'où le diagnostic manuel).

Validé : suite complète verte sous `TZ=UTC` (784), mypy OK. Débloque rc3 → **rc4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)