### PR TITLE
fix(ingestion): dbt threads=1 — tenir la RAM sur flux_r64/releves

### DIFF
--- a/electricore/ingestion/dbt/profiles.yml
+++ b/electricore/ingestion/dbt/profiles.yml
@@ -9,10 +9,14 @@ electricore_flux:
       # Schéma cible = celui que lisent les loaders core (mêmes noms de tables que
       # l'ex-chemin legacy → bascule transparente pour l'aval, ADR-0020/#134).
       schema: flux_enedis
-      # Mémoire : sur gros corpus réels (R64, modèle `releves`), les tris/fenêtres
-      # (dedup `qualify`, forward-fill RSC) saturaient la RAM (OOM à ~6 GiB). Ne pas
-      # préserver l'ordre d'insertion laisse DuckDB déverser sur disque — l'ordre des
-      # lignes matérialisées n'a aucune importance (les loaders trient, golden = match
-      # modulo ordre). Cf. https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads
+      # Mémoire : sur gros corpus réels, l'unnest des points R64 + l'agrégation par
+      # hachage saturaient la RAM (OOM DuckDB ~6 GiB sur flux_r64/flux_r151). L'opérateur
+      # fautif **ne déverse pas** sur disque (baisser memory_limit échoue plus tôt) ; son
+      # pic mémoire est proportionnel au **nombre de threads** (un jeu de travail par
+      # thread). On le ramène donc à 1 thread, à la mémoire machine pleine — batch
+      # nocturne, la lenteur est acceptable. `preserve_insertion_order: false` allège les
+      # tris (ordre des lignes sans importance : loaders trient, golden = match modulo ordre).
+      # Cf. https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads
       settings:
         preserve_insertion_order: false
+        threads: 1

--- a/electricore/ingestion/runner.py
+++ b/electricore/ingestion/runner.py
@@ -194,7 +194,7 @@ def bilan(db_path: Path) -> None:
     lignes = con.execute(
         """
         select table_schema, table_name from information_schema.tables
-        where table_name like 'raw_%' or table_name like 'flux_%'
+        where table_name like 'raw_%' or table_name like 'flux_%' or table_name = 'releves'
         order by table_schema, table_name
         """
     ).fetchall()


### PR DESCRIPTION
Le rebuild OOMait sur `flux_r64` (~6 GiB) sur le VPS contraint. Diagnostic : l'opérateur fautif (unnest des points + agrégation par hachage) **ne déverse pas** sur disque — baisser `memory_limit` échoue plus tôt (et fait tomber flux_r151 aussi). Son pic mémoire est **proportionnel au nombre de threads**.

**Fix : `threads: 1`** (à mémoire machine pleine) + `preserve_insertion_order: false`. **Validé sur données réelles** (`dbt build --select +releves` dans le conteneur) : flux_c15/r151/r64 + le mart `releves` se construisent, **tous les data tests passent** (dont `unique_releves_releve_id`, `not_null_releves_*`). 56 s, batch nocturne → lenteur mono-thread acceptable.

Aussi : `releves` apparaît désormais au `📊 Bilan` du runner (la requête filtrait `flux_%`/`raw_%`).

→ rc5.