### PR TITLE
Durcissement VPS — utilisateur ops, sshd root-off, fail2ban, unattended-upgrades (ADR-0031)

### DIFF
--- a/deploy/harden.sh
+++ b/deploy/harden.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Durcissement autonome d'un VPS déjà provisionné (ADR-0031).
+#
+# Rétro-durcit une instance existante — y compris l'ancien layout root-run
+# /opt/electricore/ — sans relancer un reconfigure complet. Le durcissement est
+# OS/SSH-level : aucune hypothèse de layout. La clé de `ops` est amorcée depuis
+# ~root/.ssh/authorized_keys quel que soit l'emplacement de la stack
+# (/srv/<slug>/ comme /opt/electricore/).
+#
+# Ce script ne fait que sourcer lib/harden.sh et appeler harden_vps() : toute la
+# logique vit dans la lib, partagée avec install.sh (pas de duplication).
+#
+# Usage :
+#   # Sur une instance au layout courant (arbre deploy/ présent) :
+#   sudo bash /srv/<slug>/deploy/harden.sh [options]
+#
+#   # Standalone (legacy /opt, ou box sans notre arbre deploy/) — bootstrap auto :
+#   curl -fsSL https://raw.githubusercontent.com/Energie-De-Nantes/electricore/main/deploy/harden.sh -o harden.sh
+#   sudo bash harden.sh [options]
+#
+# Cf. docs/deploiement.md § « Durcissement du VPS » → « Rétro-durcir un VPS existant ».
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_BASE_URL_DEFAULT="${INSTALL_BASE_URL:-https://raw.githubusercontent.com/Energie-De-Nantes/electricore/main/deploy}"
+# Sous-ensemble de lib/ dont harden_vps() a besoin (log + die ; ensure_packages).
+HARDEN_LIB_FILES=(log system harden)
+
+# Bootstrap : si lib/ est absent (run standalone via curl sur une box sans notre
+# arbre deploy/), télécharge les helpers requis depuis main (ou INSTALL_BASE_URL).
+if [[ ! -d "${SCRIPT_DIR}/lib" ]]; then
+    echo "→ Bootstrap : téléchargement des helpers depuis ${INSTALL_BASE_URL_DEFAULT}/lib/…"
+    command -v curl >/dev/null || { echo "curl introuvable, install curl puis relance." >&2; exit 1; }
+    install -d "${SCRIPT_DIR}/lib"
+    for f in "${HARDEN_LIB_FILES[@]}"; do
+        if ! curl -fsSL "${INSTALL_BASE_URL_DEFAULT}/lib/${f}.sh" -o "${SCRIPT_DIR}/lib/${f}.sh"; then
+            echo "✗ Échec téléchargement ${f}.sh depuis ${INSTALL_BASE_URL_DEFAULT}/lib/" >&2
+            exit 1
+        fi
+    done
+fi
+
+for f in "${HARDEN_LIB_FILES[@]}"; do
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/lib/${f}.sh"
+done
+
+usage_harden() {
+    cat <<EOF
+Usage: sudo bash harden.sh [options]
+
+Rétro-durcit un VPS déjà déployé (ADR-0031) : utilisateur admin ops + sudo,
+sshd root-off clé-uniquement, fail2ban, unattended-upgrades. Idempotent.
+Aucune hypothèse de layout : fonctionne sur /srv/<slug>/ comme /opt/electricore/.
+
+Options :
+  --admin-pubkey <key>      Clé SSH publique pour ops (défaut: copie ~root)
+  --no-sshd                 Ne verrouille pas sshd (garde root SSH actif)
+  --no-fail2ban             Saute fail2ban
+  --no-unattended-upgrades  Saute les mises à jour automatiques
+  --no-color                Désactive les couleurs ANSI
+  -h, --help                Affiche cette aide
+EOF
+}
+
+# parse_harden_args "$@" — remplit OPT_ADMIN_PUBKEY, OPT_NO_SSHD, OPT_NO_FAIL2BAN,
+# OPT_NO_UNATTENDED (noms partagés avec cli.sh → harden_vps les lit indifféremment).
+parse_harden_args() {
+    OPT_ADMIN_PUBKEY=""
+    OPT_NO_SSHD=0
+    OPT_NO_FAIL2BAN=0
+    OPT_NO_UNATTENDED=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --admin-pubkey)           OPT_ADMIN_PUBKEY="${2:-}"; shift 2 ;;
+            --no-sshd)                OPT_NO_SSHD=1; shift ;;
+            --no-fail2ban)            OPT_NO_FAIL2BAN=1; shift ;;
+            --no-unattended-upgrades) OPT_NO_UNATTENDED=1; shift ;;
+            --no-color)               export NO_COLOR=1; shift ;;
+            -h|--help)                usage_harden; exit 0 ;;
+            *) echo "Argument inconnu : $1" >&2; usage_harden; exit 2 ;;
+        esac
+    done
+}
+
+main_harden() {
+    set -euo pipefail
+    parse_harden_args "$@"
+    LOG_TOTAL_STEPS=1
+    [[ $EUID -eq 0 ]] || die "à lancer en root (sudo bash $0 ...)"
+    log_step "Durcissement VPS (rétro, ADR-0031)"
+    harden_vps
+    log_ok "Durcissement terminé. Prochaine connexion admin : ssh ops@<vps> (root SSH coupé sauf --no-sshd)."
+}
+
+# Guard : n'exécute `main_harden` que si le script est exécuté, pas sourcé
+# (les tests unitaires sourcent pour récupérer parse_harden_args).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main_harden "$@"
+fi

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -9,7 +9,7 @@
 #   3. Docker (idempotent)
 #   4. UFW : OpenSSH + 80 + 443
 #   5. Création user système <slug> + SSH key
-#   6. Durcissement VPS (admin ops + sudo + clé + verrouillage sshd, ADR-0031 ; --no-harden)
+#   6. Durcissement VPS (admin ops + sshd root-off + fail2ban, ADR-0031 ; --no-harden)
 #   7. Téléchargement config tag-pinné
 #   8. Substitutions (slug, domaine, email)
 #   9. Édition .env + validation (loop)
@@ -161,7 +161,7 @@ main() {
     # ─── Étape 6 : durcissement VPS (ADR-0031) ──────────────────────────────
     # Actif par défaut, juste après l'étape user/clé. Le garde-fou anti-verrouillage
     # (clé de ops non vide) protège la bascule root-off ; --no-harden pour sauter.
-    log_step "Durcissement VPS — admin ops + verrouillage sshd"
+    log_step "Durcissement VPS — admin ops + sshd + fail2ban"
     if [[ "${OPT_NO_HARDEN:-0}" -eq 1 ]]; then
         log_skip "durcissement ignoré (--no-harden)"
     else

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -9,7 +9,7 @@
 #   3. Docker (idempotent)
 #   4. UFW : OpenSSH + 80 + 443
 #   5. Création user système <slug> + SSH key
-#   6. Durcissement VPS (admin ops + sudo + clé, ADR-0031 ; --no-harden pour sauter)
+#   6. Durcissement VPS (admin ops + sudo + clé + verrouillage sshd, ADR-0031 ; --no-harden)
 #   7. Téléchargement config tag-pinné
 #   8. Substitutions (slug, domaine, email)
 #   9. Édition .env + validation (loop)
@@ -161,7 +161,7 @@ main() {
     # ─── Étape 6 : durcissement VPS (ADR-0031) ──────────────────────────────
     # Actif par défaut, juste après l'étape user/clé. Le garde-fou anti-verrouillage
     # (clé de ops non vide) protège la bascule root-off ; --no-harden pour sauter.
-    log_step "Durcissement VPS — utilisateur admin ops"
+    log_step "Durcissement VPS — admin ops + verrouillage sshd"
     if [[ "${OPT_NO_HARDEN:-0}" -eq 1 ]]; then
         log_skip "durcissement ignoré (--no-harden)"
     else
@@ -252,13 +252,21 @@ main() {
 
     # ─── Étape 13 : récap ───────────────────────────────────────────────────
     log_step "Récapitulatif"
+    # Récap SSH : une fois durci (ADR-0031), l'admin passe par ops (root SSH coupé) ;
+    # le user de service <slug> reste joignable. Sans durcissement, seul <slug>.
+    if [[ "${OPT_NO_HARDEN:-0}" -eq 1 ]]; then
+        ssh_recap="  SSH (service)    ssh ${OPT_SLUG}@${OPT_DOMAIN}"
+    else
+        ssh_recap="  SSH (admin)      ssh ops@${OPT_DOMAIN}   ← root SSH désactivé
+  SSH (service)    ssh ${OPT_SLUG}@${OPT_DOMAIN}"
+    fi
     cat <<EOF
 
   ${_C_GREEN}${_C_BOLD}✓ Instance ${OPT_SLUG} opérationnelle.${_C_RESET}
 
   URL              https://${OPT_DOMAIN}
   /health          curl https://${OPT_DOMAIN}/health
-  SSH              ssh ${OPT_SLUG}@${OPT_DOMAIN}
+${ssh_recap}
   Logs             sudo -u ${OPT_SLUG} docker compose -f ${DOCKER_DIR}/docker-compose.yml logs -f
   Stop/Start       sudo -u ${OPT_SLUG} docker compose -f ${DOCKER_DIR}/docker-compose.yml {down,up -d}
   Backups          ${HOME_DIR}/backups/ (rotation 14 snapshots, cron 03:30 Europe/Paris)

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -9,7 +9,7 @@
 #   3. Docker (idempotent)
 #   4. UFW : OpenSSH + 80 + 443
 #   5. Création user système <slug> + SSH key
-#   6. Durcissement VPS (admin ops + sshd root-off + fail2ban, ADR-0031 ; --no-harden)
+#   6. Durcissement VPS (admin ops + sshd root-off + fail2ban + maj auto, ADR-0031 ; --no-harden)
 #   7. Téléchargement config tag-pinné
 #   8. Substitutions (slug, domaine, email)
 #   9. Édition .env + validation (loop)
@@ -161,7 +161,7 @@ main() {
     # ─── Étape 6 : durcissement VPS (ADR-0031) ──────────────────────────────
     # Actif par défaut, juste après l'étape user/clé. Le garde-fou anti-verrouillage
     # (clé de ops non vide) protège la bascule root-off ; --no-harden pour sauter.
-    log_step "Durcissement VPS — admin ops + sshd + fail2ban"
+    log_step "Durcissement VPS — admin ops + sshd + fail2ban + maj auto"
     if [[ "${OPT_NO_HARDEN:-0}" -eq 1 ]]; then
         log_skip "durcissement ignoré (--no-harden)"
     else

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -9,13 +9,14 @@
 #   3. Docker (idempotent)
 #   4. UFW : OpenSSH + 80 + 443
 #   5. Création user système <slug> + SSH key
-#   6. Téléchargement config tag-pinné
-#   7. Substitutions (slug, domaine, email)
-#   8. Édition .env + validation (loop)
-#   9. DNS check bloquant
-#  10. docker compose up + wait_for_health
-#  11. ETL test (mode test, ~3s)
-#  12. Récap final
+#   6. Durcissement VPS (admin ops + sudo + clé, ADR-0031 ; --no-harden pour sauter)
+#   7. Téléchargement config tag-pinné
+#   8. Substitutions (slug, domaine, email)
+#   9. Édition .env + validation (loop)
+#  10. DNS check bloquant
+#  11. docker compose up + wait_for_health
+#  12. ETL test (mode test, ~3s)
+#  13. Récap final
 #
 # Mode reconfigure : si /srv/<slug>/.env existe déjà, on backup le .env,
 # on saute la création user/Docker/UFW (idempotents de toute façon), on
@@ -28,7 +29,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_BASE_URL_DEFAULT="${INSTALL_BASE_URL:-https://raw.githubusercontent.com/Energie-De-Nantes/electricore/main/deploy}"
-LIB_FILES=(log cli validate os system user config env_validate dns stack ingestion)
+LIB_FILES=(log cli validate os system user harden config env_validate dns stack ingestion)
 
 # fetch_lib_files <base_url> <target_dir>
 # Télécharge les helpers `${LIB_FILES[@]}` depuis <base_url> vers <target_dir>.
@@ -75,7 +76,7 @@ _source_lib "${SCRIPT_DIR}/lib"
 main() {
     set -euo pipefail
 
-    LOG_TOTAL_STEPS=12
+    LOG_TOTAL_STEPS=13
 
     # Trap propre : Ctrl+C, kill, exit non-zero. Nettoie le script get-docker.sh
     # temporaire et signale clairement l'abandon. Ne touche jamais à la DB ni au .env.
@@ -157,12 +158,22 @@ main() {
     create_instance_user "$OPT_SLUG"
     setup_ssh_authorized_keys "$OPT_SLUG" "$OPT_SSH_PUBKEY"
 
-    # ─── Étape 6 : config files ─────────────────────────────────────────────
+    # ─── Étape 6 : durcissement VPS (ADR-0031) ──────────────────────────────
+    # Actif par défaut, juste après l'étape user/clé. Le garde-fou anti-verrouillage
+    # (clé de ops non vide) protège la bascule root-off ; --no-harden pour sauter.
+    log_step "Durcissement VPS — utilisateur admin ops"
+    if [[ "${OPT_NO_HARDEN:-0}" -eq 1 ]]; then
+        log_skip "durcissement ignoré (--no-harden)"
+    else
+        harden_vps
+    fi
+
+    # ─── Étape 7 : config files ─────────────────────────────────────────────
     log_step "Téléchargement config (tag ${OPT_VERSION})"
     download_config_files "$OPT_VERSION" "$HOME_DIR"
     chown_instance_home "$OPT_SLUG"
 
-    # ─── Étape 7 : substitutions ────────────────────────────────────────────
+    # ─── Étape 8 : substitutions ────────────────────────────────────────────
     log_step "Patch des templates (slug + domaine + email)"
     substitute_env "$ENV_FILE" "$OPT_SLUG" "$OPT_VERSION"
     substitute_caddyfile "$CADDYFILE" "$OPT_DOMAIN" "$OPT_EMAIL"
@@ -171,7 +182,7 @@ main() {
                  "Éditer à la main avant de mettre en prod."
     fi
 
-    # ─── Étape 8 : édition .env + validation ────────────────────────────────
+    # ─── Étape 9 : édition .env + validation ────────────────────────────────
     log_step "Configuration .env (édition + validation)"
     if [[ "$MODE_RECONFIGURE" -eq 1 ]]; then
         backup="${ENV_FILE}.bak.$(date +%Y%m%dT%H%M%SZ)"
@@ -208,7 +219,7 @@ main() {
         sleep 2
     done
 
-    # ─── Étape 9 : DNS ──────────────────────────────────────────────────────
+    # ─── Étape 10 : DNS ─────────────────────────────────────────────────────
     log_step "Vérification DNS"
     if [[ "$OPT_SKIP_DNS" -eq 1 ]]; then
         log_skip "DNS check ignoré (--skip-dns)"
@@ -221,7 +232,7 @@ main() {
             "Vérifier le A-record de ${OPT_DOMAIN}. Relancer le script quand c'est propre."
     fi
 
-    # ─── Étape 10 : stack ───────────────────────────────────────────────────
+    # ─── Étape 11 : stack ───────────────────────────────────────────────────
     log_step "Démarrage de la stack docker compose"
     compose_up "$OPT_SLUG"
     log_info "Attente du healthcheck API (jusqu'à 60s)…"
@@ -229,7 +240,7 @@ main() {
         "API non healthy après 60s." \
         "Voir les logs : sudo -u $OPT_SLUG docker compose -f $DOCKER_DIR/docker-compose.yml logs"
 
-    # ─── Étape 11 : ETL test ────────────────────────────────────────────────
+    # ─── Étape 12 : ETL test ────────────────────────────────────────────────
     log_step "ETL test (mode test, ~3s)"
     if run_ingestion_test "$OPT_SLUG"; then
         log_ok "ETL test réussi — clés AES OK, SFTP accessible, DuckDB écrit."
@@ -239,7 +250,7 @@ main() {
         log_warn "Stack laissée en place. Corrige .env et réessaye (commande ci-dessus)."
     fi
 
-    # ─── Étape 12 : récap ───────────────────────────────────────────────────
+    # ─── Étape 13 : récap ───────────────────────────────────────────────────
     log_step "Récapitulatif"
     cat <<EOF
 

--- a/deploy/lib/README.md
+++ b/deploy/lib/README.md
@@ -1,8 +1,10 @@
 # `deploy/lib/`
 
-Helpers bash sourcés par [`../install.sh`](../install.sh).
+Helpers bash sourcés par [`../install.sh`](../install.sh) (et, pour le sous-ensemble
+durcissement, par le wrapper autonome [`../harden.sh`](../harden.sh)).
 
 - [`validate.sh`](validate.sh) — validateurs purs (slug, AES, URL, email, domaine). Renvoient 0/1, pas de sortie.
 - [`os.sh`](os.sh) — détection OS via `/etc/os-release`, mockable avec `OS_RELEASE_PATH=...` (utilisé par les tests).
+- [`harden.sh`](harden.sh) — durcissement VPS (ADR-0031) : `harden_vps()` orchestre admin `ops` + sudo, verrouillage sshd (root-off, clé only), fail2ban, unattended-upgrades. Fonctions de rendu pures (`render_sshd_hardening`, `render_fail2ban_jail`, …) testables, side-effects idempotents.
 
 Tests : [`../tests/unit.sh`](../tests/unit.sh).

--- a/deploy/lib/cli.sh
+++ b/deploy/lib/cli.sh
@@ -20,7 +20,10 @@ Options :
   --env-from <file>      Charge un .env pré-rempli au lieu d'ouvrir l'éditeur
                          (utile pour les tests e2e et déploiements scriptés)
   --skip-dns             N'attend pas la propagation DNS (test local)
-  --no-harden            Saute le durcissement VPS (ops/sshd/fail2ban/upgrades, ADR-0031)
+  --no-harden            Saute tout le durcissement VPS (ADR-0031)
+  --no-sshd              Durcit mais ne verrouille pas sshd (garde root SSH actif)
+  --no-fail2ban          Durcit mais saute fail2ban
+  --no-unattended-upgrades  Durcit mais saute les mises à jour automatiques
   --no-color             Désactive les couleurs ANSI dans la sortie
   -h, --help             Affiche cette aide
 
@@ -29,8 +32,8 @@ EOF
 }
 
 # parse_args "$@" — remplit les vars globales OPT_SLUG, OPT_DOMAIN, OPT_SSH_PUBKEY,
-# OPT_ADMIN_PUBKEY, OPT_EMAIL, OPT_VERSION, OPT_ENV_FROM, OPT_SKIP_DNS, OPT_NO_HARDEN.
-# Renvoie 0 si OK, 1 si erreur.
+# OPT_ADMIN_PUBKEY, OPT_EMAIL, OPT_VERSION, OPT_ENV_FROM, OPT_SKIP_DNS, OPT_NO_HARDEN,
+# OPT_NO_SSHD, OPT_NO_FAIL2BAN, OPT_NO_UNATTENDED. Renvoie 0 si OK, 1 si erreur.
 parse_args() {
     OPT_SLUG=""
     OPT_DOMAIN=""
@@ -41,6 +44,9 @@ parse_args() {
     OPT_ENV_FROM=""
     OPT_SKIP_DNS=0
     OPT_NO_HARDEN=0
+    OPT_NO_SSHD=0
+    OPT_NO_FAIL2BAN=0
+    OPT_NO_UNATTENDED=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --slug)         OPT_SLUG="${2:-}"; shift 2 ;;
@@ -52,6 +58,9 @@ parse_args() {
             --env-from)     OPT_ENV_FROM="${2:-}"; shift 2 ;;
             --skip-dns)     OPT_SKIP_DNS=1; shift ;;
             --no-harden)    OPT_NO_HARDEN=1; shift ;;
+            --no-sshd)      OPT_NO_SSHD=1; shift ;;
+            --no-fail2ban)  OPT_NO_FAIL2BAN=1; shift ;;
+            --no-unattended-upgrades) OPT_NO_UNATTENDED=1; shift ;;
             --no-color)     export NO_COLOR=1; shift ;;
             -h|--help)      usage; exit 0 ;;
             *)

--- a/deploy/lib/cli.sh
+++ b/deploy/lib/cli.sh
@@ -10,7 +10,9 @@ Arguments obligatoires :
   --domain <fqdn>        Domaine public (ex: edn.electricore.fr)
 
 Options :
-  --ssh-pubkey <key>     Clé SSH publique pour le user <slug>
+  --ssh-pubkey <key>     Clé SSH publique pour le user de service <slug>
+                         (défaut: copie depuis ~root/.ssh/authorized_keys)
+  --admin-pubkey <key>   Clé SSH publique pour l'admin ops (durcissement, ADR-0031)
                          (défaut: copie depuis ~root/.ssh/authorized_keys)
   --email <addr>         Email pour les notifications Let's Encrypt
                          (défaut: laisse le placeholder du Caddyfile, à éditer)
@@ -18,6 +20,7 @@ Options :
   --env-from <file>      Charge un .env pré-rempli au lieu d'ouvrir l'éditeur
                          (utile pour les tests e2e et déploiements scriptés)
   --skip-dns             N'attend pas la propagation DNS (test local)
+  --no-harden            Saute le durcissement VPS (ops/sshd/fail2ban/upgrades, ADR-0031)
   --no-color             Désactive les couleurs ANSI dans la sortie
   -h, --help             Affiche cette aide
 
@@ -26,26 +29,31 @@ EOF
 }
 
 # parse_args "$@" — remplit les vars globales OPT_SLUG, OPT_DOMAIN, OPT_SSH_PUBKEY,
-# OPT_VERSION, OPT_ENV_FROM, OPT_SKIP_DNS. Renvoie 0 si OK, 1 si erreur.
+# OPT_ADMIN_PUBKEY, OPT_EMAIL, OPT_VERSION, OPT_ENV_FROM, OPT_SKIP_DNS, OPT_NO_HARDEN.
+# Renvoie 0 si OK, 1 si erreur.
 parse_args() {
     OPT_SLUG=""
     OPT_DOMAIN=""
     OPT_SSH_PUBKEY=""
+    OPT_ADMIN_PUBKEY=""
     OPT_EMAIL=""
     OPT_VERSION="latest"
     OPT_ENV_FROM=""
     OPT_SKIP_DNS=0
+    OPT_NO_HARDEN=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --slug)        OPT_SLUG="${2:-}"; shift 2 ;;
-            --domain)      OPT_DOMAIN="${2:-}"; shift 2 ;;
-            --ssh-pubkey)  OPT_SSH_PUBKEY="${2:-}"; shift 2 ;;
-            --email)       OPT_EMAIL="${2:-}"; shift 2 ;;
-            --version)     OPT_VERSION="${2:-}"; shift 2 ;;
-            --env-from)    OPT_ENV_FROM="${2:-}"; shift 2 ;;
-            --skip-dns)    OPT_SKIP_DNS=1; shift ;;
-            --no-color)    export NO_COLOR=1; shift ;;
-            -h|--help)     usage; exit 0 ;;
+            --slug)         OPT_SLUG="${2:-}"; shift 2 ;;
+            --domain)       OPT_DOMAIN="${2:-}"; shift 2 ;;
+            --ssh-pubkey)   OPT_SSH_PUBKEY="${2:-}"; shift 2 ;;
+            --admin-pubkey) OPT_ADMIN_PUBKEY="${2:-}"; shift 2 ;;
+            --email)        OPT_EMAIL="${2:-}"; shift 2 ;;
+            --version)      OPT_VERSION="${2:-}"; shift 2 ;;
+            --env-from)     OPT_ENV_FROM="${2:-}"; shift 2 ;;
+            --skip-dns)     OPT_SKIP_DNS=1; shift ;;
+            --no-harden)    OPT_NO_HARDEN=1; shift ;;
+            --no-color)     export NO_COLOR=1; shift ;;
+            -h|--help)      usage; exit 0 ;;
             *)
                 echo "Argument inconnu : $1" >&2
                 return 1 ;;

--- a/deploy/lib/harden.sh
+++ b/deploy/lib/harden.sh
@@ -1,0 +1,120 @@
+# shellcheck shell=bash
+# Durcissement OS/SSH du VPS (ADR-0031). Sourcé par install.sh (étape par défaut)
+# et par le wrapper autonome deploy/harden.sh.
+#
+# Trois rôles, distincts par construction :
+#   - ops      : admin, sudo NOPASSWD, login SSH par clé uniquement
+#   - <slug>   : service, groupe docker, pas de sudo (inchangé, ADR-0017)
+#   - root     : SSH désactivé ; atteignable via sudo depuis ops
+#
+# Toutes les fonctions sont idempotentes et requièrent root (l'orchestrateur
+# install.sh garantit EUID 0 ; le wrapper deploy/harden.sh re-vérifie).
+
+# Utilisateur admin dédié. Override possible via env (tests, exotique).
+HARDEN_ADMIN_USER="${HARDEN_ADMIN_USER:-ops}"
+
+# ─── Utilisateur admin ──────────────────────────────────────────────────────
+
+# ensure_admin_user <user>
+# Crée l'utilisateur admin (home + shell) s'il n'existe pas. Idempotent :
+# une fois par VPS, un reconfigure réutilise l'existant sans erreur.
+ensure_admin_user() {
+    local user="$1"
+    if id "$user" >/dev/null 2>&1; then
+        log_skip "user admin $user déjà présent"
+    else
+        useradd --create-home --shell /bin/bash "$user"
+        log_ok "user admin $user créé"
+    fi
+}
+
+# grant_nopasswd_sudo <user>
+# Octroie sudo sans mot de passe via /etc/sudoers.d/<user>. NOPASSWD est imposé
+# par le modèle clé-uniquement (ADR-0031) : l'admin n'a pas de mot de passe, un
+# sudo interactif serait inutilisable. Validé par `visudo -cf` avant installation
+# (une règle sudoers cassée verrouille tout escalade).
+grant_nopasswd_sudo() {
+    local user="$1"
+    local file="/etc/sudoers.d/${user}"
+    local tmp
+    tmp="$(mktemp)"
+    printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$user" > "$tmp"
+    if visudo -cf "$tmp" >/dev/null 2>&1; then
+        install -m 0440 -o root -g root "$tmp" "$file"
+        rm -f "$tmp"
+        log_ok "sudo NOPASSWD pour $user (${file})"
+    else
+        rm -f "$tmp"
+        die "règle sudoers invalide pour $user — abandon (sécurité)."
+    fi
+}
+
+# seed_admin_key <user> [<pubkey>]
+# Amorce le authorized_keys de l'admin. Si <pubkey> fournie : l'écrit (override
+# --admin-pubkey). Sinon : copie ~root/.ssh/authorized_keys (l'ancre de confiance
+# de la première install). Idempotent : réécrit le fichier à chaque appel.
+seed_admin_key() {
+    local user="$1"
+    local pubkey="${2:-}"
+    local home
+    home="$(getent passwd "$user" | cut -d: -f6)"
+    [[ -n "$home" ]] || die "impossible de résoudre le home de $user"
+    local ssh_dir="${home}/.ssh"
+    local auth_file="${ssh_dir}/authorized_keys"
+    install -d -m 700 -o "$user" -g "$user" "$ssh_dir"
+    if [[ -n "$pubkey" ]]; then
+        printf '%s\n' "$pubkey" > "$auth_file"
+        log_ok "clé SSH installée pour $user (depuis --admin-pubkey)"
+    elif [[ -s /root/.ssh/authorized_keys ]]; then
+        cp /root/.ssh/authorized_keys "$auth_file"
+        log_ok "clé SSH de $user copiée depuis /root/.ssh/authorized_keys"
+    else
+        log_warn "aucune clé SSH disponible pour $user." \
+                 "Fournir --admin-pubkey avant de couper le SSH root (garde-fou anti-verrouillage)."
+        return 0
+    fi
+    chown "$user:$user" "$auth_file"
+    chmod 600 "$auth_file"
+}
+
+# ─── Garde-fou anti-verrouillage ────────────────────────────────────────────
+
+# authorized_keys_present <file>
+# 0 si le fichier existe et contient au moins une entrée de clé (ligne non vide
+# et non commentaire). Pur, sans side-effect — testable hors VPS.
+authorized_keys_present() {
+    local file="$1"
+    [[ -f "$file" ]] || return 1
+    grep -qE '^[[:space:]]*[^#[:space:]]' "$file"
+}
+
+# admin_has_authorized_key <user>
+# Applique authorized_keys_present au home de l'utilisateur. C'est le verrou du
+# garde-fou : on refuse de couper root/mot-de-passe SSH tant que l'admin n'a pas
+# de clé exploitable (sinon : verrouillage à distance définitif).
+admin_has_authorized_key() {
+    local user="$1"
+    local home
+    home="$(getent passwd "$user" | cut -d: -f6)"
+    [[ -n "$home" ]] || return 1
+    authorized_keys_present "${home}/.ssh/authorized_keys"
+}
+
+# ─── Orchestrateur ──────────────────────────────────────────────────────────
+
+# harden_vps
+# Orchestre le durcissement (ADR-0031). Lit les globals OPT_* posés par cli.sh :
+#   OPT_ADMIN_PUBKEY   clé SSH override pour l'admin (sinon copie root)
+#
+# Cette tranche ne pose que la partie SÛRE : utilisateur admin + sudo + clé.
+# Aucune modification sshd ici → le SSH root reste actif, aucun verrouillage
+# possible. Le verrouillage sshd, fail2ban et unattended-upgrades arrivent dans
+# les tranches suivantes.
+harden_vps() {
+    local user="${HARDEN_ADMIN_USER}"
+    local pubkey="${OPT_ADMIN_PUBKEY:-}"
+
+    ensure_admin_user "$user"
+    seed_admin_key "$user" "$pubkey"
+    grant_nopasswd_sudo "$user"
+}

--- a/deploy/lib/harden.sh
+++ b/deploy/lib/harden.sh
@@ -151,6 +151,47 @@ harden_sshd() {
     log_ok "sshd durci : root-off, clé uniquement, MaxAuthTries 3 (${SSHD_HARDEN_DROPIN})"
 }
 
+# ─── fail2ban ───────────────────────────────────────────────────────────────
+
+# Jail fail2ban. Override pour les tests.
+FAIL2BAN_JAIL="${FAIL2BAN_JAIL:-/etc/fail2ban/jail.d/electricore.conf}"
+
+# render_fail2ban_jail
+# Émet la conf du jail sshd sur stdout. Pur, sans side-effect — testable.
+# `backend = systemd` est REQUIS : sur Debian/Ubuntu récents les logins SSH vont
+# dans le journal systemd, pas dans /var/log/auth.log (le défaut historique ne
+# lirait rien). Cf. ADR-0031, alternative écartée « backend auth.log ».
+render_fail2ban_jail() {
+    cat <<'EOF'
+# Jail fail2ban ElectriCore (ADR-0031) — généré par deploy/lib/harden.sh.
+[sshd]
+enabled  = true
+backend  = systemd
+port     = ssh
+maxretry = 3
+findtime = 10m
+bantime  = 1h
+EOF
+}
+
+# setup_fail2ban
+# Installe fail2ban et active le jail sshd (backend systemd). Idempotent :
+# ensure_packages saute si déjà là, la conf est réécrite, le service redémarré
+# pour recharger le jail. Marginal une fois le mot de passe coupé — sert surtout
+# à réduire le bruit des scanners dans les logs.
+setup_fail2ban() {
+    ensure_packages fail2ban
+    install -d -m 755 "$(dirname "$FAIL2BAN_JAIL")"
+    render_fail2ban_jail > "$FAIL2BAN_JAIL"
+    chmod 0644 "$FAIL2BAN_JAIL"
+    systemctl enable fail2ban >/dev/null 2>&1 || true
+    if systemctl restart fail2ban 2>/dev/null || systemctl start fail2ban 2>/dev/null; then
+        log_ok "fail2ban actif : jail sshd, backend=systemd (${FAIL2BAN_JAIL})"
+    else
+        die "échec du (re)démarrage de fail2ban — vérifier 'systemctl status fail2ban'."
+    fi
+}
+
 # ─── Orchestrateur ──────────────────────────────────────────────────────────
 
 # harden_vps
@@ -169,4 +210,5 @@ harden_vps() {
     seed_admin_key "$user" "$pubkey"
     grant_nopasswd_sudo "$user"
     harden_sshd
+    setup_fail2ban
 }

--- a/deploy/lib/harden.sh
+++ b/deploy/lib/harden.sh
@@ -192,6 +192,52 @@ setup_fail2ban() {
     fi
 }
 
+# ─── Mises à jour automatiques ──────────────────────────────────────────────
+
+# Fichiers apt.conf.d. Override pour les tests.
+UNATTENDED_PERIODIC="${UNATTENDED_PERIODIC:-/etc/apt/apt.conf.d/20auto-upgrades}"
+UNATTENDED_OVERRIDE="${UNATTENDED_OVERRIDE:-/etc/apt/apt.conf.d/52electricore-unattended}"
+# Après le backup de 03:30 (cf. crontab) : un patch kernel/openssl en attente
+# s'applique vraiment, et la stack revient seule (restart: unless-stopped).
+UNATTENDED_REBOOT_TIME="${UNATTENDED_REBOOT_TIME:-04:30}"
+
+# render_unattended_periodic
+# Active la maj des listes de paquets + l'application unattended. Pur, testable.
+render_unattended_periodic() {
+    cat <<'EOF'
+// ElectriCore (ADR-0031) — active les mises à jour de sécurité automatiques.
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+EOF
+}
+
+# render_unattended_override
+# Redémarrage auto après application des correctifs, à l'heure configurée. Pur.
+# Les origines de sécurité sont déjà activées par défaut dans
+# /etc/apt/apt.conf.d/50unattended-upgrades (Debian & Ubuntu) — on ne touche
+# qu'au comportement de reboot pour éviter les patterns d'origine distro-spécifiques.
+render_unattended_override() {
+    cat <<EOF
+// ElectriCore (ADR-0031) — redémarrage auto après mise à jour, après le backup.
+Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot-Time "${UNATTENDED_REBOOT_TIME}";
+EOF
+}
+
+# setup_unattended_upgrades
+# Installe unattended-upgrades, active les maj de sécurité + l'auto-reboot.
+# Idempotent. Risque faible : la stack est `restart: unless-stopped` et Docker
+# démarre au boot → auto-rétablissement en ~1 min après le reboot.
+setup_unattended_upgrades() {
+    ensure_packages unattended-upgrades
+    render_unattended_periodic > "$UNATTENDED_PERIODIC"
+    chmod 0644 "$UNATTENDED_PERIODIC"
+    render_unattended_override > "$UNATTENDED_OVERRIDE"
+    chmod 0644 "$UNATTENDED_OVERRIDE"
+    systemctl enable apt-daily-upgrade.timer >/dev/null 2>&1 || true
+    log_ok "unattended-upgrades : maj sécurité + reboot auto ${UNATTENDED_REBOOT_TIME} (après backup 03:30)"
+}
+
 # ─── Orchestrateur ──────────────────────────────────────────────────────────
 
 # harden_vps
@@ -211,4 +257,5 @@ harden_vps() {
     grant_nopasswd_sudo "$user"
     harden_sshd
     setup_fail2ban
+    setup_unattended_upgrades
 }

--- a/deploy/lib/harden.sh
+++ b/deploy/lib/harden.sh
@@ -241,8 +241,12 @@ setup_unattended_upgrades() {
 # ─── Orchestrateur ──────────────────────────────────────────────────────────
 
 # harden_vps
-# Orchestre le durcissement (ADR-0031). Lit les globals OPT_* posés par cli.sh :
+# Orchestre le durcissement (ADR-0031). Lit les globals OPT_* (cli.sh côté
+# install.sh, parse_harden_args côté deploy/harden.sh) :
 #   OPT_ADMIN_PUBKEY   clé SSH override pour l'admin (sinon copie root)
+#   OPT_NO_SSHD        saute le verrouillage sshd (garde root SSH actif)
+#   OPT_NO_FAIL2BAN    saute fail2ban
+#   OPT_NO_UNATTENDED  saute unattended-upgrades
 #
 # Ordre impératif (ADR-0031) : on amorce d'abord l'admin (user + sudo + clé),
 # le garde-fou anti-verrouillage (au seuil de harden_sshd) vérifie que ops a une
@@ -255,7 +259,20 @@ harden_vps() {
     ensure_admin_user "$user"
     seed_admin_key "$user" "$pubkey"
     grant_nopasswd_sudo "$user"
-    harden_sshd
-    setup_fail2ban
-    setup_unattended_upgrades
+
+    if [[ "${OPT_NO_SSHD:-0}" -eq 1 ]]; then
+        log_skip "verrouillage sshd ignoré (--no-sshd) — SSH root inchangé"
+    else
+        harden_sshd
+    fi
+    if [[ "${OPT_NO_FAIL2BAN:-0}" -eq 1 ]]; then
+        log_skip "fail2ban ignoré (--no-fail2ban)"
+    else
+        setup_fail2ban
+    fi
+    if [[ "${OPT_NO_UNATTENDED:-0}" -eq 1 ]]; then
+        log_skip "unattended-upgrades ignoré (--no-unattended-upgrades)"
+    else
+        setup_unattended_upgrades
+    fi
 }

--- a/deploy/lib/harden.sh
+++ b/deploy/lib/harden.sh
@@ -100,16 +100,67 @@ admin_has_authorized_key() {
     authorized_keys_present "${home}/.ssh/authorized_keys"
 }
 
+# ─── Verrouillage sshd ──────────────────────────────────────────────────────
+
+# Drop-in de durcissement. Le répertoire sshd_config.d/ est inclus par défaut
+# sur Debian 12 / Ubuntu 22.04+ (cf. is_supported_os). Override pour les tests.
+SSHD_HARDEN_DROPIN="${SSHD_HARDEN_DROPIN:-/etc/ssh/sshd_config.d/50-electricore-harden.conf}"
+
+# render_sshd_hardening
+# Émet le contenu du drop-in sshd sur stdout. Pur, sans side-effect — testable.
+render_sshd_hardening() {
+    cat <<'EOF'
+# Durcissement SSH ElectriCore (ADR-0031) — généré par deploy/lib/harden.sh.
+# Ne pas éditer à la main : régénéré à chaque durcissement. Rechargé via
+# `systemctl reload ssh` après validation `sshd -t`.
+PermitRootLogin no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PubkeyAuthentication yes
+X11Forwarding no
+MaxAuthTries 3
+EOF
+}
+
+# harden_sshd
+# Pose le drop-in (root-off, clé uniquement), valide par `sshd -t`, puis
+# `reload` (jamais `restart` — les sessions ouvertes survivent). Précédé du
+# garde-fou anti-verrouillage : refuse de basculer si l'admin n'a pas de clé.
+harden_sshd() {
+    local user="${HARDEN_ADMIN_USER}"
+    # ── Garde-fou anti-verrouillage (ordre impératif, ADR-0031) ──
+    if ! admin_has_authorized_key "$user"; then
+        die "garde-fou anti-verrouillage : $user n'a pas de clé SSH exploitable." \
+            "Refus de couper le SSH root. Fournir --admin-pubkey puis relancer."
+    fi
+    install -d -m 755 "$(dirname "$SSHD_HARDEN_DROPIN")"
+    render_sshd_hardening > "$SSHD_HARDEN_DROPIN"
+    chmod 0644 "$SSHD_HARDEN_DROPIN"
+    # Valider AVANT de recharger : une conf cassée empêcherait sshd de démarrer.
+    if ! sshd -t 2>/dev/null; then
+        rm -f "$SSHD_HARDEN_DROPIN"
+        die "sshd -t a rejeté le durcissement — drop-in retiré, sshd inchangé."
+    fi
+    # reload, jamais restart : ne tue pas les sessions en cours (dont la session
+    # root d'installation). Les nouveaux logins root/mot-de-passe échouent.
+    if systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null; then
+        :
+    else
+        die "échec du reload sshd — vérifier 'systemctl status ssh'."
+    fi
+    log_ok "sshd durci : root-off, clé uniquement, MaxAuthTries 3 (${SSHD_HARDEN_DROPIN})"
+}
+
 # ─── Orchestrateur ──────────────────────────────────────────────────────────
 
 # harden_vps
 # Orchestre le durcissement (ADR-0031). Lit les globals OPT_* posés par cli.sh :
 #   OPT_ADMIN_PUBKEY   clé SSH override pour l'admin (sinon copie root)
 #
-# Cette tranche ne pose que la partie SÛRE : utilisateur admin + sudo + clé.
-# Aucune modification sshd ici → le SSH root reste actif, aucun verrouillage
-# possible. Le verrouillage sshd, fail2ban et unattended-upgrades arrivent dans
-# les tranches suivantes.
+# Ordre impératif (ADR-0031) : on amorce d'abord l'admin (user + sudo + clé),
+# le garde-fou anti-verrouillage (au seuil de harden_sshd) vérifie que ops a une
+# clé exploitable, et SEULEMENT ensuite on coupe le SSH root. La session root en
+# cours survit au `reload` ; la prochaine connexion se fait en ops.
 harden_vps() {
     local user="${HARDEN_ADMIN_USER}"
     local pubkey="${OPT_ADMIN_PUBKEY:-}"
@@ -117,4 +168,5 @@ harden_vps() {
     ensure_admin_user "$user"
     seed_admin_key "$user" "$pubkey"
     grant_nopasswd_sudo "$user"
+    harden_sshd
 }

--- a/deploy/tests/e2e/assert_harden.sh
+++ b/deploy/tests/e2e/assert_harden.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Assertions e2e du durcissement VPS (ADR-0031). Conçu pour tourner DANS la VM
+# (ou sur un vrai VPS), en root, après un `install.sh` sans --no-harden.
+#
+# Le harnais multipass l'invoque via `multipass exec` (pas SSH), donc couper le
+# SSH root ne casse pas ce script :
+#   ./deploy/tests/e2e/multipass.sh verify
+#
+# Sur un vrai VPS :
+#   sudo bash /srv/<slug>/deploy/tests/e2e/assert_harden.sh
+#
+# Exit 0 si toutes les assertions passent, 1 sinon.
+set -u
+
+ADMIN_USER="${HARDEN_ADMIN_USER:-ops}"
+PASS=0; FAIL=0
+ok() { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+ko() { printf '  \033[31m✗\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+check() { if eval "$2" >/dev/null 2>&1; then ok "$1"; else ko "$1"; fi; }
+
+[[ $EUID -eq 0 ]] || { echo "à lancer en root (sudo bash $0)" >&2; exit 2; }
+
+echo "→ Durcissement #258 : utilisateur admin ${ADMIN_USER}"
+check "user ${ADMIN_USER} existe"                "id ${ADMIN_USER}"
+check "${ADMIN_USER} a une clé authorized_keys"  "test -s \"\$(getent passwd ${ADMIN_USER} | cut -d: -f6)/.ssh/authorized_keys\""
+check "/etc/sudoers.d/${ADMIN_USER} présent"     "test -f /etc/sudoers.d/${ADMIN_USER}"
+check "règle sudoers valide (visudo -c)"         "visudo -cf /etc/sudoers.d/${ADMIN_USER}"
+check "sudo NOPASSWD effectif pour ${ADMIN_USER}" "sudo -u ${ADMIN_USER} sudo -n true"
+check "${ADMIN_USER} n'est PAS dans le groupe docker (rôle admin ≠ service)" \
+      "! id -nG ${ADMIN_USER} | tr ' ' '\\n' | grep -qx docker"
+
+echo
+if [[ "$FAIL" -eq 0 ]]; then
+    printf "\033[32m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
+    exit 0
+else
+    printf "\033[31m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
+    exit 1
+fi

--- a/deploy/tests/e2e/assert_harden.sh
+++ b/deploy/tests/e2e/assert_harden.sh
@@ -30,6 +30,18 @@ check "${ADMIN_USER} n'est PAS dans le groupe docker (rôle admin ≠ service)" 
       "! id -nG ${ADMIN_USER} | tr ' ' '\\n' | grep -qx docker"
 
 echo
+echo "→ Durcissement #259 : verrouillage sshd (config effective via sshd -T)"
+check "drop-in présent"                          "test -f /etc/ssh/sshd_config.d/50-electricore-harden.conf"
+check "sshd -t valide la config"                 "sshd -t"
+check "PermitRootLogin no (effectif)"            "sshd -T | grep -qix 'permitrootlogin no'"
+check "PasswordAuthentication no (effectif)"     "sshd -T | grep -qix 'passwordauthentication no'"
+check "KbdInteractiveAuthentication no (effectif)" "sshd -T | grep -qix 'kbdinteractiveauthentication no'"
+check "PubkeyAuthentication yes (effectif)"       "sshd -T | grep -qix 'pubkeyauthentication yes'"
+check "X11Forwarding no (effectif)"               "sshd -T | grep -qix 'x11forwarding no'"
+check "MaxAuthTries 3 (effectif)"                 "sshd -T | grep -qix 'maxauthtries 3'"
+check "service ssh actif (reload, pas restart)"   "systemctl is-active ssh || systemctl is-active sshd"
+
+echo
 if [[ "$FAIL" -eq 0 ]]; then
     printf "\033[32m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
     exit 0

--- a/deploy/tests/e2e/assert_harden.sh
+++ b/deploy/tests/e2e/assert_harden.sh
@@ -50,6 +50,15 @@ check "backend=systemd dans la conf"             "grep -q 'backend  = systemd' /
 check "jail sshd présent (fail2ban-client)"      "fail2ban-client status sshd"
 
 echo
+echo "→ Durcissement #261 : unattended-upgrades + auto-reboot 04:30"
+check "paquet unattended-upgrades installé"      "dpkg -s unattended-upgrades"
+check "20auto-upgrades active l'unattended"      "grep -q 'APT::Periodic::Unattended-Upgrade \"1\"' /etc/apt/apt.conf.d/20auto-upgrades"
+check "origine sécurité activée (50unattended)"  "grep -iE '^[[:space:]]*[^/[:space:]].*security' /etc/apt/apt.conf.d/50unattended-upgrades"
+check "Automatic-Reboot true"                    "grep -q 'Automatic-Reboot \"true\"' /etc/apt/apt.conf.d/52electricore-unattended"
+check "Automatic-Reboot-Time 04:30"              "grep -q 'Automatic-Reboot-Time \"04:30\"' /etc/apt/apt.conf.d/52electricore-unattended"
+check "timer apt-daily-upgrade activé"           "systemctl is-enabled apt-daily-upgrade.timer"
+
+echo
 if [[ "$FAIL" -eq 0 ]]; then
     printf "\033[32m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
     exit 0

--- a/deploy/tests/e2e/assert_harden.sh
+++ b/deploy/tests/e2e/assert_harden.sh
@@ -42,6 +42,14 @@ check "MaxAuthTries 3 (effectif)"                 "sshd -T | grep -qix 'maxautht
 check "service ssh actif (reload, pas restart)"   "systemctl is-active ssh || systemctl is-active sshd"
 
 echo
+echo "→ Durcissement #260 : fail2ban (jail sshd, backend systemd)"
+check "fail2ban installé"                        "command -v fail2ban-client"
+check "service fail2ban actif"                   "systemctl is-active fail2ban"
+check "conf jail présente"                       "test -f /etc/fail2ban/jail.d/electricore.conf"
+check "backend=systemd dans la conf"             "grep -q 'backend  = systemd' /etc/fail2ban/jail.d/electricore.conf"
+check "jail sshd présent (fail2ban-client)"      "fail2ban-client status sshd"
+
+echo
 if [[ "$FAIL" -eq 0 ]]; then
     printf "\033[32m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
     exit 0

--- a/deploy/tests/e2e/multipass.sh
+++ b/deploy/tests/e2e/multipass.sh
@@ -17,6 +17,8 @@ Commands:
   down              Supprime la VM (delete + purge).
   run [args...]     Exécute install.sh dans la VM.
                     Défaut: --slug test --domain test.local --skip-dns
+  harden [args...]  Exécute le wrapper autonome deploy/harden.sh dans la VM
+                    (rétro-durcissement, ADR-0031 #262).
   verify            Lance les assertions de durcissement (ADR-0031) dans la VM,
                     via `multipass exec` (pas SSH — survit au root-off).
   shell             Ouvre un shell interactif dans la VM.
@@ -64,6 +66,7 @@ cmd_run() {
     multipass exec "$VM_NAME" -- sudo bash /repo/deploy/install.sh "${args[@]}"
 }
 
+cmd_harden()  { multipass exec "$VM_NAME" -- sudo bash /repo/deploy/harden.sh "$@"; }
 cmd_verify()  { multipass exec "$VM_NAME" -- sudo bash /repo/deploy/tests/e2e/assert_harden.sh "$@"; }
 cmd_shell()   { multipass shell "$VM_NAME"; }
 cmd_snap()    { multipass snapshot "$VM_NAME" --name "${1:?nom de snapshot requis}"; }
@@ -73,6 +76,6 @@ cmd_status()  { multipass info "$VM_NAME" 2>/dev/null || echo "VM ${VM_NAME} n'e
 require_multipass
 CMD="${1:-}"; shift || true
 case "$CMD" in
-    up|down|run|verify|shell|snap|restore|status) "cmd_$CMD" "$@" ;;
+    up|down|run|harden|verify|shell|snap|restore|status) "cmd_$CMD" "$@" ;;
     *) usage; exit 1 ;;
 esac

--- a/deploy/tests/e2e/multipass.sh
+++ b/deploy/tests/e2e/multipass.sh
@@ -17,6 +17,8 @@ Commands:
   down              Supprime la VM (delete + purge).
   run [args...]     Exécute install.sh dans la VM.
                     Défaut: --slug test --domain test.local --skip-dns
+  verify            Lance les assertions de durcissement (ADR-0031) dans la VM,
+                    via `multipass exec` (pas SSH — survit au root-off).
   shell             Ouvre un shell interactif dans la VM.
   snap <name>       Crée un snapshot.
   restore <name>    Restaure un snapshot (rapide pour itérer).
@@ -62,6 +64,7 @@ cmd_run() {
     multipass exec "$VM_NAME" -- sudo bash /repo/deploy/install.sh "${args[@]}"
 }
 
+cmd_verify()  { multipass exec "$VM_NAME" -- sudo bash /repo/deploy/tests/e2e/assert_harden.sh "$@"; }
 cmd_shell()   { multipass shell "$VM_NAME"; }
 cmd_snap()    { multipass snapshot "$VM_NAME" --name "${1:?nom de snapshot requis}"; }
 cmd_restore() { multipass restore "${VM_NAME}.${1:?nom de snapshot requis}"; }
@@ -70,6 +73,6 @@ cmd_status()  { multipass info "$VM_NAME" 2>/dev/null || echo "VM ${VM_NAME} n'e
 require_multipass
 CMD="${1:-}"; shift || true
 case "$CMD" in
-    up|down|run|shell|snap|restore|status) "cmd_$CMD" "$@" ;;
+    up|down|run|verify|shell|snap|restore|status) "cmd_$CMD" "$@" ;;
     *) usage; exit 1 ;;
 esac

--- a/deploy/tests/fixtures/fake_lib/harden.sh
+++ b/deploy/tests/fixtures/fake_lib/harden.sh
@@ -1,0 +1,1 @@
+# stub harden

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -24,6 +24,12 @@ source "${LIB_DIR}/harden.sh"
 # shellcheck source=../install.sh
 source "${SCRIPT_DIR}/../install.sh"
 
+# `harden.sh` (wrapper autonome) est protégé par un guard `main_harden` ; le
+# sourcer expose `parse_harden_args` sans rien exécuter. NB : sourcer install.sh
+# ci-dessus a écrasé SCRIPT_DIR (→ deploy/) ; on passe par LIB_DIR, stable.
+# shellcheck source=../harden.sh
+source "${LIB_DIR}/../harden.sh"
+
 PASS=0; FAIL=0
 ok() { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
 ko() { printf '  \033[31m✗\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
@@ -147,6 +153,25 @@ assert_fail "parse_args flag inconnu"     parse_args --slug edn --domain edn.fr 
 ( parse_args --slug edn --domain edn.fr --admin-pubkey "ssh-ed25519 AAAA ops" >/dev/null 2>&1
   [[ "$OPT_ADMIN_PUBKEY" == "ssh-ed25519 AAAA ops" ]]
 ) && ok "parse_args: --admin-pubkey capturé" || ko "parse_args --admin-pubkey"
+
+# Toggles granulaires (cohérents avec harden.sh, #262)
+( parse_args --slug edn --domain edn.fr --no-fail2ban --no-unattended-upgrades --no-sshd >/dev/null 2>&1
+  [[ "$OPT_NO_SSHD" == "1" && "$OPT_NO_FAIL2BAN" == "1" && "$OPT_NO_UNATTENDED" == "1" ]]
+) && ok "parse_args: toggles granulaires --no-sshd/--no-fail2ban/--no-unattended-upgrades" || ko "parse_args toggles granulaires"
+
+echo
+echo "→ harden.sh (wrapper autonome) / parse_harden_args"
+( parse_harden_args >/dev/null 2>&1
+  [[ "$OPT_NO_SSHD" == "0" && "$OPT_NO_FAIL2BAN" == "0" && "$OPT_NO_UNATTENDED" == "0" && -z "$OPT_ADMIN_PUBKEY" ]]
+) && ok "parse_harden_args: défauts (tout durci, pas d'override)" || ko "parse_harden_args défauts"
+
+( parse_harden_args --admin-pubkey "ssh-ed25519 BBBB ops" --no-fail2ban >/dev/null 2>&1
+  [[ "$OPT_ADMIN_PUBKEY" == "ssh-ed25519 BBBB ops" && "$OPT_NO_FAIL2BAN" == "1" && "$OPT_NO_SSHD" == "0" ]]
+) && ok "parse_harden_args: --admin-pubkey + --no-fail2ban" || ko "parse_harden_args options"
+
+( parse_harden_args --no-sshd --no-unattended-upgrades >/dev/null 2>&1
+  [[ "$OPT_NO_SSHD" == "1" && "$OPT_NO_UNATTENDED" == "1" ]]
+) && ok "parse_harden_args: --no-sshd + --no-unattended-upgrades" || ko "parse_harden_args no-sshd/no-unattended"
 
 echo
 echo "→ install.sh / fetch_lib_files"

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -89,6 +89,17 @@ rm -f "$tmp_ak"
 assert_fail "fichier absent → 1"               authorized_keys_present "/nonexistent-ak-$$"
 
 echo
+echo "→ harden.sh / render_sshd_hardening (drop-in sshd)"
+sshd_conf="$(render_sshd_hardening)"
+grep -qx "PermitRootLogin no"              <<<"$sshd_conf" && ok "drop-in: PermitRootLogin no" || ko "drop-in PermitRootLogin"
+grep -qx "PasswordAuthentication no"       <<<"$sshd_conf" && ok "drop-in: PasswordAuthentication no" || ko "drop-in PasswordAuthentication"
+grep -qx "KbdInteractiveAuthentication no" <<<"$sshd_conf" && ok "drop-in: KbdInteractiveAuthentication no" || ko "drop-in KbdInteractive"
+grep -qx "PubkeyAuthentication yes"        <<<"$sshd_conf" && ok "drop-in: PubkeyAuthentication yes (clé conservée)" || ko "drop-in Pubkey"
+grep -qx "X11Forwarding no"                <<<"$sshd_conf" && ok "drop-in: X11Forwarding no" || ko "drop-in X11Forwarding"
+grep -qx "MaxAuthTries 3"                  <<<"$sshd_conf" && ok "drop-in: MaxAuthTries 3" || ko "drop-in MaxAuthTries"
+! grep -qi "AllowUsers" <<<"$sshd_conf"    && ok "drop-in: pas d'AllowUsers (piège évité, ADR-0031)" || ko "drop-in AllowUsers présent"
+
+echo
 echo "→ cli.sh / parse_args"
 ( parse_args --slug edn --domain edn.fr >/dev/null 2>&1
   [[ "$OPT_SLUG" == "edn" && "$OPT_DOMAIN" == "edn.fr" && "$OPT_VERSION" == "latest" ]]

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -16,6 +16,8 @@ source "${LIB_DIR}/cli.sh"
 source "${LIB_DIR}/config.sh"
 # shellcheck source=../lib/env_validate.sh
 source "${LIB_DIR}/env_validate.sh"
+# shellcheck source=../lib/harden.sh
+source "${LIB_DIR}/harden.sh"
 
 # `install.sh` est protégé par un guard `main` ; le sourcer expose
 # `fetch_lib_files` sans déclencher l'exécution du script.
@@ -75,6 +77,18 @@ assert_fail "is_supported_os Alpine"         bash -c "export OS_RELEASE_PATH='${
 assert_fail "is_supported_os Ubuntu 20.04"   bash -c "export OS_RELEASE_PATH='${FIXTURES_DIR}/os-release-ubuntu-20.04'; source '${LIB_DIR}/os.sh'; is_supported_os"
 
 echo
+echo "→ harden.sh / authorized_keys_present (garde-fou anti-verrouillage)"
+tmp_ak=$(mktemp)
+printf 'ssh-ed25519 AAAAC3Nz... ops@host\n' > "$tmp_ak"
+assert_ok   "clé présente → 0"                 authorized_keys_present "$tmp_ak"
+: > "$tmp_ak"
+assert_fail "fichier vide → 1"                 authorized_keys_present "$tmp_ak"
+printf '# que des commentaires\n\n   \n' > "$tmp_ak"
+assert_fail "commentaires/blancs seuls → 1"    authorized_keys_present "$tmp_ak"
+rm -f "$tmp_ak"
+assert_fail "fichier absent → 1"               authorized_keys_present "/nonexistent-ak-$$"
+
+echo
 echo "→ cli.sh / parse_args"
 ( parse_args --slug edn --domain edn.fr >/dev/null 2>&1
   [[ "$OPT_SLUG" == "edn" && "$OPT_DOMAIN" == "edn.fr" && "$OPT_VERSION" == "latest" ]]
@@ -88,12 +102,25 @@ assert_fail "parse_args sans --slug"      parse_args --domain edn.fr
 assert_fail "parse_args sans --domain"    parse_args --slug edn
 assert_fail "parse_args flag inconnu"     parse_args --slug edn --domain edn.fr --foo
 
+# Durcissement (ADR-0031) : --no-harden et --admin-pubkey
+( parse_args --slug edn --domain edn.fr >/dev/null 2>&1
+  [[ "$OPT_NO_HARDEN" == "0" && -z "$OPT_ADMIN_PUBKEY" ]]
+) && ok "parse_args: durcissement actif par défaut (OPT_NO_HARDEN=0)" || ko "parse_args durcissement par défaut"
+
+( parse_args --slug edn --domain edn.fr --no-harden >/dev/null 2>&1
+  [[ "$OPT_NO_HARDEN" == "1" ]]
+) && ok "parse_args: --no-harden → OPT_NO_HARDEN=1" || ko "parse_args --no-harden"
+
+( parse_args --slug edn --domain edn.fr --admin-pubkey "ssh-ed25519 AAAA ops" >/dev/null 2>&1
+  [[ "$OPT_ADMIN_PUBKEY" == "ssh-ed25519 AAAA ops" ]]
+) && ok "parse_args: --admin-pubkey capturé" || ko "parse_args --admin-pubkey"
+
 echo
 echo "→ install.sh / fetch_lib_files"
 tmp_target=$(mktemp -d)
 fetch_lib_files "file://${FIXTURES_DIR}/fake_lib" "$tmp_target"
-[[ -f "${tmp_target}/log.sh" && -f "${tmp_target}/cli.sh" && -f "${tmp_target}/config.sh" ]] \
-    && ok "fetch_lib_files: les 11 helpers sont téléchargés au 1er appel" \
+[[ -f "${tmp_target}/log.sh" && -f "${tmp_target}/cli.sh" && -f "${tmp_target}/config.sh" && -f "${tmp_target}/harden.sh" ]] \
+    && ok "fetch_lib_files: les 12 helpers sont téléchargés au 1er appel" \
     || ko "fetch_lib_files: helpers manquants après 1er appel"
 # 2e appel idempotent (les fichiers existent déjà, doit re-télécharger sans erreur)
 fetch_lib_files "file://${FIXTURES_DIR}/fake_lib" "$tmp_target"

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -110,6 +110,18 @@ grep -qE "^findtime = "       <<<"$jail_conf" && ok "jail: findtime défini" || 
 grep -qE "^bantime  = "       <<<"$jail_conf" && ok "jail: bantime défini" || ko "jail bantime"
 
 echo
+echo "→ harden.sh / unattended-upgrades (maj auto + reboot 04:30)"
+periodic_conf="$(render_unattended_periodic)"
+grep -qx 'APT::Periodic::Update-Package-Lists "1";' <<<"$periodic_conf" && ok "periodic: maj des listes activée" || ko "periodic update-lists"
+grep -qx 'APT::Periodic::Unattended-Upgrade "1";'   <<<"$periodic_conf" && ok "periodic: unattended-upgrade activé" || ko "periodic unattended"
+override_conf="$(render_unattended_override)"
+grep -qx 'Unattended-Upgrade::Automatic-Reboot "true";'          <<<"$override_conf" && ok "override: Automatic-Reboot true" || ko "override reboot true"
+grep -qx 'Unattended-Upgrade::Automatic-Reboot-Time "04:30";'    <<<"$override_conf" && ok "override: reboot 04:30 (après backup 03:30)" || ko "override reboot time"
+# Heure paramétrable
+override_05="$(UNATTENDED_REBOOT_TIME=05:15 render_unattended_override)"
+grep -q '"05:15"' <<<"$override_05" && ok "override: heure de reboot paramétrable" || ko "override heure non paramétrable"
+
+echo
 echo "→ cli.sh / parse_args"
 ( parse_args --slug edn --domain edn.fr >/dev/null 2>&1
   [[ "$OPT_SLUG" == "edn" && "$OPT_DOMAIN" == "edn.fr" && "$OPT_VERSION" == "latest" ]]

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -100,6 +100,16 @@ grep -qx "MaxAuthTries 3"                  <<<"$sshd_conf" && ok "drop-in: MaxAu
 ! grep -qi "AllowUsers" <<<"$sshd_conf"    && ok "drop-in: pas d'AllowUsers (piège évité, ADR-0031)" || ko "drop-in AllowUsers présent"
 
 echo
+echo "→ harden.sh / render_fail2ban_jail (jail sshd)"
+jail_conf="$(render_fail2ban_jail)"
+grep -qx "\[sshd\]"            <<<"$jail_conf" && ok "jail: section [sshd]" || ko "jail [sshd]"
+grep -qx "enabled  = true"    <<<"$jail_conf" && ok "jail: enabled = true" || ko "jail enabled"
+grep -qx "backend  = systemd" <<<"$jail_conf" && ok "jail: backend = systemd (piège Debian/Ubuntu moderne)" || ko "jail backend systemd"
+grep -qx "maxretry = 3"       <<<"$jail_conf" && ok "jail: maxretry = 3" || ko "jail maxretry"
+grep -qE "^findtime = "       <<<"$jail_conf" && ok "jail: findtime défini" || ko "jail findtime"
+grep -qE "^bantime  = "       <<<"$jail_conf" && ok "jail: bantime défini" || ko "jail bantime"
+
+echo
 echo "→ cli.sh / parse_args"
 ( parse_args --slug edn --domain edn.fr >/dev/null 2>&1
   [[ "$OPT_SLUG" == "edn" && "$OPT_DOMAIN" == "edn.fr" && "$OPT_VERSION" == "latest" ]]

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -334,6 +334,21 @@ La clé de `ops` est amorcée depuis `~root/.ssh/authorized_keys` (override
 > `User root` → `User ops`. Ne le fais pas avant — `ops` n'existe pas tant que
 > l'install n'a pas tourné.
 
+### fail2ban (force brute SSH)
+
+Le durcissement installe `fail2ban` et active le jail `sshd` via
+`/etc/fail2ban/jail.d/electricore.conf`, avec **`backend = systemd`** (journald).
+C'est le piège Debian/Ubuntu moderne : le défaut historique lit
+`/var/log/auth.log`, vide sur ces images — il faut lire le journal systemd.
+Paramètres : `maxretry = 3`, `findtime = 10m`, `bantime = 1h`.
+
+```bash
+sudo fail2ban-client status sshd   # IP bannies, compteurs
+```
+
+fail2ban est marginal une fois le mot de passe SSH coupé (plus rien à brute-forcer) ;
+il sert surtout à réduire le bruit des scanners dans les logs.
+
 ## Accès distant depuis un notebook Python
 
 Depuis la v1.5, l'API expose les résultats des pipelines opérationnels en flux

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -14,15 +14,16 @@ de bout en bout. Ce document décrit son usage, puis ce qu'il fait sous le capot
 3. [Variables `.env`](#variables-env)
 4. [Provisionner une nouvelle instance](#provisionner-une-nouvelle-instance)
 5. [Reconfigurer une instance existante](#reconfigurer-une-instance-existante)
-6. [Accès distant depuis un notebook Python](#accès-distant-depuis-un-notebook-python)
-7. [Mode SFTP distant vs fichiers collocés](#mode-sftp-distant-vs-fichiers-collocés)
-8. [Rotation des clés AES](#rotation-des-clés-aes)
-9. [Sauvegarde et restauration](#sauvegarde-et-restauration)
-10. [Mise à jour de version](#mise-à-jour-de-version)
-11. [Fenêtre d'ingestion et concurrence DuckDB](#fenêtre-dingestion-et-concurrence-duckdb)
-12. [Migration depuis l'ancien layout `/opt/electricore/`](#migration-depuis-lancien-layout-optelectricore)
-13. [Annexe : déploiement manuel pas-à-pas](#annexe--déploiement-manuel-pas-à-pas)
-14. [Dépannage](#dépannage)
+6. [Durcissement du VPS](#durcissement-du-vps)
+7. [Accès distant depuis un notebook Python](#accès-distant-depuis-un-notebook-python)
+8. [Mode SFTP distant vs fichiers collocés](#mode-sftp-distant-vs-fichiers-collocés)
+9. [Rotation des clés AES](#rotation-des-clés-aes)
+10. [Sauvegarde et restauration](#sauvegarde-et-restauration)
+11. [Mise à jour de version](#mise-à-jour-de-version)
+12. [Fenêtre d'ingestion et concurrence DuckDB](#fenêtre-dingestion-et-concurrence-duckdb)
+13. [Migration depuis l'ancien layout `/opt/electricore/`](#migration-depuis-lancien-layout-optelectricore)
+14. [Annexe : déploiement manuel pas-à-pas](#annexe--déploiement-manuel-pas-à-pas)
+15. [Dépannage](#dépannage)
 
 ---
 
@@ -68,8 +69,11 @@ du layout `/srv/<slug>/` + user dédié.
 
 - **VPS Linux** Ubuntu 22.04+/24.04+ ou Debian 12+, 2 vCPU et 4 Go RAM minimum,
   40 Go SSD recommandés.
-- **Accès root SSH** sur le VPS (le script copie `~root/.ssh/authorized_keys`
-  vers le home du user `<slug>` pour permettre `ssh <slug>@<vps>` ensuite).
+- **Accès root SSH** sur le VPS — **uniquement pour la première installation**.
+  Le script copie `~root/.ssh/authorized_keys` vers les users `ops` (admin) et
+  `<slug>` (service), puis **désactive le SSH root** (durcissement par défaut,
+  ADR-0031). Les opérations suivantes passent par `ssh ops@<vps>` — voir
+  [Durcissement du VPS](#durcissement-du-vps).
 - **Un nom de domaine** avec un A-record pointant vers l'IP publique du VPS.
 - **Ports 80 et 443** ouverts dans le pare-feu cloud (ACME HTTP-01 + HTTPS).
 - **Les clés AES Enedis** (clé + IV en hexadécimal) — fournies par Enedis au
@@ -195,17 +199,20 @@ publique doit donc déjà se trouver dans `~root/.ssh/authorized_keys` du VPS.
    ```
    Host electricore-<slug>
        HostName <slug>.electricore.fr   # ou l'IP publique du VPS
-       User <slug>                       # root avant l'install, <slug> après
+       User ops                          # root pour la 1ʳᵉ install ; ops (admin) après durcissement
        IdentityFile ~/.ssh/id_ed25519
        IdentitiesOnly yes
    ```
 
-   Ensuite : `ssh electricore-<slug>` suffit.
+   Ensuite : `ssh electricore-<slug>` suffit. (`User <slug>` pour un login sur le
+   compte de service plutôt que l'admin.)
 
-> Le script propage ensuite `~root/.ssh/authorized_keys` vers le user `<slug>`,
-> ce qui permet `ssh <slug>@<vps>` après l'installation. Pour donner au user
-> `<slug>` une clé dédiée plutôt qu'hériter de celles de root, passer l'option
-> `--ssh-pubkey "ssh-ed25519 ..."` au script (cf. [Lancer le script](#5-lancer-le-script)).
+> Le script propage `~root/.ssh/authorized_keys` vers `ops` (admin) **et** vers
+> `<slug>` (service), ce qui permet `ssh ops@<vps>` et `ssh <slug>@<vps>` après
+> l'installation. Pour donner à `<slug>` ou à `ops` une clé dédiée plutôt
+> qu'hériter de celles de root, passer `--ssh-pubkey "ssh-ed25519 ..."` (service)
+> ou `--admin-pubkey "ssh-ed25519 ..."` (admin) au script
+> (cf. [Lancer le script](#5-lancer-le-script)).
 
 ### 5. Lancer le script
 
@@ -268,9 +275,14 @@ l'instance, backup `.env` vers `.env.bak.<timestamp>`, ouvre `$EDITOR`, valide,
 restart la stack. **Jamais touche à la DB ni aux backups.**
 
 ```bash
-ssh root@<vps>
+# VPS durci (ADR-0031) : login admin via ops — le SSH root est désactivé
+ssh ops@<vps>
 sudo bash /srv/<slug>/deploy/install.sh --slug <slug> --domain <slug>.electricore.fr
 ```
+
+> Sur un VPS pas encore durci (ancienne instance, ou install lancée avec
+> `--no-harden`), c'est encore `ssh root@<vps>`. Le durcissement est idempotent :
+> le reconfigure le (re)pose au passage.
 
 Couvre les cas :
 
@@ -284,6 +296,43 @@ Couvre les cas :
 > le piège stale-lib où un `install.sh` à jour sourçait un `lib/` figé sur une
 > version antérieure (cas reproduit lors de la migration rc2 → rc3). Override
 > possible via `INSTALL_BASE_URL` pour pinner sur un tag spécifique en dev.
+
+## Durcissement du VPS
+
+Depuis [ADR-0031](adr/0031-durcissement-ssh-vps-utilisateur-ops.md), `install.sh`
+durcit le VPS **par défaut** (étape 6, juste après la création du user de service).
+Trois rôles distincts par construction :
+
+| Rôle | Compte | Accès | Usage |
+|---|---|---|---|
+| **admin** | `ops` | SSH par clé, **sudo NOPASSWD** | login humain, lance `install.sh` (install + reconfigure) |
+| **service** | `<slug>` | SSH par clé, groupe `docker`, **pas de sudo** | possède `/srv/<slug>/`, fait tourner la stack (ADR-0017) |
+| ~~root~~ | `root` | **SSH désactivé**, local + sudo depuis `ops` | — |
+
+Pour sauter entièrement le durcissement : `--no-harden`. Pour rétro-durcir un VPS
+déjà déployé sans reconfigure complet, voir le script autonome
+[`deploy/harden.sh`](#rétro-durcir-un-vps-existant).
+
+### SSH (root-off, clé uniquement)
+
+Le durcissement pose un drop-in `/etc/ssh/sshd_config.d/50-electricore-harden.conf` :
+
+- `PermitRootLogin no` — plus de login root en SSH.
+- `PasswordAuthentication no` + `KbdInteractiveAuthentication no` — clé uniquement.
+- `PubkeyAuthentication yes`, `X11Forwarding no`, `MaxAuthTries 3`.
+
+La config est validée par `sshd -t` **avant** un `systemctl reload ssh` (jamais
+`restart`) : la session root en cours **survit**, seuls les nouveaux logins
+root/mot-de-passe échouent. La connexion suivante se fait en `ops`.
+
+**Garde-fou anti-verrouillage** : la bascule root-off est refusée tant que `ops`
+n'a pas de `authorized_keys` exploitable — impossible de se verrouiller dehors.
+La clé de `ops` est amorcée depuis `~root/.ssh/authorized_keys` (override
+`--admin-pubkey "ssh-ed25519 …"`).
+
+> ⚠️ Après le premier durcissement, mets à jour ton `~/.ssh/config` :
+> `User root` → `User ops`. Ne le fais pas avant — `ops` n'existe pas tant que
+> l'install n'a pas tourné.
 
 ## Accès distant depuis un notebook Python
 

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -349,6 +349,24 @@ sudo fail2ban-client status sshd   # IP bannies, compteurs
 fail2ban est marginal une fois le mot de passe SSH coupé (plus rien à brute-forcer) ;
 il sert surtout à réduire le bruit des scanners dans les logs.
 
+### Mises à jour automatiques (unattended-upgrades)
+
+Le durcissement installe `unattended-upgrades` et active les **correctifs de
+sécurité** automatiques (`/etc/apt/apt.conf.d/20auto-upgrades`), avec un
+**redémarrage automatique à 04:30** Europe/Paris
+(`/etc/apt/apt.conf.d/52electricore-unattended`,
+`Automatic-Reboot "true"` + `Automatic-Reboot-Time "04:30"`).
+
+Pourquoi 04:30 et pourquoi rebooter :
+
+- **Après le backup de 03:30** (cf. [Sauvegarde](#sauvegarde-et-restauration)) :
+  on ne reboote jamais au milieu d'un snapshot.
+- **Sans reboot, les patchs kernel/openssl restent dormants.** Le redémarrage
+  nocturne les applique réellement.
+- **Risque faible** : la stack est `restart: unless-stopped` et Docker démarre au
+  boot — elle revient seule en ~1 min. Micro-coupure non planifiée seulement les
+  nuits où un reboot est en attente (VPS sans HA, ADR-0011).
+
 ## Accès distant depuis un notebook Python
 
 Depuis la v1.5, l'API expose les résultats des pipelines opérationnels en flux

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -367,6 +367,28 @@ Pourquoi 04:30 et pourquoi rebooter :
   boot — elle revient seule en ~1 min. Micro-coupure non planifiée seulement les
   nuits où un reboot est en attente (VPS sans HA, ADR-0011).
 
+### Rétro-durcir un VPS existant
+
+Pour durcir une instance **déjà déployée** sans relancer un reconfigure complet,
+le script autonome [`deploy/harden.sh`](../deploy/harden.sh) source la même
+logique (`harden_vps`) et l'applique seule. **Aucune hypothèse de layout** : la
+clé de `ops` est amorcée depuis `~root/.ssh/authorized_keys` quel que soit
+l'emplacement de la stack (`/srv/<slug>/` comme l'ancien `/opt/electricore/`).
+
+```bash
+# Instance au layout courant (arbre deploy/ présent) :
+ssh root@<vps>          # ou ssh ops@<vps> si déjà partiellement durci
+sudo bash /srv/<slug>/deploy/harden.sh
+
+# Ancien layout /opt/electricore/ (root-run), ou box sans notre arbre deploy/ :
+curl -fsSL https://raw.githubusercontent.com/Energie-De-Nantes/electricore/main/deploy/harden.sh -o harden.sh
+sudo bash harden.sh
+```
+
+Le même **garde-fou anti-verrouillage** s'applique (refus de couper root SSH si
+`ops` n'a pas de clé). Options : `--admin-pubkey "ssh-ed25519 …"`, et les `--no-*`
+(`--no-sshd`, `--no-fail2ban`, `--no-unattended-upgrades`) pour durcir par morceaux.
+
 ## Accès distant depuis un notebook Python
 
 Depuis la v1.5, l'API expose les résultats des pipelines opérationnels en flux
@@ -665,6 +687,11 @@ supprimer `/opt/electricore/` :
 ```bash
 rm -rf /opt/electricore
 ```
+
+> La migration ci-dessus ne durcit pas le VPS. Pour appliquer le durcissement
+> SSH (ADR-0031) sur la box migrée — ou directement sur l'ancien layout avant
+> migration — lancer le script autonome
+> [`deploy/harden.sh`](#rétro-durcir-un-vps-existant).
 
 ## Annexe : déploiement manuel pas-à-pas
 


### PR DESCRIPTION
Implémente le durcissement VPS par défaut décrit dans [ADR-0031](https://github.com/Energie-De-Nantes/electricore/blob/main/docs/adr/0031-durcissement-ssh-vps-utilisateur-ops.md), en 5 tranches (chaîne de dépendances #258 → #259/#260/#261 → #262). Toute la logique vit dans `deploy/lib/harden.sh` (orchestrateur `harden_vps()`), câblée comme **étape active par défaut** dans `install.sh` juste après l'étape user/clé, avec échappatoire `--no-harden`.

## Séparation de rôles (ADR-0031)

| Rôle | Compte | Accès |
|---|---|---|
| **admin** | `ops` | SSH par clé, sudo NOPASSWD |
| **service** | `<slug>` | SSH par clé, groupe docker, pas de sudo (inchangé, ADR-0017) |
| ~~root~~ | `root` | **SSH désactivé**, sudo depuis ops |

## Tranches

- **#258** — user admin `ops` (idempotent) + sudo NOPASSWD (`/etc/sudoers.d/ops`, validé `visudo -cf`) + amorçage de clé depuis `~root/.ssh/authorized_keys` (override `--admin-pubkey`). Aucune modif sshd → zéro risque de verrouillage.
- **#259** — drop-in `/etc/ssh/sshd_config.d/50-electricore-harden.conf` (root-off, clé only, `MaxAuthTries 3`, `X11Forwarding no`, pas d'`AllowUsers`). `sshd -t` **avant** `systemctl reload ssh` (jamais `restart` → sessions ouvertes survivent). **Garde-fou anti-verrouillage** : refuse la bascule si `ops` n'a pas de clé.
- **#260** — fail2ban, jail `sshd` avec `backend=systemd` (le piège journald des Debian/Ubuntu récents).
- **#261** — unattended-upgrades (correctifs sécurité) + `Automatic-Reboot "true"` à **04:30** (après le backup de 03:30 ; la stack `restart: unless-stopped` revient seule).
- **#262** — wrapper autonome `deploy/harden.sh` (rétro-durcissement d'une box existante, y compris l'ancien layout `/opt/electricore/`, sans hypothèse de layout) + toggles granulaires `--no-sshd` / `--no-fail2ban` / `--no-unattended-upgrades`, cohérents entre `install.sh` et `harden.sh`.

## Tests

- **Unitaires** (`deploy/tests/unit.sh`) : 103 assertions vertes — parsing des flags, garde-fou `authorized_keys_present`, génération pure des drop-ins (sshd, jail fail2ban, unattended), `parse_harden_args`.
- **e2e** (`deploy/tests/e2e/`) : nouvelle commande `multipass.sh verify` lançant `assert_harden.sh` (via `multipass exec`, pas SSH → survit au root-off) ; assertions par tranche (ops+sudo, `sshd -T`, `fail2ban-client`, conf unattended). `multipass.sh harden` exerce le wrapper autonome.
- Suite Python complète inchangée (802 passed).

## Docs

`docs/deploiement.md` : Prérequis (root SSH 1ʳᵉ install seulement), flux reconfigure (`ssh root` → `ssh ops`), nouvelle section « Durcissement du VPS » (SSH, fail2ban, mises à jour auto, rétro-durcissement) + renvoi depuis la section migration. `deploy/lib/README.md` mis à jour.

Closes #258
Closes #259
Closes #260
Closes #261
Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)