### PR TITLE
Réversion du durcissement (unharden.sh) + bootstrap helpers en /tmp (ADR-0031)

### DIFF
--- a/deploy/harden.sh
+++ b/deploy/harden.sh
@@ -25,14 +25,26 @@ INSTALL_BASE_URL_DEFAULT="${INSTALL_BASE_URL:-https://raw.githubusercontent.com/
 # Sous-ensemble de lib/ dont harden_vps() a besoin (log + die ; ensure_packages).
 HARDEN_LIB_FILES=(log system harden)
 
-# Bootstrap : si lib/ est absent (run standalone via curl sur une box sans notre
-# arbre deploy/), télécharge les helpers requis depuis main (ou INSTALL_BASE_URL).
-if [[ ! -d "${SCRIPT_DIR}/lib" ]]; then
-    echo "→ Bootstrap : téléchargement des helpers depuis ${INSTALL_BASE_URL_DEFAULT}/lib/…"
+# _lib_complete <dir> : vrai si <dir> contient tous les helpers de HARDEN_LIB_FILES.
+_lib_complete() {
+    local f
+    [[ -d "$1" ]] || return 1
+    for f in "${HARDEN_LIB_FILES[@]}"; do [[ -f "$1/${f}.sh" ]] || return 1; done
+}
+
+# Résolution des helpers : co-localisés si complets (arbre deploy/ présent),
+# sinon copie FRAÎCHE en /tmp (run standalone via curl, OU lib/ figé d'un run
+# antérieur). Jamais de lib/ persistant laissé à pourrir à côté du script.
+HELPERS_DIR="${SCRIPT_DIR}/lib"
+HELPERS_DIR_TEMP=""
+if ! _lib_complete "$HELPERS_DIR"; then
     command -v curl >/dev/null || { echo "curl introuvable, install curl puis relance." >&2; exit 1; }
-    install -d "${SCRIPT_DIR}/lib"
+    HELPERS_DIR_TEMP="$(mktemp -d "${TMPDIR:-/tmp}/electricore-lib.XXXXXX")"
+    HELPERS_DIR="$HELPERS_DIR_TEMP"
+    trap '[[ -n "${HELPERS_DIR_TEMP:-}" ]] && rm -rf "$HELPERS_DIR_TEMP"' EXIT
+    echo "→ Bootstrap : téléchargement des helpers (copie fraîche) dans ${HELPERS_DIR}…"
     for f in "${HARDEN_LIB_FILES[@]}"; do
-        if ! curl -fsSL "${INSTALL_BASE_URL_DEFAULT}/lib/${f}.sh" -o "${SCRIPT_DIR}/lib/${f}.sh"; then
+        if ! curl -fsSL "${INSTALL_BASE_URL_DEFAULT}/lib/${f}.sh" -o "${HELPERS_DIR}/${f}.sh"; then
             echo "✗ Échec téléchargement ${f}.sh depuis ${INSTALL_BASE_URL_DEFAULT}/lib/" >&2
             exit 1
         fi
@@ -41,7 +53,7 @@ fi
 
 for f in "${HARDEN_LIB_FILES[@]}"; do
     # shellcheck source=/dev/null
-    source "${SCRIPT_DIR}/lib/${f}.sh"
+    source "${HELPERS_DIR}/${f}.sh"
 done
 
 usage_harden() {

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -62,15 +62,37 @@ _source_lib() {
     done
 }
 
-# Bootstrap initial : si lib/ est absent (quickstart `curl install.sh | bash`),
-# on télécharge les helpers depuis main (ou INSTALL_BASE_URL si surchargé).
-if [[ ! -d "${SCRIPT_DIR}/lib" ]]; then
-    echo "→ Bootstrap : téléchargement des helpers depuis ${INSTALL_BASE_URL_DEFAULT}/lib/…"
-    fetch_lib_files "${INSTALL_BASE_URL_DEFAULT}/lib" "${SCRIPT_DIR}/lib" || exit 1
-    echo "✓ Helpers téléchargés dans ${SCRIPT_DIR}/lib/"
+# lib_dir_complete <dir> : vrai si <dir> existe ET contient TOUS les helpers
+# attendus (`${LIB_FILES[@]}`). Un lib/ figé sur une version antérieure du script
+# ne contient pas les nouveaux helpers (ex. harden.sh ajouté pour ADR-0031) :
+# `_source_lib` échouerait et le vieux cli.sh rejetterait les nouvelles options
+# (#62, trap stale-lib).
+lib_dir_complete() {
+    local dir="$1" f
+    [[ -d "$dir" ]] || return 1
+    for f in "${LIB_FILES[@]}"; do
+        [[ -f "${dir}/${f}.sh" ]] || return 1
+    done
+}
+
+# Résolution du répertoire des helpers :
+#   - lib/ co-localisé ET complet (checkout repo, /srv/<slug>/deploy/, tests,
+#     run offline/pinné) → on l'utilise tel quel.
+#   - sinon (quickstart `curl install.sh`, OU lib/ figé d'un run antérieur) → on
+#     télécharge une copie FRAÎCHE dans un dossier temporaire, jamais réutilisée
+#     ni laissée à pourrir à côté du script. Élimine le trap stale-lib à la racine
+#     (pas de lib/ persistant dans /root) plutôt que de le rattraper après coup.
+HELPERS_DIR="${SCRIPT_DIR}/lib"
+HELPERS_DIR_TEMP=""
+if ! lib_dir_complete "$HELPERS_DIR"; then
+    HELPERS_DIR_TEMP="$(mktemp -d "${TMPDIR:-/tmp}/electricore-lib.XXXXXX")"
+    HELPERS_DIR="$HELPERS_DIR_TEMP"
+    echo "→ Bootstrap : téléchargement des helpers (copie fraîche) dans ${HELPERS_DIR}…"
+    fetch_lib_files "${INSTALL_BASE_URL_DEFAULT}/lib" "$HELPERS_DIR" || exit 1
+    echo "✓ Helpers téléchargés (temporaire, nettoyé en fin de run)."
 fi
 
-_source_lib "${SCRIPT_DIR}/lib"
+_source_lib "$HELPERS_DIR"
 
 
 main() {
@@ -83,6 +105,8 @@ main() {
     cleanup() {
         local rc=$?
         [[ -f /tmp/get-docker.sh ]] && rm -f /tmp/get-docker.sh
+        # Copie temporaire des helpers (bootstrap /tmp) : on nettoie en sortie.
+        [[ -n "${HELPERS_DIR_TEMP:-}" ]] && rm -rf "$HELPERS_DIR_TEMP"
         if [[ $rc -ne 0 ]] && [[ "${_CLEAN_EXIT:-0}" -ne 1 ]]; then
             echo
             printf '%s\n' "Script interrompu (exit $rc). Aucune modification destructive faite." >&2
@@ -118,14 +142,15 @@ main() {
             "État ambigu — choisir un autre slug ou supprimer ${HOME_DIR} à la main."
     fi
 
-    # En mode reconfigure : refresh inconditionnel des helpers lib/ pour éviter
-    # qu'un lib/ figé sur une version antérieure du script ne court-circuite
-    # les fixes embarqués dans cette nouvelle install.sh (#62).
-    if [[ "$MODE_RECONFIGURE" -eq 1 ]]; then
-        log_info "Mode reconfigure : refresh des helpers lib/ depuis ${INSTALL_BASE_URL_DEFAULT}/lib/…"
-        if fetch_lib_files "${INSTALL_BASE_URL_DEFAULT}/lib" "${SCRIPT_DIR}/lib"; then
-            _source_lib "${SCRIPT_DIR}/lib"
-            log_ok "Helpers lib/ rafraîchis."
+    # En mode reconfigure avec des helpers CO-LOCALISÉS : refresh pour éviter
+    # qu'un lib/ figé sur une version antérieure ne court-circuite les fixes de
+    # cette install.sh (#62). Inutile si le bootstrap a déjà tiré une copie fraîche
+    # en /tmp (HELPERS_DIR_TEMP non vide).
+    if [[ "$MODE_RECONFIGURE" -eq 1 && -z "$HELPERS_DIR_TEMP" ]]; then
+        log_info "Mode reconfigure : refresh des helpers depuis ${INSTALL_BASE_URL_DEFAULT}/lib/…"
+        if fetch_lib_files "${INSTALL_BASE_URL_DEFAULT}/lib" "$HELPERS_DIR"; then
+            _source_lib "$HELPERS_DIR"
+            log_ok "Helpers rafraîchis."
         else
             log_warn "Refresh des helpers échoué — on continue avec la version locale (potentiellement stale)."
         fi

--- a/deploy/lib/README.md
+++ b/deploy/lib/README.md
@@ -5,6 +5,6 @@ durcissement, par le wrapper autonome [`../harden.sh`](../harden.sh)).
 
 - [`validate.sh`](validate.sh) — validateurs purs (slug, AES, URL, email, domaine). Renvoient 0/1, pas de sortie.
 - [`os.sh`](os.sh) — détection OS via `/etc/os-release`, mockable avec `OS_RELEASE_PATH=...` (utilisé par les tests).
-- [`harden.sh`](harden.sh) — durcissement VPS (ADR-0031) : `harden_vps()` orchestre admin `ops` + sudo, verrouillage sshd (root-off, clé only), fail2ban, unattended-upgrades. Fonctions de rendu pures (`render_sshd_hardening`, `render_fail2ban_jail`, …) testables, side-effects idempotents.
+- [`harden.sh`](harden.sh) — durcissement VPS (ADR-0031) : `harden_vps()` orchestre admin `ops` + sudo, verrouillage sshd (root-off, clé only), fail2ban, unattended-upgrades. Réversion `unharden_vps()` (retire le drop-in sshd, la jail, la conf upgrades ; `ops` conservé sauf `--purge-ops`). Fonctions de rendu pures (`render_sshd_hardening`, `render_fail2ban_jail`, …) testables, side-effects idempotents. Wrappers autonomes : [`../harden.sh`](../harden.sh) / [`../unharden.sh`](../unharden.sh).
 
 Tests : [`../tests/unit.sh`](../tests/unit.sh).

--- a/deploy/lib/harden.sh
+++ b/deploy/lib/harden.sh
@@ -276,3 +276,94 @@ harden_vps() {
         setup_unattended_upgrades
     fi
 }
+
+# ─── Réversibilité (désinstallation) ────────────────────────────────────────
+# Inverse de harden_vps : retire ce que le durcissement a posé. Idempotent.
+# Pensé pour un retour arrière sûr — rétablir l'accès root AVANT tout nettoyage.
+
+# unharden_sshd
+# Retire le drop-in de durcissement et recharge sshd → restaure le comportement
+# par défaut de l'image (root SSH ré-autorisé, auth selon le défaut cloud). C'est
+# LA réversion critique : exécutée en premier pour regagner l'accès root.
+unharden_sshd() {
+    if [[ ! -f "$SSHD_HARDEN_DROPIN" ]]; then
+        log_skip "drop-in sshd absent — sshd déjà au défaut, rien à retirer"
+        return 0
+    fi
+    rm -f "$SSHD_HARDEN_DROPIN"
+    if ! sshd -t 2>/dev/null; then
+        die "sshd -t a échoué après retrait du drop-in — vérifier la conf sshd à la main."
+    fi
+    if systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null; then
+        log_ok "drop-in sshd retiré, sshd rechargé — accès root rétabli (défaut image)"
+    else
+        die "échec du reload sshd après retrait du drop-in — vérifier 'systemctl status ssh'."
+    fi
+}
+
+# remove_fail2ban_jail
+# Retire la conf de jail ElectriCore et recharge fail2ban. Laisse le paquet
+# installé (on ne désinstalle pas : d'autres jails peuvent en dépendre).
+remove_fail2ban_jail() {
+    if [[ ! -f "$FAIL2BAN_JAIL" ]]; then
+        log_skip "jail fail2ban ElectriCore absente — rien à retirer"
+        return 0
+    fi
+    rm -f "$FAIL2BAN_JAIL"
+    systemctl restart fail2ban 2>/dev/null || true
+    log_ok "jail fail2ban ElectriCore retirée (${FAIL2BAN_JAIL})"
+}
+
+# remove_unattended_config
+# Retire les fichiers apt.conf.d posés par le durcissement (auto-reboot + maj
+# auto). N'efface pas la conf distro par défaut (50unattended-upgrades) ni le
+# paquet : on revient simplement au comportement d'origine de l'image.
+remove_unattended_config() {
+    local removed=0
+    [[ -f "$UNATTENDED_OVERRIDE" ]] && { rm -f "$UNATTENDED_OVERRIDE"; removed=1; }
+    [[ -f "$UNATTENDED_PERIODIC" ]] && { rm -f "$UNATTENDED_PERIODIC"; removed=1; }
+    if [[ "$removed" -eq 1 ]]; then
+        log_ok "conf unattended-upgrades ElectriCore retirée (auto-reboot 04:30 désactivé)"
+    else
+        log_skip "conf unattended-upgrades ElectriCore absente — rien à retirer"
+    fi
+}
+
+# remove_admin_user <user>
+# Retrait OPT-IN de l'admin (sudoers + compte + home). Destructif → réservé à
+# --purge-ops. À n'exécuter qu'après unharden_sshd (root SSH déjà rétabli),
+# sinon on se prive du seul accès non-root.
+remove_admin_user() {
+    local user="$1"
+    rm -f "/etc/sudoers.d/${user}"
+    if id "$user" >/dev/null 2>&1; then
+        if userdel -r "$user" 2>/dev/null; then
+            log_ok "user admin $user retiré (sudoers + compte + home)"
+        else
+            log_warn "échec userdel $user (session active ?) — sudoers retiré, compte à supprimer à la main."
+        fi
+    else
+        rm -f "/etc/sudoers.d/${user}"
+        log_skip "user admin $user absent — sudoers nettoyé"
+    fi
+}
+
+# unharden_vps
+# Inverse de harden_vps. Lit les globals OPT_* :
+#   OPT_PURGE_OPS   supprime aussi le user ops (destructif ; défaut: conservé)
+#
+# Ordre impératif : on rétablit le SSH root EN PREMIER (regagner l'accès), puis
+# on nettoie fail2ban + unattended ; le retrait de ops (opt-in) vient en dernier,
+# une fois root réaccessible.
+unharden_vps() {
+    local user="${HARDEN_ADMIN_USER}"
+
+    unharden_sshd
+    remove_fail2ban_jail
+    remove_unattended_config
+    if [[ "${OPT_PURGE_OPS:-0}" -eq 1 ]]; then
+        remove_admin_user "$user"
+    else
+        log_info "user admin $user conservé (le supprimer : --purge-ops ; re-durcir : deploy/harden.sh)"
+    fi
+}

--- a/deploy/tests/e2e/assert_unharden.sh
+++ b/deploy/tests/e2e/assert_unharden.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Assertions e2e de la RÉVERSION du durcissement (ADR-0031), à lancer DANS la VM
+# (ou sur un vrai VPS) après `unharden.sh`. Vérifie qu'on est revenu au défaut :
+# drop-in sshd retiré (root SSH rétabli), jail fail2ban et conf unattended retirées.
+# Par défaut le user ops est conservé (lancer sans --purge-ops).
+#
+#   ./deploy/tests/e2e/multipass.sh verify-reverse
+#
+# Exit 0 si toutes les assertions passent, 1 sinon.
+set -u
+
+ADMIN_USER="${HARDEN_ADMIN_USER:-ops}"
+PASS=0; FAIL=0
+ok() { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+ko() { printf '  \033[31m✗\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+check() { if eval "$2" >/dev/null 2>&1; then ok "$1"; else ko "$1"; fi; }
+
+[[ $EUID -eq 0 ]] || { echo "à lancer en root (sudo bash $0)" >&2; exit 2; }
+
+echo "→ Réversion : sshd (accès root rétabli)"
+check "drop-in de durcissement retiré"           "! test -f /etc/ssh/sshd_config.d/50-electricore-harden.conf"
+check "sshd -t valide la config"                 "sshd -t"
+check "PermitRootLogin n'est plus 'no' (root SSH rétabli)" "! sshd -T | grep -qix 'permitrootlogin no'"
+
+echo
+echo "→ Réversion : fail2ban + unattended-upgrades"
+check "jail fail2ban ElectriCore retirée"        "! test -f /etc/fail2ban/jail.d/electricore.conf"
+check "override auto-reboot retiré"              "! test -f /etc/apt/apt.conf.d/52electricore-unattended"
+check "periodic unattended retiré"               "! test -f /etc/apt/apt.conf.d/20auto-upgrades"
+
+echo
+echo "→ Réversion : user admin (conservé par défaut, sans --purge-ops)"
+check "${ADMIN_USER} toujours présent"           "id ${ADMIN_USER}"
+
+echo
+if [[ "$FAIL" -eq 0 ]]; then
+    printf "\033[32m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
+    exit 0
+else
+    printf "\033[31m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
+    exit 1
+fi

--- a/deploy/tests/e2e/multipass.sh
+++ b/deploy/tests/e2e/multipass.sh
@@ -19,8 +19,10 @@ Commands:
                     Défaut: --slug test --domain test.local --skip-dns
   harden [args...]  Exécute le wrapper autonome deploy/harden.sh dans la VM
                     (rétro-durcissement, ADR-0031 #262).
+  unharden [args]   Exécute deploy/unharden.sh dans la VM (réversion).
   verify            Lance les assertions de durcissement (ADR-0031) dans la VM,
                     via `multipass exec` (pas SSH — survit au root-off).
+  verify-reverse    Assertions de réversion (drop-in retiré, root SSH rétabli).
   shell             Ouvre un shell interactif dans la VM.
   snap <name>       Crée un snapshot.
   restore <name>    Restaure un snapshot (rapide pour itérer).
@@ -66,8 +68,10 @@ cmd_run() {
     multipass exec "$VM_NAME" -- sudo bash /repo/deploy/install.sh "${args[@]}"
 }
 
-cmd_harden()  { multipass exec "$VM_NAME" -- sudo bash /repo/deploy/harden.sh "$@"; }
-cmd_verify()  { multipass exec "$VM_NAME" -- sudo bash /repo/deploy/tests/e2e/assert_harden.sh "$@"; }
+cmd_harden()         { multipass exec "$VM_NAME" -- sudo bash /repo/deploy/harden.sh "$@"; }
+cmd_unharden()       { multipass exec "$VM_NAME" -- sudo bash /repo/deploy/unharden.sh "$@"; }
+cmd_verify()         { multipass exec "$VM_NAME" -- sudo bash /repo/deploy/tests/e2e/assert_harden.sh "$@"; }
+cmd_verify_reverse() { multipass exec "$VM_NAME" -- sudo bash /repo/deploy/tests/e2e/assert_unharden.sh "$@"; }
 cmd_shell()   { multipass shell "$VM_NAME"; }
 cmd_snap()    { multipass snapshot "$VM_NAME" --name "${1:?nom de snapshot requis}"; }
 cmd_restore() { multipass restore "${VM_NAME}.${1:?nom de snapshot requis}"; }
@@ -76,6 +80,7 @@ cmd_status()  { multipass info "$VM_NAME" 2>/dev/null || echo "VM ${VM_NAME} n'e
 require_multipass
 CMD="${1:-}"; shift || true
 case "$CMD" in
-    up|down|run|harden|verify|shell|snap|restore|status) "cmd_$CMD" "$@" ;;
+    up|down|run|harden|unharden|verify|shell|snap|restore|status) "cmd_$CMD" "$@" ;;
+    verify-reverse) cmd_verify_reverse "$@" ;;
     *) usage; exit 1 ;;
 esac

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -30,6 +30,11 @@ source "${SCRIPT_DIR}/../install.sh"
 # shellcheck source=../harden.sh
 source "${LIB_DIR}/../harden.sh"
 
+# `unharden.sh` (wrapper de réversion) — guard `main_unharden` ; expose
+# parse_unharden_args + les fonctions de réversion (déjà dans lib/harden.sh).
+# shellcheck source=../unharden.sh
+source "${LIB_DIR}/../unharden.sh"
+
 PASS=0; FAIL=0
 ok() { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
 ko() { printf '  \033[31m✗\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
@@ -172,6 +177,35 @@ echo "→ harden.sh (wrapper autonome) / parse_harden_args"
 ( parse_harden_args --no-sshd --no-unattended-upgrades >/dev/null 2>&1
   [[ "$OPT_NO_SSHD" == "1" && "$OPT_NO_UNATTENDED" == "1" ]]
 ) && ok "parse_harden_args: --no-sshd + --no-unattended-upgrades" || ko "parse_harden_args no-sshd/no-unattended"
+
+echo
+echo "→ unharden.sh (réversion) / parse_unharden_args + no-op"
+( parse_unharden_args >/dev/null 2>&1; [[ "$OPT_PURGE_OPS" == "0" ]] ) \
+    && ok "parse_unharden_args: ops conservé par défaut (OPT_PURGE_OPS=0)" || ko "parse_unharden_args défaut"
+( parse_unharden_args --purge-ops >/dev/null 2>&1; [[ "$OPT_PURGE_OPS" == "1" ]] ) \
+    && ok "parse_unharden_args: --purge-ops → 1" || ko "parse_unharden_args --purge-ops"
+( parse_unharden_args --bogus >/dev/null 2>&1 ); [[ "$?" -eq 2 ]] \
+    && ok "parse_unharden_args: argument inconnu → exit 2" || ko "parse_unharden_args arg inconnu"
+# Réversions no-op (rien à retirer) — branches sûres, sans toucher sshd/systemd
+( SSHD_HARDEN_DROPIN="/nonexistent-$$" unharden_sshd >/dev/null 2>&1 ) \
+    && ok "unharden_sshd: drop-in absent → no-op (pas de reload sshd)" || ko "unharden_sshd no-op"
+( FAIL2BAN_JAIL="/nonexistent-$$" remove_fail2ban_jail >/dev/null 2>&1 ) \
+    && ok "remove_fail2ban_jail: jail absente → no-op" || ko "remove_fail2ban_jail no-op"
+( UNATTENDED_OVERRIDE="/nope1-$$" UNATTENDED_PERIODIC="/nope2-$$" remove_unattended_config >/dev/null 2>&1 ) \
+    && ok "remove_unattended_config: conf absente → no-op" || ko "remove_unattended_config no-op"
+# remove_unattended_config retire bien les fichiers présents (file-only, sûr)
+uov=$(mktemp); uop=$(mktemp)
+( UNATTENDED_OVERRIDE="$uov" UNATTENDED_PERIODIC="$uop" remove_unattended_config >/dev/null 2>&1 )
+[[ ! -f "$uov" && ! -f "$uop" ]] && ok "remove_unattended_config: retire les fichiers présents" || ko "remove_unattended_config retrait"
+rm -f "$uov" "$uop"
+
+echo
+echo "→ install.sh / lib_dir_complete (anti trap stale-lib)"
+assert_ok   "lib/ du repo est complet"          lib_dir_complete "${LIB_DIR}"
+assert_fail "répertoire absent → incomplet"     lib_dir_complete "/nonexistent-libdir-$$"
+incdir=$(mktemp -d); : > "${incdir}/log.sh"   # un seul helper sur douze
+assert_fail "lib/ partiel (helper manquant) → incomplet" lib_dir_complete "$incdir"
+rm -rf "$incdir"
 
 echo
 echo "→ install.sh / fetch_lib_files"

--- a/deploy/unharden.sh
+++ b/deploy/unharden.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Réversion autonome du durcissement VPS (ADR-0031) — « uninstall ».
+#
+# Inverse de deploy/harden.sh : retire le drop-in sshd (SSH root rétabli), la
+# jail fail2ban et la conf unattended-upgrades posés par le durcissement. Le user
+# admin `ops` est CONSERVÉ par défaut (--purge-ops pour le supprimer aussi).
+# Idempotent, sans hypothèse de layout (OS/SSH-level, comme harden.sh).
+#
+# Ne fait que sourcer lib/harden.sh et appeler unharden_vps() : toute la logique
+# vit dans la lib (aucune duplication).
+#
+# Usage :
+#   # Sur une instance au layout courant (arbre deploy/ présent) :
+#   sudo bash /srv/<slug>/deploy/unharden.sh [--purge-ops]
+#
+#   # Standalone (legacy /opt, ou box sans notre arbre deploy/) — bootstrap auto :
+#   curl -fsSL https://raw.githubusercontent.com/Energie-De-Nantes/electricore/main/deploy/unharden.sh -o unharden.sh
+#   sudo bash unharden.sh [--purge-ops]
+#
+# Cf. docs/deploiement.md § « Durcissement du VPS » → « Réverser le durcissement ».
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_BASE_URL_DEFAULT="${INSTALL_BASE_URL:-https://raw.githubusercontent.com/Energie-De-Nantes/electricore/main/deploy}"
+# Sous-ensemble de lib/ dont unharden_vps() a besoin (log + die ; harden).
+HARDEN_LIB_FILES=(log harden)
+
+# _lib_complete <dir> : vrai si <dir> contient tous les helpers de HARDEN_LIB_FILES.
+_lib_complete() {
+    local f
+    [[ -d "$1" ]] || return 1
+    for f in "${HARDEN_LIB_FILES[@]}"; do [[ -f "$1/${f}.sh" ]] || return 1; done
+}
+
+# Résolution des helpers : co-localisés si complets (arbre deploy/ présent),
+# sinon copie FRAÎCHE en /tmp (run standalone via curl, OU lib/ figé d'un run
+# antérieur). Jamais de lib/ persistant laissé à pourrir à côté du script.
+HELPERS_DIR="${SCRIPT_DIR}/lib"
+HELPERS_DIR_TEMP=""
+if ! _lib_complete "$HELPERS_DIR"; then
+    command -v curl >/dev/null || { echo "curl introuvable, install curl puis relance." >&2; exit 1; }
+    HELPERS_DIR_TEMP="$(mktemp -d "${TMPDIR:-/tmp}/electricore-lib.XXXXXX")"
+    HELPERS_DIR="$HELPERS_DIR_TEMP"
+    trap '[[ -n "${HELPERS_DIR_TEMP:-}" ]] && rm -rf "$HELPERS_DIR_TEMP"' EXIT
+    echo "→ Bootstrap : téléchargement des helpers (copie fraîche) dans ${HELPERS_DIR}…"
+    for f in "${HARDEN_LIB_FILES[@]}"; do
+        if ! curl -fsSL "${INSTALL_BASE_URL_DEFAULT}/lib/${f}.sh" -o "${HELPERS_DIR}/${f}.sh"; then
+            echo "✗ Échec téléchargement ${f}.sh depuis ${INSTALL_BASE_URL_DEFAULT}/lib/" >&2
+            exit 1
+        fi
+    done
+fi
+
+for f in "${HARDEN_LIB_FILES[@]}"; do
+    # shellcheck source=/dev/null
+    source "${HELPERS_DIR}/${f}.sh"
+done
+
+usage_unharden() {
+    cat <<EOF
+Usage: sudo bash unharden.sh [options]
+
+Réverse le durcissement VPS (ADR-0031) : retire le drop-in sshd (SSH root
+rétabli), la jail fail2ban et la conf unattended-upgrades. Idempotent.
+Le user admin ops est conservé par défaut.
+
+Options :
+  --purge-ops    Supprime AUSSI le user admin ops (sudoers + compte + home)
+  --no-color     Désactive les couleurs ANSI
+  -h, --help     Affiche cette aide
+EOF
+}
+
+# parse_unharden_args "$@" — remplit OPT_PURGE_OPS (lu par unharden_vps).
+parse_unharden_args() {
+    OPT_PURGE_OPS=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --purge-ops) OPT_PURGE_OPS=1; shift ;;
+            --no-color)  export NO_COLOR=1; shift ;;
+            -h|--help)   usage_unharden; exit 0 ;;
+            *) echo "Argument inconnu : $1" >&2; usage_unharden; exit 2 ;;
+        esac
+    done
+}
+
+main_unharden() {
+    set -euo pipefail
+    parse_unharden_args "$@"
+    LOG_TOTAL_STEPS=1
+    [[ $EUID -eq 0 ]] || die "à lancer en root (sudo bash $0 ...)"
+    log_step "Réversion du durcissement VPS (ADR-0031)"
+    unharden_vps
+    log_ok "Réversion terminée. SSH root rétabli (défaut image) — pense à remettre 'User root' dans ~/.ssh/config si besoin."
+}
+
+# Guard : n'exécute `main_unharden` que si le script est exécuté, pas sourcé
+# (les tests unitaires sourcent pour récupérer parse_unharden_args).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main_unharden "$@"
+fi

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -291,11 +291,12 @@ Couvre les cas :
 - Changement de domaine (`--domain nouveau.electricore.fr`)
 - Ajout/retrait de Telegram, Odoo, etc.
 
-> **Auto-refresh des helpers `lib/`** : en mode reconfigure, le script
-> re-télécharge inconditionnellement les helpers de `deploy/lib/` (#62). Évite
-> le piège stale-lib où un `install.sh` à jour sourçait un `lib/` figé sur une
-> version antérieure (cas reproduit lors de la migration rc2 → rc3). Override
-> possible via `INSTALL_BASE_URL` pour pinner sur un tag spécifique en dev.
+> **Helpers `lib/` toujours frais** : si le `lib/` co-localisé avec `install.sh`
+> est absent ou incomplet (un `install.sh` à jour à côté d'un `lib/` figé d'un run
+> antérieur — le piège stale-lib, #62), le script télécharge une copie **fraîche
+> dans `/tmp`** plutôt que de réutiliser/laisser pourrir un `lib/` à côté du script.
+> En mode reconfigure, un `lib/` co-localisé complet est en plus re-téléchargé.
+> Override possible via `INSTALL_BASE_URL` pour pinner sur un tag spécifique en dev.
 
 ## Durcissement du VPS
 
@@ -388,6 +389,38 @@ sudo bash harden.sh
 Le même **garde-fou anti-verrouillage** s'applique (refus de couper root SSH si
 `ops` n'a pas de clé). Options : `--admin-pubkey "ssh-ed25519 …"`, et les `--no-*`
 (`--no-sshd`, `--no-fail2ban`, `--no-unattended-upgrades`) pour durcir par morceaux.
+
+### Réverser le durcissement (désinstallation)
+
+Pour revenir en arrière — repasser sur un accès root classique, ou annuler en cas
+de souci — [`deploy/unharden.sh`](../deploy/unharden.sh) défait ce que le
+durcissement a posé :
+
+- retire le drop-in sshd → **SSH root rétabli** (défaut de l'image) ;
+- retire la jail fail2ban (laisse le paquet installé) ;
+- retire la conf unattended-upgrades (auto-reboot 04:30 désactivé).
+
+Le user admin `ops` est **conservé** par défaut ; `--purge-ops` le supprime aussi
+(sudoers + compte + home).
+
+```bash
+# Instance au layout courant :
+ssh ops@<vps>          # ou root si tu y as encore accès
+sudo bash /srv/<slug>/deploy/unharden.sh               # garde ops
+sudo bash /srv/<slug>/deploy/unharden.sh --purge-ops   # supprime aussi ops
+
+# Standalone (legacy /opt, ou box sans notre arbre deploy/) :
+curl -fsSL https://raw.githubusercontent.com/Energie-De-Nantes/electricore/main/deploy/unharden.sh -o unharden.sh
+sudo bash unharden.sh
+```
+
+La réversion rétablit le SSH root **en premier**, donc même un `--purge-ops` ne
+peut pas te verrouiller dehors. Pense ensuite à remettre `User root` dans ton
+`~/.ssh/config` si tu l'avais basculé sur `ops`.
+
+> La réversion retire entièrement `/etc/apt/apt.conf.d/20auto-upgrades`. Si ton
+> image l'avait déjà avant durcissement, les mises à jour auto repassent au défaut
+> du paquet (généralement inactif sans ce fichier).
 
 ## Accès distant depuis un notebook Python
 


### PR DESCRIPTION
Suite de la rollout durcissement [ADR-0031](https://github.com/Energie-De-Nantes/electricore/blob/main/docs/adr/0031-durcissement-ssh-vps-utilisateur-ops.md) (#258–#262, mergée), deux ajouts nés de l'usage réel sur un VPS :

## 1. `fix` — bootstrap des helpers en `/tmp` (anti stale-lib)

Le bootstrap ne (re)téléchargeait `lib/` que si le **dossier** était absent. Un `install.sh` à jour posé à côté d'un `lib/` figé d'un run antérieur (sans `harden.sh`) sourçait l'ancien `lib/` → `_source_lib` échouait sur le helper manquant et le vieux `cli.sh` rejetait `--no-sshd`. Rencontré en posant le durcissement sur une box déjà installée.

Désormais : `lib/` co-localisé utilisé **uniquement s'il est complet** (checkout repo, `/srv/<slug>/deploy/`, tests, run offline/pinné) ; sinon copie **fraîche en `/tmp`**, nettoyée en fin de run. On élimine le piège à la racine (pas de `lib/` persistant qui rancit dans `/root`) plutôt que de le rattraper. Appliqué à `install.sh` + au wrapper `harden.sh`.

## 2. `feat` — réversion du durcissement (`unharden.sh`)

`unharden_vps()` défait `harden_vps()`, dans l'ordre **sûr** (rétablir l'accès root d'abord) :

- `unharden_sshd` — retire le drop-in, `sshd -t`, `reload` → **SSH root rétabli en premier** ;
- `remove_fail2ban_jail` — retire la jail ElectriCore (laisse le paquet) ;
- `remove_unattended_config` — retire l'auto-reboot 04:30 + la maj auto ;
- `remove_admin_user` — **opt-in** `--purge-ops` ; `ops` conservé par défaut.

Wrapper autonome `deploy/unharden.sh` (même bootstrap `/tmp`, sans hypothèse de layout). Comme root SSH revient en premier, `--purge-ops` ne peut pas verrouiller dehors.

```bash
sudo bash /srv/<slug>/deploy/unharden.sh                # défait, garde ops
sudo bash /srv/<slug>/deploy/unharden.sh --purge-ops    # + supprime ops
# standalone : curl .../deploy/unharden.sh -o unharden.sh && sudo bash unharden.sh
```

## Tests

- **Unit** (`deploy/tests/unit.sh`) : **113 vertes** — `parse_unharden_args`, `lib_dir_complete`, branches no-op des réversions (sans toucher sshd/systemd), retrait de fichiers.
- **e2e** (`deploy/tests/e2e/`) : `multipass.sh unharden` + `verify-reverse` → `assert_unharden.sh` (drop-in retiré, `PermitRootLogin` ≠ `no`, jail/conf retirées, `ops` conservé).
- Suite Python complète : 802 passed (aucun `.py` touché).

## Docs

`docs/deploiement.md` : sous-section « Réverser le durcissement » + note bootstrap `/tmp`. `deploy/lib/README.md` mis à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)