### PR TITLE
fix(ingestion): attributs feuilles XML (statut leaf) + rc8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.0.0rc8] - 2026-06-16
+
+Correctif d'ingestion : `ingestion all` échouait en prod sur le data test `not_null`
+de `flux_affaires.statut` (rc7).
+
+### 🐛 Correctifs (ingestion)
+
+- **`xml_vers_dict` garde les attributs des feuilles** : en données réelles, certains
+  `<statut code="COURS"/>` n'ont pas d'enfant `<libelle>` (feuille porteuse d'attribut) ;
+  le parseur ne capturait les attributs que sur les *conteneurs* → `@code` perdu →
+  `statut` null → `not_null` KO → `dbt build` KO → job d'ingestion en échec. Une feuille
+  à attribut devient désormais un nœud `{"@code": …}` listé (même forme que le conteneur,
+  accès `statut[0]."@code"` uniforme) ; une feuille sans attribut reste scalaire (zéro
+  régression element-only). Vérifié sur le corpus réel EDN : 0 `statut` null (était 14).
+- Les **commentaires / PI XML** (`.tag` non-`str`) sont ignorés au parsing (sinon clé de
+  dict non sérialisable au landing JSON).
+
 ## [3.0.0rc7] - 2026-06-16
 
 Suivi opérationnel des **affaires SGE** (flux X12/X13) de bout en bout, parité de

--- a/electricore/ingestion/parsing/xml.py
+++ b/electricore/ingestion/parsing/xml.py
@@ -31,20 +31,35 @@ def xml_vers_dict(xml_bytes: bytes) -> dict:
 
 def _element_vers_dict(element: Any) -> Any:
     enfants = list(element)
+    texte = element.text.strip() if element.text and element.text.strip() else None
     if not enfants:
-        # Feuille : sa valeur texte (None si vide, pour rester sérialisable). Les
-        # attributs d'une feuille sont ignorés — aucun flux n'en porte de signifiants,
-        # et renvoyer un dict casserait le type scalaire attendu par l'aval element-only.
-        return element.text.strip() if element.text and element.text.strip() else None
+        # Feuille SANS attribut : sa valeur texte (None si vide), scalaire — zéro
+        # régression pour les flux element-only.
+        if not element.attrib:
+            return texte
+        # Feuille PORTEUSE d'attribut (ex X12 : <statut code="COURS"/> sans libelle) :
+        # l'attribut est de la donnée → nœud `{"@attr": …}` (+ `#text` si texte présent),
+        # jamais un scalaire qui perdrait l'attribut.
+        noeud = {f"@{cle}": val for cle, val in element.attrib.items()}
+        if texte is not None:
+            noeud["#text"] = texte
+        return noeud
     # Conteneur : ses attributs sous une clé préfixée `@` (X12/X13 portent l'id
     # d'affaire et les codes statut/objet/état en attributs). Le préfixe évite toute
     # collision avec un tag enfant et reste sélectionnable en JSON path (`."@code"`).
     resultat: dict[str, Any] = {f"@{cle}": val for cle, val in element.attrib.items()}
     for enfant in enfants:
+        # Commentaires / instructions de traitement : lxml en fait des nœuds dont `.tag`
+        # est une fonction (etree.Comment/PI), pas une chaîne — on les ignore (sinon clé
+        # de dict non-sérialisable au landing JSON).
+        if not isinstance(enfant.tag, str):
+            continue
         valeur = _element_vers_dict(enfant)
-        if len(enfant) > 0:
-            # Conteneur = forme répétable → toujours une liste (cast dbt uniforme),
-            # même unique.
+        if len(enfant) > 0 or enfant.attrib:
+            # Forme répétable — enfants OU attributs → toujours une liste (cast/unnest
+            # dbt uniforme). Un <statut code=…/> (feuille à attribut) est ainsi listé
+            # comme un <statut code=…><libelle/></statut> : `statut[0]."@code"` marche
+            # dans les deux cas.
             resultat.setdefault(enfant.tag, []).append(valeur)
         elif enfant.tag in resultat:
             # Feuille répétée → liste.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.0.0rc7"
+version = "3.0.0rc8"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/tests/core/loaders/test_loader_affaires.py
+++ b/tests/core/loaders/test_loader_affaires.py
@@ -78,21 +78,24 @@ def test_affaires_charge_attributs_et_instant_tzaware(base_affaires):
     df = affaires(database_path=base_affaires).collect()
 
     assert df.schema["jalon_date_heure"] == pl.Datetime("us", "Europe/Paris")
-    assert df.height == 7  # 4 + 1 + 2 jalons des 3 affaires de la fixture
+    assert df.height == 8  # 4 + 1 + 2 + 1 jalons des 4 affaires de la fixture
     assert df["origine"].unique().to_list() == ["initiee"]
     # L'état CPNR (porté par l'attribut affaireEtat/@code) est bien remonté.
     assert "CPNR" in df["affaire_etat"].to_list()
+    # statut COURS porté par un attribut SEUL (<statut code="COURS"/>) survit jusqu'au DataFrame.
+    assert "COURS" in df["statut"].to_list()
 
 
 def test_affaires_ouvertes_bout_en_bout(base_affaires):
-    """DB → loader → rollup : la seule affaire COURS de la fixture (AME) ressort
-    quand on n'exclut pas AME, avec son dernier état."""
+    """DB → loader → rollup : l'affaire CFN en cours (statut COURS porté par attribut
+    seul) ressort — AME écartée par défaut — avec son dernier état."""
     from electricore.core.loaders import affaires
     from electricore.core.pipelines.affaires import affaires_ouvertes
 
     df = affaires(database_path=base_affaires).collect()
-    vue = affaires_ouvertes(df, maintenant=datetime(2024, 11, 25, 9, tzinfo=PARIS), exclure_prestations=())
+    vue = affaires_ouvertes(df, maintenant=datetime(2024, 11, 25, 9, tzinfo=PARIS))
 
-    assert vue["affaire_id"].to_list() == ["AFF0000002"]
+    # AFF0000004 = CFN COURS (statut attribut-seul) ; AFF0000002 = AME COURS, exclue par défaut.
+    assert vue["affaire_id"].to_list() == ["AFF0000004"]
     assert vue["dernier_etat"].to_list() == ["DMTR"]
-    assert vue["prestation"].to_list() == ["AME"]
+    assert vue["prestation"].to_list() == ["CFN"]

--- a/tests/fixtures/flux/affaires_X12.xml
+++ b/tests/fixtures/flux/affaires_X12.xml
@@ -71,4 +71,24 @@
       </donneesGenerales>
     </demande>
   </affaire>
+  <affaire id="AFF0000004">
+    <donneesGenerales>
+      <referenceDemandeur>EDN</referenceDemandeur>
+      <!-- statut SANS enfant libelle (forme observée en prod) : l'attribut @code
+           doit survivre malgré l'absence de contenu textuel. -->
+      <statut code="COURS"/>
+      <jalons>
+        <jalon><num>1</num><dateHeure>2024-11-24T09:00:00.000+01:00</dateHeure><affaireDateEffet>2024-11-24+01:00</affaireDateEffet><affaireEtat code="DMTR"><libelle>Demande transmise</libelle></affaireEtat></jalon>
+      </jalons>
+      <donneesPoint><id>99000000000055</id><segmentClientele code="C5"><libelle>C5</libelle></segmentClientele></donneesPoint>
+      <segment>C5</segment>
+    </donneesGenerales>
+    <demande>
+      <donneesGenerales>
+        <objet code="CFN"><libelle>Changement de fournisseur</libelle></objet>
+        <pointId>99000000000055</pointId>
+        <media code="PTL"><libelle>PORTAIL</libelle></media>
+      </donneesGenerales>
+    </demande>
+  </affaire>
 </affaires>

--- a/tests/fixtures/flux/golden/flux_affaires.json
+++ b/tests/fixtures/flux/golden/flux_affaires.json
@@ -103,5 +103,20 @@
     "affaire_date_effet": "2024-11-23",
     "affaire_etat": "INPL",
     "affaire_etat_libelle": "Intervention planifiée"
+  },
+  {
+    "affaire_id": "AFF0000004",
+    "origine": "initiee",
+    "prestation": "CFN",
+    "prestation_libelle": "Changement de fournisseur",
+    "statut": "COURS",
+    "pdl": "99000000000055",
+    "segment": "C5",
+    "jalon_num": 1,
+    "affaire_jalon_id": "AFF0000004#1",
+    "jalon_date_heure": "2024-11-24T09:00:00+01:00",
+    "affaire_date_effet": "2024-11-24",
+    "affaire_etat": "DMTR",
+    "affaire_etat_libelle": "Demande transmise"
   }
 ]

--- a/tests/ingestion/test_xml_vers_dict.py
+++ b/tests/ingestion/test_xml_vers_dict.py
@@ -47,3 +47,22 @@ def test_attributs_de_conteneur_captures_avec_prefixe():
             }
         ]
     }
+
+
+def test_feuille_porteuse_dattribut_devient_un_noeud_liste():
+    # Observé en prod X12 : <statut code="COURS"/> SANS enfant libelle. Une feuille
+    # porteuse d'attribut n'est pas un scalaire — l'attribut est de la donnée. Elle
+    # devient un nœud `[{"@code": ...}]`, MÊME forme que le conteneur, pour que le modèle
+    # dbt y accède uniformément (`statut[0]."@code"`) qu'il y ait un libelle ou non.
+    # Une feuille SANS attribut reste scalaire (zéro régression element-only).
+    assert xml_vers_dict(b'<root><statut code="COURS"/><vide/><texte>x</texte></root>') == {
+        "statut": [{"@code": "COURS"}],  # feuille à attribut → nœud listé
+        "vide": None,  # feuille sans attribut ni texte → scalaire None
+        "texte": "x",  # feuille texte sans attribut → scalaire
+    }
+
+
+def test_commentaires_xml_ignores():
+    # lxml expose un commentaire comme un nœud dont `.tag` est une fonction (pas une
+    # chaîne) — utilisé tel quel en clé de dict, il casse le landing JSON. On l'ignore.
+    assert xml_vers_dict(b"<root><!-- note --><a>1</a></root>") == {"a": "1"}

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.0.0rc7"
+version = "3.0.0rc8"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Pourquoi

`ingestion all` a **échoué en prod sous rc7** : le data test `not_null` de
`flux_affaires.statut` casse → `dbt build` non-zéro → job d'ingestion `failed`.
(Le « error » du job ne montrait qu'un warning psutil, qui masquait la vraie cause.)

## Cause

En données réelles, certains `<statut code="COURS"/>` n'ont **pas** d'enfant `<libelle>` →
c'est une **feuille porteuse d'attribut**. Le parseur ne capturait les attributs que sur
les *conteneurs* → `@code` perdu → `statut` null. (11 cas bruts → 14 lignes sur le
corpus EDN de 5702.)

## Fix

- Une **feuille à attribut** devient un nœud `{"@code": …}` *listé* — même forme que le
  conteneur → `statut[0]."@code"` marche avec ou sans `libelle`. Feuille sans attribut =
  scalaire inchangé (**zéro régression element-only**, golden des autres flux intacts).
- Les **commentaires / PI XML** sont ignorés au parsing (leur `.tag` non-`str` cassait le
  landing JSON — orjson « non-str key »).
- Régression verrouillée : affaire `<statut code="COURS"/>` (attribut seul) ajoutée au
  golden X12 ; test parseur dédié.

Vérifié en rejouant le modèle sur le **corpus réel EDN complet** : `statut` null **0** (était 14),
clés uniques OK, autres `not_null` OK. Suite verte sous `TZ=UTC` (hors `test_historique_monotonie_horizon`, pré-existant et vert en CI).

## Release

Bump **rc7 → rc8** inclus (pyproject + uv.lock + CHANGELOG). Après merge : tag `v3.0.0rc8`
→ image `ghcr.io/.../electricore:3.0.0rc8` à redéployer pour re-tester `ingestion all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
