### PR TITLE
chore(ingestion): ajoute psutil (stats mémoire dlt)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ ingestion = [
     "pycryptodome>=3.23.0,<4.0.0",
     "paramiko>=4.0.0,<5.0.0",
     "lxml>=6.1.0,<7.0.0",  # XXE fix (CVE-2026-41066)
+    "psutil>=5.9.0,<8.0.0",  # stats mémoire dlt sur VPS contraint (sinon UserWarning au run)
 ]
 viz = [
     "altair>=5.5.0,<6.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -761,6 +761,7 @@ ingestion = [
     { name = "dlt", extra = ["filesystem"] },
     { name = "lxml" },
     { name = "paramiko" },
+    { name = "psutil" },
     { name = "pycryptodome" },
 ]
 viz = [
@@ -800,6 +801,7 @@ requires-dist = [
     { name = "paramiko", marker = "extra == 'ingestion'", specifier = ">=4.0.0,<5.0.0" },
     { name = "plotly", extras = ["express"], marker = "extra == 'viz'", specifier = ">=6.2.0" },
     { name = "polars", specifier = ">=1.0.0,<2.0.0" },
+    { name = "psutil", marker = "extra == 'ingestion'", specifier = ">=5.9.0,<8.0.0" },
     { name = "pyarrow", specifier = ">=23.0.1,<24.0.0" },
     { name = "pycryptodome", marker = "extra == 'ingestion'", specifier = ">=3.23.0,<4.0.0" },
     { name = "pydantic-settings", specifier = ">=2.14.1" },


### PR DESCRIPTION
## Quoi

Ajoute **`psutil`** à l'extra `ingestion` (là où vit `dlt`).

## Pourquoi

Au run d'ingestion, dlt émet `UserWarning: psutil dependency is not installed and memory stats will not be available`. Plutôt que de taire l'alerte (`dump_system_stats=False`), on installe psutil : sur le VPS contraint (dbt `threads=1` pour tenir la RAM, cf. rc5), les **stats mémoire par étape dlt** sont une observabilité utile.

Bonus : c'est ce warning qui s'était glissé dans le champ `error` du job d'ingestion et **masquait** la vraie cause d'un échec — le supprimer rend les futurs `error` de job plus lisibles. (Le bug d'échec lui-même est corrigé indépendamment dans #283.)

## Portée

`pyproject` +1 ligne, `uv.lock` +2 (psutil déjà résolu en transitif → seules les réfs de dépendance electricore[ingestion] sont ajoutées). Aucune autre dépendance touchée. PR **indépendante** du correctif affaires / rc8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
