### PR TITLE
fix(ingestion,core): statut d'affaire nullable + cockpit surface les affaires en attente Enedis (#296)

### DIFF
--- a/electricore/core/pipelines/affaires.py
+++ b/electricore/core/pipelines/affaires.py
@@ -29,7 +29,11 @@ def affaires_ouvertes(
         Une ligne par affaire en cours, avec son dernier état (jalon de `num` max) et
         son ancienneté en jours (maintenant − premier jalon).
     """
-    lf = jalons.lazy().filter(pl.col("statut") == "COURS")
+    # « Non soldée » = COURS, mais aussi statut NULL : Enedis envoie un <statut> vide pour
+    # une affaire fraîchement initiée qu'il n'a pas encore rangée (jalon 0 DMTR, demande
+    # transmise). C'est l'affaire la plus ouverte qui soit — « en attente Enedis ». Seules
+    # TERMN/ANNUL sont soldées (#296).
+    lf = jalons.lazy().filter((pl.col("statut") == "COURS") | pl.col("statut").is_null())
     if exclure_prestations:
         # is_in(...) renvoie null pour une prestation nulle → fill_null(False) garde la
         # réclamation (prestation absente), seules les prestations exclues sont retirées.

--- a/electricore/ingestion/dbt/models/flux/schema.yml
+++ b/electricore/ingestion/dbt/models/flux/schema.yml
@@ -127,8 +127,10 @@ models:
         description: initiee (X12, on initie) / recue (X13, autre acteur).
         data_tests: [not_null]
       - name: statut
-        description: Cycle de vie grossier COURS / TERMN / ANNUL.
-        data_tests: [not_null]
+        description: >
+          Cycle de vie grossier COURS / TERMN / ANNUL. NULLABLE (#296) : Enedis envoie
+          un <statut> vide pour une affaire fraîchement initiée qu'il n'a pas encore
+          rangée (jalon 0, demande transmise) → null, ingéré fidèlement (ADR-0029).
       - name: jalon_num
         description: Numéro d'ordre du jalon dans l'affaire.
         data_tests: [not_null]

--- a/tests/core/pipelines/test_affaires.py
+++ b/tests/core/pipelines/test_affaires.py
@@ -66,6 +66,24 @@ def test_anciennete_comptee_depuis_le_premier_jalon():
     assert vue["anciennete_jours"].to_list() == [15]  # 25 - 10 nov
 
 
+def test_statut_null_traite_comme_en_attente_enedis():
+    # Enedis envoie un <statut> vide → null pour une affaire fraîchement initiée (jalon 0
+    # DMTR, demande transmise mais pas encore rangée). C'est une affaire OUVERTE « en
+    # attente Enedis » : elle doit apparaître au cockpit avec son dernier état, au même
+    # titre que COURS. Seules TERMN/ANNUL sont soldées.
+    jalons = pl.DataFrame(
+        [
+            _jalon("PEND1", 0, "DMTR", datetime(2024, 11, 20, 9, tzinfo=PARIS), statut=None),
+            _jalon("DONE1", 1, "CPRE", datetime(2024, 11, 23, 9, tzinfo=PARIS), statut="TERMN"),
+        ]
+    )
+
+    vue = affaires_ouvertes(jalons, maintenant=datetime(2024, 11, 25, 9, tzinfo=PARIS))
+
+    assert vue["affaire_id"].to_list() == ["PEND1"]
+    assert vue["dernier_etat"].to_list() == ["DMTR"]
+
+
 def test_ame_exclu_mais_prestation_nulle_gardee():
     # AME (45 % du volume) = souscription de flux de données, pas une intervention de
     # périmètre → écarté du cockpit. Une affaire à prestation nulle (réclamation) est

--- a/tests/ingestion/test_dbt_affaires_dedup.py
+++ b/tests/ingestion/test_dbt_affaires_dedup.py
@@ -24,20 +24,73 @@ RACINE = Path(__file__).parents[2]
 PROJET_DBT = RACINE / "electricore" / "ingestion" / "dbt"
 
 
-def _affaire(statut: str, jalons: list[tuple[int, str]]) -> bytes:
-    """Document <affaires> minimal d'une affaire AFF1, statut donné, jalons (num, état)."""
+def _affaire(statut: str | None, jalons: list[tuple[int, str]]) -> bytes:
+    """Document <affaires> minimal d'une affaire AFF1, statut donné, jalons (num, état).
+
+    `statut=None` émet une balise `<statut/>` vide — la forme prod d'une affaire
+    fraîchement initiée qu'Enedis n'a pas encore rangée (statut absent → null)."""
     lignes = "".join(
         f"<jalon><num>{n}</num><dateHeure>2024-11-2{n}T09:00:00+01:00</dateHeure>"
         f'<affaireEtat code="{e}"><libelle>{e}</libelle></affaireEtat></jalon>'
         for n, e in jalons
     )
+    bloc_statut = "<statut/>" if statut is None else f'<statut code="{statut}"><libelle>{statut}</libelle></statut>'
     return (
         '<affaires><affaire id="AFF1"><donneesGenerales>'
-        f'<statut code="{statut}"><libelle>{statut}</libelle></statut>'
+        f"{bloc_statut}"
         f"<jalons>{lignes}</jalons>"
         "<donneesPoint><id>99000000000017</id></donneesPoint><segment>C5</segment>"
         "</donneesGenerales></affaire></affaires>"
     ).encode()
+
+
+def test_statut_vide_donne_null_sans_casser_le_build(tmp_path, monkeypatch):
+    """Une affaire fraîchement initiée, qu'Enedis n'a pas encore rangée, arrive avec un
+    `<statut>` vide (→ null). Le build ne doit PAS la rejeter (statut nullable, #296) et
+    `statut` sort null. Garde-fou contre un retour du `not_null` sur statut."""
+    import dlt
+
+    from electricore.ingestion.raw_landing import lander_documents_bruts
+
+    db_path = tmp_path / "flux.duckdb"
+    pipeline = dlt.pipeline(
+        pipeline_name="test_affaires_statut_vide",
+        destination=dlt.destinations.duckdb(str(db_path)),
+        dataset_name="flux_raw",
+    )
+    lander_documents_bruts(
+        pipeline,
+        "raw_affaires",
+        [
+            {
+                "file_name": "ENEDIS_X12_pending.xml",
+                "modification_date": "2024-11-22T09:30:00",
+                "content": xml_vers_dict(_affaire(None, [(0, "DMTR")])),
+            },
+        ],
+    )
+    monkeypatch.setenv("DBT_DUCKDB_PATH", str(db_path))
+    resultat = dbtRunner().invoke(
+        [
+            "build",
+            "--select",
+            "+flux_affaires",
+            "--project-dir",
+            str(PROJET_DBT),
+            "--profiles-dir",
+            str(PROJET_DBT),
+            "--target-path",
+            str(tmp_path / "target"),
+        ]
+    )
+    # not_null retiré de statut (#296) : le build passe malgré statut null.
+    assert resultat.success, f"dbt build a échoué : {resultat.exception}"
+
+    con = duckdb.connect(str(db_path))
+    rows = con.execute("select jalon_num, statut from flux_enedis.flux_affaires").fetchall()
+    con.close()
+    # L'affaire en attente Enedis est ingérée fidèlement : statut null, jalon 0 conservé.
+    assert rows == [(0, None)]
 
 
 def test_jalon_reemis_dedupe_derniere_livraison_gagne(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problème (diagnostiqué sur données EDN live)

`dbt build` échouait en prod sur `not_null_flux_affaires_statut` (45 lignes) → job d'ingestion `exit 1` → déploiement bloqué. Cause : Enedis envoie un **`<statut>` vide → `null`** pour les **affaires fraîchement initiées qu'il n'a pas encore rangées** : `referenceDemandeur` EDN, jalon `num 0` ("demande transmise"), **pas d'`objet`/prestation**, et **pas encore de cycle de vie** (COURS/TERMN/ANNUL). rc8 n'avait corrigé que le cas `<statut code="X"/>` (attribut sur feuille) — un `<statut>` *vide* n'a pas d'attribut à capter, donc reste null.

`statut` est donc **légitimement nullable** : ce sont de vraies affaires, pas du bruit.

## Décision — Option B (relax + surface)

- **dbt** : retrait du `not_null` sur `flux_affaires.statut` (nullable, fidèle à la source — [ADR-0029](https://github.com/Energie-De-Nantes/electricore/blob/main/docs/adr/0029-modele-releves-canonique-dbt-assemble-coeur-arbitre.md)). Le build passe sur les affaires en attente.
- **Cockpit** : `affaires_ouvertes` traite `statut IS NULL` comme **ouvert** ("en attente Enedis") au même titre que `COURS` ; `TERMN`/`ANNUL` restent soldées. Une demande tout juste déposée — la chose la plus *non soldée* qui soit — apparaît désormais au cockpit avec son dernier état (`DMTR`). Elle passe déjà le filtre AME (prestation nulle conservée), et la sortie du rollup n'a pas de colonne `statut` → affichage inchangé.

## Tests (TDD)

- **Cœur** (`test_affaires.py`) : un jalon à `statut` null apparaît dans `affaires_ouvertes` avec son `dernier_etat` ; une affaire `TERMN` reste exclue.
- **dbt** (`test_dbt_affaires_dedup.py`) : un `<statut>` vide → `null`, `dbt build` réussit (garde-fou contre un retour du `not_null`). Échouait avant le retrait du `not_null` (RED→GREEN).
- Golden X12/X13 + loader + endpoint + bot affaires : inchangés, verts.
- Suite complète : **841 passed**. Seul échec = `test_historique_monotonie_horizon` (property), **préexistant et indépendant** (n'importe aucun module touché ici).

Bug distinct du correctif rc9 (Wh→kWh) — devient rc10.

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)
