### PR TITLE
fix(api): job d'ingestion en échec expose la vraie erreur (stdout) (#298)

### DIFF
--- a/electricore/api/services/ingestion_service.py
+++ b/electricore/api/services/ingestion_service.py
@@ -131,6 +131,12 @@ async def start_job(mode: str) -> JobIngestion:
     return job
 
 
+def _tail(texte: str, lignes: int = 40) -> str:
+    """Dernières `lignes` lignes non vides : la cause utile d'un échec dbt/dlt est en fin
+    de sortie. Garde l'`error` lisible sans y noyer tout le log (qui vit dans `output`)."""
+    return "\n".join(texte.strip().splitlines()[-lignes:])
+
+
 def _run_pipeline(job: JobIngestion) -> None:
     """Exécute le pipeline d'ingestion via subprocess (isolation des dépendances DLT)."""
     try:
@@ -139,10 +145,14 @@ def _run_pipeline(job: JobIngestion) -> None:
             capture_output=True,
             text=True,
         )
-        if result.returncode != 0:
-            raise RuntimeError(result.stderr.strip() or f"exit code {result.returncode}")
-        job.status = StatutIngestion.completed
+        # dlt/dbt loguent leurs diagnostics sur stdout → capturer la sortie dans TOUS les
+        # cas (succès comme échec), sinon la vraie cause d'un échec est jetée (#298).
         job.output = result.stdout.strip() or None
+        if result.returncode != 0:
+            # stderr est souvent vide (logs sur stdout) → reporter le tail de stdout pour
+            # une `error` lisible, pas un « exit code 1 » nu.
+            raise RuntimeError(result.stderr.strip() or _tail(result.stdout) or f"exit code {result.returncode}")
+        job.status = StatutIngestion.completed
     except Exception as exc:
         job.status = StatutIngestion.failed
         job.error = str(exc)

--- a/tests/ingestion/test_ingestion.py
+++ b/tests/ingestion/test_ingestion.py
@@ -67,3 +67,31 @@ def test_l_api_subprocess_le_runner_dbt():
     commande = _build_pipeline_command("all")
     assert "electricore.ingestion" in commande
     assert "electricore.ingestion.pipeline_production" not in commande
+
+
+def test_job_en_echec_expose_la_sortie_reelle(monkeypatch):
+    """dlt/dbt écrivent leurs diagnostics sur stdout : un job en échec doit exposer cette
+    sortie — `error` lisible ET `output` capturé — pas un « exit code 1 » nu (#298)."""
+    import subprocess
+    from datetime import datetime
+
+    from electricore.api.services import ingestion_service
+    from electricore.api.services.ingestion_service import (
+        JobIngestion,
+        StatutIngestion,
+        _run_pipeline,
+    )
+
+    erreur_dbt = "Failure in test not_null_flux_affaires_statut — Got 45 results"
+    monkeypatch.setattr(
+        ingestion_service.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(args=a, returncode=1, stdout=f"{erreur_dbt}\n", stderr=""),
+    )
+
+    job = JobIngestion(id="j1", mode="test", status=StatutIngestion.running, started_at=datetime.now())
+    _run_pipeline(job)
+
+    assert job.status == StatutIngestion.failed
+    assert erreur_dbt in (job.error or ""), "l'erreur doit porter la vraie cause (stdout), pas « exit code 1 »"
+    assert erreur_dbt in (job.output or ""), "stdout doit être capturé même en échec"


### PR DESCRIPTION
## Problème

Un job d'ingestion en échec enregistrait un **`error = "exit code 1"`** nu et **`output = null`** — la vraie cause (ex. `Failure in test not_null_flux_affaires_statut — Got 45 results`) était **jetée**. `_run_pipeline` ne posait `job.output = stdout` que sur le chemin *succès* (après le `raise`), et construisait l'erreur depuis **stderr** — or dlt/dbt loguent sur **stdout** (stderr vide). C'est ce qui a rendu un vrai échec de déploiement invisible derrière un `✓`.

## Correctif

- `job.output = stdout` capturé dans **tous les cas** (déplacé avant le check `returncode`).
- `error` lisible : `stderr`, sinon le **tail** de stdout (40 dernières lignes — la cause utile est en fin de log dbt), sinon `exit code N`.
- Succès inchangé.

## Tests

- TDD : un pipeline qui échoue en écrivant sur stdout (stderr vide, exit≠0) → job `failed` dont l'`error` **et** l'`output` portent la sortie réelle. Échouait avant le correctif (RED→GREEN).
- Suite complète : **840 passed** (seul échec = `test_historique_monotonie_horizon`, property, préexistant et indépendant).

Pendant installeur : #299 (le step ETL doit poller l'issue du job — ne devient lisible qu'avec ce correctif).

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)