### PR TITLE
chore(release): v3.0.0rc10 — affaires statut nullable + erreurs d'ingestion lisibles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.0.0rc10] - 2026-06-16
+
+Robustesse des affaires SGE et lisibilité des échecs d'ingestion — deux correctifs
+révélés en déployant rc9 sur données réelles.
+
+### 🐛 Correctifs (ingestion + core)
+
+- **`flux_affaires.statut` nullable + cockpit « en attente Enedis »** ([#296](https://github.com/Energie-De-Nantes/electricore/issues/296)) :
+  Enedis envoie un `<statut>` vide (→ null) pour une affaire fraîchement initiée qu'il n'a
+  pas encore rangée (jalon 0, demande transmise, pas d'objet) ; le `not_null` faisait échouer
+  `dbt build` en prod (45 lignes) → job d'ingestion en échec. `statut` devient nullable (fidèle
+  à la source, [ADR-0029](docs/adr/0029-modele-releves-canonique-dbt-assemble-coeur-arbitre.md)),
+  et `affaires_ouvertes` traite null comme **ouvert** au même titre que `COURS` — les demandes
+  tout juste déposées apparaissent au cockpit avec leur dernier état. rc8 n'avait couvert que le
+  cas `<statut code="X"/>` (attribut sur feuille), pas le `<statut>` vide.
+- **Job d'ingestion : la vraie erreur au lieu d'un « exit code 1 » nu** ([#298](https://github.com/Energie-De-Nantes/electricore/issues/298)) :
+  dlt/dbt loguent leurs diagnostics sur stdout. Un job en échec capture désormais cette sortie
+  (`output` dans tous les cas, `error` = stderr sinon le tail de stdout) au lieu de la jeter —
+  un échec d'ingestion devient lisible au niveau job/API. Suivi : [#299](https://github.com/Energie-De-Nantes/electricore/issues/299)
+  (le step « ETL test » de l'installeur doit poller l'issue du job au lieu de verdir sur le 202).
+
+### 🔧 Dépendances
+
+- Bump starlette 1.2.1 → 1.3.1, cryptography 48.0.0 → 48.0.1 (Dependabot).
+
 ## [3.0.0rc9] - 2026-06-16
 
 Correctif de correctness : les index R151/R64 étaient ~1000× trop grands dans le mart

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.0.0rc9"
+version = "3.0.0rc10"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.0.0rc9"
+version = "3.0.0rc10"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Bump **3.0.0rc9 → 3.0.0rc10** (`pyproject.toml` + `uv.lock` + `CHANGELOG.md`).

Contenu (déjà mergé) :
- [#296](https://github.com/Energie-De-Nantes/electricore/issues/296) — `flux_affaires.statut` nullable + cockpit « en attente Enedis » (PR #297). **Débloque `ingestion all` en prod.**
- [#298](https://github.com/Energie-De-Nantes/electricore/issues/298) — job d'ingestion expose la vraie erreur stdout (PR #300).
- Deps : starlette 1.2.1→1.3.1, cryptography 48.0.0→48.0.1.

Après merge : tag `v3.0.0rc10` sur le commit de merge → workflow Release (build, PyPI, GitHub release prerelease, image ghcr). Puis réinstaller avec `--version 3.0.0rc10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)