### PR TITLE
refactor(dbt): assemble releves via conformed source adapters + conformer macro (#304)

### DIFF
--- a/electricore/ingestion/dbt/dbt_project.yml
+++ b/electricore/ingestion/dbt/dbt_project.yml
@@ -17,6 +17,10 @@ models:
     flux:
       # Tables : les flux linéarisés sont les tables consommées par core/.
       +materialized: table
+    intermediate:
+      # Vues : adapters de source (ex. int_releves__c15) consommés par les marts ;
+      # testables et inspectables, coût ~nul (ADR-0029, #304).
+      +materialized: view
     marts:
       # Tables : modèles transverses (cross-flux) consommés par core/ (ADR-0029).
       +materialized: table

--- a/electricore/ingestion/dbt/macros/conformer_releve.sql
+++ b/electricore/ingestion/dbt/macros/conformer_releve.sql
@@ -1,0 +1,54 @@
+-- Contrat de colonnes du modèle de relevés canonique `releves` (ADR-0029).
+--
+-- SOURCE UNIQUE DE VÉRITÉ de l'ordre et du type de chaque colonne du contrat. Ajouter
+-- une colonne au modèle canonique = l'ajouter ICI, une fois, et non dans chaque branche
+-- de l'union (fin de la transcription bouchée `cast(null)` répétée par source).
+--
+-- `source` n'est PAS dans le contrat : il est estampillé par le conformer (constante de
+-- branche). `id_releve` natif Enedis n'y est PAS non plus (#304) : toujours NULL pour les
+-- trois sources vivantes (R151/R64 n'en ont pas ; C15 le nullait), aucun consommateur ne
+-- le lit. La traçabilité repose sur `releve_id` (clé métier ADR-0028) + `occurrence_id`
+-- (provenance fichier). Réintroduit dans le journal des relevés utilisés, pas ici, le jour
+-- où la régularisation aura besoin de l'id officiel (cf. #305).
+{% macro contrat_releve() %}
+  {{ return([
+    ('releve_id', 'varchar'),
+    ('pdl', 'varchar'),
+    ('date_releve', 'timestamptz'),
+    ('ordre_index', 'boolean'),
+    ('nature_index', 'varchar'),
+    ('occurrence_id', 'varchar'),
+    ('ref_situation_contractuelle', 'varchar'),
+    ('formule_tarifaire_acheminement', 'varchar'),
+    ('id_calendrier_distributeur', 'varchar'),
+    ('index_base_kwh', 'bigint'),
+    ('index_hp_kwh', 'bigint'),
+    ('index_hc_kwh', 'bigint'),
+    ('index_hph_kwh', 'bigint'),
+    ('index_hpb_kwh', 'bigint'),
+    ('index_hch_kwh', 'bigint'),
+    ('index_hcb_kwh', 'bigint')
+  ]) }}
+{% endmacro %}
+
+
+-- Projette une source de relevés (CTE ou modèle) sur le contrat canonique (ADR-0029).
+--
+-- PATTERN « adapter de source » : chaque source est une CTE / un modèle ÉTROIT qui n'émet
+-- que les colonnes qu'elle porte vraiment, déjà nommées et typées canoniquement, avec sa
+-- logique propre (harmonisation de date R151 +1j, ancrage Paris R64, dépivot C15…). Ce
+-- macro fait le reste, une fois : estampille `source`, et remplit en NULL typé tout ce que
+-- la source n'a pas. `fournit` = la liste des colonnes du contrat que la source porte → le
+-- complément (« ce que la source N'A PAS ») est LISIBLE au point d'appel, au lieu d'être
+-- noyé en `cast(null)` dans une union large.
+--
+-- Ajouter une source = écrire son adapter étroit + un appel ici. Ajouter une colonne =
+-- l'ajouter à `contrat_releve()` (+ aux `fournit` des sources qui la portent).
+{% macro conformer_au_contrat_releve(relation, source, fournit) %}
+    select
+        '{{ source }}' as source
+        {%- for col, type in contrat_releve() %},
+        {% if col in fournit %}{{ col }}{% else %}cast(null as {{ type }}){% endif %} as {{ col }}
+        {%- endfor %}
+    from {{ relation }}
+{% endmacro %}

--- a/electricore/ingestion/dbt/models/flux/flux_r64.sql
+++ b/electricore/ingestion/dbt/models/flux/flux_r64.sql
@@ -114,6 +114,7 @@ points as (
 points_valides as (
     select
         mesure_id,
+        id_calendrier,
         lower(id_classe)                       as cadran,
         cast(date_point as timestamp)          as date_releve,
         cast(valeur_point as bigint)           as valeur
@@ -137,6 +138,10 @@ pivot_cadrans as (
     select
         mesure_id,
         date_releve,
+        -- Calendrier distributeur de la mesure (points déjà filtrés sur les calendriers
+        -- distributeur ci-dessus) : conservé au lieu d'être jeté (#304). Un (mesure, date)
+        -- n'a qu'un calendrier distributeur actif → max() est déterministe.
+        max(id_calendrier)                            as id_calendrier_distributeur,
         max(case when cadran = 'base' then valeur end) as index_base_kwh,
         max(case when cadran = 'hp'   then valeur end) as index_hp_kwh,
         max(case when cadran = 'hc'   then valeur end) as index_hc_kwh,

--- a/electricore/ingestion/dbt/models/intermediate/int_releves__c15.sql
+++ b/electricore/ingestion/dbt/models/intermediate/int_releves__c15.sql
@@ -1,0 +1,53 @@
+-- Adapter de source C15 → relevés (ADR-0029, #304).
+--
+-- `flux_c15` reste FIDÈLE : grain événement, avant/après en colonnes (fidélité de
+-- l'événement + substrat d'`impacte_energie` au cœur). Ce modèle en dérive le grain
+-- *relevé* — 1 événement → 2 lignes (avant/après) — consommé par le modèle canonique
+-- `releves`. Adapter ÉTROIT : n'émet QUE ce que C15 porte. Pas d'`occurrence_id` (C15
+-- n'en a pas → null-fill par le conformer au seam `releves`). Discriminant : `ordre_index`
+-- (False = avant, True = après). `releve_id` minté au seam dbt comme les autres sources
+-- (ADR-0028), discriminé par `ordre_index`. RSC/FTA portées NATIVEMENT par l'événement.
+
+with avant as (
+    select
+        {{ mint_releve_id("'flux_C15'", "pdl", "(date_evenement at time zone 'Europe/Paris')", "false") }} as releve_id,
+        pdl,
+        date_evenement                                          as date_releve,
+        false                                                   as ordre_index,
+        {{ nature_depuis_nature_index("avant_nature_index") }}  as nature_index,
+        ref_situation_contractuelle,
+        formule_tarifaire_acheminement,
+        avant_id_calendrier_distributeur                        as id_calendrier_distributeur,
+        avant_index_base_kwh as index_base_kwh, avant_index_hp_kwh as index_hp_kwh, avant_index_hc_kwh as index_hc_kwh,
+        avant_index_hph_kwh as index_hph_kwh, avant_index_hpb_kwh as index_hpb_kwh,
+        avant_index_hch_kwh as index_hch_kwh, avant_index_hcb_kwh as index_hcb_kwh
+    from {{ ref('flux_c15') }}
+    where coalesce(
+        avant_index_base_kwh, avant_index_hp_kwh, avant_index_hc_kwh, avant_index_hph_kwh,
+        avant_index_hpb_kwh, avant_index_hch_kwh, avant_index_hcb_kwh
+    ) is not null
+),
+
+apres as (
+    select
+        {{ mint_releve_id("'flux_C15'", "pdl", "(date_evenement at time zone 'Europe/Paris')", "true") }} as releve_id,
+        pdl,
+        date_evenement                                          as date_releve,
+        true                                                    as ordre_index,
+        {{ nature_depuis_nature_index("apres_nature_index") }}  as nature_index,
+        ref_situation_contractuelle,
+        formule_tarifaire_acheminement,
+        apres_id_calendrier_distributeur                        as id_calendrier_distributeur,
+        apres_index_base_kwh as index_base_kwh, apres_index_hp_kwh as index_hp_kwh, apres_index_hc_kwh as index_hc_kwh,
+        apres_index_hph_kwh as index_hph_kwh, apres_index_hpb_kwh as index_hpb_kwh,
+        apres_index_hch_kwh as index_hch_kwh, apres_index_hcb_kwh as index_hcb_kwh
+    from {{ ref('flux_c15') }}
+    where coalesce(
+        apres_index_base_kwh, apres_index_hp_kwh, apres_index_hc_kwh, apres_index_hph_kwh,
+        apres_index_hpb_kwh, apres_index_hch_kwh, apres_index_hcb_kwh
+    ) is not null
+)
+
+select * from avant
+union all
+select * from apres

--- a/electricore/ingestion/dbt/models/marts/releves.sql
+++ b/electricore/ingestion/dbt/models/marts/releves.sql
@@ -1,113 +1,87 @@
 -- Modèle de relevés canonique (ADR-0029) : la ligne de temps des relevés consommée
 -- par l'aval. Union des sources (1 ligne = 1 relevé) : périodiques télérelevées
--- (R151, R64) + relevés contractuels C15 avant/après dépivotés. Dates harmonisées
--- « début de journée » Europe/Paris (ADR-0003 : R151 J → J+1). Mint uniforme de
--- releve_id (clé métier ADR-0028) pour TOUTES les sources, C15 comprise (l'exception
--- « en core pour c15 » d'ADR-0028 disparaît). Dedup même-source par releve_id (on
--- garde la livraison la plus récente).
+-- (R151, R64) + relevés contractuels C15 avant/après dépivotés (via int_releves__c15).
 --
--- À VENIR : enrichissement contractuel RSC/FTA des lignes périodiques, piloté par C15
--- (#243). L'arbitrage de priorité inter-sources (C15 > R64 > R151) et la sélection des
--- bornes de facturation restent au cœur (#244, ADR-0029). flux_c15 reste fidèle :
--- avant/après y sont conservés (fidélité de l'événement + substrat d'impacte_energie).
+-- ASSEMBLAGE PAR ADAPTERS CONFORMÉS (#304) : chaque source est un adapter ÉTROIT
+-- (CTE pour R151/R64, modèle int_releves__c15 pour le dépivot C15) n'émettant que ce
+-- qu'elle porte vraiment, avec sa logique propre (harmonisation J→J+1 ADR-0003 pour R151,
+-- ancrage heure-mur Paris). Le macro `conformer_au_contrat_releve()` (cf.
+-- macros/conformer_releve.sql) estampille `source` et remplit en NULL typé ce que la
+-- source n'a pas — le contrat de colonnes vit en UN endroit (`contrat_releve()`), plus
+-- une transcription `cast(null)` répétée par branche. « Ce que la source n'a pas » est
+-- lisible au point d'appel (l'argument `fournit`).
+--
+-- Mint uniforme de releve_id (clé métier ADR-0028) pour TOUTES les sources, C15 comprise.
+-- Dedup même-source par releve_id (on garde la livraison la plus récente). L'arbitrage de
+-- priorité inter-sources (C15 > R64 > R151) et la sélection des bornes de facturation
+-- restent au cœur (#244, ADR-0029). flux_c15 reste fidèle (avant/après conservés).
 
-with unifies as (
-    -- R151 : télérelevés périodiques. Harmonisation J → J+1 (ADR-0003) puis ancrage
-    -- heure-mur Paris. releve_id (clé métier) est minté sur la date BRUTE en amont
-    -- (flux_r151) : l'harmonisation d'affichage ne change pas l'identité.
+with
+-- R151 : adapter de source. Télérelevés périodiques. Harmonisation J → J+1 (ADR-0003)
+-- puis ancrage heure-mur Paris. releve_id (clé métier) est minté sur la date BRUTE en
+-- amont (flux_r151) : l'harmonisation d'affichage ne change pas l'identité. Ne porte pas
+-- de RSC/FTA (null-fill au conformer).
+r151_raw as (
     select
         releve_id,
-        'flux_R151'                                                                 as source,
         pdl,
         timezone('Europe/Paris', cast(date_releve as timestamp) + interval '1 day') as date_releve,
         false                                                                       as ordre_index,
         nature_index,
-        id_releve,
         occurrence_id,
-        cast(null as varchar)                                                       as ref_situation_contractuelle,
-        cast(null as varchar)                                                       as formule_tarifaire_acheminement,
         id_calendrier_distributeur,
         index_base_kwh, index_hp_kwh, index_hc_kwh,
         index_hph_kwh, index_hpb_kwh, index_hch_kwh, index_hcb_kwh
     from {{ ref('flux_r151') }}
+),
 
-    union all
-
-    -- R64 : relevés JSON timeseries (déjà dédoublonnés intra-source dans flux_r64).
-    -- date_releve naïve → ancrage heure-mur Paris (convention début de journée native,
-    -- pas de décalage).
+-- R64 : adapter de source. Relevés JSON timeseries (déjà dédoublonnés intra-source dans
+-- flux_r64). date_releve naïve → ancrage heure-mur Paris (convention début de journée
+-- native). Porte son calendrier distributeur (#304). Ne porte pas de RSC/FTA.
+r64_raw as (
     select
         releve_id,
-        'flux_R64'                                                                  as source,
         pdl,
         timezone('Europe/Paris', date_releve)                                       as date_releve,
         false                                                                       as ordre_index,
         nature_index,
-        id_releve,
         occurrence_id,
-        cast(null as varchar)                                                       as ref_situation_contractuelle,
-        cast(null as varchar)                                                       as formule_tarifaire_acheminement,
-        cast(null as varchar)                                                       as id_calendrier_distributeur,
+        id_calendrier_distributeur,
         index_base_kwh, index_hp_kwh, index_hc_kwh,
         index_hph_kwh, index_hpb_kwh, index_hch_kwh, index_hcb_kwh
     from {{ ref('flux_r64') }}
+),
+
+unifies as (
+    {{ conformer_au_contrat_releve('r151_raw', 'flux_R151', fournit=[
+        'releve_id', 'pdl', 'date_releve', 'ordre_index', 'nature_index', 'occurrence_id',
+        'id_calendrier_distributeur',
+        'index_base_kwh', 'index_hp_kwh', 'index_hc_kwh',
+        'index_hph_kwh', 'index_hpb_kwh', 'index_hch_kwh', 'index_hcb_kwh'
+    ]) }}
 
     union all
 
-    -- C15 « avant » : index relevé immédiatement AVANT l'événement contractuel
-    -- (ordre_index = false). date_releve = date_evenement (instant). RSC/FTA sont
-    -- portées NATIVEMENT par l'événement (C15 = source contractuelle). releve_id minté
-    -- en dbt comme les autres sources (discriminant = ordre_index).
-    select
-        {{ mint_releve_id("'flux_C15'", "pdl", "(date_evenement at time zone 'Europe/Paris')", "false") }} as releve_id,
-        'flux_C15'                                                                  as source,
-        pdl,
-        date_evenement                                                              as date_releve,
-        false                                                                       as ordre_index,
-        {{ nature_depuis_nature_index("avant_nature_index") }}                      as nature_index,
-        cast(null as varchar)                                                       as id_releve,
-        cast(null as varchar)                                                       as occurrence_id,
-        ref_situation_contractuelle,
-        formule_tarifaire_acheminement,
-        avant_id_calendrier_distributeur                                            as id_calendrier_distributeur,
-        avant_index_base_kwh as index_base_kwh, avant_index_hp_kwh as index_hp_kwh, avant_index_hc_kwh as index_hc_kwh,
-        avant_index_hph_kwh as index_hph_kwh, avant_index_hpb_kwh as index_hpb_kwh,
-        avant_index_hch_kwh as index_hch_kwh, avant_index_hcb_kwh as index_hcb_kwh
-    from {{ ref('flux_c15') }}
-    where coalesce(
-        avant_index_base_kwh, avant_index_hp_kwh, avant_index_hc_kwh, avant_index_hph_kwh,
-        avant_index_hpb_kwh, avant_index_hch_kwh, avant_index_hcb_kwh
-    ) is not null
+    {{ conformer_au_contrat_releve('r64_raw', 'flux_R64', fournit=[
+        'releve_id', 'pdl', 'date_releve', 'ordre_index', 'nature_index', 'occurrence_id',
+        'id_calendrier_distributeur',
+        'index_base_kwh', 'index_hp_kwh', 'index_hc_kwh',
+        'index_hph_kwh', 'index_hpb_kwh', 'index_hch_kwh', 'index_hcb_kwh'
+    ]) }}
 
     union all
 
-    -- C15 « après » : index relevé immédiatement APRÈS l'événement (ordre_index = true).
-    select
-        {{ mint_releve_id("'flux_C15'", "pdl", "(date_evenement at time zone 'Europe/Paris')", "true") }} as releve_id,
-        'flux_C15'                                                                  as source,
-        pdl,
-        date_evenement                                                              as date_releve,
-        true                                                                        as ordre_index,
-        {{ nature_depuis_nature_index("apres_nature_index") }}                      as nature_index,
-        cast(null as varchar)                                                       as id_releve,
-        cast(null as varchar)                                                       as occurrence_id,
-        ref_situation_contractuelle,
-        formule_tarifaire_acheminement,
-        apres_id_calendrier_distributeur                                            as id_calendrier_distributeur,
-        apres_index_base_kwh as index_base_kwh, apres_index_hp_kwh as index_hp_kwh, apres_index_hc_kwh as index_hc_kwh,
-        apres_index_hph_kwh as index_hph_kwh, apres_index_hpb_kwh as index_hpb_kwh,
-        apres_index_hch_kwh as index_hch_kwh, apres_index_hcb_kwh as index_hcb_kwh
-    from {{ ref('flux_c15') }}
-    where coalesce(
-        apres_index_base_kwh, apres_index_hp_kwh, apres_index_hc_kwh, apres_index_hph_kwh,
-        apres_index_hpb_kwh, apres_index_hch_kwh, apres_index_hcb_kwh
-    ) is not null
+    {{ conformer_au_contrat_releve(ref('int_releves__c15'), 'flux_C15', fournit=[
+        'releve_id', 'pdl', 'date_releve', 'ordre_index', 'nature_index',
+        'ref_situation_contractuelle', 'formule_tarifaire_acheminement', 'id_calendrier_distributeur',
+        'index_base_kwh', 'index_hp_kwh', 'index_hc_kwh',
+        'index_hph_kwh', 'index_hpb_kwh', 'index_hch_kwh', 'index_hcb_kwh'
+    ]) }}
 ),
 
 -- Dedup même-source (re-livraison) : 1 ligne par relevé logique = 1 par releve_id
--- (clé métier ADR-0028, encode source|pdl|date|discriminant). On garde la livraison
--- la plus récente ; occurrence_id (fichier#position / mesure_id) départage de façon
--- déterministe. R64 est déjà unique en amont (qualify dans flux_r64).
+-- (clé métier ADR-0028). On garde la livraison la plus récente ; occurrence_id départage
+-- de façon déterministe. R64 est déjà unique en amont (qualify dans flux_r64).
 dedup as (
     select *
     from unifies
@@ -116,12 +90,9 @@ dedup as (
 
 -- Enrichissement contractuel piloté par C15 (#243, ADR-0029) : les lignes périodiques
 -- (R151/R64) ne portent pas de RSC/FTA ; on les propage (forward-fill) depuis les
--- relevés C15 — la source contractuelle — par PDL, le long du temps. Remplace le
--- join_asof incident sur les événements FACTURATION par une attribution déterministe
--- et découplée de la facturation. Tie-break à date égale : C15 d'abord (sa RSC est vue
--- par un relevé périodique du même jour), puis « après » avant « avant » non — on
--- ordonne ordre_index croissant pour que la situation APRÈS l'événement (nouvelle RSC
--- d'une entrée) prime. Multi-source préservé : pas de dedup inter-sources ici,
+-- relevés C15 — la source contractuelle — par PDL, le long du temps. Tie-break à date
+-- égale : C15 d'abord, puis R64, puis R151 ; ordre_index croissant pour que la situation
+-- APRÈS l'événement prime. Multi-source préservé : pas de dedup inter-sources ici,
 -- l'arbitrage de priorité reste au cœur (#244).
 select * replace (
     coalesce(

--- a/electricore/ingestion/dbt/models/marts/schema.yml
+++ b/electricore/ingestion/dbt/models/marts/schema.yml
@@ -13,7 +13,13 @@ models:
           dans le modèle canonique — le dedup même-source collapse les re-livraisons.
         data_tests: [not_null, unique]
       - name: source
-        description: Source du relevé (flux_R151, flux_R64, …).
+        description: Source du relevé — énumération fermée (assemblage par adapters, #304).
+        data_tests:
+          - not_null
+          - accepted_values:
+              values: ["flux_C15", "flux_R64", "flux_R151"]
+      - name: pdl
+        description: Point de livraison ; non-null pour toute source (contrat, #304).
         data_tests: [not_null]
       - name: date_releve
         description: Date du relevé harmonisée (début de journée, Europe/Paris).

--- a/tests/ingestion/test_dbt_releves_golden.py
+++ b/tests/ingestion/test_dbt_releves_golden.py
@@ -147,6 +147,40 @@ def test_releves_inclut_c15_avant_apres(base_periodiques):
     assert all(r["nature_index"] in {"réel", "estimé", "corrigé"} for r in c15)
 
 
+def test_releves_sans_colonne_id_releve_natif(base_periodiques):
+    """L'id natif Enedis est retiré du contrat canonique (#304) : toujours NULL pour les
+    trois sources vivantes (R151/R64 n'en ont pas, C15 le nullait), aucun consommateur ne
+    le lit (ni ChronologieReleves ni RelevéIndex). La traçabilité repose sur releve_id
+    (clé métier) + occurrence_id (provenance fichier). flux_r15/flux_r15_acc le gardent."""
+    resultat = _build_releves(base_periodiques.parent)
+    assert resultat.success, f"dbt build releves a échoué : {resultat.exception}"
+
+    con = duckdb.connect(str(base_periodiques))
+    cols = [r[0] for r in con.execute("describe flux_enedis.releves").fetchall()]
+    con.close()
+
+    assert "id_releve" not in cols, f"id_releve doit être retiré du contrat canonique, vu : {cols}"
+
+
+def test_r64_porte_son_calendrier_distributeur(base_periodiques):
+    """Fidélité R64 (#304) : un relevé R64 porte son calendrier distributeur (DI00000X)
+    au lieu d'un NULL codé en dur — `flux_r64` filtre déjà sur ce calendrier puis le
+    jette. Le cœur en dérive précision et cadrans (RelevéIndex). Fixture R64 = DI000003."""
+    resultat = _build_releves(base_periodiques.parent)
+    assert resultat.success, f"dbt build releves a échoué : {resultat.exception}"
+
+    con = duckdb.connect(str(base_periodiques))
+    cals = [
+        r[0]
+        for r in con.execute(
+            "select distinct id_calendrier_distributeur from flux_enedis.releves where source = 'flux_R64'"
+        ).fetchall()
+    ]
+    con.close()
+
+    assert cals == ["DI000003"], f"R64 doit porter son calendrier distributeur, vu : {cals}"
+
+
 def test_forward_fill_rsc_pilote_par_c15():
     """Enrichissement contractuel (#243) : une ligne périodique hérite la RSC/FTA du
     dernier relevé C15 amont (par PDL). Vérifie la fenêtre de forward-fill du modèle


### PR DESCRIPTION
## What & why

Candidate 1 from the architecture review — deepen the canonical relevés model (`releves`). The mart was a four-branch padded `union all` where each source restated the full ~18-column contract and padded what it lacked with `cast(null)`. The union *transcribed*; now it *conforms*.

Closes #304

## Changes

- **conformer macro** (`macros/conformer_releve.sql`) — `contrat_releve()` is the single source of truth for the canonical column list; `conformer_au_contrat_releve()` stamps `source` and null-fills each source's gaps. The `fournit` arg makes "what this source lacks" legible at the call site. No `dbt_utils`, no new package.
- **`int_releves__c15`** (new `intermediate/` layer, view) — the C15 avant/après depivot. `flux_c15` stays event-grained (ADR-0029). R151/R64 stay narrow conformed CTEs in `releves.sql`.
- **Drop native `id_releve`** from the canonical contract — always-NULL (no live source fills it, no consumer reads it; neither `ChronologieReleves` nor `RelevéIndex` declare it). Traceability rests on `releve_id` (business key) + `occurrence_id` (provenance). `flux_r15`/`flux_r15_acc` untouched.
- **Carry R64's distributor calendar** — `flux_r64` filtered on `id_calendrier` then dropped it; now surfaced so R64 relevés stop hard-NULLing `id_calendrier_distributeur` (the cœur derives precision/cadrans from it).
- **New contract tests** on `releves`: `accepted_values(source)`, `not_null(pdl)`.

Dedup (`order by occurrence_id desc`) and the RSC/FTA forward-fill are copied **verbatim** — their smells (occurrence_id-as-dedup-key; forward-fill duplicated in core) are tracked as separate architecture candidates, out of scope.

## Verification

Behaviour-preserving except the two intended changes. EXCEPT-diff of `releves` built from `origin/main` vs this branch over identical fixtures:

```
rows: before=5 after=5
before-only (16 shared cols): 0
after-only  (16 shared cols): 0
R64 id_calendrier_distributeur  before: [None]   after: ['DI000003']
id_releve column                before: True      after: False
VERDICT: BEHAVIOUR PRESERVED ✅
```

Tests: `tests/ingestion/` + `test_chronologie_releves` + `test_pipeline_energie` + loaders → **139 passed, 1 skipped** (pre-existing env skip — that loader test needs `releves` in the shared dev DB). New golden assertions added: R64 carries its calendar, `id_releve` dropped.

## Follow-up

- #305 (HITL): reconcile R15 — ADR-0029's "four sources" vs the realized three; drop `flux_R15` from `SOURCES_CHRONOLOGIE` / `RelevéIndex.source` if permanently out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
