### PR TITLE
fix(ingestion) + release: v3.0.0rc12 — runner construit int_releves__c15 (hotfix rc11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.0.0rc12] - 2026-06-16
+
+Hotfix rc11 : l'ingestion de prod échouait au `dbt build` — l'adapter intermédiaire
+`int_releves__c15` introduit en rc11 n'était pas construit par le runner.
+
+### 🐛 Correctif (ingestion)
+
+- **Le runner construit `int_releves__c15`** ([#304](https://github.com/Energie-De-Nantes/electricore/issues/304)) :
+  `construire_dbt` sélectionnait `releves` nu (sans ancêtres), s'appuyant sur le fait que
+  les ancêtres de `releves` étaient déjà couverts par les `+flux_*`. rc11 a introduit
+  l'adapter intermédiaire `int_releves__c15` — un ancêtre de `releves` qui **n'est pas** un
+  `flux_*` → non construit → `Catalog Error: Table int_releves__c15 does not exist` au
+  `dbt build` de prod. Le runner sélectionne désormais `+releves` (graph operator tirant
+  tous les ancêtres). Régression couverte par un test qui exerce la **vraie** sélection du
+  runner — le golden utilisait `+releves` codé en dur et ne traversait pas ce chemin.
+
 ## [3.0.0rc11] - 2026-06-16
 
 Approfondissement du modèle de relevés canonique : l'assemblage multi-sources passe d'une

--- a/electricore/ingestion/runner.py
+++ b/electricore/ingestion/runner.py
@@ -145,11 +145,15 @@ def construire_dbt(db_path: Path) -> bool:
     con.close()
     selection = [f"+{modele}" for raw, modeles in MODELES_PAR_RAW.items() if raw in presentes for modele in modeles]
     # Le modèle de relevés canonique `releves` (mart, ADR-0029) est un DESCENDANT des
-    # flux : les `+flux_*` (ancêtres) ne l'atteignent pas. On l'ajoute explicitement dès
-    # que ses trois sources sont matérialisables (C15 + périodiques R151/R64) — sinon un
-    # arm d'union pointerait un flux non construit. Ses ancêtres sont déjà dans `selection`.
+    # flux : les `+flux_*` (ancêtres) ne l'atteignent pas. On l'ajoute dès que ses trois
+    # sources sont matérialisables (C15 + périodiques R151/R64) — sinon un arm d'union
+    # pointerait un flux non construit. On sélectionne `+releves` (et non `releves` nu) :
+    # le graph operator tire TOUS ses ancêtres, dont l'adapter intermédiaire
+    # `int_releves__c15` qui n'est pas un `flux_*` (sinon : Catalog Error « int_releves__c15
+    # does not exist », cf. régression test_runner_construit_releves). Les flux ancêtres,
+    # déjà dans `selection` via `+flux_*`, sont dédoublonnés par dbt.
     if {"raw_c15", "raw_r151", "raw_r64"} <= presentes:
-        selection.append("releves")
+        selection.append("+releves")
     if not selection:
         _out("  aucune table brute landée — rien à construire")
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.0.0rc11"
+version = "3.0.0rc12"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/tests/ingestion/test_dbt_releves_golden.py
+++ b/tests/ingestion/test_dbt_releves_golden.py
@@ -92,6 +92,24 @@ def _build_releves(target_parent):
     )
 
 
+def test_runner_construit_releves_via_sa_propre_selection(base_periodiques):
+    """Régression rc11 : le runner de prod (`construire_dbt`) sélectionne par `+flux_*`
+    (ancêtres des raw landés) + `releves`. `int_releves__c15` est un ancêtre de `releves`
+    qui n'est PAS un `flux_*` → la sélection du runner doit l'inclure (sinon
+    `Catalog Error: int_releves__c15 does not exist`). Le golden ci-dessous utilise
+    `+releves` (qui tire les ancêtres) et ne couvrait donc PAS le chemin de prod ;
+    ce test exerce la VRAIE sélection du runner."""
+    from electricore.ingestion.runner import construire_dbt
+
+    assert construire_dbt(base_periodiques), (
+        "le runner doit construire releves ET tous ses ancêtres (dont int_releves__c15)"
+    )
+    con = duckdb.connect(str(base_periodiques))
+    n = con.execute("select count(*) from flux_enedis.releves").fetchone()[0]
+    con.close()
+    assert n > 0, "releves doit être matérialisé et non vide"
+
+
 def test_releves_union_grain_et_harmonisation(base_periodiques):
     # `dbt build` matérialise releves ET exécute `unique releve_id` : un build vert
     # prouve l'invariant de grain / dedup même-source.

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.0.0rc11"
+version = "3.0.0rc12"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
**Hotfix rc11.** L'ingestion de prod échouait au `dbt build` :
```
✗ releves [error] — Catalog Error: Table with name int_releves__c15 does not exist!
```

### Cause
`construire_dbt` (runner) sélectionnait `releves` **nu**, en s'appuyant sur le fait que les ancêtres de `releves` étaient déjà couverts par les `+flux_*`. rc11 (#306) a introduit l'adapter intermédiaire `int_releves__c15` — un ancêtre de `releves` qui **n'est pas** un `flux_*` → jamais construit → catalog error.

Le golden `test_dbt_releves_golden` utilisait `dbt build --select +releves` (le `+` tire les ancêtres) et ne traversait donc **pas** le chemin de sélection réel du runner — d'où le trou.

### Fix
- `construire_dbt` sélectionne `+releves` (graph operator → tous les ancêtres, dont `int_releves__c15` et tout futur intermédiaire). Les `+flux_*` redondants sont dédoublonnés par dbt.
- **Régression** : `test_runner_construit_releves_via_sa_propre_selection` exerce la **vraie** sélection du runner (`construire_dbt`), pas un `+releves` codé en dur — RED reproduit l'erreur prod, GREEN après fix.

### Vérification
`tests/ingestion/` + `test_ingestion_run_modes` → **69 passed**. Golden `releves` (6 tests, dont la régression) vert.

Bump **v3.0.0rc12** (pyproject + uv.lock + CHANGELOG). Après merge : tag `v3.0.0rc12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)