### PR TITLE
fix(core) + release: v3.0.0rc13 — retire unite/precision de RelevéIndex (hotfix meta-periodes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.0.0rc13] - 2026-06-16
+
+Hotfix rc12 : `/facturation/meta-periodes` renvoyait une 500 — `RelevéIndex` exigeait
+`unite`/`precision` que le modèle de relevés canonique ne porte pas.
+
+### 🐛 Correctif (core)
+
+- **Retrait de `unite`/`precision` du contrat `RelevéIndex`** : vestiges de l'ère Wh,
+  rendus inutiles par [ADR-0034](docs/adr/0034-index-kwh-entiers-floor-au-boundary-dbt.md)
+  (tout est en kWh entiers — le grain facturable atomique). Le modèle de relevés canonique
+  `releves` (#248) ne les a jamais produits → `pipeline_energie`, qui valide son entrée
+  contre `RelevéIndex`, levait `SchemaError: column 'unite' not in dataframe` = 500 sur
+  `/facturation/meta-periodes`. Bug **pré-existant** (depuis la bascule mart canonique),
+  révélé en testant rc12. Régression couverte par un test sur la **forme réelle du mart**
+  (les anciens tests, alimentés en frames déjà conformes, ne traversaient pas ce chemin).
+  Les loaders `/flux` conservent leur colonne `unite` (tolérée hors contrat, `strict=False`).
+
 ## [3.0.0rc12] - 2026-06-16
 
 Hotfix rc11 : l'ingestion de prod échouait au `dbt build` — l'adapter intermédiaire

--- a/electricore/core/models/releve_index.py
+++ b/electricore/core/models/releve_index.py
@@ -28,9 +28,11 @@ class RelevéIndex(pa.DataFrameModel):
     # Source des données
     source: pl.Utf8 = pa.Field(nullable=False, isin=["flux_R151", "flux_R15", "flux_C15", "flux_R64", "FACTURATION"])
 
-    # 📏 Unité de mesure
-    unite: pl.Utf8 = pa.Field(nullable=False, isin=["kWh", "Wh", "MWh"])
-    precision: pl.Utf8 = pa.Field(nullable=False, isin=["kWh", "Wh", "MWh"])
+    # 📏 Unité : aucune. Tout est en kWh entiers — le grain facturable atomique, normalisé
+    # Wh→kWh par floor au boundary dbt (ADR-0034). Les ex-champs `unite`/`precision`
+    # (vestiges de l'ère Wh) sont retirés du contrat : le modèle de relevés canonique
+    # `releves` ne les porte pas, et plus rien ne les lit. Un loader /flux peut encore
+    # exposer un `unite` (colonne supplémentaire tolérée, Config.strict=False).
 
     # ⚡ Index de compteurs (valeurs cumulées en kWh)
     index_hp_kwh: pl.Float64 | None = pa.Field(nullable=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.0.0rc12"
+version = "3.0.0rc13"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/tests/unit/test_pipelines_pandera_contract.py
+++ b/tests/unit/test_pipelines_pandera_contract.py
@@ -344,6 +344,63 @@ def test_pipeline_energie_rejette_releves_sans_source(historique_enrichi_valide)
         pipeline_energie(historique_enrichi_valide, releves_invalides).collect()
 
 
+def test_releve_index_accepte_la_forme_du_mart_sans_unite_precision():
+    """Régression /facturation/meta-periodes : le modèle de relevés canonique `releves`
+    ne porte NI `unite` NI `precision` — tout est en kWh entiers, le grain facturable
+    atomique (ADR-0034). Le contrat `RelevéIndex` ne doit donc plus les exiger, sinon
+    `pipeline_energie` (qui valide son entrée contre `RelevéIndex`) lève `SchemaError:
+    column 'unite' not in dataframe` → 500 sur /meta-periodes. Garde le chemin réel
+    (forme du mart) que les anciens tests, alimentés en frames déjà conformes, ne
+    couvraient pas."""
+    from electricore.core.models.releve_index import RelevéIndex
+
+    frame = pl.DataFrame(
+        {
+            # Toutes les colonnes déclarées par RelevéIndex SAUF unite/precision (retirées).
+            "source": ["flux_R64"],
+            "pdl": ["PDL00001"],
+            "date_releve": [datetime(2024, 1, 1, tzinfo=PARIS)],
+            "ordre_index": [False],
+            "ref_situation_contractuelle": ["RSC1"],
+            "formule_tarifaire_acheminement": ["BTINFCUST"],
+            "id_calendrier_fournisseur": [None],
+            "id_calendrier_distributeur": ["DI000001"],
+            "id_affaire": [None],
+            "index_base_kwh": [100.0],
+            "index_hp_kwh": [None],
+            "index_hc_kwh": [None],
+            "index_hph_kwh": [None],
+            "index_hpb_kwh": [None],
+            "index_hch_kwh": [None],
+            "index_hcb_kwh": [None],
+            "type_releve": [None],
+            "contexte_releve": [None],
+            "etape_metier": [None],
+            "grandeur_physique": [None],
+            "grandeur_metier": [None],
+        },
+        schema_overrides={
+            "date_releve": pl.Datetime(time_unit="us", time_zone="Europe/Paris"),
+            "id_calendrier_fournisseur": pl.Utf8,
+            "id_affaire": pl.Utf8,
+            "type_releve": pl.Utf8,
+            "contexte_releve": pl.Utf8,
+            "etape_metier": pl.Utf8,
+            "grandeur_physique": pl.Utf8,
+            "grandeur_metier": pl.Utf8,
+            "index_hp_kwh": pl.Float64,
+            "index_hc_kwh": pl.Float64,
+            "index_hph_kwh": pl.Float64,
+            "index_hpb_kwh": pl.Float64,
+            "index_hch_kwh": pl.Float64,
+            "index_hcb_kwh": pl.Float64,
+        },
+    )
+    # Ne doit PAS lever : le contrat n'exige plus unite/precision (DI000001 ⟹ base présent,
+    # verifier_presence_mesures satisfait).
+    RelevéIndex.validate(frame, lazy=True)
+
+
 # =============================================================================
 # Cycle 6 — pipeline_energie produit une sortie conforme à `PeriodeEnergie`
 # =============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.0.0rc12"
+version = "3.0.0rc13"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
**Hotfix rc12.** `/facturation/meta-periodes` renvoyait une **500** :
```
pandera.errors.SchemaErrors: RelevéIndex
  COLUMN_NOT_IN_DATAFRAME: 'unite'      — column 'unite' not in dataframe
  COLUMN_NOT_IN_DATAFRAME: 'precision'  — column 'precision' not in dataframe
```

### Cause (pré-existante, pas #304)
`meta_periodes → contexte_du_mois → pipeline_energie`, qui valide son entrée `releves` contre `RelevéIndex`. Ce contrat exigeait `unite`/`precision` (`nullable=False`) — mais le **modèle de relevés canonique `releves`** (bascule #248) ne les a **jamais** produits. Le chemin réel (mart → `RelevéIndex`) n'était couvert par aucun test (les tests existants injectent des frames déjà conformes), d'où le bug latent, révélé en éprouvant rc12 sur prod.

### Fix
- Retrait de `unite`/`precision` du contrat `RelevéIndex` — vestiges de l'ère Wh, inutiles depuis **ADR-0034** (tout est en kWh entiers, le grain facturable atomique).
- **Régression** : `test_releve_index_accepte_la_forme_du_mart_sans_unite_precision` valide la forme réelle du mart (sans unite/precision), avec `verifier_presence_mesures` satisfait.
- Loaders `/flux` **inchangés** → `/flux/*` gardent leur colonne `unite` (tolérée hors contrat, `Config.strict=False`). Tax-rate/F15 `unite` non touchés.

### Vérification
Repro du chemin réel (mart construit depuis fixtures → `meta_periodes`) : la SchemaError unite/precision a **disparu**. Surface affectée (pandera-contract, chronologie, energie, duckdb-loader, meta-periodes service+endpoint, snapshots) → **61 passed**.

> Nit pré-existant noté hors scope : `meta_periodes(None)` plante si `facturation_mensuelle` est vide (mois par défaut non résolu) — prod a des données, donc non bloquant.

Bump **v3.0.0rc13**. Après merge : tag `v3.0.0rc13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)