### PR TITLE
refactor(energie): retire l'alias historique reconstituer_chronologie_releves

### DIFF
--- a/electricore/core/pipelines/energie.py
+++ b/electricore/core/pipelines/energie.py
@@ -405,16 +405,6 @@ def chronologie_releves(
     return _assembler_chronologie(historique, releves)
 
 
-def reconstituer_chronologie_releves(evenements: pl.LazyFrame, releves: pl.LazyFrame) -> pl.LazyFrame:
-    """Alias historique de `chronologie_releves` sans validation Pandera (compat).
-
-    Conserve l'ancienne signature `LazyFrame -> LazyFrame` pour les appelants internes
-    et tests qui passent des frames partiels. Préfère `chronologie_releves` pour la
-    nouvelle interface contractuelle.
-    """
-    return _assembler_chronologie(evenements, releves)
-
-
 @pa.check_types(lazy=True)
 def calculer_periodes_energie(lf: pl.LazyFrame) -> LazyFrame[PeriodeEnergie]:
     """

--- a/notebooks/demos/demo_pipeline_energie.py
+++ b/notebooks/demos/demo_pipeline_energie.py
@@ -26,7 +26,6 @@ with app.setup:
     # Import des pipelines Polars
     from electricore.core.pipelines.energie import (
         pipeline_energie,
-        reconstituer_chronologie_releves,
         calculer_periodes_energie,
     )
     from electricore.core.pipelines.historique import detecter_points_de_rupture, inserer_evenements_facturation

--- a/tests/unit/test_pipeline_energie.py
+++ b/tests/unit/test_pipeline_energie.py
@@ -6,11 +6,11 @@ import polars as pl
 import pytest
 
 from electricore.core.pipelines.energie import (
+    _assembler_chronologie,
     calculer_periodes_energie,
     # Tests d'expressions ajoutés localement dans chaque test
     expr_bornes_depuis_shift,
     interroger_releves,
-    reconstituer_chronologie_releves,
 )
 
 
@@ -105,8 +105,8 @@ class TestInterrogerRelevesPolars:
         assert pdl001["releve_manquant"][0] is False
 
 
-class TestReconstituerChronologieRelevesPolars:
-    """Tests pour reconstituer_chronologie_releves."""
+class TestAssemblerChronologiePolars:
+    """Tests pour _assembler_chronologie (assemblage de la chronologie des relevés)."""
 
     def test_reconstitution_avec_evenements_et_facturation(self):
         """Test nominal : combinaison d'événements contractuels + facturation."""
@@ -154,7 +154,7 @@ class TestReconstituerChronologieRelevesPolars:
             }
         )
 
-        result = reconstituer_chronologie_releves(evenements, releves).collect()
+        result = _assembler_chronologie(evenements, releves).collect()
 
         # Vérifications
         assert len(result) >= 3  # Au moins : MES avant, MES après, FACTURATION PDL001
@@ -209,7 +209,7 @@ class TestReconstituerChronologieRelevesPolars:
             }
         )
 
-        result = reconstituer_chronologie_releves(evenements, releves).collect()
+        result = _assembler_chronologie(evenements, releves).collect()
 
         # À cette date, seuls les relevés flux_C15 doivent rester (priorité)
         releves_date = result.filter(pl.col("date_releve") == datetime(2024, 1, 15))


### PR DESCRIPTION
## Quoi

Retire l'alias public `reconstituer_chronologie_releves` de [energie.py](electricore/core/pipelines/energie.py) : il ne faisait que déléguer à `_assembler_chronologie` (sans validation Pandera) et doublonnait l'interface contractuelle `chronologie_releves`.

## Migration des appelants

- **`tests/unit/test_pipeline_energie.py`** — les deux tests qui l'utilisaient passent des *frames partiels* (incompatibles avec la validation `Historique`/`RelevéIndex` de `chronologie_releves`), donc ils ciblent désormais directement `_assembler_chronologie` (l'implémentation que l'alias enveloppait). Classe renommée `TestAssemblerChronologiePolars`.
- **`notebooks/demos/demo_pipeline_energie.py`** — l'import était **mort** (seule la version pandas accentuée `reconstituer_pandas` est appelée) → import retiré.

## Comportement

Inchangé — l'alias était une pure délégation. Suite complète : seul échec = `test_historique_monotonie_horizon` (#270, pré-existant sur main, sans rapport).

## Note

ADR-0029 mentionne le nom dans sa prose historique — **laissé tel quel** (les ADR sont append-only).