### PR TITLE
docs(core): affaires SGE requêtables, pas alertables (#217)

### DIFF
--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -153,7 +153,7 @@ Changement de FTA, de puissance souscrite ou de calendrier sur un PDL actif.
 
 ## Affaires SGE (suivi opérationnel)
 
-Le cycle de vie des demandes de prestation déposées au portail SGE, rendu requêtable et alertable. Source : flux X12/X13 (décrits dans `electricore/ingestion/CONTEXT.md`). ElectriCore *observe* l'avancement (read-only) ; il n'agit jamais sur le SGE.
+Le cycle de vie des demandes de prestation déposées au portail SGE, rendu requêtable (cockpit read-only). Source : flux X12/X13 (décrits dans `electricore/ingestion/CONTEXT.md`). ElectriCore *observe* l'avancement (read-only) ; il n'agit jamais sur le SGE.
 
 **Affaire** :
 Dossier de suivi d'une demande de prestation auprès d'Enedis, identifié par un code à 8 caractères (ex : `G08TJ7VC`). Porte un cycle de vie (*jalons*) du dépôt à la clôture. Son `id` est **le même identifiant** que l'`Id_Affaire` porté par les *événements contractuels* C15 : une affaire est le **précurseur opérationnel** d'un événement C15 (MES, CFN…), traçable **avant** que le C15 ne matérialise son issue contractuelle.


### PR DESCRIPTION
## Pourquoi

Suite à la clôture de #217 (suivi des affaires SGE) : le cockpit read-only livré (#275 → #276, PR #277) rend les affaires **requêtables**, mais l'alerte (« affaire bloquée », CFN entrant) est **différée sans être filée** — volume d'échecs à quelques-uns/mois, X13 quasi vide en C5. Le système n'est donc pas *alertable* aujourd'hui, et on a décidé de le laisser ainsi tant que le volume ne le justifie pas.

## Quoi

Une ligne du glossaire [core/CONTEXT.md](electricore/core/CONTEXT.md) annonçait les affaires « rendu requêtable **et alertable** ». On la ramène à la réalité livrée : « rendu requêtable (cockpit read-only) ». La ligne 172 (« signaux exploitables pour une **future** alerte ») garde correctement l'alerte au futur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)