### PR TITLE
chore(release): v3.0.0rc14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.0.0rc14] - 2026-06-18
+
+Finalisation de la **refonte des flags de qualité** : retrait cassant des anciens signaux
+de complétude au profit des verdicts jumeaux *qualité* + *communication*.
+
+### ⚠️ Cassant — contrat `/facturation/meta-periodes` v2
+
+- **Retrait de `data_complete` / `coverage_abo` / `coverage_energie`**
+  ([#317](https://github.com/Energie-De-Nantes/electricore/issues/317),
+  [#327](https://github.com/Energie-De-Nantes/electricore/issues/327),
+  [#278](https://github.com/Energie-De-Nantes/electricore/issues/278),
+  [ADR-0033](docs/adr/0033-qualite-periode-remplace-data-complete-coverage.md)) — remplacés
+  par `qualite` (`réelle` / `estimée` / `incalculable`, rollup *pire-gagne*) et
+  `statut_communication` (`communicante` / `non_communicante`), déjà livrés en additif
+  (rc précédentes). `CONTRAT_VERSION` **1 → 2**. Raffinement strict : l'ancien
+  `data_complete=True` se scinde en `{réelle, estimée}`, le `False` devient `incalculable`.
+  Retrait de bout en bout — modèles (`PeriodeEnergie`, `PeriodeMeta`, `EnergieMensuel`,
+  `LignesFactureRapprochees`…), pipeline facturation, contexte mensuel, contrat API et
+  notebooks rebranchés sur `qualite`.
+
+### 🧹 Nettoyage (core)
+
+- **Retrait du forward-fill RSC/FTA no-op de la chronologie des relevés**
+  ([#330](https://github.com/Energie-De-Nantes/electricore/pull/330),
+  [ADR-0029](docs/adr/0029-modele-releves-canonique-dbt-assemble-coeur-arbitre.md)) :
+  `_assembler_chronologie` ré-attribuait RSC/FTA par PDL, mais l'attribution est déjà
+  garantie en amont (mart `releves` forward-fillé + requête FACTURATION qui porte la RSC).
+  No-op prouvé par deletion-test (suite verte) ; l'attribution contractuelle vit désormais
+  en un seul endroit.
+
 ## [3.0.0rc13] - 2026-06-16
 
 Hotfix rc12 : `/facturation/meta-periodes` renvoyait une 500 — `RelevéIndex` exigeait

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.0.0rc13"
+version = "3.0.0rc14"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.0.0rc13"
+version = "3.0.0rc14"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Bump v3.0.0rc14

RC de la **refonte des flags de qualité** (PRs #329 + #330, déjà mergées dans main).

### Contenu depuis rc13
- ⚠️ **Cassant** : retrait `data_complete` / `coverage_abo` / `coverage_energie` → `qualite` + `statut_communication` ; contrat `/facturation/meta-periodes` **v2** (ADR-0033, #317/#327/#278).
- 🧹 Retrait du forward-fill RSC/FTA no-op de la chronologie (ADR-0029, #330).

### Bump
- `pyproject.toml` + `uv.lock` : `3.0.0rc13` → `3.0.0rc14`
- `CHANGELOG.md` : section `[3.0.0rc14]`

Validé localement : `uv lock --check` OK, `uv build` → `electricore-3.0.0rc14.{tar.gz,whl}` (garde-fou du workflow release).

> Après merge : tag `v3.0.0rc14` (= publication PyPI + GH release + image ghcr.io). À tester avant de cuter la **3.0.0** finale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)