### PR TITLE
fix(loaders): /flux/r64 cassé — SCHEMA_R64 aligné sur le mart (#333)

### DIFF
--- a/electricore/core/loaders/duckdb/expressions.py
+++ b/electricore/core/loaders/duckdb/expressions.py
@@ -23,7 +23,9 @@ INDEX_COLS = tuple(col_index(c) for c in CADRANS)
 DATE_COLS_HISTORIQUE = ("date_evenement", "avant_date_releve", "apres_date_releve")
 DATE_COLS_RELEVES = ("date_releve",)
 DATE_COLS_FACTURES = ("date_facture", "date_debut", "date_fin")
-DATE_COLS_R64 = ("date_releve", "modification_date")
+# `modification_date` n'est pas projetée par le mart `flux_r64` (#333) : la lister ici
+# ferait référencer une colonne absente dans le transform Polars du loader R64.
+DATE_COLS_R64 = ("date_releve",)
 
 
 # =============================================================================

--- a/electricore/core/loaders/duckdb/sql.py
+++ b/electricore/core/loaders/duckdb/sql.py
@@ -342,11 +342,12 @@ SCHEMA_R64 = FluxSchema(
         col_simple("index_hp_kwh"),
         col_simple("index_hc_kwh"),
         col_simple("index_base_kwh"),
-        # Métadonnées système
-        col_simple("modification_date"),
-        col_simple("_source_zip"),
-        col_simple("_flux_type"),
-        col_simple("_json_name"),
+        # Métadonnées système (#333) : modification_date / _source_zip / _flux_type /
+        # _json_name ne sont PAS projetées par le mart `flux_r64` (modification_date n'y
+        # sert qu'en interne, clé de tri du qualify de dédup ; les `_*` sont des colonnes de
+        # landing dlt). Les déclarer ici déclenchait un Binder Error sur tout /flux/r64
+        # depuis la refonte `releves` (#241/#304/#285). Le test de garde loader↔mart
+        # (test_loaders_sur_base_dbt) verrouille l'alignement.
         col_literal("flux_R64", "source"),
     ),
     where_clause="date_releve IS NOT NULL",

--- a/tests/core/loaders/test_loaders_sur_base_dbt.py
+++ b/tests/core/loaders/test_loaders_sur_base_dbt.py
@@ -19,6 +19,7 @@ from datetime import date, datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
+import duckdb
 import polars as pl
 import pytest
 
@@ -46,6 +47,7 @@ def base_prod_dbt(tmp_path_factory):
         ("c15_avec_releves.xml", "raw_c15"),
         ("r151.xml", "raw_r151"),
         ("r15.xml", "raw_r15"),
+        ("r64.json", "raw_r64"),
     ]
     for fixture, source in cas:
         contenu = (FIXTURES / fixture).read_bytes()
@@ -71,6 +73,7 @@ def base_prod_dbt(tmp_path_factory):
             "+flux_c15",
             "+flux_r151",
             "+flux_r15",
+            "+flux_r64",
             "--project-dir",
             str(PROJET_DBT),
             "--profiles-dir",
@@ -136,3 +139,36 @@ def test_r151_sert_la_date_brute_et_les_index_entiers(base_prod_dbt):
     # Fixture : Date_Releve 2024-04-04 (date nue, fin de journée), ancrée minuit Paris — sans +1j.
     assert date_releve == datetime(2024, 4, 4, 0, 0, tzinfo=PARIS)
     assert df.schema["index_hph_kwh"] == pl.Int64
+
+
+def test_r64_charge_le_flux_brut(base_prod_dbt):
+    """Régression #333 : le chemin loader R64 BRUT (`/flux/r64`) se chargeait en Binder
+    Error parce que `SCHEMA_R64` déclarait `modification_date` (+ `_source_zip`/`_flux_type`/
+    `_json_name`), colonnes que le mart `flux_r64` ne projette pas depuis la refonte
+    `releves` (#241/#304/#285). Le mart `releves` n'était pas affecté — d'où une régression
+    invisible jusqu'en prod. Ce test exerce le loader brut, pas seulement le mart."""
+    from electricore.core.loaders import r64
+
+    df = r64(database_path=base_prod_dbt).collect()
+    assert df.height > 0
+    assert "modification_date" not in df.columns
+    assert {"pdl", "date_releve", "index_base_kwh", "source"} <= set(df.columns)
+
+
+@pytest.mark.parametrize("flux", ["c15", "r151", "r15", "r64"])
+def test_aucune_derive_loader_mart(base_prod_dbt, flux):
+    """Garde anti-dérive loader↔mart (#333) : chaque colonne déclarée par un `FluxSchema`
+    doit exister dans le mart correspondant. On exécute le SELECT du loader avec `LIMIT 0` —
+    DuckDB lie alors toutes les colonnes référencées sans matérialiser de ligne ; une colonne
+    déclarée mais absente du mart lève un Binder Error. Une future dérive (comme #333) échoue
+    donc ICI, en test, plutôt qu'en prod sur l'endpoint."""
+    from electricore.core.loaders.duckdb.sql import FLUX_SCHEMAS, build_base_query
+
+    sql = build_base_query(FLUX_SCHEMAS[flux])
+    con = duckdb.connect(str(base_prod_dbt), read_only=True)
+    try:
+        con.execute(f"SELECT * FROM ({sql}) LIMIT 0")  # Binder Error si dérive
+    except duckdb.BinderException as exc:  # pragma: no cover - chemin d'échec explicite
+        pytest.fail(f"Dérive loader↔mart sur {flux} : {str(exc).splitlines()[0]}")
+    finally:
+        con.close()


### PR DESCRIPTION
Closes #333
Parent: #332

## Problème
En prod (`rc14`), tout accès au **R64 brut** échoue : `GET /flux/r64` → 500, `.xlsx` → 500, `.arrow` → 503 (`Binder Error: Referenced column "modification_date" not found`). `/flux/r64/info` survit (lit `information_schema`), d'où une santé trompeuse.

## Cause
`SCHEMA_R64` (loader DuckDB) déclarait `modification_date`, `_source_zip`, `_flux_type`, `_json_name` — colonnes que le mart `flux_r64` **ne projette pas** depuis la refonte du modèle canonique `releves` (#241/#304/#285) : `modification_date` n'y sert qu'en interne (tri du `qualify` de dédup), les `_*` sont des colonnes de landing dlt. Vérifié sur la base prod locale (24 colonnes, aucune des 4). Le mart `releves` n'est pas affecté.

## Correctif
- Retrait des 4 colonnes de `SCHEMA_R64`.
- Retrait de `modification_date` de `DATE_COLS_R64` (sinon le transform Polars du loader référence une colonne absente).

## Garde anti-dérive (acceptance criteria)
`test_loaders_sur_base_dbt` construit désormais `flux_r64` et ajoute :
- `test_r64_charge_le_flux_brut` — exerce le chemin loader **brut** (pas seulement le mart `releves`).
- `test_aucune_derive_loader_mart[c15|r151|r15|r64]` — exécute le SELECT de chaque loader en `LIMIT 0` ; une colonne déclarée mais absente du mart lève un Binder Error **en test, plus en prod**.

## Vérification
- Avant : `[FAIL] r64 Binder Error … "modification_date" not found` (sur base prod locale).
- Après : les 6 loaders bindent ; `r64()` charge 20 colonnes. Suite complète verte (893 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)