### PR TITLE
fix(taxes): exports Accise en 503 — lignes Odoo sans PDL exclues (#334)

### DIFF
--- a/electricore/core/pipelines/accise.py
+++ b/electricore/core/pipelines/accise.py
@@ -112,6 +112,13 @@ def agreger_consommations_mensuelles(lignes_factures: pl.LazyFrame) -> pl.LazyFr
         # Exclure les lignes de factures non validées (draft sans invoice_date) :
         # elles ne sont pas encore facturées et donc pas dans l'assiette accise.
         .filter(pl.col("invoice_date").is_not_null())
+        # Exclure les lignes sans PDL (#334) : l'accise est une taxe sur la consommation
+        # PAR point de livraison ; une ligne d'énergie rattachée à une commande Odoo sans
+        # `x_pdl` ne peut être affectée à aucun PDL. Sinon le group_by produit un bucket
+        # `pdl = null` qui viole AcciseMensuel (pdl non-nullable) → 503 sur les 3 exports
+        # accise. Contrairement à la CTA, dont le `pdl` vient de la chaîne facturation
+        # interne (jointure sur pdl_mapping, jamais null), l'accise lit `x_pdl` brut d'Odoo.
+        .filter(pl.col("x_pdl").is_not_null())
         # Calculer mois et trimestre de consommation
         .with_columns(
             [

--- a/tests/unit/test_accise.py
+++ b/tests/unit/test_accise.py
@@ -218,3 +218,74 @@ class TestPipelineAccise:
         assert len(result) == 1
         row = result.row(0, named=True)
         assert row["energie_kwh"] == 500.0  # 999 exclu
+
+    def test_lignes_sans_pdl_sont_exclues(self, regles_accise_synthetiques):
+        """Régression #334 : une ligne d'énergie sans PDL (commande Odoo dont `x_pdl`
+        n'est pas renseigné) doit être exclue de l'assiette accise.
+
+        Sinon le group_by produit un bucket `pdl = null` qui viole `AcciseMensuel`
+        (pdl non-nullable) → les 3 exports accise (rapport/detail xlsx+arrow) tombent en
+        503. L'accise est une taxe PAR point de livraison : une consommation non
+        rattachable à un PDL n'a pas d'assiette.
+        """
+        lignes = pl.LazyFrame(
+            [
+                {
+                    "x_pdl": "B",
+                    "name": "SO-B",
+                    "invoice_date": "2024-07-15",
+                    "name_product_category": "Base",
+                    "quantity": 500.0,
+                },
+                # Ligne d'énergie sans PDL : doit être ignorée
+                {
+                    "x_pdl": None,
+                    "name": "SO-X",
+                    "invoice_date": "2024-07-15",
+                    "name_product_category": "HP",
+                    "quantity": 999.0,
+                },
+            ]
+        )
+
+        result = pipeline_accise(lignes, regles_accise_synthetiques).collect()
+
+        assert result["pdl"].null_count() == 0
+        assert result["pdl"].to_list() == ["B"]
+        assert result.row(0, named=True)["energie_kwh"] == 500.0  # 999 exclu
+
+
+class TestRapportAcciseAvecPdlNull:
+    """Régression #334 de bout en bout : le build `rapport_accise` (qui valide `AcciseMensuel`
+    en profondeur sur DataFrame collecté — le point exact du 503) reste vert face à une ligne
+    Odoo sans PDL. C'est le chemin réel de l'endpoint, pas un `pipeline_accise` mocké."""
+
+    def test_rapport_accise_survit_a_une_ligne_sans_pdl(self):
+        from electricore.core.builds.rapport_taxe import RapportTaxe, rapport_accise
+
+        lignes = pl.LazyFrame(
+            [
+                {
+                    "x_pdl": "A",
+                    "name": "SO-A",
+                    "invoice_date": "2024-07-15",
+                    "name_product_category": "HP",
+                    "quantity": 600.0,
+                },
+                # Souscription Odoo sans PDL : reproduisait `non-nullable column 'pdl'
+                # contains null values` à la validation AcciseMensuel du build.
+                {
+                    "x_pdl": None,
+                    "name": "SO-X",
+                    "invoice_date": "2024-07-15",
+                    "name_product_category": "Base",
+                    "quantity": 123.0,
+                },
+            ]
+        )
+
+        rapport = rapport_accise(lignes)  # règles réelles ; lève si pdl null subsiste
+
+        assert isinstance(rapport, RapportTaxe)
+        assert rapport.detail["pdl"].null_count() == 0
+        assert rapport.detail["pdl"].to_list() == ["A"]


### PR DESCRIPTION
Closes #334
Parent: #332

## Problème
En prod (`rc14`), les 3 exports **Accise** (rapport/detail `xlsx`+`arrow`) → 503 : `non-nullable column 'pdl' contains null values`. Les exports **CTA** équivalents passent.

## Cause
`pipeline_accise` lit `x_pdl` **brut d'Odoo** et agrège par PDL. Une ligne d'énergie (catégorie Base/HP/HC, `invoice_date` non-null) rattachée à une commande **sans `x_pdl`** produit un bucket `pdl = null`, qui viole `AcciseMensuel` (pdl non-nullable) à la validation profonde du build / service (`AcciseMensuel.validate(detail)` sur DataFrame collecté — le point exact du 503). La CTA y échappe : son `pdl` vient de la chaîne facturation interne (jointure `inner` sur `pdl_mapping`), jamais null. Reproduit en local.

## Correctif
L'accise est une taxe **par point de livraison** : une consommation non rattachable à un PDL n'a pas d'assiette. Filtre `x_pdl` non-null dans `agreger_consommations_mensuelles`, au même niveau que le filtre `invoice_date` existant (lignes draft).

## Gardes (acceptance criteria)
- `test_lignes_sans_pdl_sont_exclues` — grain pipeline : la ligne sans PDL est exclue, `pdl` sans null.
- `TestRapportAcciseAvecPdlNull` — round-trip **réel** via `rapport_accise` (pipeline non mocké → validation `AcciseMensuel` profonde, le chemin du 503).
- CTA reste vert (pas de régression croisée).

## Vérification
`tests/unit/test_accise.py`, `test_rapport_taxe.py`, `test_cta.py`, `test_taxes_invariants.py`, `test_taxes_arrow_endpoints.py` verts ; suite complète 893 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)