### PR TITLE
chore(release): v3.0.0rc15 — correctifs régressions prod rc14 (épic #332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.0.0rc15] - 2026-06-18
+
+Correctifs des **régressions de validation/schéma** détectées sur les endpoints prod en
+`rc14` (épic [#332](https://github.com/Energie-De-Nantes/electricore/issues/332)) — même
+classe « schéma/loader plus étroit que la donnée prod ». Chaque correctif embarque un test
+de garde anti-dérive sur donnée prod-réaliste.
+
+### 🐛 Corrigé
+
+- **`/flux/r64` (500/503)** — `SCHEMA_R64` déclarait des colonnes (`modification_date`,
+  `_source_zip`, `_flux_type`, `_json_name`) qu'aucun mart `flux_r64` ne projette ; alignement
+  du schéma loader sur les colonnes réelles du mart
+  ([#333](https://github.com/Energie-De-Nantes/electricore/issues/333)).
+- **Exports Accise (503 `pdl null`)** — `pipeline_accise` agrégeait les lignes Odoo sans
+  `x_pdl`, créant un bucket `pdl=null` qui violait `AcciseMensuel` ; exclusion des lignes sans
+  PDL de l'assiette ([#334](https://github.com/Energie-De-Nantes/electricore/issues/334)).
+- **Facturation rapport/detail/documents (503)** — les catégories produit hors scope
+  facturation legacy (`Prestation-Enedis`, racine Odoo `All`) faisaient échouer la validation ;
+  écartées avant rapprochement
+  ([#335](https://github.com/Energie-De-Nantes/electricore/issues/335)).
+
 ## [3.0.0rc14] - 2026-06-18
 
 Finalisation de la **refonte des flags de qualité** : retrait cassant des anciens signaux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.0.0rc14"
+version = "3.0.0rc15"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.0.0rc14"
+version = "3.0.0rc15"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Bump de version **3.0.0rc14 → 3.0.0rc15**.

Contenu = rc14 + les trois correctifs de régression prod de l'épic #332, déjà mergés sur `main` :

- **#333** — `/flux/r64` : `SCHEMA_R64` aligné sur les colonnes réelles du mart `flux_r64`
- **#334** — Accise : exclusion des lignes Odoo sans PDL de l'assiette
- **#335** — Facturation : catégories produit hors scope écartées avant rapprochement

### Fichiers
- `pyproject.toml` `version` → 3.0.0rc15
- `uv.lock` (package `electricore`) → 3.0.0rc15 (`uv lock --check` ✅)
- `CHANGELOG.md` : section `[3.0.0rc15]`

Après merge : tagger `v3.0.0rc15` sur le commit de merge → déclenche `release.yml` (build + PyPI + image ghcr prerelease).

🤖 Generated with [Claude Code](https://claude.com/claude-code)