### PR TITLE
fix(taxes): autorise un mois d'accise net-négatif (avoirs/réguls) — déverrouille le 503 (#341)

### DIFF
--- a/electricore/core/models/accise_mensuel.py
+++ b/electricore/core/models/accise_mensuel.py
@@ -21,10 +21,18 @@ class AcciseMensuel(pa.DataFrameModel):
     mois_annee: pl.Utf8 = pa.Field(nullable=False, str_matches=r"^\d{4}-\d{2}$")  # ex: "2025-03"
     trimestre: pl.Utf8 = pa.Field(nullable=False)  # ex: "2025-T1"
     order_name: pl.Utf8 = pa.Field(nullable=False)
-    energie_kwh: pl.Float64 = pa.Field(nullable=False, ge=0.0)
-    energie_mwh: pl.Float64 = pa.Field(nullable=False, ge=0.0)
+    # Pas de `ge=0` sur énergie/montant (#341) : `pipeline_accise` somme les lignes de
+    # factures Odoo par (PDL, mois), et un mois peut être net-négatif quand un avoir /
+    # une régularisation y tombe sans nominal en face. La déclaration accise est
+    # *trimestrielle* et nette positif ; le grain mensuel peut légitimement être < 0.
+    # Band-aid assumé imparfait : le netting brut sous-compte les avoirs « conso réelle
+    # retournée » et ne distingue pas régul/nominal — la correctness relève du modèle de
+    # facturé maîtrisé / périodes typées (cf #225, #282). `taux_accise_eur_mwh` garde
+    # `ge=0` : un taux reste positif.
+    energie_kwh: pl.Float64 = pa.Field(nullable=False)
+    energie_mwh: pl.Float64 = pa.Field(nullable=False)
     taux_accise_eur_mwh: pl.Float64 = pa.Field(nullable=False, ge=0.0)
-    accise_eur: pl.Float64 = pa.Field(nullable=False, ge=0.0)
+    accise_eur: pl.Float64 = pa.Field(nullable=False)
 
     class Config:
         strict = False

--- a/tests/unit/test_accise.py
+++ b/tests/unit/test_accise.py
@@ -289,3 +289,47 @@ class TestRapportAcciseAvecPdlNull:
         assert isinstance(rapport, RapportTaxe)
         assert rapport.detail["pdl"].null_count() == 0
         assert rapport.detail["pdl"].to_list() == ["A"]
+
+
+class TestRapportAcciseAvecMoisNetNegatif:
+    """Régression #341 de bout en bout : un mois (PDL × mois) net-négatif — un avoir qui
+    dépasse le nominal facturé du même mois — ne doit PAS faire échouer le build
+    `rapport_accise` (qui valide `AcciseMensuel` en profondeur sur DataFrame collecté, le
+    point exact du 503). La déclaration accise est trimestrielle et nette positif ; le grain
+    mensuel peut légitimement être négatif. C'est un band-aid : le netting brut est assumé
+    imparfait (il sous-compte les avoirs « conso réelle retournée » et ne distingue pas
+    régul/nominal) — la correctness relève du modèle de facturé maîtrisé (cf #225 / #282)."""
+
+    def test_rapport_accise_survit_a_un_mois_net_negatif(self):
+        from electricore.core.builds.rapport_taxe import RapportTaxe, rapport_accise
+
+        lignes = pl.LazyFrame(
+            [
+                # Nominal facturé du mois (conso 2025-01, facturée en 2025-02).
+                {
+                    "x_pdl": "A",
+                    "name": "SO-A",
+                    "invoice_date": "2025-02-15",
+                    "name_product_category": "Base",
+                    "quantity": 90.0,
+                },
+                # Avoir (out_refund) du même mois, plus gros que le nominal → net -49 kWh.
+                # Avant #341, `AcciseMensuel.energie_kwh ge=0` faisait lever ici (503).
+                {
+                    "x_pdl": "A",
+                    "name": "SO-A",
+                    "invoice_date": "2025-02-15",
+                    "name_product_category": "Base",
+                    "quantity": -139.0,
+                },
+            ]
+        )
+
+        rapport = rapport_accise(lignes)
+
+        assert isinstance(rapport, RapportTaxe)
+        row = rapport.detail.filter(pl.col("pdl") == "A").row(0, named=True)
+        # Le mois net-négatif est conservé, ni filtré ni écrasé.
+        assert row["energie_kwh"] == -49.0
+        # Accise négative = l'avoir vient en déduction d'assiette.
+        assert row["accise_eur"] < 0

--- a/tests/unit/test_models_taxes.py
+++ b/tests/unit/test_models_taxes.py
@@ -52,6 +52,30 @@ class TestAcciseMensuel:
         with pytest.raises(pandera.errors.SchemaError):
             AcciseMensuel.validate(_accise_mensuel_frame(["janvier 2025"]))
 
+    def test_accepts_negative_energie_at_monthly_grain(self):
+        """#341 : un mois (pdl, mois_annee) net-négatif est valide.
+
+        Un avoir / une régularisation peut tomber sur un mois sans nominal en face →
+        `energie_kwh`/`energie_mwh`/`accise_eur` négatifs. La déclaration accise est
+        trimestrielle et nette positif ; le grain mensuel peut légitimement être < 0.
+        """
+        from electricore.core.models.accise_mensuel import AcciseMensuel
+
+        df = _accise_mensuel_frame(["2025-01"]).with_columns(
+            energie_kwh=pl.lit(-49.0),
+            energie_mwh=pl.lit(-0.049),
+            accise_eur=pl.lit(-1.1),
+        )
+        AcciseMensuel.validate(df)
+
+    def test_rejects_negative_taux(self):
+        """Le `ge=0` sur `taux_accise_eur_mwh` est conservé (#341) : un taux reste positif."""
+        from electricore.core.models.accise_mensuel import AcciseMensuel
+
+        df = _accise_mensuel_frame(["2025-01"]).with_columns(taux_accise_eur_mwh=pl.lit(-1.0))
+        with pytest.raises(pandera.errors.SchemaError):
+            AcciseMensuel.validate(df)
+
 
 # ---------------------------------------------------------------------------
 # CtaMensuel — contrat de pipeline_cta, grain (situation contractuelle, mois)


### PR DESCRIPTION
## What

`pipeline_accise` somme les lignes de factures Odoo par (PDL, mois) ; un avoir ou une
régularisation peut rendre un mois **net-négatif**, ce qui violait
`AcciseMensuel.energie_kwh ≥ 0` → **503** sur les 3 exports `/taxes/accise/*`
(`rapport.xlsx`, `detail.xlsx`, `detail.arrow`). Frère non couvert de #334.

Retire `ge=0` sur `energie_kwh` / `energie_mwh` / `accise_eur` : le grain mensuel peut
légitimement être < 0 (un avoir y tombe seul), alors que la déclaration accise est
**trimestrielle** et nette positif. `taux_accise_eur_mwh` garde `ge=0`.

## Dette assumée

Band-aid explicitement **imparfait** : le netting brut sous-compte les avoirs
« conso réelle retournée » (Cas A de #225) et ne distingue pas régul/nominal. La
correctness relève du **modèle de facturé maîtrisé / périodes typées** — voir l'analyse
dans #225 et la refonte #282 (épic régul #191). Erreur marginale au grain déclaration agrégé.

## Tests (TDD)

- `tests/unit/test_accise.py::TestRapportAcciseAvecMoisNetNegatif` — round-trip réel
  `rapport_accise` sur un mois net-négatif (le chemin exact du 503) ; RED avant le fix
  (`SchemaError ge(0.0) case [-49.0]`, identique à la prod), GREEN après.
- `tests/unit/test_models_taxes.py::TestAcciseMensuel` — contrat de schéma : énergie/montant
  négatifs acceptés, **taux négatif toujours rejeté** (garde anti-sur-relâchement).

Suite complète : 897 passed, 27 skipped.

Closes #341
