### PR TITLE
chore(release): v3.0.0rc16 — déverrouille les exports Accise (#341)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.0.0rc16] - 2026-06-18
+
+Suite de l'épic [#332](https://github.com/Energie-De-Nantes/electricore/issues/332) :
+déverrouille les exports Accise restés en **503** après `rc15` — frère du
+[#334](https://github.com/Energie-De-Nantes/electricore/issues/334), même classe
+« schéma plus étroit que la donnée prod ».
+
+### 🐛 Corrigé
+
+- **Exports Accise (503 `energie_kwh ≥ 0`)** — `pipeline_accise` somme les lignes de
+  factures Odoo par (PDL, mois) ; un avoir ou une régularisation peut rendre un mois
+  net-négatif, ce qui violait `AcciseMensuel`. Le `ge=0` est retiré sur
+  `energie_kwh`/`energie_mwh`/`accise_eur` (le grain mensuel peut être < 0 ; la déclaration
+  accise est trimestrielle et nette positif) ; `taux_accise_eur_mwh` le conserve. Band-aid
+  assumé imparfait — la correctness exacte de l'assiette relève du modèle de facturé maîtrisé
+  (discovery [#225](https://github.com/Energie-De-Nantes/electricore/issues/225), refonte
+  [#282](https://github.com/Energie-De-Nantes/electricore/issues/282))
+  ([#341](https://github.com/Energie-De-Nantes/electricore/issues/341)).
+
 ## [3.0.0rc15] - 2026-06-18
 
 Correctifs des **régressions de validation/schéma** détectées sur les endpoints prod en

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.0.0rc15"
+version = "3.0.0rc16"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.0.0rc15"
+version = "3.0.0rc16"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Release v3.0.0rc16

Bump `3.0.0rc15` → `3.0.0rc16` (pyproject + uv.lock + CHANGELOG).

Embarque le dernier correctif de l'épic [#332](https://github.com/Energie-De-Nantes/electricore/issues/332), déjà mergé sur `main` :

- **[#341](https://github.com/Energie-De-Nantes/electricore/issues/341)** — exports Accise restés en **503** après rc15 (frère du #334) : un mois net-négatif (avoir / régularisation) violait `AcciseMensuel.energie_kwh ≥ 0`. `ge=0` retiré sur energie/montant au grain mensuel (déclaration trimestrielle nette positif), `taux` conservé. Band-aid assumé imparfait → correctness reportée au modèle de facturé maîtrisé ([#225](https://github.com/Energie-De-Nantes/electricore/issues/225) / [#282](https://github.com/Energie-De-Nantes/electricore/issues/282)).

`uv build` vérifié → `electricore-3.0.0rc16.{tar.gz,whl}` (garde-fou CI OK).

Après merge : tag `v3.0.0rc16` sur le commit de merge → workflow Release (PyPI + image ghcr).
