### PR TITLE
fix(ingestion): check_incremental_state lit le vrai pipeline + expose les namespaces

### DIFF
--- a/electricore/ingestion/tools/check_incremental_state.py
+++ b/electricore/ingestion/tools/check_incremental_state.py
@@ -1,89 +1,100 @@
 #!/usr/bin/env python3
-"""
-Vérifie l'état incrémental de chaque resource dans le pipeline.
+"""Inspecte l'état incrémental dlt du pipeline d'ingestion brut (ADR-0020).
+
+Le curseur incrémental de chaque flux (`modification_date`) vit dans l'état dlt,
+PAS dans la base : c'est lui qui évite de re-télécharger les fichiers Enedis déjà
+landés. Cet outil le donne à lire, par namespace de source.
+
+Nom du pipeline : résolu comme le runner (`flux_brut_<stem de la base>`,
+cf. runner.lander_brut), depuis le registre runtime — donc pas de nom codé en dur.
+
+⚠️ Le namespace d'état dlt n'est pas stable : un run mono-flux (`ingestion r64`)
+et un run multi-flux (`ingestion all`) ne stockent pas leurs curseurs sous la même
+clé de source (`flux_enedis_brut` vs `flux_brut_<stem>`). Cet outil affiche TOUS
+les namespaces et signale la fragmentation le cas échéant.
+
+Usage : uv run python -m electricore.ingestion.tools.check_incremental_state
 """
 
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 
 import dlt
 
+from electricore.config import runtime
 
-def check_incremental_state():
-    """Affiche l'état incrémental détaillé de chaque resource."""
 
+def _nom_pipeline() -> str:
+    """Même résolution que le runner : `flux_brut_<stem de la base de prod>`."""
+    return f"flux_brut_{runtime.duckdb().chemin.stem}"
+
+
+def _age_jours(valeur: str) -> str:
+    """Âge en jours d'une date ISO, pour repérer un curseur qui n'avance plus."""
+    try:
+        date_obj = datetime.fromisoformat(str(valeur).replace("Z", "+00:00"))
+        if date_obj.tzinfo is None:
+            date_obj = date_obj.replace(tzinfo=UTC)
+        return f" (il y a {(datetime.now(date_obj.tzinfo) - date_obj).days} j)"
+    except (ValueError, TypeError):
+        return ""
+
+
+def check_incremental_state() -> None:
+    """Affiche le curseur incrémental de chaque resource, par namespace de source."""
+    nom = _nom_pipeline()
     print("=" * 80)
     print("🔍 ÉTAT INCRÉMENTAL DU PIPELINE")
     print("=" * 80)
+    print(f"Pipeline : {nom}")
 
-    # Charger le pipeline
-    pipeline = dlt.pipeline("flux_enedis")
+    pipeline = dlt.pipeline(pipeline_name=nom)
     state = pipeline.state
+    sources = state.get("sources", {})
+    if not sources:
+        print("\n❌ Aucune source dans l'état (pipeline jamais lancé localement ?)")
+        return
 
-    print(f"Pipeline: {pipeline.pipeline_name}")
-    print(f"Dataset: {pipeline.dataset_name}")
-    print()
+    # Namespaces portant un curseur incrémental (resources filesystem_*).
+    namespaces_avec_curseur = []
+    for source_name, source_state in sources.items():
+        resources = source_state.get("resources", {})
+        curseurs = {r: rs for r, rs in resources.items() if "incremental" in rs}
+        if not curseurs:
+            continue
+        namespaces_avec_curseur.append(source_name)
+        print(f"\n📦 Namespace de source : {source_name}")
+        for res_name, res_state in sorted(curseurs.items()):
+            for inc_name, inc_state in res_state["incremental"].items():
+                last = inc_state.get("last_value")
+                if last is None:
+                    print(f"   📄 {res_name} [{inc_name}] : non initialisé")
+                else:
+                    print(f"   📄 {res_name} [{inc_name}] : {last}{_age_jours(last)}")
 
-    # Explorer l'état des sources
-    if "sources" in state:
-        for source_name, source_state in state["sources"].items():
-            print(f"📦 Source: {source_name}")
+    # Le quirk : plusieurs namespaces = curseurs fragmentés (cf. issue à venir).
+    if len(namespaces_avec_curseur) > 1:
+        print("\n" + "=" * 80)
+        print("⚠️  CURSEURS FRAGMENTÉS SUR PLUSIEURS NAMESPACES")
+        print("=" * 80)
+        print(
+            "Plusieurs namespaces portent des curseurs : "
+            f"{', '.join(namespaces_avec_curseur)}.\n"
+            "Cause connue : le namespace d'état dlt dépend du nombre de flux du run\n"
+            "(mono-flux vs multi-flux). Un run `ingestion all` ne lit que le namespace\n"
+            "multi-flux ; les curseurs posés par un backfill mono-flux y sont invisibles\n"
+            "(re-fetch dédupliqué par le merge sur file_name — sans corruption)."
+        )
 
-            if "resources" in source_state:
-                resources = source_state["resources"]
-
-                # Afficher toutes les resources
-                print(f"   Nombre de resources: {len(resources)}")
-
-                for res_name, res_state in resources.items():
-                    print(f"\n   📄 Resource: {res_name}")
-
-                    # Vérifier l'état incrémental
-                    if "incremental" in res_state:
-                        for inc_name, inc_state in res_state["incremental"].items():
-                            print(f"      🔄 Incrémental '{inc_name}':")
-
-                            start_value = inc_state.get("start_value")
-                            end_value = inc_state.get("end_value")
-                            last_value = inc_state.get("last_value")
-
-                            if start_value:
-                                print(f"         Start: {start_value}")
-                                # Si c'est une date, calculer l'âge
-                                try:
-                                    if isinstance(start_value, str) and "T" in start_value:
-                                        date_obj = datetime.fromisoformat(start_value.replace("Z", "+00:00"))
-                                        age = datetime.now(date_obj.tzinfo) - date_obj
-                                        print(f"         Âge: {age.days} jours")
-                                except:
-                                    pass
-                            else:
-                                print("         Start: None (pas encore initialisé)")
-
-                            if end_value:
-                                print(f"         End: {end_value}")
-
-                            if last_value and last_value != start_value:
-                                print(f"         Last: {last_value}")
-                    else:
-                        print("      ❌ Pas d'incrémental configuré")
-            print()
-    else:
-        print("❌ Pas de sources dans l'état")
-
-    # Afficher aussi l'état brut pour debug
+    # État brut JSON des incréments, pour debug fin.
     print("\n" + "=" * 80)
-    print("🔧 ÉTAT BRUT (pour debug)")
+    print("🔧 ÉTAT BRUT (debug)")
     print("=" * 80)
-
-    # Afficher seulement les resources avec leur incrémental
-    if "sources" in state:
-        for source_name, source_state in state["sources"].items():
-            if "resources" in source_state:
-                for res_name, res_state in source_state["resources"].items():
-                    if "incremental" in res_state:
-                        print(f"\n{source_name}.{res_name}:")
-                        print(json.dumps(res_state["incremental"], indent=2, default=str))
+    for source_name, source_state in sources.items():
+        for res_name, res_state in source_state.get("resources", {}).items():
+            if "incremental" in res_state:
+                print(f"\n{source_name}.{res_name} :")
+                print(json.dumps(res_state["incremental"], indent=2, default=str))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Quoi

`electricore/ingestion/tools/check_incremental_state.py` pointait `dlt.pipeline("flux_enedis")` — le pipeline **legacy supprimé** à la migration landing-brut (ADR-0020). Conséquence : il s'attachait à un pipeline inexistant et affichait un état vide, donc **inutilisable pour diagnostiquer l'incrémental réel** des raw JSON.

## Changements

- **Résout le nom de pipeline comme le runner** : `flux_brut_<stem>` via le registre runtime (`runtime.duckdb().chemin.stem`) — plus de nom codé en dur, suit la base de prod / `$DUCKDB_PATH`.
- **Itère tous les namespaces de source** de l'état dlt (pas un seul supposé) et **signale la fragmentation** des curseurs quand il y en a plusieurs.
- Âge en jours par curseur, pour repérer un flux dont le watermark n'avance plus.

## Pourquoi « tous les namespaces »

En vérifiant l'incrémental, on a trouvé que l'état réel porte les curseurs sous **deux** namespaces (`flux_brut_flux_enedis` pour `ingestion all`, `flux_enedis_brut` pour un backfill mono-flux `ingestion r64`) — c'est le quirk **#346**. L'outil le rend maintenant visible plutôt que de le masquer.

## Sortie sur l'état de prod actuel

```
📦 Namespace de source : flux_brut_flux_enedis
   📄 filesystem_raw_c15 [modification_date] : 2026-06-17T03:21:30+00:00 (il y a 1 j)
   … (les 7 flux)
📦 Namespace de source : flux_enedis_brut
   📄 filesystem_raw_r64 [modification_date] : 2026-06-17T15:04:03+00:00 (il y a 0 j)

⚠️  CURSEURS FRAGMENTÉS SUR PLUSIEURS NAMESPACES
```

## Portée

Premier item de **#345** (les autres outils legacy — `diagnostic_flux`, `reset_incremental_state`, `debug_single_flux` — restent à traiter, listés dans l'issue). Surface **#346**. Outil de diagnostic isolé : aucun importeur, aucun test existant ; vérifié en l'exécutant sur l'état dlt réel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
