### PR TITLE
fix(ingestion): namespace d'état incrémental stable — stoppe le re-téléchargement mono-flux

### DIFF
--- a/electricore/ingestion/sources/sftp_enedis.py
+++ b/electricore/ingestion/sources/sftp_enedis.py
@@ -13,6 +13,18 @@ from dlt.sources.filesystem import filesystem
 
 logger = logging.getLogger(__name__)
 
+# Namespace d'état incrémental stable (issue #346).
+#
+# Le curseur incrémental vit sur la resource `filesystem` interne, qui n'est PAS
+# liée à notre `@dlt.source`. Sa clé d'état (`source_state_key`) se résout sinon
+# différemment selon le nombre de flux du run : mono-flux → nom de la source,
+# multi-flux → nom dérivé du pipeline. Deux namespaces → un `ingestion <flux>` seul
+# repart d'un curseur vide et RE-TÉLÉCHARGE tout le flux. On épingle donc le
+# `source_name` de la resource filesystem sur cette constante : l'état atterrit
+# toujours au même endroit. C'est aussi le nom de la source (`flux_enedis_brut`),
+# pour que mono- et multi-flux partagent un seul namespace.
+ESPACE_ETAT_INCREMENTAL = "flux_enedis_brut"
+
 
 def mask_password_in_url(url: str) -> str:
     """
@@ -60,6 +72,12 @@ def create_sftp_resource(flux_type: str, table_name: str, file_pattern: str, sft
         files = filesystem(bucket_url=sftp_url, file_glob=file_pattern).with_name(
             f"filesystem_{table_name}"
         )  # Nom unique pour état incrémental indépendant
+
+        # Épingle le namespace d'état : sans ça, dlt résout la clé d'état de cette
+        # resource selon le nombre de flux du run (mono vs multi) → curseurs orphelins
+        # et re-téléchargement complet (#346). `source_name` est le 1er terme de la
+        # résolution de `source_state_key` (dlt resource.py).
+        files.source_name = ESPACE_ETAT_INCREMENTAL
 
         # Appliquer l'incrémental sur la date de modification.
         # modification_date est un pendulum.DateTime dans le filesystem source DLT,

--- a/tests/ingestion/test_namespace_etat_incremental.py
+++ b/tests/ingestion/test_namespace_etat_incremental.py
@@ -1,0 +1,67 @@
+"""Le namespace d'état incrémental est stable quel que soit le nombre de flux (#346).
+
+Avant le fix, un run mono-flux (`ingestion r64`) et un run multi-flux (`ingestion all`)
+stockaient leurs curseurs sous DEUX namespaces dlt différents (`flux_enedis_brut` vs
+`flux_brut_<stem>`). Conséquence : un `ingestion <flux>` seul repartait d'un curseur
+vide et RE-TÉLÉCHARGEAIT tout le flux. Le fix épingle le `source_name` de la resource
+filesystem interne sur `ESPACE_ETAT_INCREMENTAL` → un seul namespace.
+
+Ce test verrouille l'invariant : mono et multi posent le curseur sous le MÊME namespace.
+"""
+
+import json
+import os
+import time
+
+import dlt
+import pytest
+
+from electricore.config import runtime
+from electricore.ingestion.sources.sftp_enedis import ESPACE_ETAT_INCREMENTAL
+from electricore.ingestion.sources.sftp_enedis_brut import flux_enedis_brut
+
+_CONFIG = {
+    "C15": {"file_pattern": "**/*_C15_*.zip", "format": "xml", "file_regex": "*_C15_*.xml"},
+    "R64": {"file_pattern": "**/R63_R64_R65_R66_R67_C68/*_R64_*.zip", "format": "json", "file_regex": "*.JSON"},
+}
+
+
+@pytest.fixture
+def bucket_local(tmp_path):
+    """Un bucket file:// avec un leurre C15 et un leurre R64 (datés, contenu bidon)."""
+    b = tmp_path / "bucket"
+    (b / "R63_R64_R65_R66_R67_C68").mkdir(parents=True)
+    for nom in ("a_C15_x.zip", "R63_R64_R65_R66_R67_C68/a_R64_x.zip"):
+        f = b / nom
+        f.write_bytes(b"pas un vrai zip")
+        ts = time.mktime((2026, 1, 1, 12, 0, 0, 0, 0, -1))
+        os.utime(f, (ts, ts))
+    return b
+
+
+def _namespace_du_curseur(pipelines_dir, resource: str) -> str | None:
+    state = json.loads((pipelines_dir / "flux_brut_t" / "state.json").read_text())
+    for source_name, source_state in state.get("sources", {}).items():
+        if resource in source_state.get("resources", {}):
+            return source_name
+    return None
+
+
+@pytest.mark.parametrize("flux", [["R64"], ["C15", "R64"]], ids=["mono", "multi"])
+def test_namespace_etat_stable_quel_que_soit_le_nombre_de_flux(flux, tmp_path, bucket_local, monkeypatch):
+    monkeypatch.setenv("SFTP__URL", f"file://{bucket_local}/")
+    monkeypatch.setenv("AES__KEY", "00112233445566778899aabbccddeeff")
+    monkeypatch.setenv("AES__IV", "ffeeddccbbaa99887766554433221100")
+    runtime.vider_cache()
+
+    pipelines_dir = tmp_path / "pipelines"
+    pipeline = dlt.pipeline(
+        pipeline_name="flux_brut_t",
+        destination=dlt.destinations.duckdb(str(tmp_path / "t.duckdb")),
+        dataset_name="flux_raw",
+        pipelines_dir=str(pipelines_dir),
+    )
+    pipeline.run(flux_enedis_brut({k: _CONFIG[k] for k in flux}, max_files=None))
+
+    # Le curseur R64 (présent en mono ET en multi) doit toujours vivre au même endroit.
+    assert _namespace_du_curseur(pipelines_dir, "filesystem_raw_r64") == ESPACE_ETAT_INCREMENTAL


### PR DESCRIPTION
Corrige le quirk #346 : ton observation initiale (`ingestion r64` qui re-télécharge **tout** après l'ajout de quelques fichiers).

## Cause

Le curseur incrémental vit sur la resource `filesystem` **interne**, non liée à la `@dlt.source`. dlt résolvait sa clé d'état (`source_state_key`) **selon le nombre de flux du run** :

| Run | namespace d'état |
|-----|------------------|
| `ingestion r64` (mono) | `flux_enedis_brut` (nom de la source) |
| `ingestion all` (multi) | `flux_brut_<stem>` (nom dérivé du pipeline) |

Deux namespaces → un run mono-flux repart d'un **curseur vide** et re-télécharge tout. Le merge sur `file_name` évite la duplication de lignes, mais le re-download + re-déchiffrement + re-parse intégral a bien lieu (le coût réel que tu as vu).

## Fix

`sftp_enedis.py` épingle le `source_name` de la resource filesystem sur une constante `ESPACE_ETAT_INCREMENTAL = "flux_enedis_brut"` — 1er terme de la résolution de `source_state_key` (dlt `resource.py`). Mono et multi partagent désormais **un seul namespace**.

## Vérifs

- **Test paramétré** (`test_namespace_etat_incremental.py`, mono + multi) verrouillant l'invariant « même namespace ».
- **Avant/après reproduit** : après un `all`, un `ingestion r64` re-traitait **3** fichiers (tout) sans le fix → **2** (seulement les nouveaux) avec.
- Suite `tests/ingestion/` verte (61 passed).

## Transition au déploiement — aucune action requise

Le premier `ingestion all` après le fix re-liste le SFTP pour les flux qui n'ont pas encore de curseur sous le namespace cible et **MERGE** (sur `file_name`) dans les tables `raw_*` existantes : **sans perte ni duplication**, juste un run un peu plus lourd (≈ fenêtre de rétention SFTP, ~15 min). Les curseurs se reconstruisent sous le namespace épinglé et l'incrémental reprend normalement ensuite.

⚠️ **Ne pas utiliser `resync`** (`drop_sources`) pour cette transition : il *droppe* les tables `raw_*` puis re-télécharge → perte de l'historique aged-off du SFTP. Le simple `all` (merge, sans drop) est le chemin sûr.

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
