### PR TITLE
chore(release): v3.0.0rc17 — incrémental d'ingestion stable + nettoyage outils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.0.0rc17] - 2026-06-18
+
+Stabilise l'**état incrémental de l'ingestion** (raw JSON) et aligne les outils de
+diagnostic hérités de la bascule legacy→dbt (ADR-0020).
+
+### 🐛 Corrigé
+
+- **Incrémental : re-téléchargement complet sur un run mono-flux** — le curseur dlt vit
+  sur la resource `filesystem` interne, non liée à la `@dlt.source` ; sa clé d'état se
+  résolvait sous un namespace variable selon le nombre de flux du run (`ingestion <flux>`
+  seul → nom de la source, `ingestion all` → nom dérivé du pipeline). Deux namespaces : un
+  run mono-flux repartait d'un curseur vide et **re-téléchargeait tout le flux** (dédupliqué
+  par le merge sur `file_name`, donc sans duplication de lignes, mais re-fetch +
+  re-déchiffrement + re-parse intégral). Le `source_name` de la resource filesystem est
+  désormais épinglé → mono et multi partagent un namespace unique ; test paramétré de garde
+  ([#346](https://github.com/Energie-De-Nantes/electricore/issues/346)).
+
+  > _Déploiement : aucune action requise. Le premier `ingestion all` ré-aligne les curseurs
+  > en re-listant le SFTP pour les flux concernés et **merge** dans les `raw_*` existants —
+  > sans perte ni duplication, un run un peu plus lourd (≈ fenêtre de rétention SFTP), puis
+  > incrémental normal. Ne pas utiliser `resync` (il droppe les `raw_*` → perte de
+  > l'historique aged-off du SFTP)._
+
+### 🧹 Nettoyage (outils d'ingestion)
+
+- **Outils alignés post-bascule (ADR-0020)** — `check_incremental_state` résout le vrai
+  pipeline (`flux_brut_<stem>`) et expose tous les namespaces d'état (au lieu de pointer le
+  pipeline legacy `flux_enedis` supprimé) ; suppression des outils morts `debug_single_flux`
+  (import cassé) et `comparaison_bases` (échafaudage de bascule) ; `diagnostic_flux` réduit à
+  une découverte SFTP read-only et `reset_incremental_state` repointé sur le dataset `flux_raw`
+  ([#345](https://github.com/Energie-De-Nantes/electricore/issues/345)).
+
 ## [3.0.0rc16] - 2026-06-18
 
 Suite de l'épic [#332](https://github.com/Energie-De-Nantes/electricore/issues/332) :

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.0.0rc16"
+version = "3.0.0rc17"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}
@@ -186,7 +186,5 @@ no_implicit_optional = true         # forbid `x: str = None`
 "electricore/ingestion/runner.py" = ["E402"]  # chargement .env avant imports (secrets DLT)
 "electricore/ingestion/sources/sftp_enedis.py" = ["E402"]  # imports after section banner
 "electricore/ingestion/transformers/archive.py" = ["E402"]  # cross-module import after constants block
-"electricore/ingestion/tools/debug_single_flux.py" = ["E722"]  # debug-only script, bare except OK
-"electricore/ingestion/tools/check_incremental_state.py" = ["E722"]  # debug-only script, bare except OK
 "tests/integration/test_odoo_writer.py" = ["B017"]  # XML-RPC raises raw Exception, no specific type
 

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.0.0rc16"
+version = "3.0.0rc17"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Bump de version pour **rc17** : `3.0.0rc16` → `3.0.0rc17` (pyproject + uv.lock + CHANGELOG).

Package les 3 PRs déjà mergées depuis rc16 :
- **#349 (Closes #346)** — namespace d'état incrémental stable : un `ingestion <flux>` seul ne re-télécharge plus tout le flux.
- **#348 / #347 (Closes #345)** — outils d'ingestion alignés post-bascule ADR-0020 (résolution du vrai pipeline, suppression des outils morts, adaptations).

Retire aussi deux `per-file-ignores` ruff devenus morts (E722 sur `debug_single_flux` supprimé et `check_incremental_state` réécrit sans bare except) — restes que #347/#348 avaient laissés dans pyproject.

### Procédure
1. Merger cette PR (bump sur `main`).
2. Tagger `v3.0.0rc17` sur le commit de merge → déclenche `release.yml` (`uv build` → garde-fou `ls dist/` → image ghcr.io).

Garde-fou local vérifié : `uv build` produit `electricore-3.0.0rc17.{tar.gz,whl}` ; ruff vert après retrait des ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)