### PR TITLE
chore(release): v3.0.0 — premier stable de la ligne 3.0 (cycle rc1→rc17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,63 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-06-18
+
+Premier stable de la ligne **3.0** : aboutissement du cycle rc1→rc17. Stabilise sur données
+réelles la réécriture ELT (dbt, ligne 2.0) et **pose un modèle de relevés canonique**, ouvre
+electricore comme **source de vérité dont l'ERP _tire_** (méta-périodes, TURPE variable), et
+durcit le déploiement. Détail rc-par-rc plus bas.
+
+### ✨ Temps forts
+
+- **Modèle de relevés canonique en dbt** (`releves` — ADR-0028/0029/0032) : ligne de temps
+  unique des relevés, union arbitrée **C15 > R64 > R151** assemblée à la source, clé métier
+  déterministe `releve_id`, dépivot des index contractuels C15, adapters conformés + macro de
+  contrat. Fonde la traçabilité des index jusqu'à la facture (`releves_utilises`). Index
+  normalisés **Wh→kWh** (floor entier) au boundary dbt (ADR-0034).
+- **electricore source de vérité, l'ERP tire** : `GET /facturation/meta-periodes` (ADR-0027 —
+  Odoo construit ses périodes depuis ce flux, `source_hash` pour upsert non destructif) et
+  `POST /facturation/turpe-variable` (ADR-0030 — calculateur sans état). Routers
+  ERP-agnostiques, JSON enveloppé versionné, `X-API-Key`.
+- **Mart `releves` exposé hors `/flux`** : `GET /releves` (JSON paginé + `.xlsx` + `.arrow` +
+  `/info`), filtres prm/source/fenêtre, `client.releves()` (ADR-0032).
+- **Affaires SGE (X12/X13)** : linéarisation `flux_affaires` (grain = jalon, dédup des snapshots
+  cumulatifs) + cockpit read-only `GET /perimetre/affaires` et vue bot (#275/#276).
+- **Verdicts jumeaux qualité + communication** (ADR-0033/0036) : `qualite`
+  (réelle/estimée/incalculable, rollup pire-gagne) et `statut_communication` (communicante/non)
+  remplacent les anciens flags de complétude.
+- **Configuration runtime centralisée** (#141, ADR-0024/0025) : lecteur unique
+  pydantic-settings par domaine, précédence env > `.env`, validation fail-fast par point d'entrée.
+- **Durcissement VPS** (ADR-0031) : utilisateur ops, sshd root-off, fail2ban,
+  unattended-upgrades, `harden.sh` / `unharden.sh`.
+- **Socle property-based testing** (#194–#197) : stratégies Hypothesis dérivées des schémas
+  Pandera + invariants de conservation (TURPE, taxes, facturation, énergie).
+
+### ⚠️ Ruptures (cumul du cycle — détail par rc)
+
+- **`etl` → `ingestion`** : package, CLI (`python -m electricore.ingestion`), extra
+  (`--extra ingestion`), routes API (`/ingestion/*`, anciens `/etl/*` en 404), bot, compose (rc1).
+- **Clés AES en variables d'environnement uniquement** (retrait `.dlt/secrets.toml`),
+  `API_BASE_URL` retiré, `env.py` supprimé (rc1).
+- **Contrat `/facturation/meta-periodes` v2** : retrait de `data_complete` / `coverage_*` au
+  profit de `qualite` + `statut_communication` ; `CONTRAT_VERSION` 1 → 2 (rc14).
+- **API loaders legacy retirée** (`load_historique` / `load_releves`) au profit des query
+  builders + `charger_*` (rc1).
+
+### 🐛 Stabilisation prod (rc4→rc17)
+
+Éprouvé sur le corpus réel : OOM dbt sur `flux_r64` / `flux_r151` (threads + spill disque),
+index R151/R64 corrigés (Wh→kWh ÷1000, rc9), parsing des attributs XML (affaires `statut`),
+l'épic **#332** de régressions de validation/schéma sur endpoints prod (`/flux/r64`, exports
+Accise, facturation, puis le frère accise `ge=0` #341) — même classe « schéma plus étroit que la
+donnée prod », chacune avec un test de garde sur donnée prod-réaliste — et la **stabilité du
+namespace d'état incrémental** (#346, les runs mono-flux ne re-téléchargent plus tout) avec le
+nettoyage des outils d'ingestion périmés post-bascule legacy→dbt (#345, rc17).
+
+> **⚠️ Migration** : le chemin énergie requiert le mart dbt `releves`. Sur une base existante,
+> **relancer `dbt build`** (pipeline d'ingestion) pour matérialiser `flux_enedis.releves` avant
+> de calculer la facturation.
+
 ## [3.0.0rc17] - 2026-06-18
 
 Stabilise l'**état incrémental de l'ingestion** (raw JSON) et aligne les outils de

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.0.0rc17"
+version = "3.0.0"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.0.0rc17"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Release v3.0.0 — premier stable de la ligne 3.0 🎉

Promotion de **rc17** en stable. Bump `3.0.0rc17` → `3.0.0` (pyproject + uv.lock) + section
**[3.0.0]** consolidée au CHANGELOG (highlights du cycle rc1→rc17, trace rc-par-rc conservée).

### Temps forts du cycle

- **Modèle de relevés canonique en dbt** (`releves`, ADR-0028/0029/0032) + index Wh→kWh au boundary (ADR-0034).
- **electricore source de vérité, l'ERP tire** : `GET /facturation/meta-periodes` (ADR-0027) + `POST /facturation/turpe-variable` (ADR-0030).
- **Mart `releves` hors `/flux`** (JSON/xlsx/arrow/info, ADR-0032) ; **affaires SGE X12/X13** + cockpit `/perimetre/affaires`.
- **Verdicts jumeaux qualité + communication** (ADR-0033/0036) ; **config runtime centralisée** (#141) ; **durcissement VPS** (ADR-0031) ; **property-based testing**.
- **Stabilisation prod rc4→rc17** : OOM dbt, index Wh→kWh, épic régressions #332 (dont accise #341), incrémental d'ingestion #346.

### Ruptures (cumul du cycle)

`etl`→`ingestion`, AES en env-only, contrat `/meta-periodes` v2 (`qualite`/`statut_communication`), API loaders legacy retirée. Détail par rc au CHANGELOG.

`uv build` vérifié → `electricore-3.0.0.{tar.gz,whl}` (garde-fou CI OK).

⚠️ **Release finale** : le tag `v3.0.0` touchera les images Docker `:latest` et `:3.0` (pas seulement une prerelease).

> **Migration** : sur une base existante, relancer `dbt build` pour matérialiser `flux_enedis.releves` avant la facturation.

Après merge : tag `v3.0.0` sur le commit de merge → workflow Release.
