### PR TITLE
feat(ingestion): trousseau AES N-clés + escalade d'échec per-flux (ADR-0037)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,12 +119,10 @@ SFTP__URL=sftp://utilisateur:motdepasse@hote:22/chemin
 #    docker-compose.yml (voir deploy/docker/docker-compose.yml).
 # SFTP__URL=file:///var/enedis/
 
-# Clés AES Enedis — format simple (v1)
-AES__KEY=hex_key_32_caracteres
-AES__IV=hex_iv_32_caracteres
-
-# Ou format rotation v2 (recommandé) :
-# AES__CURRENT__KEY=nouvelle_cle_hex
-# AES__CURRENT__IV=nouvel_iv_hex
-# AES__PREVIOUS__KEY=ancienne_cle_hex   # optionnel, ~4 semaines après rotation
-# AES__PREVIOUS__IV=ancien_iv_hex
+# Clés AES Enedis — trousseau N-clés (ADR-0037). Chaque clé porte un <label>
+# parlant ; la bonne clé est sélectionnée par essai (aucune date, aucun protocole).
+# Garder les anciennes clés dans le trousseau préserve l'accès aux archives passées.
+AES__TROUSSEAU__aes256_2026__KEY=hex_key_64_caracteres   # AES-256 (32 octets)
+AES__TROUSSEAU__aes256_2026__IV=hex_iv_32_caracteres
+# AES__TROUSSEAU__aes128_2024__KEY=hex_key_32_caracteres   # AES-128 historique (16 octets)
+# AES__TROUSSEAU__aes128_2024__IV=hex_iv_32_caracteres

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,31 +220,36 @@ uv run python -m electricore.ingestion all
 
 Result: DuckDB database at `electricore/ingestion/flux_enedis_pipeline.duckdb`
 
-#### Rotation des clés AES Enedis
+#### Trousseau de clés AES Enedis (ADR-0037)
 
-Enedis effectue des rotations de clés AES périodiquement. Le registre runtime
-(`electricore/config/runtime.py`, domaine `aes`, #141/ADR-0025) supporte deux clés
-simultanément pour couvrir la transition — **en variables d'environnement uniquement**
+Enedis rote ses clés AES périodiquement et en change la longueur (bascule
+AES-128 → AES-256 du 8-9 juin 2026). Le registre runtime
+(`electricore/config/runtime.py`, domaine `aes`, #141/ADR-0025/ADR-0037) expose un
+**trousseau de taille arbitraire** — **en variables d'environnement uniquement**
 (`.env` ou env système ; le support `.dlt/secrets.toml` a été retiré) :
 
 ```bash
-AES__CURRENT__KEY=nouvelle_cle_hex
-AES__CURRENT__IV=nouvel_iv_hex
-AES__PREVIOUS__KEY=ancienne_cle_hex   # optionnel, garder ~4 semaines après rotation
-AES__PREVIOUS__IV=ancien_iv_hex
+AES__TROUSSEAU__aes256_2026__KEY=cle_hex_64   # AES-256 (32 octets)
+AES__TROUSSEAU__aes256_2026__IV=iv_hex_32
+AES__TROUSSEAU__aes128_2024__KEY=cle_hex_32   # AES-128 historique (16 octets)
+AES__TROUSSEAU__aes128_2024__IV=iv_hex_32
 ```
+
+Le `<label>` est un nom parlant choisi par l'opérateur ; il remonte dans les logs de
+déchiffrement. La bonne clé est **sélectionnée par essai** (oracle PKCS7 + magic bytes
+ZIP), sans aucune date ni notion de protocole — AES-128 et AES-256 sont le même schéma,
+la longueur de clé est auto-sélectionnée.
 
 Procédure de rotation :
 1. Obtenir la nouvelle clé Enedis
-2. Déplacer la clé active vers `previous`, mettre la nouvelle clé en `current`
-3. Relancer le pipeline — les anciens fichiers déchiffrent avec `previous`, les nouveaux avec `current`
-4. Après ~4 semaines : supprimer `previous`
+2. L'ajouter au trousseau sous un nouveau label (`AES__TROUSSEAU__<nouveau>__{KEY,IV}`)
+3. Relancer le pipeline — chaque fichier déchiffre avec la clé qui marche, par essai
+4. Retirer une vieille clé seulement quand plus aucune archive chiffrée avec elle n'est (re)téléchargeable
 
-Le format plat v1 (`AES__KEY` / `AES__IV`) reste supporté pour la compatibilité ascendante.
-La bascule **AES-128 → AES-256** (nuit du 8-9 juin 2026) est absorbée par la longueur
-de clé (16 vs 32 octets). Le cascade à deux clés ne couvre qu'une rotation ; le trousseau
-N-clés est tracé en [issue #221](https://github.com/Energie-De-Nantes/electricore/issues/221)
-(supersède [ADR-0008](docs/adr/0008-rotation-cles-aes.md)).
+L'échec de déchiffrement n'est plus silencieux : un flux qui a des fichiers mais **0**
+déchiffrement réussi fait passer le job à `failed` → la surveillance bot alerte
+(escalade per-flux, ADR-0037). Supersède [ADR-0008](docs/adr/0008-rotation-cles-aes.md) ;
+porté par [issue #221](https://github.com/Energie-De-Nantes/electricore/issues/221).
 
 ### 2. Core Pipelines
 

--- a/README.md
+++ b/README.md
@@ -349,14 +349,12 @@ API_KEY=votre_cle_api_secrete
 
 # === INGESTION ENEDIS — obligatoire pour l'ingestion ===
 SFTP__URL=sftp://utilisateur:mot_de_passe@hote:22/chemin
-AES__KEY=cle_hex_fournie_par_enedis
-AES__IV=iv_hex_fourni_par_enedis
-
-# Rotation de clés AES (format v2, après changement de clé Enedis) :
-# AES__CURRENT__KEY=nouvelle_cle_hex
-# AES__CURRENT__IV=nouvel_iv_hex
-# AES__PREVIOUS__KEY=ancienne_cle_hex  # garder ~4 semaines après rotation
-# AES__PREVIOUS__IV=ancien_iv_hex
+# Trousseau de clés AES (ADR-0037) : un <label> parlant par clé, sélection par essai.
+# Garder les anciennes clés dans le trousseau préserve l'accès aux archives passées.
+AES__TROUSSEAU__aes256_2026__KEY=cle_hex_fournie_par_enedis
+AES__TROUSSEAU__aes256_2026__IV=iv_hex_fourni_par_enedis
+# AES__TROUSSEAU__aes128_2024__KEY=ancienne_cle_hex
+# AES__TROUSSEAU__aes128_2024__IV=ancien_iv_hex
 
 # === ODOO — pour les calculs CTA/Accise et la réconciliation ===
 ODOO_ENV=test  # ou prod

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -60,21 +60,17 @@ API_KEY=  # TODO: à remplir
 SFTP__URL=  # TODO: à remplir
 
 # -------------------------------------------
-# Clés AES Enedis (toujours requises, même en mode collocé)
+# Clés AES Enedis — trousseau N-clés (ADR-0037, toujours requis même en mode collocé)
 # -------------------------------------------
-# Format recommandé v2 (supporte la rotation, cf. docs/deploiement.md).
-# Format: hexadécimal, 32 ou 64 caractères (selon la cuvée Enedis)
-AES__CURRENT__KEY=  # TODO: à remplir
-AES__CURRENT__IV=   # TODO: à remplir
-
-# Clés précédentes — à activer ~4 semaines après une rotation pour permettre
-# le déchiffrement des anciens fichiers encore présents sur le SFTP.
-# AES__PREVIOUS__KEY=ancienne_cle_hex
-# AES__PREVIOUS__IV=ancien_iv_hex
-
-# Format v1 (legacy, clé unique sans rotation) — encore supporté :
-# AES__KEY=hex_key
-# AES__IV=hex_iv
+# Chaque clé porte un <label> parlant ; la bonne est sélectionnée par essai
+# (aucune date, aucun protocole). Garder les anciennes clés préserve l'accès aux
+# archives passées. Hexadécimal : 32 caractères (AES-128) ou 64 (AES-256).
+AES__TROUSSEAU__aes256_2026__KEY=  # TODO: à remplir (AES-256, 64 hex)
+AES__TROUSSEAU__aes256_2026__IV=   # TODO: à remplir
+# Clés historiques — à conserver dans le trousseau tant que des archives chiffrées
+# avec elles peuvent encore être (re)téléchargées.
+# AES__TROUSSEAU__aes128_2024__KEY=ancienne_cle_hex
+# AES__TROUSSEAU__aes128_2024__IV=ancien_iv_hex
 
 # -------------------------------------------
 # Bot Telegram (optionnel)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,14 +20,13 @@ bot ; le runner valide `sftp`+`aes`+`duckdb`).
 | variable | rôle | défaut |
 |---|---|---|
 | `SFTP__URL` | URL SFTP Enedis (`sftp://user:pass@host/chemin` ou `file:///...` pour des zips locaux) | — (requis) |
-| `AES__CURRENT__KEY` / `AES__CURRENT__IV` | clé AES active (hex) — déchiffrement des zips ; 16 octets (AES-128) ou 32 (AES-256, bascule du 8-9 juin 2026) | — (requis) |
-| `AES__PREVIOUS__KEY` / `AES__PREVIOUS__IV` | clé précédente, gardée ~4 semaines après rotation Enedis | optionnel |
-| `AES__KEY` / `AES__IV` | format plat v1, compatibilité ascendante | optionnel |
+| `AES__TROUSSEAU__<label>__KEY` / `__IV` | une clé AES (hex) du trousseau ; 16 octets (AES-128) ou 32 (AES-256) ; `<label>` parlant choisi par l'opérateur (`aes256_2026`, `aes128_2024`…) | — (≥ 1 requis) |
 
-Le délimiteur `__` est l'`env_nested_delimiter` natif de pydantic-settings (`AES__CURRENT__KEY`
-→ modèle imbriqué `current.key`). Le support `.dlt/secrets.toml` a été retiré (#141) — les
-clés vivent en variables d'environnement uniquement. Rotation et trousseau N-clés : CLAUDE.md
-et [issue #221](https://github.com/Energie-De-Nantes/electricore/issues/221).
+Le délimiteur `__` est l'`env_nested_delimiter` natif de pydantic-settings : `AES__TROUSSEAU__aes256_2026__KEY`
+→ entrée `trousseau["aes256_2026"].key`. Le trousseau accepte un nombre arbitraire de clés ; la bonne
+est **sélectionnée par essai** au déchiffrement (oracle PKCS7 + magic bytes ZIP), sans date ni protocole
+(ADR-0037). Garder les anciennes clés préserve l'accès aux archives passées. Le support `.dlt/secrets.toml`
+a été retiré (#141) — les clés vivent en variables d'environnement uniquement.
 
 ### Bases de données
 

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -113,9 +113,9 @@ marquées `# TODO:`. Voici la table de référence (cf. aussi
 
 | Variable | Notes |
 |---|---|
-| `AES__CURRENT__KEY` | Hex 32 ou 64 chars. |
-| `AES__CURRENT__IV`  | Hex 32 ou 64 chars. |
-| `AES__PREVIOUS__*`  | Optionnel pendant ~4 semaines après rotation. |
+| `AES__TROUSSEAU__<label>__KEY` | Hex 32 (AES-128) ou 64 (AES-256) chars. `<label>` parlant (`aes256_2026`…). |
+| `AES__TROUSSEAU__<label>__IV`  | Hex 32 chars. |
+| (autres labels) | Conserver les anciennes clés dans le trousseau tant que des archives chiffrées avec elles peuvent être (re)téléchargées. |
 
 **Bot Telegram** (optionnel)
 
@@ -520,32 +520,35 @@ sudo -u <slug> docker compose -f /srv/<slug>/deploy/docker/docker-compose.yml \
     --env-file /srv/<slug>/.env up -d api
 ```
 
-## Rotation des clés AES
+## Rotation des clés AES (trousseau N-clés, ADR-0037)
 
-Enedis effectue périodiquement une rotation. Le format à deux clés
-(`current` + `previous`) permet de couvrir la période de transition.
+Enedis rote périodiquement ses clés (et en change la longueur : AES-128 → AES-256).
+Le **trousseau** porte un nombre arbitraire de clés labellisées ; la bonne est
+sélectionnée par essai (aucune date, aucun protocole).
 
 ### Procédure (via le mode reconfigure)
 
 1. Recevoir la nouvelle clé Enedis.
 2. Relancer le script : `sudo bash /srv/<slug>/deploy/install.sh --slug <slug> --domain <slug>.electricore.fr`.
-3. L'éditeur s'ouvre sur `.env`. Déplacer les valeurs actuelles vers
-   `AES__PREVIOUS__*` et mettre la nouvelle clé dans `AES__CURRENT__*` :
+3. L'éditeur s'ouvre sur `.env`. **Ajouter** la nouvelle clé au trousseau sous un
+   nouveau label, sans retirer les anciennes :
 
    ```
-   AES__CURRENT__KEY=nouvelle_cle_hex
-   AES__CURRENT__IV=nouvel_iv_hex
-   AES__PREVIOUS__KEY=ancienne_cle_hex
-   AES__PREVIOUS__IV=ancien_iv_hex
+   AES__TROUSSEAU__aes256_2026__KEY=nouvelle_cle_hex
+   AES__TROUSSEAU__aes256_2026__IV=nouvel_iv_hex
+   AES__TROUSSEAU__aes128_2024__KEY=ancienne_cle_hex
+   AES__TROUSSEAU__aes128_2024__IV=ancien_iv_hex
    ```
 
 4. Sauvegarder, fermer l'éditeur. Le script valide, restart la stack, lance
-   une ingestion test pour confirmer que les deux jeux de clés fonctionnent.
+   une ingestion test pour confirmer que le trousseau déchiffre tout.
 
-Pendant ~4 semaines, les deux clés coexistent. Les logs `[current]` / `[previous]`
-indiquent quelle clé a déchiffré quel fichier.
+Les logs `[<label>]` indiquent quelle clé a déchiffré quel fichier. Si un flux a des
+fichiers mais **0** déchiffrement réussi, le job passe à `failed` et le bot alerte
+(escalade per-flux) : signe qu'une clé manque encore au trousseau.
 
-Après transition, relancer le script et supprimer `AES__PREVIOUS__*` du `.env`.
+Retirer une vieille clé seulement quand plus aucune archive chiffrée avec elle
+n'est (re)téléchargeable depuis le SFTP.
 
 ## Sauvegarde et restauration
 
@@ -864,10 +867,11 @@ sudo -u <slug> docker compose -f /srv/<slug>/deploy/docker/docker-compose.yml lo
 
 ### L'ingestion échoue avec `Échec déchiffrement avec X clé(s)`
 
-Mauvaise clé AES ou fichier corrompu. Comparer `AES__*` dans `.env` avec ce
-qu'Enedis a fourni. En période de rotation, s'assurer que `AES__PREVIOUS__*`
-est toujours configurée. Relancer le script en mode reconfigure pour ré-éditer
-`.env` proprement.
+Aucune clé du trousseau n'a déchiffré ce flux (clé manquante ou fichier corrompu).
+Comparer les `AES__TROUSSEAU__<label>__*` dans `.env` avec ce qu'Enedis a fourni ;
+en période de rotation, vérifier que **l'ancienne clé** est toujours dans le trousseau
+(elle reste nécessaire pour les archives historiques). Relancer le script en mode
+reconfigure pour ré-éditer `.env` proprement.
 
 ### Le bot Telegram ne répond pas
 

--- a/electricore/config/runtime.py
+++ b/electricore/config/runtime.py
@@ -83,31 +83,25 @@ class PaireCles(BaseSettings):
 
 
 class Aes(BaseSettings):
-    """Domaine aes : clés de déchiffrement des flux, avec rotation (ADR-0008).
+    """Domaine aes : trousseau de clés de déchiffrement des flux (ADR-0037).
 
-    Cascade : `current` (+ `previous` pendant la transition), sinon le format
-    plat v1 (`AES__KEY`/`AES__IV`) en compatibilité ascendante.
+    Trousseau de taille arbitraire alimenté par `AES__TROUSSEAU__<label>__KEY` /
+    `__IV`. Le `<label>` est un nom parlant choisi par l'opérateur (`aes256_2026`,
+    `aes128_2024`…) qui remonte tel quel dans `chaine()`, donc dans les logs. La
+    sélection de la bonne clé se fait par essai (cf. `decrypt_with_key_chain`),
+    sans date ni protocole. Rupture de format assumée : `current`/`previous`/plat-v1
+    d'ADR-0008 sont retirés (instance unique, ADR-0015).
     """
 
     model_config = SettingsConfigDict(
         env_prefix="AES__", env_nested_delimiter="__", populate_by_name=True, extra="ignore"
     )
 
-    current: PaireCles | None = None
-    previous: PaireCles | None = None
-    key: str | None = None  # format plat v1
-    iv: str | None = None
+    trousseau: dict[str, PaireCles] = Field(default_factory=dict)
 
     def chaine(self) -> list[tuple[str, bytes, bytes]]:
-        """Chaîne de déchiffrement ordonnée : [(étiquette, clé, iv), …]."""
-        if self.current is not None:
-            chaine = [("current", *self.current.octets("current"))]
-            if self.previous is not None:
-                chaine.append(("previous", *self.previous.octets("previous")))
-            return chaine
-        if self.key and self.iv:
-            return [("legacy", *PaireCles(key=self.key, iv=self.iv).octets("key"))]
-        return []
+        """Trousseau aplati en [(label, clé, iv), …] — ordre indifférent (sélection par essai)."""
+        return [(label, *paire.octets(label)) for label, paire in self.trousseau.items()]
 
 
 class Odoo(BaseSettings):
@@ -193,7 +187,7 @@ def sftp() -> Sftp:
 def aes() -> Aes:
     domaine = _instancier("aes", Aes, "AES__")
     if not domaine.chaine():
-        raise ConfigurationManquante({"aes": ["AES__CURRENT__KEY", "AES__CURRENT__IV"]})
+        raise ConfigurationManquante({"aes": ["AES__TROUSSEAU__<label>__KEY", "AES__TROUSSEAU__<label>__IV"]})
     return domaine
 
 

--- a/electricore/ingestion/README.md
+++ b/electricore/ingestion/README.md
@@ -38,25 +38,20 @@ uv run --extra ingestion --extra dbt python -m electricore.ingestion rebuild # d
 uv run --extra ingestion --extra dbt python -m electricore.ingestion resync  # re-télécharge tout (brut perdu)
 ```
 
-## Configuration (`secrets.toml`)
+## Configuration (variables d'environnement)
 
-```toml
-[sftp]
-url = "sftp://user:pass@host/path/"
+Les secrets vivent en variables d'environnement (`.env` à la racine ou env système ;
+le support `.dlt/secrets.toml` a été retiré, #141).
 
-# Format recommandé — supporte la rotation de clés
-[aes.current]
-key = "hex_encoded_key"
-iv  = "hex_encoded_iv"
+```bash
+SFTP__URL=sftp://user:pass@host/path/
 
-[aes.previous]           # optionnel, garder ~4 semaines après rotation
-key = "ancienne_clé_hex"
-iv  = "ancien_iv_hex"
-
-# Format hérité (toujours supporté)
-# [aes]
-# key = "..."
-# iv  = "..."
+# Trousseau de clés AES (ADR-0037) : un <label> parlant par clé, sélection par essai.
+# Garder les anciennes clés préserve l'accès aux archives passées.
+AES__TROUSSEAU__aes256_2026__KEY=cle_hex_64   # AES-256 (32 octets)
+AES__TROUSSEAU__aes256_2026__IV=iv_hex_32
+AES__TROUSSEAU__aes128_2024__KEY=cle_hex_32   # AES-128 historique (16 octets)
+AES__TROUSSEAU__aes128_2024__IV=iv_hex_32
 ```
 
 ## Flux supportés
@@ -70,14 +65,17 @@ iv  = "ancien_iv_hex"
 | **R151** | Relevés périodiques Linky | `flux_r151` |
 | **R64** | Timeseries JSON | `flux_r64` |
 
-## Rotation des clés AES
+## Rotation des clés AES (trousseau N-clés, ADR-0037)
 
-Enedis effectue des rotations de clés périodiquement. Procédure :
+Enedis rote ses clés périodiquement (et en change la longueur). Procédure :
 
 1. Obtenir la nouvelle clé Enedis
-2. Dans `secrets.toml` : déplacer `[aes]` → `[aes.previous]`, créer `[aes.current]`
-3. Relancer le pipeline — les fichiers anciens déchiffrent avec `previous`, les nouveaux avec `current`
-4. Après ~4 semaines : supprimer `[aes.previous]`
+2. L'ajouter au trousseau sous un nouveau label : `AES__TROUSSEAU__<nouveau>__{KEY,IV}`
+3. Relancer le pipeline — chaque fichier déchiffre par essai avec la clé qui marche
+4. Retirer une vieille clé seulement quand plus aucune archive chiffrée avec elle n'est (re)téléchargeable
+
+L'échec n'est plus silencieux : un flux sans aucun déchiffrement réussi fait passer le
+job à `failed` (escalade per-flux) → la surveillance bot alerte.
 
 ## Reset de l'état incrémental
 

--- a/electricore/ingestion/runner.py
+++ b/electricore/ingestion/runner.py
@@ -32,6 +32,7 @@ import yaml
 
 from electricore.config import runtime
 from electricore.ingestion.sources.sftp_enedis_brut import flux_enedis_brut
+from electricore.ingestion.transformers.crypto import StatsDechiffrement
 
 # DLT écrit sur stderr — on laisse faire, on ne lit que stdout
 logging.disable(logging.CRITICAL)
@@ -100,22 +101,38 @@ def interpreter_flux(flux: list[str], max_files: int | None) -> PlanRun:
     return PlanRun(selection=[f.upper() for f in flux], max_files=max_files, refresh=None)
 
 
-def lander_brut(db_path: Path, plan: PlanRun) -> None:
-    """Étape 1 : SFTP → tables raw_<flux> (colonne JSON) dans flux_raw."""
+def lander_brut(db_path: Path, plan: PlanRun) -> dict[str, StatsDechiffrement]:
+    """Étape 1 : SFTP → tables raw_<flux> (colonne JSON) dans flux_raw.
+
+    Retourne les stats de déchiffrement agrégées par flux (escalade per-flux, ADR-0037) :
+    le caller décide ensuite si un flux aveugle doit faire échouer le job.
+    """
     config = yaml.safe_load((ICI / "config" / "flux.yaml").read_text())
     if plan.selection:
         config = {k: v for k, v in config.items() if k in plan.selection}
 
+    stats: dict[str, StatsDechiffrement] = {}
     pipeline = dlt.pipeline(
         pipeline_name=f"flux_brut_{db_path.stem}",
         destination=dlt.destinations.duckdb(str(db_path)),
         dataset_name="flux_raw",
         progress="log",
     )
-    info = pipeline.run(flux_enedis_brut(config, max_files=plan.max_files), refresh=plan.refresh)
+    info = pipeline.run(flux_enedis_brut(config, max_files=plan.max_files, stats=stats), refresh=plan.refresh)
     for paquet in info.load_packages:
         for job in paquet.jobs.get("completed_jobs", []):
             _out(f"  landé : {job.job_file_info.table_name}")
+    return stats
+
+
+def flux_sans_dechiffrement(stats: dict[str, StatsDechiffrement]) -> list[str]:
+    """Flux aveugles : des fichiers, mais 0 déchiffrement réussi (≥ 1 échec) → clé manquante.
+
+    Cœur de l'escalade per-flux (ADR-0037) : Enedis fait évoluer le chiffrement par flux
+    indépendamment, donc on capte exactement le flux qui bascule seul, sans noyer dans un
+    seuil global. Un échec isolé (autres fichiers OK) n'y figure pas — il est toléré.
+    """
+    return [flux for flux, s in stats.items() if s.flux_aveugle()]
 
 
 # Modèles dbt servis par chaque table brute (raw_r15 sert deux linéarisations).
@@ -237,21 +254,35 @@ def main() -> None:
 
     args.db = args.db or chemin_db_defaut()
 
+    aveugles: list[str] = []
     if plan.rebuild:
         _out(f"↻ Rebuild : re-matérialisation depuis le brut de {args.db} (zéro réseau)")
     else:
         debut = time.time()
         _out(f"🚀 Landing brut → {args.db}")
-        lander_brut(args.db, plan)
+        stats = lander_brut(args.db, plan)
+        aveugles = flux_sans_dechiffrement(stats)
         _out(f"⏱️  Landing : {time.time() - debut:.1f}s")
 
     debut = time.time()
     _out("🔨 dbt build")
     if not construire_dbt(args.db):
-        _out("❌ dbt build a échoué")
+        # Si rien n'a été construit alors que des flux sont aveugles, la vraie cause est
+        # la clé AES manquante, pas dbt — surfacer le bon diagnostic.
+        if aveugles:
+            _out(f"❌ Aucun déchiffrement réussi pour : {', '.join(aveugles)} (clé AES manquante ?)")
+        else:
+            _out("❌ dbt build a échoué")
         sys.exit(1)
     _out(f"⏱️  dbt : {time.time() - debut:.1f}s")
 
     _out("📊 Bilan")
     bilan(args.db)
+
+    # Escalade per-flux (ADR-0037) : un flux qui a des fichiers mais 0 déchiffrement réussi
+    # fait échouer le job — la surveillance bot alerte alors sur un job `failed`. Placé après
+    # le dbt build pour que les flux sains continuent de couler malgré le flux aveugle.
+    if aveugles:
+        _out(f"❌ Flux sans aucun déchiffrement réussi (clé AES manquante ?) : {', '.join(aveugles)}")
+        sys.exit(1)
     _out("✅ Terminé")

--- a/electricore/ingestion/sources/sftp_enedis_brut.py
+++ b/electricore/ingestion/sources/sftp_enedis_brut.py
@@ -22,7 +22,11 @@ from electricore.config import runtime
 from electricore.ingestion.parsing.xml import xml_vers_dict
 from electricore.ingestion.sources.sftp_enedis import create_sftp_resource, mask_password_in_url
 from electricore.ingestion.transformers.archive import create_unzip_transformer
-from electricore.ingestion.transformers.crypto import create_decrypt_transformer
+from electricore.ingestion.transformers.crypto import (
+    StatsDechiffrement,
+    create_decrypt_transformer,
+    load_aes_key_chain,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,18 +50,24 @@ def _create_brut_transformer(flux_type: str, est_json: bool):
 
 
 @dlt.source(name="flux_enedis_brut")
-def flux_enedis_brut(flux_config: dict, max_files: int = None):
+def flux_enedis_brut(flux_config: dict, max_files: int = None, stats: dict[str, StatsDechiffrement] | None = None):
     """Source DLT déposant le brut JSON de chaque flux dans `raw_<flux>`.
 
     Args:
         flux_config: Sections de flux.yaml (C15, R15, …) : file_pattern (glob SFTP),
             format (xml/json) et file_regex (fichiers à extraire des zips).
         max_files: Limitation par flux (smoke tests).
+        stats: Dict mutable {flux: StatsDechiffrement} peuplé par flux (escalade per-flux,
+            ADR-0037). Le caller (runner) le crée et le relit après le run pour décider
+            d'un échec de job. None → dict interne jetable (callers indifférents au comptage).
     """
     sftp_url = runtime.sftp().url
     logger.info("Source URL: %s", mask_password_in_url(sftp_url))
 
-    decrypt_transformer = create_decrypt_transformer()
+    stats = stats if stats is not None else {}
+    # Trousseau résolu une seule fois (pas par flux) — partagé entre les transformers.
+    key_chain = load_aes_key_chain()
+    logger.info("%d clé(s) AES chargée(s) : %s", len(key_chain), [name for name, _, _ in key_chain])
 
     for flux_type, config_flux in flux_config.items():
         file_pattern = config_flux["file_pattern"]
@@ -68,6 +78,8 @@ def flux_enedis_brut(flux_config: dict, max_files: int = None):
         file_regex = config_flux.get("file_regex", f"*{extension}")
 
         sftp_resource = create_sftp_resource(flux_type, table, file_pattern, sftp_url, max_files)
+        stats_flux = stats.setdefault(flux_type, StatsDechiffrement())
+        decrypt_transformer = create_decrypt_transformer(key_chain=key_chain, stats=stats_flux)
         unzip_transformer = create_unzip_transformer(extension, file_regex)
         brut = _create_brut_transformer(flux_type, est_json)
 

--- a/electricore/ingestion/transformers/crypto.py
+++ b/electricore/ingestion/transformers/crypto.py
@@ -2,24 +2,26 @@
 Transformer DLT pour le déchiffrement AES des fichiers Enedis.
 Inclut les fonctions pures de cryptographie et le transformer DLT.
 
-Gestion de la rotation de clés (ADR-0008, registre runtime #141) :
-  Les clés AES Enedis sont rotées périodiquement. Le registre runtime supporte
-  plusieurs clés simultanément pour couvrir la période de transition, en variables
-  d'environnement (`.env` compris) :
+Trousseau de clés N-clés (ADR-0037, registre runtime #141) :
+  Les clés AES Enedis sont rotées périodiquement et évoluent en longueur (la
+  bascule AES-128 → AES-256 du 8-9 juin 2026). Le registre runtime expose un
+  trousseau de taille arbitraire, alimenté par des variables d'environnement
+  nommées (`.env` compris) :
 
-      AES__CURRENT__KEY=nouvelle_clé_hex
-      AES__CURRENT__IV=nouvel_iv_hex
-      AES__PREVIOUS__KEY=ancienne_clé_hex   # optionnel, ~4 semaines après rotation
-      AES__PREVIOUS__IV=ancien_iv_hex
+      AES__TROUSSEAU__aes256_2026__KEY=…    # 32 octets hex (AES-256)
+      AES__TROUSSEAU__aes256_2026__IV=…
+      AES__TROUSSEAU__aes128_2024__KEY=…    # 16 octets hex (AES-128)
+      AES__TROUSSEAU__aes128_2024__IV=…
 
-  Le format plat v1 (`AES__KEY`/`AES__IV`) reste supporté en compatibilité
-  ascendante. Lors du déchiffrement, la clé `current` est essayée en premier ;
-  si elle échoue, `previous` est tentée. Un log indique quelle clé a fonctionné
-  pour faciliter le diagnostic lors d'une transition.
+  La sélection se fait **par essai** : chaque clé du trousseau est tentée dans un
+  ordre indifférent ; le déchiffrement est son propre oracle (padding PKCS7 +
+  magic bytes ZIP). Aucune date ni protocole ne pilote la sélection. Le `<label>`
+  parlant remonte dans les logs pour faciliter le diagnostic.
 """
 
 import logging
 from collections.abc import Iterator
+from dataclasses import dataclass
 
 import dlt
 from Crypto.Cipher import AES
@@ -32,6 +34,27 @@ logger = logging.getLogger(__name__)
 
 # Magic bytes d'un fichier ZIP (PK local file header)
 _ZIP_MAGIC = b"PK\x03\x04"
+
+
+@dataclass
+class StatsDechiffrement:
+    """Compteur de déchiffrement d'un flux (resource) — escalade per-flux (ADR-0037).
+
+    Le transformer incrémente `succes`/`echecs` au fil des fichiers ; le runner
+    agrège ensuite par flux et décide si l'absence totale de succès (`flux_aveugle`)
+    doit faire échouer le job.
+    """
+
+    succes: int = 0
+    echecs: int = 0
+
+    def flux_aveugle(self) -> bool:
+        """Flux ayant des fichiers mais aucun déchiffrement réussi (≥ 1 échec) → clé manquante.
+
+        Un échec isolé noyé dans des succès (fichier corrompu) n'est PAS aveugle : il est
+        toléré. Un flux sans aucun fichier (succès comme échec à 0) ne l'est pas non plus.
+        """
+        return self.succes == 0 and self.echecs > 0
 
 
 # =============================================================================
@@ -79,17 +102,16 @@ def decrypt_file_aes(encrypted_data: bytes, key: bytes, iv: bytes) -> bytes:
 
 def load_aes_key_chain() -> list[tuple[str, bytes, bytes]]:
     """
-    Charge la chaîne de clés AES depuis le registre runtime (#141, ADR-0025).
+    Charge le trousseau de clés AES depuis le registre runtime (#141, ADR-0037).
 
-    La cascade de rotation (current → previous, sinon legacy v1) et le parsing
+    Le trousseau nommé (`AES__TROUSSEAU__<label>__KEY/IV`) et le parsing
     hexadécimal vivent dans le domaine `aes` du registre.
 
     Returns:
-        Liste de tuples (nom, clé, iv) dans l'ordre de tentative.
-        La clé `current` (ou la clé unique en v1) est toujours en premier.
+        Liste de tuples (label, clé, iv) — ordre indifférent (sélection par essai).
 
     Raises:
-        ConfigurationManquante: Si aucune clé valide n'est configurée.
+        ConfigurationManquante: Si le trousseau est vide.
         ValueError: Si une clé/IV n'est pas un hexadécimal valide.
     """
     return runtime.aes().chaine()
@@ -161,17 +183,21 @@ def read_sftp_file(encrypted_item: FileItemDict) -> bytes:
 def _decrypt_aes_transformer_base(
     encrypted_file: FileItemDict,
     key_chain: list[tuple[str, bytes, bytes]],
+    stats: StatsDechiffrement,
 ) -> Iterator[dict]:
     """
     Fonction de base pour déchiffrer les fichiers AES depuis SFTP.
 
-    Tente chaque clé de key_chain dans l'ordre. Si toutes échouent,
-    le fichier est ignoré (yield rien) et une erreur est loguée.
-    Le fichier sera re-tenté au prochain run DLT.
+    Tente chaque clé de key_chain par essai. Fin du fail silencieux (ADR-0037) :
+    un échec de déchiffrement est **compté** dans `stats`, tracé en warn-log, et le
+    fichier est sauté (pas de poison-pill : un fichier corrompu isolé ne fait pas
+    tomber tout le flux). Le runner agrège ensuite `stats` par flux et décide si
+    l'absence totale de succès doit faire échouer le job.
 
     Args:
         encrypted_file: Fichier chiffré depuis une resource SFTP
-        key_chain: Chaîne de clés [(nom, clé, iv), ...] à essayer
+        key_chain: Chaîne de clés [(label, clé, iv), ...] à essayer
+        stats: Compteur succès/échec du flux courant (muté en place)
 
     Yields:
         dict: {
@@ -183,55 +209,65 @@ def _decrypt_aes_transformer_base(
             'key_used': str,
         }
     """
+    encrypted_data = read_sftp_file(encrypted_file)
+    original_size = len(encrypted_data)
+
     try:
-        encrypted_data = read_sftp_file(encrypted_file)
-        original_size = len(encrypted_data)
-
         decrypted_data, key_used = decrypt_with_key_chain(encrypted_data, key_chain)
-        decrypted_size = len(decrypted_data)
-
-        if len(key_chain) > 1:
-            logger.debug("Déchiffré avec clé '%s' : %s", key_used, encrypted_file["file_name"])
-
-        yield {
-            "file_name": encrypted_file["file_name"],
-            "modification_date": encrypted_file["modification_date"],
-            "decrypted_content": decrypted_data,
-            "original_size": original_size,
-            "decrypted_size": decrypted_size,
-            "key_used": key_used,
-        }
-
-    except Exception as e:
-        logger.error("Erreur déchiffrement %s: %s", encrypted_file["file_name"], e)
+    except ValueError as e:
+        stats.echecs += 1
+        logger.warning("Échec déchiffrement %s : %s", encrypted_file["file_name"], e)
         return
 
+    stats.succes += 1
+    if len(key_chain) > 1:
+        logger.debug("Déchiffré avec clé '%s' : %s", key_used, encrypted_file["file_name"])
 
-def create_decrypt_transformer(aes_key: bytes = None, aes_iv: bytes = None):
+    yield {
+        "file_name": encrypted_file["file_name"],
+        "modification_date": encrypted_file["modification_date"],
+        "decrypted_content": decrypted_data,
+        "original_size": original_size,
+        "decrypted_size": len(decrypted_data),
+        "key_used": key_used,
+    }
+
+
+def create_decrypt_transformer(
+    aes_key: bytes = None,
+    aes_iv: bytes = None,
+    *,
+    key_chain: list[tuple[str, bytes, bytes]] | None = None,
+    stats: StatsDechiffrement | None = None,
+):
     """
-    Factory pour créer un transformer de déchiffrement avec chaîne de clés pré-chargée.
+    Factory pour créer un transformer de déchiffrement avec trousseau pré-chargé.
 
-    Les clés sont chargées une seule fois à la création du transformer (pas à chaque
-    fichier). Si aes_key et aes_iv sont fournis, ils sont utilisés directement comme
-    clé unique (compatibilité ascendante).
+    Le trousseau est résolu une seule fois à la création du transformer (pas à chaque
+    fichier). Précédence : `key_chain` explicite > `aes_key`/`aes_iv` (clé unique, tests)
+    > trousseau du registre runtime.
 
     Args:
         aes_key: Clé AES explicite (optionnel, pour les tests)
         aes_iv: IV AES explicite (optionnel, pour les tests)
+        key_chain: Trousseau déjà résolu [(label, clé, iv), …] — partagé entre flux par la source
+        stats: Compteur succès/échec du flux courant (escalade per-flux, ADR-0037)
 
     Returns:
         Transformer DLT configuré
     """
-    if aes_key is not None and aes_iv is not None:
-        key_chain = [("explicit", aes_key, aes_iv)]
-    else:
-        key_chain = load_aes_key_chain()
-        nb = len(key_chain)
-        names = [name for name, _, _ in key_chain]
-        logger.info("%d clé(s) AES chargée(s) : %s", nb, names)
+    if key_chain is None:
+        if aes_key is not None and aes_iv is not None:
+            key_chain = [("explicit", aes_key, aes_iv)]
+        else:
+            key_chain = load_aes_key_chain()
+            names = [name for name, _, _ in key_chain]
+            logger.info("%d clé(s) AES chargée(s) : %s", len(key_chain), names)
+
+    stats = stats if stats is not None else StatsDechiffrement()
 
     @dlt.transformer
     def configured_decrypt_transformer(encrypted_file: FileItemDict) -> Iterator[dict]:
-        return _decrypt_aes_transformer_base(encrypted_file, key_chain)
+        return _decrypt_aes_transformer_base(encrypted_file, key_chain, stats)
 
     return configured_decrypt_transformer

--- a/tests/fixtures/flux/anonymiser.py
+++ b/tests/fixtures/flux/anonymiser.py
@@ -24,7 +24,7 @@ Usage :
     uv run python tests/fixtures/flux/anonymiser.py --r64-zip SOURCE.zip DESTINATION.json
 
 Le mode `--r64-zip` fait la chaîne complète sur un R64 chiffré : déchiffrement
-AES (clés lues dans AES__CURRENT__KEY / AES__CURRENT__IV, jamais persistées),
+AES (trousseau lu dans AES__TROUSSEAU__<label>__KEY/IV, jamais persisté),
 extraction ZIP, anonymisation JSON, et rapport d'audit (clés rencontrées +
 alarmes sur valeurs suspectes non mappées) pour la relecture.
 

--- a/tests/ingestion/test_crypto.py
+++ b/tests/ingestion/test_crypto.py
@@ -21,6 +21,8 @@ from Crypto.Util.Padding import pad
 
 from electricore.config import runtime
 from electricore.ingestion.transformers.crypto import (
+    StatsDechiffrement,
+    _decrypt_aes_transformer_base,
     decrypt_file_aes,
     decrypt_with_key_chain,
     load_aes_key_chain,
@@ -33,17 +35,9 @@ from electricore.ingestion.transformers.crypto import (
 
 @pytest.fixture(autouse=True)
 def _isoler_env_aes(monkeypatch):
-    """Isole les tests crypto : vars AES__* effacées, .env du dépôt neutralisé,
-    cache des accessors runtime vidé (#141)."""
-    for var in (
-        "AES__CURRENT__KEY",
-        "AES__CURRENT__IV",
-        "AES__PREVIOUS__KEY",
-        "AES__PREVIOUS__IV",
-        "AES__KEY",
-        "AES__IV",
-    ):
-        monkeypatch.delenv(var, raising=False)
+    """Isole les tests crypto : .env du dépôt neutralisé, cache des accessors
+    runtime vidé (#141). Les labels du trousseau (ADR-0037) étant arbitraires, on
+    neutralise la source `.env` plutôt que d'énumérer des noms de variables."""
     monkeypatch.setattr(runtime, "FICHIER_ENV", None)
     runtime.vider_cache()
     yield
@@ -190,53 +184,116 @@ def test_decrypt_with_key_chain_single_key(encrypted_zip, zip_bytes, aes_key, ae
     assert key_used == "legacy"
 
 
+@pytest.mark.unit
+def test_trousseau_mixe_aes128_et_aes256_dechiffre_par_essai(zip_bytes, aes_key, aes_iv):
+    """Corpus mêlant AES-128 et AES-256 : chaque fichier déchiffre par essai (ADR-0037, #352).
+
+    Le même trousseau (ordre indifférent) déchiffre les deux ciphers ; AES.new auto-sélectionne
+    la longueur de clé. Le label de la clé qui déchiffre est retourné (→ logs).
+    """
+    cle_256 = bytes.fromhex("ee" * 32)  # 32 octets → AES-256
+    iv_256 = bytes.fromhex("ff" * 16)
+    chiffre_128 = AES.new(aes_key, AES.MODE_CBC, aes_iv).encrypt(pad(zip_bytes, AES.block_size))
+    chiffre_256 = AES.new(cle_256, AES.MODE_CBC, iv_256).encrypt(pad(zip_bytes, AES.block_size))
+
+    # Ordre indifférent : la clé AES-256 est en tête, l'AES-128 ensuite.
+    trousseau = [("aes256_2026", cle_256, iv_256), ("aes128_2024", aes_key, aes_iv)]
+
+    contenu_128, label_128 = decrypt_with_key_chain(chiffre_128, trousseau)
+    contenu_256, label_256 = decrypt_with_key_chain(chiffre_256, trousseau)
+
+    assert contenu_128 == zip_bytes and label_128 == "aes128_2024"
+    assert contenu_256 == zip_bytes and label_256 == "aes256_2026"
+
+
 # =============================================================================
-# TESTS load_aes_key_chain (registre runtime — #141, ADR-0025 ; rotation ADR-0008)
+# TESTS load_aes_key_chain (registre runtime — #141, ADR-0025 ; trousseau ADR-0037)
 # =============================================================================
 
 
 @pytest.mark.unit
-def test_load_key_chain_v1_format(aes_key, aes_iv, monkeypatch):
-    """Format plat v1 (AES__KEY/AES__IV) → une clé nommée 'legacy'."""
-    monkeypatch.setenv("AES__KEY", aes_key.hex())
-    monkeypatch.setenv("AES__IV", aes_iv.hex())
+def test_load_key_chain_trousseau_une_cle(aes_key, aes_iv, monkeypatch):
+    """Un trousseau d'une clé → une entrée portant son label."""
+    monkeypatch.setenv("AES__TROUSSEAU__aes128_2024__KEY", aes_key.hex())
+    monkeypatch.setenv("AES__TROUSSEAU__aes128_2024__IV", aes_iv.hex())
     runtime.vider_cache()
 
     chain = load_aes_key_chain()
 
-    assert chain == [("legacy", aes_key, aes_iv)]
+    assert chain == [("aes128_2024", aes_key, aes_iv)]
 
 
 @pytest.mark.unit
-def test_load_key_chain_v2_current_only(aes_key, aes_iv, monkeypatch):
-    """AES__CURRENT__* sans previous → une clé nommée 'current'."""
-    monkeypatch.setenv("AES__CURRENT__KEY", aes_key.hex())
-    monkeypatch.setenv("AES__CURRENT__IV", aes_iv.hex())
-    runtime.vider_cache()
-
-    chain = load_aes_key_chain()
-
-    assert chain == [("current", aes_key, aes_iv)]
-
-
-@pytest.mark.unit
-def test_load_key_chain_v2_with_previous(aes_key, aes_iv, monkeypatch):
-    """AES__CURRENT__* + AES__PREVIOUS__* → deux clés, current en premier."""
+def test_load_key_chain_trousseau_n_cles(aes_key, aes_iv, monkeypatch):
+    """Plusieurs labels → autant d'entrées (ordre indifférent), labels préservés."""
     old_key = bytes([0xFF] * 16)
     old_iv = bytes([0xFE] * 16)
-    monkeypatch.setenv("AES__CURRENT__KEY", aes_key.hex())
-    monkeypatch.setenv("AES__CURRENT__IV", aes_iv.hex())
-    monkeypatch.setenv("AES__PREVIOUS__KEY", old_key.hex())
-    monkeypatch.setenv("AES__PREVIOUS__IV", old_iv.hex())
+    monkeypatch.setenv("AES__TROUSSEAU__aes256_2026__KEY", aes_key.hex())
+    monkeypatch.setenv("AES__TROUSSEAU__aes256_2026__IV", aes_iv.hex())
+    monkeypatch.setenv("AES__TROUSSEAU__aes128_2024__KEY", old_key.hex())
+    monkeypatch.setenv("AES__TROUSSEAU__aes128_2024__IV", old_iv.hex())
     runtime.vider_cache()
 
     chain = load_aes_key_chain()
 
-    assert chain == [("current", aes_key, aes_iv), ("previous", old_key, old_iv)]
+    assert set(chain) == {("aes256_2026", aes_key, aes_iv), ("aes128_2024", old_key, old_iv)}
 
 
 @pytest.mark.unit
-def test_load_key_chain_sans_cles_leve_configuration_manquante():
-    """Aucune variable AES__* → ConfigurationManquante nommant les vars attendues."""
-    with pytest.raises(runtime.ConfigurationManquante, match="AES__CURRENT__KEY"):
+def test_load_key_chain_trousseau_vide_leve_configuration_manquante():
+    """Aucune variable AES__TROUSSEAU__* → ConfigurationManquante nommant le format attendu."""
+    with pytest.raises(runtime.ConfigurationManquante, match="AES__TROUSSEAU__<label>__KEY"):
         load_aes_key_chain()
+
+
+# =============================================================================
+# TESTS escalade per-flux : comptage du déchiffrement (ADR-0037, #353)
+# =============================================================================
+
+
+class _FauxFichierSftp(dict):
+    """Double minimal d'un FileItemDict : accès par clé + .open() sur des octets."""
+
+    def __init__(self, file_name: str, data: bytes):
+        super().__init__(file_name=file_name, modification_date=None)
+        self._data = data
+
+    def open(self):  # noqa: A003 — mime l'API FileItemDict
+        return io.BytesIO(self._data)
+
+
+@pytest.mark.unit
+def test_transformer_compte_un_succes_et_yield(encrypted_zip, aes_key, aes_iv):
+    """Un fichier déchiffrable : compté en succès, document brut produit."""
+    stats = StatsDechiffrement()
+    item = _FauxFichierSftp("a_R64_x.zip", encrypted_zip)
+
+    produits = list(_decrypt_aes_transformer_base(item, [("aes128_2024", aes_key, aes_iv)], stats))
+
+    assert stats.succes == 1 and stats.echecs == 0
+    assert len(produits) == 1 and produits[0]["key_used"] == "aes128_2024"
+
+
+@pytest.mark.unit
+def test_transformer_compte_un_echec_et_ne_yield_pas(encrypted_zip, aes_iv, caplog):
+    """Fin du fail silencieux (ADR-0037) : un échec est compté, warn-loggé, le fichier
+    est sauté — pas d'exception propagée (pas de poison-pill)."""
+    stats = StatsDechiffrement()
+    item = _FauxFichierSftp("corrompu.zip", encrypted_zip)
+    mauvaise_chaine = [("aes256_2026", bytes(16), aes_iv)]  # clé nulle → échec
+
+    with caplog.at_level("WARNING"):
+        produits = list(_decrypt_aes_transformer_base(item, mauvaise_chaine, stats))
+
+    assert produits == []
+    assert stats.succes == 0 and stats.echecs == 1
+    assert "corrompu.zip" in caplog.text
+
+
+@pytest.mark.unit
+def test_flux_aveugle_seulement_si_zero_succes_et_au_moins_un_echec():
+    """flux_aveugle() : True ssi des échecs existent sans aucun succès (clé manquante)."""
+    assert StatsDechiffrement(succes=0, echecs=2).flux_aveugle() is True
+    assert StatsDechiffrement(succes=3, echecs=1).flux_aveugle() is False  # échec isolé toléré
+    assert StatsDechiffrement(succes=5, echecs=0).flux_aveugle() is False
+    assert StatsDechiffrement(succes=0, echecs=0).flux_aveugle() is False  # flux sans fichier

--- a/tests/ingestion/test_escalade_dechiffrement.py
+++ b/tests/ingestion/test_escalade_dechiffrement.py
@@ -1,0 +1,106 @@
+"""Escalade d'échec de déchiffrement per-flux (ADR-0037, #353).
+
+Bout-en-bout sur un bucket `file://` : la source `flux_enedis_brut` agrège les
+succès/échecs de déchiffrement **par flux**. Deux cas couverts dans un même run :
+
+- **Flux entier KO** (C15) : tous les fichiers indéchiffrables → flux aveugle →
+  `flux_sans_dechiffrement` le remonte → le runner ferait échouer le job → alerte bot.
+- **Fichier isolé KO** (R64) : un fichier corrompu noyé dans des succès → toléré,
+  compté, le bon fichier landé quand même (pas de poison-pill) → flux NON aveugle.
+"""
+
+import io
+import os
+import time
+import zipfile
+from pathlib import Path
+
+import dlt
+import pytest
+
+pytest.importorskip("Crypto", reason="Nécessite l'extra [ingestion] : uv sync --extra ingestion")
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import pad
+
+from electricore.config import runtime
+from electricore.ingestion.runner import flux_sans_dechiffrement
+from electricore.ingestion.sources.sftp_enedis_brut import flux_enedis_brut
+from electricore.ingestion.transformers.crypto import StatsDechiffrement
+
+_KEY = bytes.fromhex("00112233445566778899aabbccddeeff")  # 16 octets (AES-128)
+_IV = bytes.fromhex("ffeeddccbbaa99887766554433221100")
+
+_CONFIG = {
+    "C15": {"file_pattern": "**/*_C15_*.zip", "format": "xml", "file_regex": "*_C15_*.xml"},
+    "R64": {"file_pattern": "**/R63_R64_R65_R66_R67_C68/*_R64_*.zip", "format": "json", "file_regex": "*.JSON"},
+}
+
+_R64_JSON = (Path(__file__).parents[1] / "fixtures" / "flux" / "r64.json").read_bytes()
+
+
+def _zip_chiffre(nom_interne: str, contenu: bytes) -> bytes:
+    """ZIP contenant `nom_interne`, chiffré AES-128-CBC + PKCS7 avec la clé du trousseau."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(nom_interne, contenu)
+    return AES.new(_KEY, AES.MODE_CBC, _IV).encrypt(pad(buf.getvalue(), AES.block_size))
+
+
+def _ecrire(chemin: Path, data: bytes, jour: int) -> None:
+    chemin.parent.mkdir(parents=True, exist_ok=True)
+    chemin.write_bytes(data)
+    ts = time.mktime((2026, 6, jour, 12, 0, 0, 0, 0, -1))
+    os.utime(chemin, (ts, ts))
+
+
+@pytest.fixture(autouse=True)
+def _trousseau(monkeypatch):
+    monkeypatch.setattr(runtime, "FICHIER_ENV", None)
+    monkeypatch.setenv("AES__TROUSSEAU__test__KEY", _KEY.hex())
+    monkeypatch.setenv("AES__TROUSSEAU__test__IV", _IV.hex())
+    runtime.vider_cache()
+    yield
+    runtime.vider_cache()
+
+
+@pytest.fixture
+def bucket(tmp_path, monkeypatch):
+    """Bucket file:// : C15 entièrement indéchiffrable, R64 = 1 bon + 1 corrompu."""
+    b = tmp_path / "bucket"
+    # C15 : deux zips de pur bruit (multiples de 16) → padding/magic KO → flux aveugle.
+    _ecrire(b / "a_C15_1.zip", os.urandom(48), jour=1)
+    _ecrire(b / "a_C15_2.zip", os.urandom(48), jour=2)
+    # R64 : un zip valide (déchiffre + parse + land) + un corrompu (échec isolé toléré).
+    sub = "R63_R64_R65_R66_R67_C68"
+    _ecrire(b / sub / "a_R64_ok.zip", _zip_chiffre("mesure.JSON", _R64_JSON), jour=1)
+    _ecrire(b / sub / "a_R64_ko.zip", os.urandom(48), jour=2)
+    monkeypatch.setenv("SFTP__URL", f"file://{b}/")
+    runtime.vider_cache()
+    return b
+
+
+def test_escalade_per_flux_aveugle_vs_echec_isole(bucket, tmp_path):
+    stats: dict[str, StatsDechiffrement] = {}
+    pipeline = dlt.pipeline(
+        pipeline_name="flux_brut_escalade",
+        destination=dlt.destinations.duckdb(str(tmp_path / "esc.duckdb")),
+        dataset_name="flux_raw",
+        pipelines_dir=str(tmp_path / "pipelines"),
+    )
+    pipeline.run(flux_enedis_brut(_CONFIG, stats=stats))
+
+    # Cas « flux entier KO » : C15 aveugle (0 succès, 2 échecs).
+    assert stats["C15"].succes == 0 and stats["C15"].echecs == 2
+    # Cas « fichier isolé KO » : R64 toléré (1 succès, 1 échec) → NON aveugle.
+    assert stats["R64"].succes == 1 and stats["R64"].echecs == 1
+
+    # Seul C15 remonte comme flux à escalader (→ job failed → alerte bot).
+    assert flux_sans_dechiffrement(stats) == ["C15"]
+
+    # Pas de poison-pill : le bon R64 a bien été landé malgré le fichier corrompu.
+    import duckdb
+
+    con = duckdb.connect(str(tmp_path / "esc.duckdb"))
+    (n_r64,) = con.execute("select count(*) from flux_raw.raw_r64").fetchone()
+    con.close()
+    assert n_r64 == 1

--- a/tests/ingestion/test_ingestion.py
+++ b/tests/ingestion/test_ingestion.py
@@ -7,7 +7,19 @@ complet via drop_sources).
 """
 
 from electricore.api.services.ingestion_service import ModeIngestion
-from electricore.ingestion.runner import PlanRun, interpreter_flux
+from electricore.ingestion.runner import PlanRun, flux_sans_dechiffrement, interpreter_flux
+from electricore.ingestion.transformers.crypto import StatsDechiffrement
+
+
+def test_flux_sans_dechiffrement_ne_retient_que_les_flux_aveugles():
+    """Escalade per-flux (ADR-0037) : seuls les flux à 0 succès + ≥ 1 échec remontent."""
+    stats = {
+        "R64": StatsDechiffrement(succes=0, echecs=3),  # aveugle → clé manquante
+        "C15": StatsDechiffrement(succes=10, echecs=1),  # échec isolé toléré
+        "R151": StatsDechiffrement(succes=5, echecs=0),  # tout va bien
+        "F15": StatsDechiffrement(succes=0, echecs=0),  # aucun fichier
+    }
+    assert flux_sans_dechiffrement(stats) == ["R64"]
 
 
 def test_les_modes_de_l_api_sont_interpretables():
@@ -95,3 +107,25 @@ def test_job_en_echec_expose_la_sortie_reelle(monkeypatch):
     assert job.status == StatutIngestion.failed
     assert erreur_dbt in (job.error or ""), "l'erreur doit porter la vraie cause (stdout), pas « exit code 1 »"
     assert erreur_dbt in (job.output or ""), "stdout doit être capturé même en échec"
+
+
+def test_main_echoue_si_un_flux_est_aveugle(monkeypatch):
+    """Escalade per-flux bout-en-bout (ADR-0037, #353) : un flux à 0 déchiffrement réussi
+    fait sortir `main` en code ≠ 0 → l'API marque le job `failed` → la surveillance bot
+    alerte (chaîne existante, aucun nouveau code bot)."""
+    import sys
+
+    import pytest
+
+    from electricore.ingestion import runner
+    from electricore.ingestion.transformers.crypto import StatsDechiffrement
+
+    monkeypatch.setattr(runner.runtime, "valider", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "lander_brut", lambda db, plan: {"R64": StatsDechiffrement(succes=0, echecs=3)})
+    monkeypatch.setattr(runner, "construire_dbt", lambda db: True)  # les flux sains ont buildé
+    monkeypatch.setattr(runner, "bilan", lambda db: None)
+    monkeypatch.setattr(sys, "argv", ["prog", "all", "--db", "/tmp/peu_importe.duckdb"])
+
+    with pytest.raises(SystemExit) as exc:
+        runner.main()
+    assert exc.value.code == 1

--- a/tests/ingestion/test_namespace_etat_incremental.py
+++ b/tests/ingestion/test_namespace_etat_incremental.py
@@ -50,8 +50,8 @@ def _namespace_du_curseur(pipelines_dir, resource: str) -> str | None:
 @pytest.mark.parametrize("flux", [["R64"], ["C15", "R64"]], ids=["mono", "multi"])
 def test_namespace_etat_stable_quel_que_soit_le_nombre_de_flux(flux, tmp_path, bucket_local, monkeypatch):
     monkeypatch.setenv("SFTP__URL", f"file://{bucket_local}/")
-    monkeypatch.setenv("AES__KEY", "00112233445566778899aabbccddeeff")
-    monkeypatch.setenv("AES__IV", "ffeeddccbbaa99887766554433221100")
+    monkeypatch.setenv("AES__TROUSSEAU__test__KEY", "00112233445566778899aabbccddeeff")
+    monkeypatch.setenv("AES__TROUSSEAU__test__IV", "ffeeddccbbaa99887766554433221100")
     runtime.vider_cache()
 
     pipelines_dir = tmp_path / "pipelines"

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -56,50 +56,38 @@ class TestDomaineSftp:
 HEX_A = "aa" * 16
 HEX_B = "bb" * 16
 HEX_C = "cc" * 16
-HEX_D = "dd" * 16
 
 
 class TestDomaineAes:
-    """Cascade de rotation d'ADR-0008, format env AES__CURRENT__* / AES__PREVIOUS__*."""
+    """Trousseau N-clés d'ADR-0037, format env AES__TROUSSEAU__<label>__KEY/IV."""
 
-    def test_current_seule(self, monkeypatch):
-        monkeypatch.setenv("AES__CURRENT__KEY", HEX_A)
-        monkeypatch.setenv("AES__CURRENT__IV", HEX_B)
-        for var in ("AES__PREVIOUS__KEY", "AES__PREVIOUS__IV", "AES__KEY", "AES__IV"):
-            monkeypatch.delenv(var, raising=False)
-        assert runtime.aes().chaine() == [("current", bytes.fromhex(HEX_A), bytes.fromhex(HEX_B))]
+    def test_trousseau_n_cles(self, monkeypatch):
+        """AES__TROUSSEAU__<label>__KEY/IV peuple un trousseau ; chaine() rend les N entrées labellisées."""
+        monkeypatch.setenv("AES__TROUSSEAU__aes256_2026__KEY", "ee" * 32)
+        monkeypatch.setenv("AES__TROUSSEAU__aes256_2026__IV", HEX_B)
+        monkeypatch.setenv("AES__TROUSSEAU__aes128_2024__KEY", HEX_A)
+        monkeypatch.setenv("AES__TROUSSEAU__aes128_2024__IV", HEX_C)
+        assert set(runtime.aes().chaine()) == {
+            ("aes256_2026", bytes.fromhex("ee" * 32), bytes.fromhex(HEX_B)),
+            ("aes128_2024", bytes.fromhex(HEX_A), bytes.fromhex(HEX_C)),
+        }
 
-    def test_rotation_current_puis_previous(self, monkeypatch):
-        monkeypatch.setenv("AES__CURRENT__KEY", HEX_A)
-        monkeypatch.setenv("AES__CURRENT__IV", HEX_B)
-        monkeypatch.setenv("AES__PREVIOUS__KEY", HEX_C)
-        monkeypatch.setenv("AES__PREVIOUS__IV", HEX_D)
-        assert [nom for nom, _, _ in runtime.aes().chaine()] == ["current", "previous"]
+    def test_cle_unique(self, monkeypatch):
+        """Un trousseau d'une seule clé : chaine() rend cette unique entrée labellisée."""
+        monkeypatch.setenv("AES__TROUSSEAU__aes128_2024__KEY", HEX_A)
+        monkeypatch.setenv("AES__TROUSSEAU__aes128_2024__IV", HEX_B)
+        assert runtime.aes().chaine() == [("aes128_2024", bytes.fromhex(HEX_A), bytes.fromhex(HEX_B))]
 
-    def test_format_legacy_v1(self, monkeypatch):
-        for var in ("AES__CURRENT__KEY", "AES__CURRENT__IV", "AES__PREVIOUS__KEY", "AES__PREVIOUS__IV"):
-            monkeypatch.delenv(var, raising=False)
-        monkeypatch.setenv("AES__KEY", HEX_A)
-        monkeypatch.setenv("AES__IV", HEX_B)
-        assert runtime.aes().chaine() == [("legacy", bytes.fromhex(HEX_A), bytes.fromhex(HEX_B))]
-
-    def test_aucune_cle_leve_configuration_manquante(self, monkeypatch):
-        for var in (
-            "AES__CURRENT__KEY",
-            "AES__CURRENT__IV",
-            "AES__PREVIOUS__KEY",
-            "AES__PREVIOUS__IV",
-            "AES__KEY",
-            "AES__IV",
-        ):
-            monkeypatch.delenv(var, raising=False)
+    def test_trousseau_vide_leve_configuration_manquante(self):
+        """Aucune clé AES__TROUSSEAU__* (.env neutralisé) → ConfigurationManquante nommant le format attendu."""
         with pytest.raises(runtime.ConfigurationManquante) as exc:
             runtime.aes()
-        assert "AES__CURRENT__KEY" in str(exc.value)
+        assert "AES__TROUSSEAU__<label>__KEY" in str(exc.value)
 
     def test_hex_invalide_signale(self):
-        aes = runtime.Aes(current=runtime.PaireCles(key="pas-du-hex", iv=HEX_B))
-        with pytest.raises(ValueError, match="AES__CURRENT"):
+        """Une clé non-hexadécimale est signalée avec son label dans le message."""
+        aes = runtime.Aes(trousseau={"aes256_2026": runtime.PaireCles(key="pas-du-hex", iv=HEX_B)})
+        with pytest.raises(ValueError, match="AES256_2026"):
             aes.chaine()
 
 


### PR DESCRIPTION
Implémente [ADR-0037](https://github.com/Energie-De-Nantes/electricore/blob/main/docs/adr/0037-trousseau-cles-aes-n-cles-selection-par-essai.md) (supersède ADR-0008), parent épique #221. Deux slices agent sur une branche ; #354 (réécriture du `.env` prod + resync) reste une tâche **opérateur** hors de cette PR.

## Slice 1 — Trousseau AES N-clés (#352)

- `Aes` du registre runtime ne porte plus qu'un `trousseau: dict[str, PaireCles]`, alimenté par `AES__TROUSSEAU__<label>__{KEY,IV}` (dict nommé — la liste indexée `AES__0__` n'est pas supportée par pydantic-settings).
- `current` / `previous` / `AES__KEY` / `AES__IV` **retirés** (rupture de format assumée, instance unique). Compat de *données* préservée : les anciennes AES-128 deviennent des entrées labellisées → l'archive historique reste déchiffrable.
- `chaine()` rend les N entrées `(label, clé, iv)`, ordre indifférent.
- Docs opérateur réécrites au format trousseau (`.env.example` ×2, configuration / deploiement / README / ingestion-README — qui pointait encore vers le `.dlt/secrets.toml` retiré en #141 —, CLAUDE.md).

## Slice 2 — Escalade d'échec per-flux (#353)

- `crypto.py` n'avale plus l'échec (`except Exception: return`) : `StatsDechiffrement` compte succès/échec **par flux**, chaque échec est warn-loggé et le fichier sauté (pas de poison-pill).
- La source crée un transformer de déchiffrement par flux lié à son compteur ; le runner agrège : `flux_sans_dechiffrement` remonte les flux à 0 succès + ≥ 1 échec → `main` sort en code ≠ 0 → l'API marque le job `failed` → la surveillance bot alerte (**chaîne existante, aucun nouveau code bot**).
- Per-flux délibéré : Enedis fait évoluer le chiffrement par flux indépendamment ; un seuil global noierait un flux qui bascule seul.

## Tests (TDD, red→green vertical)

- Trousseau N-clés + message `ConfigurationManquante` ; corpus **mêlant AES-128 et AES-256** déchiffré par essai (AC #352).
- Comptage succès/échec du transformer + `flux_aveugle()` ; `flux_sans_dechiffrement`.
- **Intégration bout-en-bout** sur bucket `file://` couvrant les deux cas : flux entier KO (aveugle) vs fichier isolé KO (toléré, bon fichier landé) ; `main` échoue sur flux aveugle.
- Suite complète : **904 passed, 27 skipped** ; ruff + gitleaks OK.

Closes #352
Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)