### PR TITLE
docs(deploy): trousseau AES côté déploiement + bump 3.1.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.1.0rc1] - 2026-06-19
+
+Trousseau de clés AES (ADR-0037) : déverrouille l'ingestion bloquée depuis la bascule
+Enedis **AES-128 → AES-256 (8-9 juin 2026)** et met fin à l'échec de déchiffrement silencieux.
+
+### ✨ Temps forts
+
+- **Trousseau de clés AES N-clés** (ADR-0037, #352) : le domaine `aes` du registre runtime
+  porte un `trousseau: dict[str, PaireCles]` de taille arbitraire, alimenté par
+  `AES__TROUSSEAU__<label>__{KEY,IV}`. La bonne clé est **sélectionnée par essai** (oracle
+  PKCS7 + magic bytes ZIP), sans date ni protocole — AES-128 et AES-256 sont le même schéma,
+  la longueur de clé est auto-sélectionnée. Le `<label>` parlant remonte dans les logs.
+  Supersède la cascade à deux clés d'[ADR-0008](docs/adr/0008-rotation-cles-aes.md).
+- **Escalade d'échec de déchiffrement per-flux** (ADR-0037, #353) : fin du *fail silencieux*.
+  `crypto.py` n'avale plus l'échec ; le runner agrège succès/échec **par flux**, et un flux qui
+  a des fichiers mais **0 déchiffrement réussi** fait passer le job à `failed` → la surveillance
+  bot alerte (chaîne existante). Un échec isolé (fichier corrompu) reste toléré, compté, warn-loggé.
+
+### ⚠️ Ruptures
+
+- **Format `.env` des clés AES** : `AES__CURRENT__*`, `AES__PREVIOUS__*` et le plat-v1
+  `AES__KEY` / `AES__IV` sont **retirés** au profit de `AES__TROUSSEAU__<label>__{KEY,IV}`
+  (rupture assumée, instance unique — ADR-0015). La compat de *données* est préservée : les
+  anciennes clés AES-128 deviennent des entrées labellisées du trousseau, l'archive historique
+  reste déchiffrable. Migration opérateur (réécriture du `.env` + resync) : **#354**.
+  Le validateur de déploiement (`deploy/lib/env_validate.sh`) attend désormais le format trousseau.
+
 ## [3.0.0] - 2026-06-18
 
 Premier stable de la ligne **3.0** : aboutissement du cycle rc1→rc17. Stabilise sur données

--- a/deploy/lib/env_validate.sh
+++ b/deploy/lib/env_validate.sh
@@ -26,9 +26,9 @@ read_env_var() {
 }
 
 # validate_env_file <env_file> <expected_slug>
-# Vérifie INSTANCE_SLUG matche expected, API_KEY, AES__CURRENT__{KEY,IV},
-# SFTP__URL sont présents et valides. Imprime les erreurs sur stdout.
-# Retour : 0 si valide, 1 sinon.
+# Vérifie INSTANCE_SLUG matche expected, API_KEY, SFTP__URL et le trousseau AES
+# (AES__TROUSSEAU__<label>__{KEY,IV}) sont présents et valides. Imprime les erreurs
+# sur stdout. Retour : 0 si valide, 1 sinon.
 validate_env_file() {
     local file="$1"
     local expected_slug="$2"
@@ -36,12 +36,10 @@ validate_env_file() {
 
     [[ -r "$file" ]] || { echo "fichier introuvable : $file"; return 1; }
 
-    local slug api_key sftp aes_key aes_iv
+    local slug api_key sftp
     slug=$(read_env_var "$file" INSTANCE_SLUG)
     api_key=$(read_env_var "$file" API_KEY)
     sftp=$(read_env_var "$file" SFTP__URL)
-    aes_key=$(read_env_var "$file" AES__CURRENT__KEY)
-    aes_iv=$(read_env_var "$file" AES__CURRENT__IV)
 
     [[ "$slug" == "$expected_slug" ]] || \
         errors+=("INSTANCE_SLUG='${slug}' ne matche pas le slug attendu '${expected_slug}'")
@@ -52,15 +50,23 @@ validate_env_file() {
     validate_url "$sftp" || \
         errors+=("SFTP__URL invalide (attendu sftp://… ou file://…) : '${sftp}'")
 
-    # Format v1 (AES__KEY/IV) accepté en fallback pour compatibilité ascendante
-    if [[ -z "$aes_key" ]]; then
-        aes_key=$(read_env_var "$file" AES__KEY)
-        aes_iv=$(read_env_var "$file" AES__IV)
+    # Trousseau AES (ADR-0037) : ≥ 1 paire AES__TROUSSEAU__<label>__{KEY,IV}, chacune en
+    # hex 32 (AES-128) ou 64 (AES-256). Les <label> sont arbitraires → on les découvre dans
+    # le fichier (les lignes commentées `#` sont ignorées par l'ancrage `^[[:space:]]*`).
+    local labels label
+    mapfile -t labels < <(
+        grep -oE '^[[:space:]]*AES__TROUSSEAU__.+__KEY[[:space:]]*=' "$file" 2>/dev/null \
+            | sed -E 's/^[[:space:]]*AES__TROUSSEAU__(.+)__KEY[[:space:]]*=.*/\1/' | sort -u
+    )
+    if [[ ${#labels[@]} -eq 0 ]]; then
+        errors+=("trousseau AES vide : ajoutez au moins une paire AES__TROUSSEAU__<label>__{KEY,IV} (hex 32 ou 64)")
+    else
+        for label in "${labels[@]}"; do
+            validate_aes_key "$(read_env_var "$file" "AES__TROUSSEAU__${label}__KEY")" \
+                && validate_aes_iv "$(read_env_var "$file" "AES__TROUSSEAU__${label}__IV")" \
+                || errors+=("AES__TROUSSEAU__${label}__{KEY,IV} absent ou pas en hex 32/64 chars")
+        done
     fi
-    validate_aes_key "$aes_key" || \
-        errors+=("AES__CURRENT__KEY (ou AES__KEY) absent ou pas en hex 32/64 chars")
-    validate_aes_iv "$aes_iv" || \
-        errors+=("AES__CURRENT__IV (ou AES__IV) absent ou pas en hex 32/64 chars")
 
     if [[ ${#errors[@]} -gt 0 ]]; then
         printf '%s\n' "${errors[@]}"

--- a/deploy/lib/ingestion.sh
+++ b/deploy/lib/ingestion.sh
@@ -28,7 +28,7 @@ show_ingestion_failure_hints() {
     local slug="$1"
     local home="/srv/${slug}"
     log_warn "Causes typiques :"
-    log_info "  - AES__CURRENT__KEY / IV faux (déchiffrement fichier raté)"
+    log_info "  - Clé manquante au trousseau AES__TROUSSEAU__<label>__{KEY,IV} (flux non déchiffré → job failed)"
     log_info "  - SFTP__URL inaccessible (credentials ou réseau)"
     log_info "  - file://… pointe vers un dossier vide/inexistant (mode B)"
     log_info ""

--- a/deploy/tests/fixtures/env-invalid
+++ b/deploy/tests/fixtures/env-invalid
@@ -1,8 +1,8 @@
-# .env fixture invalide : slug mismatch, API_KEY trop courte, AES non-hex
+# .env fixture invalide : slug mismatch, API_KEY trop courte, trousseau AES non-hex + IV vide
 INSTANCE_SLUG=wrong-slug
 ELECTRICORE_VERSION=latest
 BACKUPS_PATH=/srv/edn/backups
 API_KEY=tooshort
 SFTP__URL=not-a-url
-AES__CURRENT__KEY=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
-AES__CURRENT__IV=
+AES__TROUSSEAU__aes256_2026__KEY=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+AES__TROUSSEAU__aes256_2026__IV=

--- a/deploy/tests/fixtures/env-valid
+++ b/deploy/tests/fixtures/env-valid
@@ -4,8 +4,11 @@ ELECTRICORE_VERSION=1.7.0
 BACKUPS_PATH=/srv/edn/backups
 API_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  # gitleaks:allow
 SFTP__URL=sftp://user:pass@host.fr:22/exports  # gitleaks:allow
-AES__CURRENT__KEY=00112233445566778899aabbccddeeff  # gitleaks:allow
-AES__CURRENT__IV=ffeeddccbbaa99887766554433221100  # gitleaks:allow
+# Trousseau AES (ADR-0037) : labels arbitraires, AES-256 (64 hex) et AES-128 (32 hex) mêlés.
+AES__TROUSSEAU__aes256_2026__KEY=00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff  # gitleaks:allow
+AES__TROUSSEAU__aes256_2026__IV=ffeeddccbbaa99887766554433221100  # gitleaks:allow
+AES__TROUSSEAU__aes128_2024__KEY=00112233445566778899aabbccddeeff  # gitleaks:allow
+AES__TROUSSEAU__aes128_2024__IV=ffeeddccbbaa99887766554433221100  # gitleaks:allow
 TELEGRAM_BOT_TOKEN=
 QUOTED_VALUE="hello world"
 WITH_COMMENT=foo   # trailing comment ignored

--- a/electricore/ingestion/README.md
+++ b/electricore/ingestion/README.md
@@ -21,10 +21,10 @@ electricore/ingestion/
 │   └── settings.py
 ├── runner.py            # Ingestion (landing brut → dbt build)
 ├── __main__.py          # CLI : python -m electricore.ingestion
-├── dbt/                    # Modèles dbt (staging + flux_*)
-└── .dlt/
-    ├── config.toml
-    └── secrets.toml        # Clés AES + URL SFTP (non commité)
+└── dbt/                    # Modèles dbt (staging + flux_*)
+
+# Secrets (trousseau AES, URL SFTP) : variables d'environnement / .env à la racine
+# du dépôt (le support .dlt/secrets.toml a été retiré, #141).
 ```
 
 ## Utilisation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.0.0"
+version = "3.1.0rc1"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.0.0"
+version = "3.1.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Suite de [#356](https://github.com/Energie-De-Nantes/electricore/pull/356) (mergée) : complète l'aval **opérateur/déploiement** du trousseau AES (ADR-0037) — le seul angle resté sur l'ancien format — et bump la version.

## docs(deploy) — aligne le déploiement sur le trousseau

- **`deploy/lib/env_validate.sh`** (fonctionnel, critique) : validait un nom fixe `AES__CURRENT__{KEY,IV}` (+ fallback plat-v1) → **rejetait** le nouveau `.env`. Découvre maintenant les `AES__TROUSSEAU__<label>__{KEY,IV}` (labels arbitraires) et exige ≥ 1 paire hex 32/64 valide. **Débloque la migration prod #354.**
- Fixtures deploy (`env-valid` mêle AES-256 64-hex + AES-128 32-hex ; `env-invalid` trousseau non-hex + IV vide) → `deploy/tests/unit.sh` **vert**.
- `deploy/lib/ingestion.sh` (hint d'échec) et l'arbre de `electricore/ingestion/README.md` (pointait encore vers le `.dlt/secrets.toml` retiré en #141) recalés.

## chore(release) — bump 3.1.0rc1

- `pyproject.toml` + `uv.lock` : 3.0.0 → **3.1.0rc1**.
- Entrée CHANGELOG (temps forts #352/#353 + ⚠️ rupture du format `.env` AES, migration #354).
- Le tag reste une étape humaine.

## Vérifs

- `deploy/tests/unit.sh` OK (dont `validate_env_file` valide/invalide/slug-mismatch).
- pytest ciblé (crypto/runtime/escalade/ingestion/namespace) : 52 passed après bump.
- gitleaks OK ; aucune réf au format AES legacy hors ADR-0008/0025 (historiques) et CHANGELOG (historique).

🤖 Generated with [Claude Code](https://claude.com/claude-code)