### PR TITLE
fix(deploy): message ETL test honnête + bump 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
-## [3.1.0rc1] - 2026-06-19
+## [3.1.0] - 2026-06-19
 
 Trousseau de clés AES (ADR-0037) : déverrouille l'ingestion bloquée depuis la bascule
 Enedis **AES-128 → AES-256 (8-9 juin 2026)** et met fin à l'échec de déchiffrement silencieux.
@@ -35,6 +35,17 @@ Enedis **AES-128 → AES-256 (8-9 juin 2026)** et met fin à l'échec de déchif
   anciennes clés AES-128 deviennent des entrées labellisées du trousseau, l'archive historique
   reste déchiffrable. Migration opérateur (réécriture du `.env` + resync) : **#354**.
   Le validateur de déploiement (`deploy/lib/env_validate.sh`) attend désormais le format trousseau.
+
+### 🐛 Corrections
+
+- **Message de l'ETL test de déploiement honnête** : l'étape `ETL test` (`mode test`)
+  affichait « clés AES OK » alors qu'elle n'échantillonne que 2 fichiers dans l'ordre de
+  listing (non trié par date) — sur un état dlt vierge, des fichiers anciens (AES-128) que
+  n'importe quelle clé legacy déchiffre. Un trou de clé courante (ex. AES-256 manquante)
+  passait donc le test au vert. Le message reflète désormais ce qui est réellement prouvé
+  (chaîne SFTP→déchiffrement→DuckDB OK sur un échantillon) et invite à un **resync** pour
+  valider la couverture du trousseau. Correctif message uniquement (`install.sh`,
+  `lib/ingestion.sh`), pas de changement de comportement.
 
 ## [3.0.0] - 2026-06-18
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -268,7 +268,8 @@ main() {
     # ─── Étape 12 : ETL test ────────────────────────────────────────────────
     log_step "ETL test (mode test, ~3s)"
     if run_ingestion_test "$OPT_SLUG"; then
-        log_ok "ETL test réussi — clés AES OK, SFTP accessible, DuckDB écrit."
+        log_ok "ETL test réussi — chaîne SFTP→déchiffrement→DuckDB OK sur un échantillon (2 fichiers)."
+        log_warn "Échantillon non daté → ne garantit PAS la couverture du trousseau AES ; lancer un resync pour valider la clé courante."
     else
         log_err "ETL test échoué — la stack tourne mais la chaîne ETL ne valide pas."
         show_ingestion_failure_hints "$OPT_SLUG"

--- a/deploy/lib/ingestion.sh
+++ b/deploy/lib/ingestion.sh
@@ -1,6 +1,8 @@
 # shellcheck shell=bash
-# Lancement d'un ETL test pour valider la chaîne complète :
-# SFTP/file accessible → clés AES correctes → DuckDB écrit.
+# Lancement d'un ETL test (mode test = échantillon de 2 fichiers/flux) pour vérifier
+# que la chaîne SFTP/file → déchiffrement AES → DuckDB répond. ATTENTION : l'échantillon
+# n'est pas trié par date → il ne valide PAS la couverture du trousseau AES (une clé
+# courante manquante peut passer inaperçue). Validation réelle = resync (cf. install.sh).
 
 # run_ingestion_test <slug>
 # Appelle POST /ingestion/run mode=test via le scheduler. Renvoie 0 si succès,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.1.0rc1"
+version = "3.1.0"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.1.0rc1"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Le problème (repéré par Virgile en prod)

L'étape 12 du déploiement (`ETL test`, `mode test`) affichait **« ETL test réussi — clés AES OK »** alors qu'aucune clé AES-256 n'était dans le `.env`. Diagnostic :

- `mode test` = `max_files=2` par flux, pris dans **l'ordre de listing fsspec** ([sftp_enedis.py:96-104](electricore/ingestion/sources/sftp_enedis.py#L96-L104)) — **rien ne trie par date**.
- Sur un état dlt vierge (déploiement frais), les 2 premiers fichiers sont **anciens → AES-128**, déchiffrés par les clés legacy déjà présentes.
- La clé courante (AES-256, la cause des 10 jours dark) n'est **jamais sollicitée** → test vert, message « clés AES OK » mensonger.
- L'escalade per-flux (#353) n'aide pas ici : elle n'échoue qu'à **0** succès sur l'échantillon ; 2 vieux AES-128 OK → flux vert.

C'est la **même classe de faux-positif silencieux** que l'incident qu'ADR-0037 visait, ressortie au niveau du smoke-test de déploiement.

## Le correctif (scope (a) : honnêteté du message)

- `install.sh` : le succès dit désormais ce qu'il prouve réellement (*chaîne SFTP→déchiffrement→DuckDB OK sur un échantillon de 2 fichiers*) + **warn explicite** : ne garantit pas la couverture du trousseau, lancer un **resync** pour valider la clé courante.
- `lib/ingestion.sh` : commentaire d'en-tête recalé (échantillon non daté ≠ validation du trousseau).

Pas de changement de comportement du test (option (b) — échantillonner les fichiers récents — délibérément écartée pour rester minimal). `deploy/tests/unit.sh` reste vert.

## Bump version

- `pyproject.toml` + `uv.lock` : → **3.1.0** (final direct, on saute la pré-release).
- CHANGELOG : section `[3.1.0]` consolidant trousseau (#352) + escalade per-flux (#353) + ce correctif. Le tag reste une étape humaine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)