### PR TITLE
fix(meta-periodes): releves_utilises porte tous les cadrans réels + bump 3.2.0rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.2.0rc2] - 2026-06-20
+
+### ✨ Temps forts
+
+- **`releves_utilises` porte tous les cadrans réels** (ADR-0038) : le bloc imbriqué expose
+  désormais les **7 registres d'index canoniques** — `base`/`hp`/`hc` (C5) **et** les
+  4 quadrants `hph`/`hch`/`hpb`/`hcb` (C4/Tempo), dérivés de la source unique `cadrans.py` —
+  au lieu des seuls `base`/`hp`/`hc` de rc1. Seuls les registres **présents** sur le compteur
+  ressortent (clé non émise sinon) ; le mart ne synthétisant jamais, un registre exposé est
+  toujours un cadran réellement affiché. Le périmètre C4 est donc inclus dès l'origine.
+  `CONTRAT_VERSION` reste `3` (ajout de clés optionnelles dans l'objet relevé = additif).
+
 ## [3.2.0rc1] - 2026-06-20
 
 Trace d'index légale (ADR-0038) : les relevés bornant chaque mois sont exposés à Odoo,

--- a/docs/adr/0038-releves-utilises-imbriques-meta-periodes.md
+++ b/docs/adr/0038-releves-utilises-imbriques-meta-periodes.md
@@ -40,8 +40,13 @@ le sous-ensemble bornant réellement consommé par le calcul d'énergie, avec `r
 - **Objet relevé = `{ releve_id, date_releve, nature_index, registres index réels }`.**
   Registres **réels** uniquement (jamais de cadran synthétisé) ; `nature_index` = mention
   légale ; `releve_id` = handle de **reprise** ([#191](https://github.com/Energie-De-Nantes/electricore/issues/191)).
-  `source`/`ordre_index` ne sont **pas** exposés (subsumés par `releve_id`). Périmètre C5
-  (`index_base_kwh` / `index_hp_kwh` / `index_hc_kwh`) ; le 4-cadran C4 sera **additif**.
+  `source`/`ordre_index` ne sont **pas** exposés (subsumés par `releve_id`). Tous les
+  **registres réels** du compteur sont portés — les 7 cadrans canoniques (`base`/`hp`/`hc`
+  C5 **et** les 4 quadrants `hph`/`hch`/`hpb`/`hcb` C4/Tempo), dérivés de la source unique
+  `cadrans.py` — seuls les non-nuls ressortant. *Note d'implémentation (rc2)* : le périmètre
+  C4 a été inclus **dès l'origine** plutôt que différé, car le mart ne synthétise jamais
+  (`pivot_cadrans` ne pose un index que pour les cadrans réellement portés par le flux) —
+  exposer tous les registres non nuls reste donc « réels uniquement », sans cas C5 vs C4.
 
 - **Invariant « vide ssi incalculable ».** `releves_utilises` non vide **⟺**
   `qualite ∈ {réelle, estimée}` ; `qualite = incalculable` **⟹** `[]`. Plein-ou-rien,

--- a/docs/contrat-meta-periodes.md
+++ b/docs/contrat-meta-periodes.md
@@ -118,8 +118,7 @@ porte deux lignes.
 
 La *Traçabilité des index* exigée par la loi : les relevés effectivement consommés par le
 calcul d'énergie qui **bornent** le mois, qu'Odoo tire et stocke (copie de travail sur
-`souscription.periode`, gel légal au posting de `account.move`). Périmètre **C5** ; le
-4-cadran C4 sera additif.
+`souscription.periode`, gel légal au posting de `account.move`).
 
 Chaque entrée du tableau :
 
@@ -128,7 +127,7 @@ Chaque entrée du tableau :
 | `releve_id` | `str` (hex 16) | non | **Identité de relevé** (clé métier, ADR-0028) = *handle de reprise* d'une régularisation (#191). |
 | `date_releve` | `str` ISO8601 (Europe/Paris) | non | Date du relevé. |
 | `nature_index` | `str` | non | Mention légale : `réel` / `estimé` / `corrigé`. |
-| `index_base_kwh` \| `index_hp_kwh` \| `index_hc_kwh` | `int` | — | **Registres réels** (kWh) du relevé — *uniquement ceux que le compteur porte* (jamais de cadran synthétisé). Une clé absente = registre non applicable. |
+| `index_<cadran>_kwh` | `int` | — | **Registres réels** (kWh) du relevé, pour les 7 cadrans canoniques : `base`, `hp`, `hc` (C5) **et** `hph`/`hch`/`hpb`/`hcb` (4 quadrants C4/Tempo). **Seuls les registres présents** sur le compteur ressortent (clé non émise sinon) — jamais de cadran agrégé synthétisé (le mart ne pose un index que pour les cadrans réellement portés par le flux). |
 
 **Invariant « vide ssi incalculable ».** `releves_utilises` non vide **⟺**
 `qualite ∈ {réelle, estimée}` ; `qualite = incalculable` **⟹** `[]` (plein-ou-rien, miroir
@@ -202,7 +201,10 @@ tranchés (suivis côté electricore) :
 
 ## Hors périmètre v1
 
-- **C4 / 4 cadrans réseau** : la méta-période v1 est C5 (`base`/`hp`/`hc`, une puissance).
-  Le détail 4 cadrans + 4 puissances existe en amont et sera exposé en **colonnes
-  additionnelles** (sans rupture) le jour où un C4 entre au périmètre.
+- **C4 / 4 cadrans réseau** : les **quantités d'énergie** de la méta-période restent C5
+  (`energie_base`/`hp`/`hc`, une puissance). Le détail 4 cadrans + 4 puissances existe en
+  amont et sera exposé en **colonnes additionnelles** (sans rupture) le jour où un C4 entre
+  au périmètre. *Exception* : le bloc `releves_utilises` porte déjà les **registres d'index**
+  des 7 cadrans réels (les 4 quadrants C4/Tempo compris) — l'index imprimé est légal quel
+  que soit le compteur.
 - **`accise_eur`** : non exposé (cf. règle taux vs montant ci-dessus).

--- a/electricore/api/services/meta_periodes_service.py
+++ b/electricore/api/services/meta_periodes_service.py
@@ -17,6 +17,7 @@ import json
 import polars as pl
 
 from electricore.core.builds.contexte_mensuel import contexte_du_mois
+from electricore.core.models.cadrans import CADRANS, col_index
 from electricore.core.pipelines.accise import load_accise_rules
 from electricore.core.pipelines.cta import ajouter_cta
 from electricore.core.pipelines.taux import ajouter_taux_en_vigueur
@@ -54,9 +55,13 @@ COLONNES_CONTRAT: tuple[str, ...] = (
     "statut_communication",
 )
 
-# Registres d'index RÉELS exposés dans la trace (ADR-0038). Périmètre C5 ; jamais de
-# cadran synthétisé. Le 4-cadran C4 (hph/hpb/hch/hcb) sera additif.
-REGISTRES_REELS: tuple[str, ...] = ("index_base_kwh", "index_hp_kwh", "index_hc_kwh")
+# Registres d'index RÉELS exposés dans la trace (ADR-0038), dérivés de la SOURCE UNIQUE
+# des cadrans (`cadrans.py`, ADR-0035 §1) : les 7 registres canoniques (base, hp, hc + les
+# 4 saisonniers hph/hch/hpb/hcb du C4/Tempo). Seuls les NON-NULS d'un relevé ressortent —
+# et comme le mart ne synthétise jamais (`pivot_cadrans` ne pose un index que si le cadran
+# est présent dans le flux), un registre exposé est toujours un cadran que le compteur
+# affiche réellement (jamais de cadran agrégé synthétisé).
+REGISTRES_REELS: tuple[str, ...] = tuple(col_index(cadran) for cadran in CADRANS)
 
 # Colonnes lues dans `releves_utilises` (forme *Chronologie des relevés*, ADR-0029).
 _COLONNES_RELEVE: tuple[str, ...] = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.2.0rc1"
+version = "3.2.0rc2"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/tests/integration/test_meta_periodes_service.py
+++ b/tests/integration/test_meta_periodes_service.py
@@ -76,9 +76,15 @@ def _releves_utilises_synthetiques(decalage_index: int = 0) -> pl.LazyFrame:
             "ordre_index": [False, False, False, False],
             "releve_id": ["a1b2c3d4e5f60718", "1122334455667788", "99aabbccddeeff00", "deadbeefdeadbeef"],
             "nature_index": ["réel", "réel", "réel", "réel"],
+            # Compteur HP/HC : seuls hp/hc portés (le mart ne synthétise jamais → les
+            # 4 cadrans saisonniers restent nuls, donc non exposés).
             "index_base_kwh": [None, None, None, 420],
             "index_hp_kwh": [1000 + k, 1150, 1312 + k, None],
             "index_hc_kwh": [500 + k, 580, 645 + k, None],
+            "index_hph_kwh": [None, None, None, None],
+            "index_hch_kwh": [None, None, None, None],
+            "index_hpb_kwh": [None, None, None, None],
+            "index_hcb_kwh": [None, None, None, None],
         }
     ).lazy()
 
@@ -190,6 +196,76 @@ def test_releves_utilises_present_si_calculable_vide_si_incalculable(monkeypatch
     assert premier["releve_id"] == "a1b2c3d4e5f60718"
     assert premier["nature_index"] == "réel"
     assert "2025-03-01" in str(premier["date_releve"])
+
+
+def test_releves_utilises_expose_tous_les_cadrans_reels(monkeypatch):
+    """Tous les **registres réels** du compteur sont exposés, pas seulement base/hp/hc.
+
+    Un compteur 4-quadrants (Tempo/C4) porte ses index `hph/hch/hpb/hcb` ; le mart ne
+    synthétise jamais (hp/hc restent nuls), donc le tableau doit rendre exactement les
+    4 cadrans réels non nuls — jamais un cadran agrégé absent du compteur."""
+    facturation = pl.DataFrame(
+        {
+            "ref_situation_contractuelle": ["RSC-T"],
+            "pdl": ["12345678909999"],
+            "mois_annee": ["2025-03"],
+            "debut": [datetime(2025, 3, 1, tzinfo=PARIS)],
+            "fin": [datetime(2025, 4, 1, tzinfo=PARIS)],
+            "nb_jours": [31],
+            "puissance_moyenne_kva": [36.0],
+            "formule_tarifaire_acheminement": ["BTSUPCU4"],
+            "energie_base_kwh": [None],
+            "energie_hp_kwh": [None],
+            "energie_hc_kwh": [None],
+            "turpe_fixe_eur": [50.0],
+            "turpe_variable_eur": [120.0],
+            "has_changement": [False],
+            "qualite": ["réelle"],
+            "statut_communication": ["communicante"],
+        }
+    )
+    releves = pl.DataFrame(
+        {
+            "ref_situation_contractuelle": ["RSC-T", "RSC-T"],
+            "date_releve": [datetime(2025, 3, 1, tzinfo=PARIS), datetime(2025, 4, 1, tzinfo=PARIS)],
+            "ordre_index": [False, False],
+            "releve_id": ["1111111111111111", "2222222222222222"],
+            "nature_index": ["réel", "réel"],
+            "index_base_kwh": [None, None],
+            "index_hp_kwh": [None, None],
+            "index_hc_kwh": [None, None],
+            "index_hph_kwh": [100, 250],
+            "index_hch_kwh": [200, 360],
+            "index_hpb_kwh": [300, 480],
+            "index_hcb_kwh": [400, 590],
+        }
+    ).lazy()
+    vide = pl.LazyFrame()
+    ctx = ContexteMensuel(
+        mois="2025-03-01",
+        historique_enrichi=vide,
+        abonnements=vide,
+        energie=vide,
+        releves_utilises=releves,
+        facturation_mensuelle=facturation,
+    )
+    monkeypatch.setattr(meta_periodes_service, "contexte_du_mois", lambda mois=None: ctx)
+
+    _, df = meta_periodes_service.meta_periodes("2025-03-01")
+    objet = df["releves_utilises"].to_list()[0][0]
+
+    assert set(objet) == {
+        "releve_id",
+        "date_releve",
+        "nature_index",
+        "index_hph_kwh",
+        "index_hch_kwh",
+        "index_hpb_kwh",
+        "index_hcb_kwh",
+    }
+    assert objet["index_hph_kwh"] == 100 and objet["index_hcb_kwh"] == 400
+    # Jamais de cadran agrégé absent du compteur (hp/hc nuls non synthétisés).
+    assert "index_hp_kwh" not in objet and "index_hc_kwh" not in objet
 
 
 def test_releves_utilises_inclut_releves_intermediaires_mct(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.2.0rc1"
+version = "3.2.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Suite à #361 : rc1 n'exposait que `base`/`hp`/`hc` dans les objets `releves_utilises`. **On a besoin des valeurs de tous les cadrans** — un compteur 4-quadrants (C4/Tempo) porte ses index sur `hph`/`hch`/`hpb`/`hcb`, qui n'apparaissaient pas.

## Fix

`REGISTRES_REELS` dérivé de la **source unique** `cadrans.py` (les 7 cadrans canoniques) au lieu d'une liste C5 codée en dur. Seuls les registres **non nuls** d'un relevé ressortent.

**Pourquoi c'est sûr** (« registres réels uniquement, jamais de cadran synthétisé », ADR-0038) : le mart ne synthétise jamais — `pivot_cadrans` ne pose un `index_X_kwh` que si le cadran `X` est présent dans le flux. Donc tout registre non nul est un cadran que le compteur **affiche réellement** ; exposer tous les non-nuls n'introduit aucun agrégat synthétisé, et couvre n'importe quel type de compteur sans cas C5 vs C4.

`CONTRAT_VERSION` reste **3** : ajout de clés optionnelles dans l'objet relevé = additif strict (rc1 n'est pas figé).

## TDD

- RED→GREEN : un relevé Tempo expose `hph`/`hch`/`hpb`/`hcb` et **jamais** `hp`/`hc` (non synthétisés). Tests existants verts (compteur HP/HC inchangé).
- Suite complète : 910 passed.

## Bump

`pyproject` + `uv.lock` + `CHANGELOG` → **3.2.0rc2** (build vérifié : `electricore-3.2.0rc2`, matche le garde-fou release). Après merge je tague `v3.2.0rc2`.

Docs : contrat-meta-periodes + ADR-0038 (note d'implémentation : C4 inclus dès l'origine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)