### PR TITLE
fix(deploy): IV optionnel dans le validateur .env + sweep docs (ADR-0040) — 3.3.0rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.3.0rc2] - 2026-06-20
+
+### 🐛 Corrections
+
+- **IV optionnel jusqu'au bout de la chaîne de déploiement** (ADR-0040, suite de #370). Le
+  validateur `.env` d'installation (`deploy/lib/env_validate.sh`) exigeait encore une paire
+  `__{KEY,IV}` par label et **rejetait** une clé AES-256 ajoutée **sans `__IV`** (le cas réel
+  du schéma IV-préfixé) — bloquant la migration prod #354. Désormais le validateur n'exige que
+  `__KEY` (hex 32/64) ; `__IV` est optionnel et, s'il est présent, doit être valide. Le guide de
+  déploiement (rotation), les README, `docs/configuration.md`, `CLAUDE.md` et les docstrings
+  cessent de montrer un `aes256_2026__IV` trompeur : la clé AES-256 s'ajoute **sans IV** (schéma
+  IV-préfixé). Fixture `deploy/tests/env-valid` passée à la forme de prod mixte (AES-256 sans IV
+  + AES-128 avec IV) → couverte par les tests d'installation. _NB : le gabarit `deploy/docker/.env.example`
+  reste à corriger à la main (montre encore `aes256_2026__IV`)._
+
 ## [3.3.0rc1] - 2026-06-20
 
 ### ✨ Temps forts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,11 +229,13 @@ AES-128 → AES-256 du 8-9 juin 2026). Le registre runtime
 (`.env` ou env système ; le support `.dlt/secrets.toml` a été retiré) :
 
 ```bash
-AES__TROUSSEAU__aes256_2026__KEY=cle_hex_64   # AES-256 (32 octets)
-AES__TROUSSEAU__aes256_2026__IV=iv_hex_32
+AES__TROUSSEAU__aes256_2026__KEY=cle_hex_64   # AES-256 (32 octets), SANS __IV → schéma IV-préfixé (ADR-0040)
 AES__TROUSSEAU__aes128_2024__KEY=cle_hex_32   # AES-128 historique (16 octets)
-AES__TROUSSEAU__aes128_2024__IV=iv_hex_32
+AES__TROUSSEAU__aes128_2024__IV=iv_hex_32     # IV présent → schéma IV-fixe
 ```
+
+L'`__IV` est **optionnel** (ADR-0040) : présent ⇒ schéma **IV-fixe** (AES-128, IV en
+config) ; absent ⇒ schéma **IV-préfixé** (AES-256, l'IV est en tête de chaque fichier).
 
 Le `<label>` est un nom parlant choisi par l'opérateur ; il remonte dans les logs de
 déchiffrement. La bonne clé est **sélectionnée par essai** (oracle PKCS7 + magic bytes
@@ -242,7 +244,7 @@ la longueur de clé est auto-sélectionnée.
 
 Procédure de rotation :
 1. Obtenir la nouvelle clé Enedis
-2. L'ajouter au trousseau sous un nouveau label (`AES__TROUSSEAU__<nouveau>__{KEY,IV}`)
+2. L'ajouter au trousseau sous un nouveau label (`AES__TROUSSEAU__<nouveau>__KEY`, plus `__IV` seulement si Enedis en fournit un — schéma IV-fixe ; sans IV ⇒ IV-préfixé, ADR-0040)
 3. Relancer le pipeline — chaque fichier déchiffre avec la clé qui marche, par essai
 4. Retirer une vieille clé seulement quand plus aucune archive chiffrée avec elle n'est (re)téléchargeable
 

--- a/README.md
+++ b/README.md
@@ -351,9 +351,9 @@ API_KEY=votre_cle_api_secrete
 SFTP__URL=sftp://utilisateur:mot_de_passe@hote:22/chemin
 # Trousseau de clés AES (ADR-0037) : un <label> parlant par clé, sélection par essai.
 # Garder les anciennes clés dans le trousseau préserve l'accès aux archives passées.
-AES__TROUSSEAU__aes256_2026__KEY=cle_hex_fournie_par_enedis
-AES__TROUSSEAU__aes256_2026__IV=iv_hex_fourni_par_enedis
-# AES__TROUSSEAU__aes128_2024__KEY=ancienne_cle_hex
+# __IV optionnel (ADR-0040) : absent ⇒ schéma IV-préfixé (AES-256) ; présent ⇒ IV-fixe (AES-128).
+AES__TROUSSEAU__aes256_2026__KEY=cle_hex_fournie_par_enedis   # AES-256 : pas de __IV
+# AES__TROUSSEAU__aes128_2024__KEY=ancienne_cle_hex           # AES-128 : clé + IV
 # AES__TROUSSEAU__aes128_2024__IV=ancien_iv_hex
 
 # === ODOO — pour les calculs CTA/Accise et la réconciliation ===

--- a/deploy/lib/env_validate.sh
+++ b/deploy/lib/env_validate.sh
@@ -50,21 +50,27 @@ validate_env_file() {
     validate_url "$sftp" || \
         errors+=("SFTP__URL invalide (attendu sftp://… ou file://…) : '${sftp}'")
 
-    # Trousseau AES (ADR-0037) : ≥ 1 paire AES__TROUSSEAU__<label>__{KEY,IV}, chacune en
-    # hex 32 (AES-128) ou 64 (AES-256). Les <label> sont arbitraires → on les découvre dans
-    # le fichier (les lignes commentées `#` sont ignorées par l'ancrage `^[[:space:]]*`).
-    local labels label
+    # Trousseau AES (ADR-0037, ADR-0040) : ≥ 1 clé AES__TROUSSEAU__<label>__KEY en hex 32
+    # (AES-128) ou 64 (AES-256). L'IV (__IV) est OPTIONNEL : présent ⇒ schéma IV-fixe ;
+    # absent ⇒ schéma IV-préfixé (AES-256, l'IV est en tête de chaque fichier). Les <label>
+    # sont arbitraires → on les découvre dans le fichier (lignes `#` ignorées par l'ancrage).
+    local labels label key iv
     mapfile -t labels < <(
         grep -oE '^[[:space:]]*AES__TROUSSEAU__.+__KEY[[:space:]]*=' "$file" 2>/dev/null \
             | sed -E 's/^[[:space:]]*AES__TROUSSEAU__(.+)__KEY[[:space:]]*=.*/\1/' | sort -u
     )
     if [[ ${#labels[@]} -eq 0 ]]; then
-        errors+=("trousseau AES vide : ajoutez au moins une paire AES__TROUSSEAU__<label>__{KEY,IV} (hex 32 ou 64)")
+        errors+=("trousseau AES vide : ajoutez au moins une clé AES__TROUSSEAU__<label>__KEY (hex 32 ou 64)")
     else
         for label in "${labels[@]}"; do
-            validate_aes_key "$(read_env_var "$file" "AES__TROUSSEAU__${label}__KEY")" \
-                && validate_aes_iv "$(read_env_var "$file" "AES__TROUSSEAU__${label}__IV")" \
-                || errors+=("AES__TROUSSEAU__${label}__{KEY,IV} absent ou pas en hex 32/64 chars")
+            key=$(read_env_var "$file" "AES__TROUSSEAU__${label}__KEY")
+            iv=$(read_env_var "$file" "AES__TROUSSEAU__${label}__IV")
+            if ! validate_aes_key "$key"; then
+                errors+=("AES__TROUSSEAU__${label}__KEY absent ou pas en hex 32/64 chars")
+            elif [[ -n "$iv" ]] && ! validate_aes_iv "$iv"; then
+                # IV optionnel (ADR-0040) : absent ⇒ schéma IV-préfixé. Présent ⇒ doit être valide.
+                errors+=("AES__TROUSSEAU__${label}__IV présent mais pas en hex 32/64 (retire-le pour le schéma IV-préfixé AES-256)")
+            fi
         done
     fi
 

--- a/deploy/tests/fixtures/env-valid
+++ b/deploy/tests/fixtures/env-valid
@@ -4,9 +4,9 @@ ELECTRICORE_VERSION=1.7.0
 BACKUPS_PATH=/srv/edn/backups
 API_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  # gitleaks:allow
 SFTP__URL=sftp://user:pass@host.fr:22/exports  # gitleaks:allow
-# Trousseau AES (ADR-0037) : labels arbitraires, AES-256 (64 hex) et AES-128 (32 hex) mêlés.
+# Trousseau AES (ADR-0037, ADR-0040) : forme de prod mixte.
+# AES-256 (64 hex) SANS __IV → schéma IV-préfixé ; AES-128 (32 hex) AVEC __IV → schéma IV-fixe.
 AES__TROUSSEAU__aes256_2026__KEY=00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff  # gitleaks:allow
-AES__TROUSSEAU__aes256_2026__IV=ffeeddccbbaa99887766554433221100  # gitleaks:allow
 AES__TROUSSEAU__aes128_2024__KEY=00112233445566778899aabbccddeeff  # gitleaks:allow
 AES__TROUSSEAU__aes128_2024__IV=ffeeddccbbaa99887766554433221100  # gitleaks:allow
 TELEGRAM_BOT_TOKEN=

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -273,6 +273,13 @@ assert_fail "validate_env_file (fixture invalide)" validate_env_file "${FIXTURES
 assert_fail "validate_env_file (slug mismatch)"    validate_env_file "${FIXTURES_DIR}/env-valid" "wrong-slug"
 assert_fail "validate_env_file (fichier absent)"   validate_env_file "/nonexistent" "edn"
 
+# IV optionnel (ADR-0040) : une clé AES-256 SANS __IV (schéma IV-préfixé) est déjà acceptée
+# par la fixture env-valid ci-dessus. Inversement, un __IV présent mais non-hex doit échouer.
+tmp_env=$(mktemp); cp "${FIXTURES_DIR}/env-valid" "$tmp_env"
+echo "AES__TROUSSEAU__aes256_2026__IV=zzzz" >> "$tmp_env"
+assert_fail "validate_env_file (__IV présent mais non-hex)" validate_env_file "$tmp_env" "edn"
+rm -f "$tmp_env"
+
 # prepend_errors_to_env doit insérer un bloc en tête sans dupliquer si rappelée
 tmp_env=$(mktemp); cp "${FIXTURES_DIR}/env-template" "$tmp_env"
 prepend_errors_to_env "$tmp_env" $'erreur A\nerreur B'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ bot ; le runner valide `sftp`+`aes`+`duckdb`).
 | variable | rôle | défaut |
 |---|---|---|
 | `SFTP__URL` | URL SFTP Enedis (`sftp://user:pass@host/chemin` ou `file:///...` pour des zips locaux) | — (requis) |
-| `AES__TROUSSEAU__<label>__KEY` / `__IV` | une clé AES (hex) du trousseau ; 16 octets (AES-128) ou 32 (AES-256) ; `<label>` parlant choisi par l'opérateur (`aes256_2026`, `aes128_2024`…) | — (≥ 1 requis) |
+| `AES__TROUSSEAU__<label>__KEY` (+ `__IV` optionnel) | une clé AES (hex) du trousseau ; 16 octets (AES-128) ou 32 (AES-256) ; `<label>` parlant choisi par l'opérateur (`aes256_2026`, `aes128_2024`…). `__IV` **optionnel** (ADR-0040) : présent ⇒ schéma IV-fixe ; absent ⇒ schéma IV-préfixé (AES-256) | — (≥ 1 `__KEY` requis) |
 
 Le délimiteur `__` est l'`env_nested_delimiter` natif de pydantic-settings : `AES__TROUSSEAU__aes256_2026__KEY`
 → entrée `trousseau["aes256_2026"].key`. Le trousseau accepte un nombre arbitraire de clés ; la bonne

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -114,7 +114,7 @@ marquées `# TODO:`. Voici la table de référence (cf. aussi
 | Variable | Notes |
 |---|---|
 | `AES__TROUSSEAU__<label>__KEY` | Hex 32 (AES-128) ou 64 (AES-256) chars. `<label>` parlant (`aes256_2026`…). |
-| `AES__TROUSSEAU__<label>__IV`  | Hex 32 chars. |
+| `AES__TROUSSEAU__<label>__IV`  | Hex 32 chars. **Optionnel** : présent ⇒ schéma IV-fixe (AES-128) ; **absent ⇒ schéma IV-préfixé** (AES-256, l'IV est en tête de chaque fichier — ADR-0040). |
 | (autres labels) | Conserver les anciennes clés dans le trousseau tant que des archives chiffrées avec elles peuvent être (re)téléchargées. |
 
 **Bot Telegram** (optionnel)
@@ -534,8 +534,10 @@ sélectionnée par essai (aucune date, aucun protocole).
    nouveau label, sans retirer les anciennes :
 
    ```
+   # AES-256 (depuis juin 2026) : Enedis ne fournit QUE la clé, sans IV → pas de __IV.
+   # Schéma IV-préfixé (ADR-0040) : l'IV est en tête de chaque fichier. NE PAS mettre d'__IV.
    AES__TROUSSEAU__aes256_2026__KEY=nouvelle_cle_hex
-   AES__TROUSSEAU__aes256_2026__IV=nouvel_iv_hex
+   # AES-128 (archives chiffrées avant juin 2026) : clé + IV fournis (schéma IV-fixe).
    AES__TROUSSEAU__aes128_2024__KEY=ancienne_cle_hex
    AES__TROUSSEAU__aes128_2024__IV=ancien_iv_hex
    ```

--- a/electricore/ingestion/README.md
+++ b/electricore/ingestion/README.md
@@ -48,10 +48,10 @@ SFTP__URL=sftp://user:pass@host/path/
 
 # Trousseau de clés AES (ADR-0037) : un <label> parlant par clé, sélection par essai.
 # Garder les anciennes clés préserve l'accès aux archives passées.
-AES__TROUSSEAU__aes256_2026__KEY=cle_hex_64   # AES-256 (32 octets)
-AES__TROUSSEAU__aes256_2026__IV=iv_hex_32
+# __IV optionnel (ADR-0040) : absent ⇒ schéma IV-préfixé (AES-256) ; présent ⇒ IV-fixe (AES-128).
+AES__TROUSSEAU__aes256_2026__KEY=cle_hex_64   # AES-256 (32 octets), SANS __IV (IV-préfixé)
 AES__TROUSSEAU__aes128_2024__KEY=cle_hex_32   # AES-128 historique (16 octets)
-AES__TROUSSEAU__aes128_2024__IV=iv_hex_32
+AES__TROUSSEAU__aes128_2024__IV=iv_hex_32     # IV-fixe
 ```
 
 ## Flux supportés

--- a/electricore/ingestion/transformers/crypto.py
+++ b/electricore/ingestion/transformers/crypto.py
@@ -8,13 +8,16 @@ Trousseau de clés N-clés (ADR-0037, registre runtime #141) :
   trousseau de taille arbitraire, alimenté par des variables d'environnement
   nommées (`.env` compris) :
 
-      AES__TROUSSEAU__aes256_2026__KEY=…    # 32 octets hex (AES-256)
-      AES__TROUSSEAU__aes256_2026__IV=…
+      AES__TROUSSEAU__aes256_2026__KEY=…    # 32 octets hex (AES-256), SANS __IV
       AES__TROUSSEAU__aes128_2024__KEY=…    # 16 octets hex (AES-128)
       AES__TROUSSEAU__aes128_2024__IV=…
 
-  La sélection se fait **par essai** : chaque clé du trousseau est tentée dans un
-  ordre indifférent ; le déchiffrement est son propre oracle (padding PKCS7 +
+  L'IV (`__IV`) est **optionnel** et détermine le schéma de déchiffrement (ADR-0040) :
+  présent ⇒ schéma **IV-fixe** (l'IV est en config, AES-128 legacy) ; absent ⇒ schéma
+  **IV-préfixé** (l'IV est les 16 premiers octets de chaque fichier, AES-256).
+
+  La sélection de la clé se fait **par essai** : chaque clé du trousseau est tentée dans
+  un ordre indifférent ; le déchiffrement est son propre oracle (padding PKCS7 +
   magic bytes ZIP). Aucune date ni protocole ne pilote la sélection. Le `<label>`
   parlant remonte dans les logs pour faciliter le diagnostic.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.3.0rc1"
+version = "3.3.0rc2"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.3.0rc1"
+version = "3.3.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Le bug

Pendant la migration prod (#354), l'ajout de la clé AES-256 **sans `__IV`** (le cas réel du schéma IV-préfixé livré en 3.3.0rc1) est **rejeté** par le validateur `.env` d'installation :

```
x AES__TROUSSEAU__aes256_2026__{KEY,IV} absent ou pas en hex 32/64 chars
```

`deploy/lib/env_validate.sh` exigeait encore une **paire** `__{KEY,IV}` par label — exactement le downstream que le changement de modèle d'ADR-0040 (PR #371) n'avait pas atteint. rc1 a livré le support Python du schéma IV-préfixé, mais la chaîne de **déploiement** continuait de refuser sa config valide.

## Le correctif

- **`deploy/lib/env_validate.sh`** — seul `__KEY` est requis (hex 32/64). `__IV` **optionnel** : absent ⇒ schéma IV-préfixé ; présent ⇒ doit être valide. Messages d'erreur séparés KEY / IV.
- **Tests d'installation** — fixture `deploy/tests/env-valid` passée à la **forme de prod mixte** (AES-256 **sans** IV + AES-128 **avec** IV) ; nouvel assert « `__IV` présent mais non-hex → échec ». `bash deploy/tests/unit.sh` : **114 passed**.
- **Sweep docs/docstrings** qui montraient un `aes256_2026__IV` trompeur : `docs/deploiement.md` (table + procédure de rotation), `README.md`, `electricore/ingestion/README.md`, `docs/configuration.md`, `CLAUDE.md`, docstring `crypto.py`. La clé AES-256 s'ajoute **sans IV**.

## ⚠️ Reste à faire à la main

`deploy/docker/.env.example` (le gabarit que `install.sh` ouvre dans l'éditeur) montre **encore** `aes256_2026__IV` — je n'ai pas pu l'éditer (bloqué par les règles sandbox sur `.env.example`). **À corriger manuellement** : retirer la ligne `AES__TROUSSEAU__aes256_2026__IV=…` et noter que l'IV est optionnel (IV-préfixé). C'est le fichier le plus visible pour l'opérateur — important pour ne pas re-piéger #354.

## Vérification

- `deploy/tests/unit.sh` : 114 passed, 0 failed (dont les nouveaux cas IV-optionnel).
- `tests/ingestion/test_crypto.py` : 20 passed. ruff propre.

Suite de #370 / #371 (ADR-0040). Débloque **#354**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)