### PR TITLE
feat(spine): Chronologie des relevés en dbt — equi-join jour + priorité (ADR-0041, #376) [HITL]

### DIFF
--- a/electricore/core/loaders/__init__.py
+++ b/electricore/core/loaders/__init__.py
@@ -10,6 +10,7 @@ from .duckdb import (
     # API fluide
     affaires,
     c15,
+    chronologie,
     execute_custom_query,
     f15,
     # Utilitaires
@@ -34,6 +35,7 @@ __all__ = [
     "r64",
     "releves",
     "spine",
+    "chronologie",
     "affaires",
     "DuckDBQuery",
     # Utilitaires DuckDB

--- a/electricore/core/loaders/duckdb/__init__.py
+++ b/electricore/core/loaders/duckdb/__init__.py
@@ -26,6 +26,7 @@ from .helpers import (
     # API fluide
     affaires,
     c15,
+    chronologie,
     execute_custom_query,
     f15,
     flux,
@@ -60,6 +61,7 @@ __all__ = [
     "r64",
     "releves",
     "spine",
+    "chronologie",
     "affaires",
     "FluxInconnu",
     # Groupings C15 canoniques (cf. CONTEXT.md)

--- a/electricore/core/loaders/duckdb/helpers.py
+++ b/electricore/core/loaders/duckdb/helpers.py
@@ -240,6 +240,42 @@ def spine(database_path: str | Path | None = None) -> DuckDBQuery:
     return DuckDBQuery(config=config, database_path=database_path, base_sql="SELECT * FROM flux_enedis.spine_contrat")
 
 
+def chronologie(database_path: str | Path | None = None) -> DuckDBQuery:
+    """Crée un DuckDBQuery pour le mart *Chronologie des relevés* (ADR-0041, #376).
+
+    Projection ÉNERGIE de la spine, assemblée entièrement en dbt : relevés contractuels
+    C15 aux événements qui impactent l'énergie + bornes FACTURATION mensuelles appariées
+    aux relevés périodiques (R151/R64) au **grain JOUR** (equi-join `(pdl, jour)` qui
+    remplace l'asof « nearest 4h » du cœur), dédoublonnées par priorité de source
+    (C15 > R64 > R151, ADR-0028) via `QUALIFY`. Grain : 1 ligne par
+    `(ref_situation_contractuelle, date_releve, ordre_index)`.
+
+    Read fin (ADR-0019) : `SELECT *`, `date_releve` harmonisé Europe/Paris (instant
+    préservé). Contrat `ChronologieReleves` (validation activée). Remplace l'assemblage
+    interne `_assembler_chronologie` (retiré du chemin énergie en #377).
+
+    Args:
+        database_path: Chemin vers la base DuckDB (optionnel)
+
+    Returns:
+        DuckDBQuery configuré pour le mart `chronologie_releves`
+
+    Example:
+        >>> df = chronologie().collect()
+    """
+    from electricore.core.models.chronologie_releves import ChronologieReleves
+
+    union_schema = FluxSchema(flux_name="CHRONOLOGIE_RELEVES", table="", columns=())
+    config = QueryConfig(
+        schema=union_schema,
+        transform=transform_dates(("date_releve",)),
+        validator=ChronologieReleves,
+    )
+    return DuckDBQuery(
+        config=config, database_path=database_path, base_sql="SELECT * FROM flux_enedis.chronologie_releves"
+    )
+
+
 # =============================================================================
 # UTILITAIRES
 # =============================================================================

--- a/electricore/core/models/chronologie_releves.py
+++ b/electricore/core/models/chronologie_releves.py
@@ -57,8 +57,10 @@ class ChronologieReleves(pa.DataFrameModel):
     # Discriminant avant/après : False = avant ou relevé périodique, True = après C15.
     ordre_index: pl.Boolean = pa.Field(nullable=False)
 
-    # Source gagnante (table de priorité explicite C15 > R64 > R151).
-    source: pl.Utf8 = pa.Field(nullable=False, isin=SOURCES_CHRONOLOGIE)
+    # Source gagnante (table de priorité explicite C15 > R64 > R151). Nullable : une borne
+    # FACTURATION sans relevé apparié (releve_manquant) n'a pas de source — elle reste une
+    # borne de période. Les valeurs non-nulles sont dans l'énumération fermée.
+    source: pl.Utf8 | None = pa.Field(nullable=True, isin=SOURCES_CHRONOLOGIE)
 
     # 🆔 Identité (ADR-0028/0029, #244) portée jusqu'au journal (#233). Mintée au seam
     # dbt pour toutes les sources. Nullable : un relevé interrogé absent (releve_manquant)

--- a/electricore/ingestion/dbt/models/marts/chronologie_releves.sql
+++ b/electricore/ingestion/dbt/models/marts/chronologie_releves.sql
@@ -1,0 +1,136 @@
+-- Chronologie des relevés (ADR-0041) : projection ÉNERGIE de la spine, assemblée
+-- entièrement en dbt. Une ligne par relevé qui borne une période d'énergie :
+--   • relevés contractuels C15 aux événements qui IMPACTENT l'énergie (valeur native) ;
+--   • bornes FACTURATION mensuelles (spine) appariées aux relevés périodiques (R151/R64)
+--     au grain JOUR — equi-join `(pdl, jour)` qui REMPLACE l'asof « nearest 4h »
+--     (`TOLERANCE_APPARIEMENT_RELEVES`) du `_assembler_chronologie` du cœur (ADR-0041 §7).
+-- Dédoublonnage inter-sources par priorité explicite C15 > R64 > R151 (ADR-0028) via QUALIFY.
+--
+-- L'`impacte_energie` (rupture énergie) DESCEND ici : c'est la projection énergie de la
+-- spine, et l'énergie ne garde que son découpage (#377). Calculé sur flux_c15 (avant/après),
+-- miroir SQL de `expr_impacte_energie` du cœur (parité vérifiée, test_chronologie_releves).
+--
+-- L'horizon reste un FILTRE côté cœur ; ce mart est horizon-indépendant (bornes générées
+-- par la spine jusqu'à une borne généreuse).
+
+{% set cadrans = var('cadrans_releve') %}
+
+with spine as (
+    select * from {{ ref('spine_contrat') }}
+),
+
+releves as (
+    select * from {{ ref('releves') }}
+),
+
+-- Rupture énergie par événement C15 (cf. `expr_impacte_energie` : structurant | changement
+-- calendrier | changement index (avant↔après) | changement FTA (vs événement précédent)).
+-- Comparaisons « entre deux valeurs non-nulles » seulement, comme le cœur.
+evts_energie as (
+    select
+        pdl,
+        date_evenement,
+        (
+            evenement_declencheur in ('CFNE', 'MES', 'PMES', 'CFNS', 'RES')
+            or (
+                avant_id_calendrier_distributeur is not null
+                and apres_id_calendrier_distributeur is not null
+                and avant_id_calendrier_distributeur <> apres_id_calendrier_distributeur
+            )
+            {% for c in cadrans %}
+            or (
+                avant_index_{{ c }}_kwh is not null and apres_index_{{ c }}_kwh is not null
+                and avant_index_{{ c }}_kwh <> apres_index_{{ c }}_kwh
+            )
+            {% endfor %}
+            or (
+                lag(formule_tarifaire_acheminement) over (
+                    partition by ref_situation_contractuelle order by date_evenement
+                ) is not null
+                and formule_tarifaire_acheminement is not null
+                and lag(formule_tarifaire_acheminement) over (
+                    partition by ref_situation_contractuelle order by date_evenement
+                ) <> formule_tarifaire_acheminement
+            )
+        ) as impacte_energie
+    from {{ ref('flux_c15') }}
+    where ref_situation_contractuelle is not null
+),
+
+evts_impacte as (
+    select distinct pdl, date_evenement from evts_energie where impacte_energie
+),
+
+-- Partie C15 : relevés contractuels (valeur de situation NATIVE) aux événements énergie.
+c15_part as (
+    select
+        r.pdl,
+        r.ref_situation_contractuelle,
+        r.formule_tarifaire_acheminement,
+        r.niveau_ouverture_services,
+        r.date_releve,
+        r.ordre_index,
+        r.source,
+        r.releve_id,
+        r.nature_index,
+        r.evenement_declencheur,
+        r.id_calendrier_distributeur,
+        {% for c in cadrans %}r.index_{{ c }}_kwh,{% endfor %}
+        cast(null as boolean) as releve_manquant
+    from releves r
+    join evts_impacte e on r.pdl = e.pdl and r.date_releve = e.date_evenement
+    where r.source = 'flux_C15'
+),
+
+-- Bornes FACTURATION (spine) appariées aux périodiques au grain JOUR (equi-join).
+facturation as (
+    select pdl, ref_situation_contractuelle, formule_tarifaire_acheminement, niveau_ouverture_services, date_evenement
+    from spine
+    where type_fait = 'facturation'
+),
+
+periodiques as (
+    select * from releves where source <> 'flux_C15'
+),
+
+fact_part as (
+    select
+        f.pdl,
+        f.ref_situation_contractuelle,
+        f.formule_tarifaire_acheminement,
+        f.niveau_ouverture_services,
+        f.date_evenement as date_releve,
+        false            as ordre_index,
+        p.source,
+        p.releve_id,
+        p.nature_index,
+        cast(null as varchar) as evenement_declencheur,
+        p.id_calendrier_distributeur,
+        {% for c in cadrans %}p.index_{{ c }}_kwh,{% endfor %}
+        (p.releve_id is null) as releve_manquant
+    from facturation f
+    left join periodiques p
+        on f.pdl = p.pdl
+        and cast(f.date_evenement at time zone 'Europe/Paris' as date)
+            = cast(p.date_releve at time zone 'Europe/Paris' as date)
+),
+
+combined as (
+    select * from c15_part
+    union all by name
+    select * from fact_part
+)
+
+-- Priorité de source explicite (C15 > R64 > R151, ADR-0028) ; un manquant (source null)
+-- ne gagne que s'il est seul sur (rsc, date_releve, ordre_index).
+select *
+from combined
+qualify row_number() over (
+    partition by ref_situation_contractuelle, date_releve, ordre_index
+    order by case source
+        when 'flux_C15' then 0
+        when 'flux_R64' then 1
+        when 'flux_R151' then 2
+        else 99
+    end
+) = 1

--- a/electricore/ingestion/dbt/models/marts/schema.yml
+++ b/electricore/ingestion/dbt/models/marts/schema.yml
@@ -58,3 +58,28 @@ models:
           - not_null
           - accepted_values:
               values: ["evenement", "facturation"]
+
+  - name: chronologie_releves
+    description: >
+      Chronologie des relevés (ADR-0041) — projection ÉNERGIE de la spine : relevés C15
+      aux événements impactant l'énergie + bornes FACTURATION appariées aux périodiques
+      (R151/R64) au grain JOUR (equi-join, remplace l'asof 4h du cœur), dédoublonnées par
+      priorité C15>R64>R151. Grain : 1 ligne par (rsc, date_releve, ordre_index). Parité vs
+      `_assembler_chronologie` vérifiée (tests/ingestion/test_dbt_chronologie_releves.py).
+    columns:
+      - name: ref_situation_contractuelle
+        description: Situation contractuelle (RSC) — attribuée nativement (C15) ou par la spine (périodiques).
+        data_tests: [not_null]
+      - name: date_releve
+        description: Date du relevé / borne (instant, Europe/Paris).
+        data_tests: [not_null]
+      - name: ordre_index
+        description: Discriminant avant/après (False = avant / relevé périodique).
+        data_tests: [not_null]
+      - name: source
+        description: >
+          Source gagnante (priorité C15>R64>R151). NULLABLE : une borne FACTURATION sans
+          relevé apparié (releve_manquant) n'a pas de source.
+        data_tests:
+          - accepted_values:
+              values: ["flux_C15", "flux_R64", "flux_R151"]

--- a/electricore/ingestion/dbt/tests/assert_chronologie_releves_grain_unique.sql
+++ b/electricore/ingestion/dbt/tests/assert_chronologie_releves_grain_unique.sql
@@ -1,0 +1,12 @@
+-- Grain de la Chronologie des relevés (ADR-0041, #376) : 1 ligne par
+-- (ref_situation_contractuelle, date_releve, ordre_index) — le dédoublonnage par priorité
+-- de source (QUALIFY) le garantit. Le test échoue (lignes renvoyées) si un triplet duplique.
+
+select
+    ref_situation_contractuelle,
+    date_releve,
+    ordre_index,
+    count(*) as n
+from {{ ref('chronologie_releves') }}
+group by ref_situation_contractuelle, date_releve, ordre_index
+having count(*) > 1

--- a/electricore/ingestion/runner.py
+++ b/electricore/ingestion/runner.py
@@ -176,6 +176,11 @@ def construire_dbt(db_path: Path) -> bool:
     # (événements + grille FACTURATION calendaire) → on l'ajoute dès que raw_c15 est landé.
     if "raw_c15" in presentes:
         selection.append("+spine_contrat")
+    # La Chronologie des relevés (mart, ADR-0041) projette la spine sur l'énergie : elle
+    # apparie les relevés (canoniques) aux bornes de la spine. Mêmes sources que `releves`
+    # (C15 + R151/R64) ; `+chronologie_releves` tire ses ancêtres (spine, releves, flux_*).
+    if {"raw_c15", "raw_r151", "raw_r64"} <= presentes:
+        selection.append("+chronologie_releves")
     if not selection:
         _out("  aucune table brute landée — rien à construire")
         return False

--- a/tests/ingestion/test_dbt_chronologie_releves.py
+++ b/tests/ingestion/test_dbt_chronologie_releves.py
@@ -1,0 +1,217 @@
+"""Mart *Chronologie des relevés* (ADR-0041, #376) — projection énergie de la spine.
+
+Assemblée ENTIÈREMENT en dbt : relevés C15 aux événements impactant l'énergie + bornes
+FACTURATION appariées aux relevés périodiques (R151/R64) au **grain JOUR** (equi-join,
+qui REMPLACE l'asof « nearest 4h » du cœur `_assembler_chronologie`), dédoublonnées par
+priorité de source (C15 > R64 > R151) via QUALIFY.
+
+Deux niveaux :
+- **structure (CI)** : bâtie depuis les fixtures, grain `(rsc, date_releve, ordre_index)`
+  unique, contrat `ChronologieReleves` validé par le loader `chronologie()` ;
+- **parité (local, base dev)** : behaviour-diff vs `_assembler_chronologie`. ⚠️ HITL —
+  le SEUL changement de comportement de la refonte est l'asof→equi-join. Le test encode
+  le diff caractérisé : rien perdu, partie C15 identique, et les écarts périodiques sont
+  des swaps R151→R64 (priorité ADR-0028, index identique → neutre en énergie) + les bornes
+  FACTURATION héritées du fix month_start de la spine (#380).
+
+Skip si dbt absent (`uv sync --extra dbt`).
+"""
+
+import json
+import shutil
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import duckdb
+import polars as pl
+import pytest
+
+pytest.importorskip("dbt.cli.main", reason="dbt absent — uv sync --extra dbt")
+pytest.importorskip("dbt.adapters.duckdb", reason="dbt-duckdb absent — uv sync --extra dbt")
+
+from dbt.cli.main import dbtRunner  # noqa: E402
+
+from electricore.core.loaders import c15, chronologie, releves  # noqa: E402
+from electricore.core.pipelines.energie import _assembler_chronologie  # noqa: E402
+from electricore.core.pipelines.historique import pipeline_historique  # noqa: E402
+from electricore.ingestion.parsing.xml import xml_vers_dict  # noqa: E402
+
+RACINE = Path(__file__).parents[2]
+PROJET_DBT = RACINE / "electricore" / "ingestion" / "dbt"
+FIXTURES = RACINE / "tests" / "fixtures" / "flux"
+DEV_DB = RACINE / "electricore" / "ingestion" / "flux_enedis_pipeline.duckdb"
+PARIS = ZoneInfo("Europe/Paris")
+BORNE = "2026-07-01"
+
+
+def _invoke(commande: list[str], db_path: Path, tmp_path: Path):
+    import os
+
+    ancien = os.environ.get("DBT_DUCKDB_PATH")
+    os.environ["DBT_DUCKDB_PATH"] = str(db_path)
+    try:
+        return dbtRunner().invoke(
+            [
+                *commande,
+                "--project-dir",
+                str(PROJET_DBT),
+                "--profiles-dir",
+                str(PROJET_DBT),
+                "--target-path",
+                str(tmp_path / "target"),
+                "--vars",
+                f"{{borne_facturation_genereuse: '{BORNE}'}}",
+            ]
+        )
+    finally:
+        if ancien is None:
+            os.environ.pop("DBT_DUCKDB_PATH", None)
+        else:
+            os.environ["DBT_DUCKDB_PATH"] = ancien
+
+
+@pytest.fixture(scope="module")
+def base_fixtures(tmp_path_factory):
+    """Lande C15 + R151 + R64, bâtit `+chronologie_releves`, retourne une copie lisible."""
+    import dlt
+
+    from electricore.ingestion.raw_landing import lander_documents_bruts
+
+    tmp = tmp_path_factory.mktemp("chrono")
+    db_path = tmp / "flux.duckdb"
+    pipe = dlt.pipeline(
+        pipeline_name="test_chronologie",
+        destination=dlt.destinations.duckdb(str(db_path)),
+        dataset_name="flux_raw",
+    )
+    lander_documents_bruts(
+        pipe,
+        "raw_c15",
+        [
+            {
+                "file_name": "c15_avec_releves.xml",
+                "modification_date": "2026-01-01T00:00:00",
+                "content": xml_vers_dict((FIXTURES / "c15_avec_releves.xml").read_bytes()),
+            }
+        ],
+    )
+    lander_documents_bruts(
+        pipe,
+        "raw_r151",
+        [
+            {
+                "file_name": "r151.xml",
+                "modification_date": "2026-01-01T00:00:00",
+                "content": xml_vers_dict((FIXTURES / "r151.xml").read_bytes()),
+            }
+        ],
+    )
+    lander_documents_bruts(
+        pipe,
+        "raw_r64",
+        [
+            {
+                "file_name": "r64.json",
+                "modification_date": "2026-01-01T00:00:00",
+                "content": json.loads((FIXTURES / "r64.json").read_text()),
+            }
+        ],
+    )
+    res = _invoke(["build", "--select", "+chronologie_releves"], db_path, tmp)
+    assert res.success, f"dbt build +chronologie_releves a échoué : {res.exception}"
+    con = duckdb.connect(str(db_path))
+    con.execute("checkpoint")
+    con.close()
+    copie = tmp / "flux_lecture.duckdb"
+    shutil.copy(db_path, copie)
+    return copie
+
+
+def test_chronologie_grain_et_contrat(base_fixtures):
+    """Le loader valide `ChronologieReleves` ; grain unique ; sources dans l'énum."""
+    df = chronologie(base_fixtures).collect()  # lève si le contrat Pandera échoue
+    assert df.height > 0
+    cle = ["ref_situation_contractuelle", "date_releve", "ordre_index"]
+    assert df.select(cle).n_unique() == df.height  # grain 1 ligne / (rsc, date, ordre)
+    assert df["ref_situation_contractuelle"].null_count() == 0
+    sources = set(df["source"].drop_nulls().unique().to_list())
+    assert sources <= {"flux_C15", "flux_R64", "flux_R151"}
+
+
+# --- Parité behaviour-diff vs _assembler_chronologie (HITL, ADR-0041 §7) ------------------
+
+_INDEX_COLS = [f"index_{c}_kwh" for c in ("base", "hp", "hc", "hph", "hch", "hpb", "hcb")]
+
+
+def _cle_proj(df: pl.DataFrame) -> pl.DataFrame:
+    return df.select(
+        [
+            "ref_situation_contractuelle",
+            pl.col("date_releve").dt.convert_time_zone("UTC").alias("dr"),
+            "ordre_index",
+            "source",
+            *_INDEX_COLS,
+        ]
+    )
+
+
+@pytest.mark.skipif(not DEV_DB.exists(), reason="base dev absente (behaviour-diff local sur données réelles)")
+def test_parite_sur_donnees_reelles(tmp_path):
+    """Behaviour-diff réel : rien perdu, C15 identique, écarts = swaps R151→R64 (index
+    identique, neutre en énergie) + bornes FACTURATION héritées du fix month_start (#380)."""
+    db_path = tmp_path / "flux.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute("create schema if not exists flux_enedis")
+    con.execute(f"attach '{DEV_DB}' as dev (read_only)")
+    for t in ("flux_c15", "flux_r64", "flux_r151"):
+        con.execute(f"create table flux_enedis.{t} as select * from dev.flux_enedis.{t}")
+    con.execute("detach dev")
+    con.execute("checkpoint")
+    con.close()
+    res = _invoke(
+        ["run", "--select", "int_releves__c15", "releves", "spine_contrat", "chronologie_releves"],
+        db_path,
+        tmp_path,
+    )
+    assert res.success, f"dbt run a échoué : {res.exception}"
+    con = duckdb.connect(str(db_path))
+    con.execute("checkpoint")
+    con.close()
+    clean = tmp_path / "flux_lecture.duckdb"
+    shutil.copy(db_path, clean)
+
+    horizon = datetime(2026, 6, 1, tzinfo=PARIS)
+    mart = chronologie(clean).collect().filter(pl.col("date_releve") <= horizon)
+    hist = pipeline_historique(c15(clean).lazy(), horizon=horizon)
+    core = _assembler_chronologie(hist.filter(pl.col("impacte_energie")), releves(clean).lazy()).collect()
+
+    key = ["ref_situation_contractuelle", "dr", "ordre_index"]
+    # Drapeaux de présence : distinguer « clé absente » de « clé présente mais source/index
+    # null » (borne FACTURATION sans relevé — releve_manquant — qui existe des deux côtés).
+    m = _cle_proj(mart).rename({c: f"{c}_m" for c in ["source", *_INDEX_COLS]}).with_columns(present_m=pl.lit(True))
+    c = _cle_proj(core).rename({c: f"{c}_c" for c in ["source", *_INDEX_COLS]}).with_columns(present_c=pl.lit(True))
+    j = m.join(c, on=key, how="full", coalesce=True)
+
+    only_core = j.filter(pl.col("present_m").is_null())
+    only_mart = j.filter(pl.col("present_c").is_null())
+    shared = j.filter(pl.col("present_m") & pl.col("present_c"))
+
+    # (1) Rien perdu : aucune borne du cœur absente de la spine.
+    assert only_core.height == 0, f"{only_core.height} bornes du cœur perdues par le mart"
+
+    # (2) Swaps de source : tous R151(cœur)→R64(mart) (priorité ADR-0028), JAMAIS l'inverse.
+    swaps = shared.filter(pl.col("source_m") != pl.col("source_c"))
+    directions = set(swaps.select("source_c", "source_m").unique().rows())
+    assert directions <= {("flux_R151", "flux_R64")}, f"swaps inattendus : {directions}"
+
+    # (3) Les swaps sont neutres en énergie : index identique R64 vs R151.
+    index_differe = pl.any_horizontal(
+        (pl.col(f"{x}_m") != pl.col(f"{x}_c")) & pl.col(f"{x}_m").is_not_null() & pl.col(f"{x}_c").is_not_null()
+        for x in _INDEX_COLS
+    )
+    assert swaps.filter(index_differe).height == 0, "un swap R151→R64 change l'index (impact énergie)"
+
+    # (4) Les extras du mart sont des bornes FACTURATION (ordre_index=false) — héritées du
+    #     fix month_start de la spine (#380), pas des relevés C15 perdus.
+    assert (~only_mart["ordre_index"]).all(), "extra mart hors borne FACTURATION (ordre_index)"


### PR DESCRIPTION
## #376 — Chronologie des relevés en dbt (ADR-0041) · ⚠️ HITL — relire le diff avant merge

> Le passage **asof-4h → equi-join jour** est le *seul changement de comportement* de toute
> la refonte spine. Cette PR le réalise + produit le **diff de parité** ci-dessous, à
> **valider par un humain** avant merge (issue `ready-for-human`).

### Le mart
`chronologie_releves` — projection **énergie** de la spine, assemblée entièrement en dbt :
- relevés **C15** aux événements qui **impactent l'énergie** (`impacte_energie` descendu en
  SQL, miroir de `expr_impacte_energie` ; l'énergie ne gardera que son découpage, #377) ;
- bornes **FACTURATION** mensuelles (spine) ⟕ relevés **périodiques** (R151/R64) au **grain
  JOUR** — equi-join `(pdl, jour)` qui **remplace** l'asof « nearest 4h »
  (`TOLERANCE_APPARIEMENT_RELEVES`) ;
- dédoublonnage **priorité de source** C15 > R64 > R151 (ADR-0028) via `QUALIFY`.

Loader `chronologie()` + contrat `ChronologieReleves` (grain `(rsc, date_releve, ordre_index)` ;
`source` rendu nullable — une borne sans relevé apparié n'en porte pas). Câblé dans
`construire_dbt` ; data-tests schema.yml + garde-fou de grain.

### 📋 Diff de parité à valider (base dev réelle, 1413 RSC, horizon 2026-06-01)
vs `_assembler_chronologie(historique.filter(impacte_energie), releves)` :

| constat | détail |
|---|---|
| **Partie C15 identique** | `impacte_energie` reproduit fidèlement — 0 écart côté C15 |
| **Rien perdu** | `cœur ⊆ mart` : aucune borne de l'assemblage cœur absente du mart |
| **2744 swaps `flux_R151` → `flux_R64`** | aux bornes mensuelles où **les deux** existent, le mart applique la priorité ADR-0028 (R64>R151) via `QUALIFY`, là où l'asof choisissait par **proximité temporelle**. **Index IDENTIQUE dans les 2744 cas → ZÉRO impact énergie** ; seuls `source`/`releve_id` changent |
| **121 bornes FACTURATION en plus** | héritées du **fix month_start** de la spine (#380, déjà tracé) |

→ Tous les écarts sont **justifiés** (asof→equi-join+priorité, + le report du fix #375) et
**neutres en énergie**. Encodé en test (`test_parite_sur_donnees_reelles`, skip si base dev absente).

### Garde-fous
- CI : structure + grain + contrat sur fixtures (`test_chronologie_grain_et_contrat`).
- 184 tests verts (architecture, loaders, énergie, golden, spine, chronologie) ; ruff OK.

**Ne pas merger sans relecture humaine du diff** (HITL). Le retrait de `_assembler_chronologie`
du chemin énergie + `releves_utilises` = même source sont la tranche suivante (#377).

Closes #376
