### PR TITLE
docs(releves): commentaire de situation aligné sur la spine (ADR-0041)

### DIFF
--- a/electricore/ingestion/dbt/models/marts/releves.sql
+++ b/electricore/ingestion/dbt/models/marts/releves.sql
@@ -90,7 +90,8 @@ dedup as (
 -- `index is not null`), et le forward-fill traînait alors une valeur périmée (bug prod
 -- RSC 834877952). Désormais : un relevé C15 garde sa valeur NATIVE (le fait propre de
 -- l'événement) ; un télérelevé périodique reste à `null`. L'attribution par-contrat
--- appartient au substrat d'événements consolidé (`pipeline_historique` forward-fille sur
--- le flux C15 COMPLET, MDPRM compris) ; la chronologie source RSC/FTA/niveau depuis la
--- requête FACTURATION, plus depuis le mart. `/releves` sert donc des lectures pures.
+-- appartient au substrat consolidé : la spine relationnelle dbt (`spine_contrat.sql`)
+-- forward-fille la situation en SQL sur le flux C15 COMPLET (MDPRM compris) ; la
+-- chronologie source RSC/FTA/niveau depuis la spine, plus depuis ce mart. `/releves`
+-- sert donc des lectures pures. Voir ADR-0041 (révise ADR-0039).
 select * from dedup


### PR DESCRIPTION
Aligne le commentaire du bloc « Attributs de situation HORS du relevé » de `releves.sql` sur l'architecture post-descente **ADR-0041** (#374→#378).

Le commentaire décrivait encore le mécanisme **ADR-0039** : forward-fill de situation au cœur (`pipeline_historique`) + sourcing du niveau via la *requête FACTURATION*. La descente ADR-0041 a déplacé l'attribution de situation vers la **spine relationnelle dbt** (`spine_contrat.sql`, forward-fill SQL sur le flux C15 complet, MDPRM compris) ; le cœur ne dérive plus la situation.

**Commentaire uniquement — aucun changement de SQL.** Loose end de la descente, repéré en faisant le ménage autour de #365 (fermé : livré en a853730 puis mécanisme révisé par ADR-0041).

🤖 Generated with [Claude Code](https://claude.com/claude-code)