### PR TITLE
feat(loaders): épingle le fuseau de session DuckDB à Europe/Paris (#393)

### DIFF
--- a/docs/adr/0042-convention-date-instant-jour-civil-boundary-flux.md
+++ b/docs/adr/0042-convention-date-instant-jour-civil-boundary-flux.md
@@ -1,0 +1,95 @@
+# Convention de date : instant (TIMESTAMPTZ) vs jour civil (DATE), harmonisés au boundary `flux_*`, fuseau posé à la lecture
+
+## Contexte
+
+Le traitement des dates était éclaté et **harmonisé deux fois** : les marts (`releves`,
+`spine_contrat`) ré-ancraient les dates naïves en instants Paris, et le loader le refaisait
+à sa façon (forme par colonne `FormeTemporelle` + ancrage + filtre déterministe, #391, PR
+#392). Les modèles `flux_*` émettaient des types **mixtes** — `TIMESTAMPTZ` (offsets
+C15/R15), `TIMESTAMP` naïf (R64), `DATE` (R151/F15) — sans convention unique, chaque
+consommateur re-décidant l'ancrage. La grille FACTURATION (1ᵉʳ du mois) doit, elle,
+calculer à **minuit Paris** et non UTC, sous peine de mauvais mois au bord.
+
+Trois fins de partie incompatibles flottaient : (a) `SET TimeZone` global, rejeté par #391 ;
+(b) forme par colonne dans le loader (#389-391, livré) qui empêche le `SELECT *` pur visé
+par [ADR-0035](0035-typage-chaine-ingestion-coeur-proprietaire-par-fait.md) ; (c) forme
+dérivée de Pandera.
+
+## Décision
+
+### 1. Deux représentations selon la *nature* (instant vs jour civil)
+
+Le canon (java.time / Noda Time) distingue le **moment** du **jour calendaire** :
+
+| Nature | Type physique | Exemples Enedis |
+|---|---|---|
+| **Instant** (point sur la ligne du temps) | `TIMESTAMPTZ` (UTC) | *événement* C15 (`date_evenement`), *relevé* (R15/R64/R151) |
+| **Jour civil** (journée, sans heure ni fuseau) | `DATE` | *date de facture* F15, borne de période, bascule de niveau C15, date d'effet d'affaire |
+
+« Tout en `TIMESTAMPTZ` » est **rejeté** : coller un fuseau à un jour civil injecte un faux
+« minuit » + un fuseau porteur → bug de bord (le `2024-10-04` relu en UTC devient le 03).
+La règle « store UTC, convert at edges » ne vaut que pour les **instants** ; un jour civil
+ne porte jamais de fuseau.
+
+### 2. Harmonisation au boundary `flux_*`, une seule fois (pattern adapter)
+
+Chaque source convertit son encodage vers le type canonique **dans son modèle `flux_*`** (le
+bord), comme un adapter hexagonal normalise au seuil :
+
+- **R64** : `TIMESTAMP` naïf → instant (ancrage heure-mur Paris).
+- **R151** : label `xs:date` *fin-de-journée* → instant **minuit Paris du jour J+1**. Le
+  « +1 jour » n'est pas une harmonisation baladeuse mais la **conversion native** de R151
+  (fin de J = début de J+1), appliquée au bord comme R64 fait son ancrage. Après ça
+  **R151 ≡ R64**, une seule convention « début de journée » en aval. L'*identité de relevé*
+  (`releve_id`, [ADR-0028](0028-identite-releve-cle-metier-priorite-sources.md)) reste mintée
+  sur la **date brute** à l'intérieur de `flux_r151` (identité stable, zéro re-hash).
+- **C15 / R15** (offsets `xsd:dateTime`) : déjà `TIMESTAMPTZ`, rien à faire.
+- **Jours civils** (F15, bascule de niveau C15, date d'effet d'affaire) : restent `DATE`.
+
+Les marts cessent de ré-ancrer ; plus aucun `TIMESTAMP` naïf ne survit. **Aucun
+consommateur en aval ne re-décide la convention.**
+
+### 3. Fuseau posé à la lecture → loader = `SELECT *` pur
+
+`SET TimeZone='Europe/Paris'` sur `duckdb_readonly_conn` : les `TIMESTAMPTZ` sortent tagués
+Paris **déterministes** (poste / CI / VPS) ET les filtres interprètent leurs littéraux en
+Paris (déterminisme du `WHERE` *gratuit*, sans enveloppe par colonne). Les `DATE` sont
+insensibles au fuseau. Le loader devient le `SELECT *` typeless d'ADR-0035 : **plus de
+`FormeTemporelle`, plus de `convert_time_zone`, plus d'enveloppe de filtre**.
+
+### 4. Conversions civil ↔ instant explicites au point d'usage
+
+Un calcul calendaire qui croise les deux natures (grille FACTURATION qui pose le 1ᵉʳ du mois
+sur la timeline d'instants des événements ; troncature au mois) convertit **explicitement**
+en `AT TIME ZONE 'Europe/Paris'` au point d'usage — le build dbt tourne en session UTC, donc
+ne jamais s'appuyer sur la session. `spine_contrat.sql` le fait déjà ; côté cœur,
+`dt.truncate("1mo")` est correct parce que la lecture tague Paris.
+
+## Le `SET TimeZone` global, rejeté par #391, est ré-adopté
+
+#391 l'avait rejeté (« la responsabilité du fuseau doit être par flux »). **Renversé ici par
+le haut** : le *fuseau* est un **invariant de domaine uniforme** — tous les flux Enedis sont
+en heure légale française (cf. `docs/conventions-dates-enedis.md`). Ce n'est pas une
+responsabilité qui varie par flux ; seule la *forme de stockage* varie, et elle est résolue
+en dbt (point 2). Poser le fuseau une fois à la lecture **encode fidèlement** cet invariant,
+il ne le masque pas.
+
+## Conséquences
+
+- **Supersède #391** (PR #392) : `FormeTemporelle` + l'enveloppe de filtre par colonne sont
+  retirées du loader.
+- **Révise [ADR-0035](0035-typage-chaine-ingestion-coeur-proprietaire-par-fait.md) §1** : le
+  loader atteint vraiment le `SELECT *` typeless — la dimension tz, laissée « à inventorier »
+  par ADR-0035, est ici tranchée.
+- **Révise l'amendement #294 d'[ADR-0003](0003-r151-date-harmonisation.md)** : le +1 jour R151
+  repasse du mart `releves` au boundary `flux_r151` ; `flux_r151` n'est plus *fidèle au label
+  brut* mais *fidèle à l'instant de relevé*. `/flux/r151` (déprécié) sert l'instant.
+- Réalise **#311** (loaders = `SELECT *`), sous un cadrage tz différent de l'issue d'origine
+  (qui supposait le `SET TimeZone` global comme seul enabler, sans la distinction
+  instant/jour civil).
+- Discipline dbt à généraliser : tout calcul calendaire en `AT TIME ZONE 'Europe/Paris'`
+  explicite (le build tourne en session UTC).
+
+## Statut
+
+Accepté. Supersède #391 (PR #392) ; révise ADR-0003 (amendement #294) et ADR-0035 §1.

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -174,6 +174,20 @@ _Éviter_ : confondre *statut* (3 valeurs) et *état* (fin, ~16 valeurs).
 
 ---
 
+## Conventions de date
+
+**Instant** :
+Un moment précis et univoque sur la ligne du temps mondiale (l'horodatage d'un *événement* C15, le moment d'un *relevé*). Le même instant partout, quel que soit le lieu où on le lit. Convention de stockage et d'harmonisation : voir [ADR-0042](../../docs/adr/0042-convention-date-instant-jour-civil-boundary-flux.md).
+_Éviter_ : timestamp, horodatage, date (un instant n'est pas un jour).
+
+**Jour civil** :
+Une journée du calendrier, **sans** heure ni fuseau (une *date de facture*, une borne de période, une date de bascule de niveau). « Le 4 octobre » désigne le même jour partout — lui coller un fuseau (« minuit Paris ») est une erreur de modélisation qui rouvre des bugs de bord.
+_Éviter_ : date, jour (seuls) quand la distinction instant / jour civil importe.
+
+**Convention début / fin de journée** :
+La borne du jour à laquelle un flux Enedis attribue son *index*. R64 / R15 / C15 : « début de journée » (index au début du jour J). R151 : « fin de journée » (index à la fin du jour J = début de J+1). Aligner R151 sur les autres avance son label d'un jour (le « +1 jour ») — conversion **native** de R151, appliquée à l'ingestion (boundary `flux_r151`), pas une harmonisation portée en aval.
+_Éviter_ : « décalage » (ce n'est pas un bug à corriger mais la convention propre de R151).
+
 ## Mesures et énergie
 
 **Index** :
@@ -361,7 +375,7 @@ Unité de facturation côté ERP : un produit, une période, une quantité, un P
 _Éviter_ : ligne Odoo (le concept est agnostique), ligne facture client (`account.move` est la facture entière).
 
 **Harmonisation des relevés** :
-Alignement des sources de relevés (R151, R64) sur la convention de date « début de journée » (R151 +1 jour). Désormais porté par le **modèle de relevés canonique** dbt `releves` (loader `releves()`, [ADR-0029](../../docs/adr/0029-modele-releves-canonique-dbt-assemble-coeur-arbitre.md)) — l'ancien `releves_harmonises()` (union SQL R151+R64 côté loader) a été retiré (#248). Convention de date : voir [ADR-0003](../../docs/adr/0003-r151-date-harmonisation.md).
+Alignement des sources de relevés (R151, R64) sur la convention de date « début de journée » (R151 +1 jour, cf. *Convention début / fin de journée*). Le +1 jour R151 et l'ancrage en *instant* sont portés à l'**ingestion**, dans le modèle `flux_r151` (boundary), comme la conversion native de chaque source — plus dans le mart ([ADR-0042](../../docs/adr/0042-convention-date-instant-jour-civil-boundary-flux.md) révise l'amendement #294 d'[ADR-0003](../../docs/adr/0003-r151-date-harmonisation.md)). L'ancien `releves_harmonises()` (union SQL R151+R64 côté loader) a été retiré (#248).
 
 **`date_ajustee`** (champ) :
 Booléen marquant les relevés dont la date a été décalée pendant l'harmonisation (R151 +1 jour).

--- a/electricore/core/loaders/duckdb/config.py
+++ b/electricore/core/loaders/duckdb/config.py
@@ -16,6 +16,8 @@ import duckdb
 
 from electricore.config import runtime
 
+from .sql import HEURE_LEGALE
+
 logger = logging.getLogger(__name__)
 
 # Politique de retry lorsque le writer d'ingestion détient le verrou exclusif.
@@ -98,6 +100,12 @@ def duckdb_readonly_conn(database_path: str | Path) -> Iterator[duckdb.DuckDBPyC
             )
             time.sleep(_LOCK_RETRY_BACKOFF_S)
             continue
+        # Fuseau de session épinglé à l'heure légale française (#393, ADR-0042) : tous les
+        # flux Enedis sont en Europe/Paris (invariant de domaine uniforme). Posé une fois à
+        # la lecture, il rend les instants (TIMESTAMPTZ) déterministes — taggés Paris quel
+        # que soit le fuseau de l'hôte (VPS/CI en UTC) — et fait interpréter les littéraux
+        # de filtre en heure de Paris, sans dépendre de la machine.
+        conn.execute(f"SET TimeZone='{HEURE_LEGALE}'")
         try:
             yield conn
         finally:

--- a/electricore/core/loaders/duckdb/sql.py
+++ b/electricore/core/loaders/duckdb/sql.py
@@ -18,10 +18,11 @@ if TYPE_CHECKING:
     from .descriptor import FluxDescriptor
 
 # Heure légale française : le fuseau de TOUS les flux Enedis (cf.
-# docs/conventions-dates-enedis.md). Constante nommée plutôt que littéral épars —
-# l'ancrage de lecture (forme `NAIF_PARIS`) et le filtre déterministe (#391) la
-# partagent. Ce n'est PAS un `SET TimeZone` global : la responsabilité du fuseau
-# reste portée par la forme, colonne par colonne.
+# docs/conventions-dates-enedis.md), invariant de domaine uniforme (ADR-0042).
+# Constante nommée plutôt que littéral épars — la partagent : le fuseau de session de
+# la connexion read-only (`duckdb_readonly_conn`, #393), l'ancrage de lecture (forme
+# `NAIF_PARIS`) et le filtre déterministe (#391). Le mécanisme par colonne est
+# transitoire : ADR-0042 le retire (#398) au profit du seul fuseau de session.
 HEURE_LEGALE = "Europe/Paris"
 
 

--- a/tests/core/loaders/test_duckdb_session_timezone.py
+++ b/tests/core/loaders/test_duckdb_session_timezone.py
@@ -1,0 +1,60 @@
+"""Fuseau de session de la connexion read-only des loaders (#393, ADR-0042).
+
+`duckdb_readonly_conn` épingle le fuseau de session DuckDB à `Europe/Paris`, de sorte
+que toute lecture d'un **instant** (`TIMESTAMPTZ`) ressorte taguée Paris et que les
+littéraux de filtre soient interprétés en heure légale française — déterministe quel
+que soit le fuseau de l'hôte (poste local en Paris, VPS/CI en UTC).
+
+Le fuseau par défaut de DuckDB est figé au démarrage du processus (ICU lit `TZ` une
+fois) : le modifier en cours de processus ne change rien. Sur une machine déjà en
+`Europe/Paris`, une assertion en process serait donc verte par accident. On force ici
+un hôte étranger via un **sous-processus** sous `TZ` choisi, seul moyen honnête de
+prouver que la connexion épingle bien Paris (et non d'hériter du défaut machine).
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import duckdb
+
+# Instant-bord : 00:01 heure de Paris le 4 octobre 2024 (= 2024-10-03 22:01 UTC), juste
+# APRÈS minuit Paris du 4 mais AVANT minuit UTC. La comparaison `>= TIMESTAMP '2024-10-04'`
+# sur cet instant dépend du fuseau de session : True sous Paris, False sous UTC. C'est la
+# sonde qui distingue une session épinglée Paris d'une session héritée de l'hôte.
+_REQUETE_BORD = "SELECT TIMESTAMPTZ '2024-10-04 00:01:00+02:00' >= TIMESTAMP '2024-10-04'"
+
+
+def _comparaison_bord_via_conn(db_path: Path, tz: str) -> str:
+    """Évalue la comparaison-bord à travers `duckdb_readonly_conn`, dans un sous-processus
+    dont l'hôte est en fuseau `tz`. Renvoie le booléen DuckDB tel quel ('True'/'False')."""
+    code = textwrap.dedent(
+        f"""
+        from electricore.core.loaders.duckdb.config import duckdb_readonly_conn
+        with duckdb_readonly_conn({str(db_path)!r}) as conn:
+            print(conn.execute({_REQUETE_BORD!r}).fetchone()[0])
+        """
+    )
+    res = subprocess.run(
+        [sys.executable, "-c", code],
+        env={"TZ": tz, "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, f"sous-processus (TZ={tz}) a échoué :\n{res.stdout}\n{res.stderr}"
+    return res.stdout.strip().splitlines()[-1]
+
+
+def test_filtre_timestamptz_interprete_paris_quel_que_soit_le_fuseau_hote(tmp_path):
+    """#393 : la connexion read-only du loader interprète un littéral de filtre sur une
+    colonne TIMESTAMPTZ en heure légale française — MÊME résultat sur un hôte UTC (VPS) et
+    un hôte Europe/Paris (dev), via la session épinglée à Paris."""
+    db = tmp_path / "vide.duckdb"
+    duckdb.connect(str(db)).close()  # fichier vide : la sonde n'a besoin d'aucune table
+
+    sous_utc = _comparaison_bord_via_conn(db, "UTC")
+    sous_paris = _comparaison_bord_via_conn(db, "Europe/Paris")
+
+    assert sous_utc == sous_paris  # déterminisme : indépendant du fuseau de l'hôte
+    assert sous_utc == "True"  # sémantique Europe/Paris : 00:01 Paris ≥ minuit Paris du 4


### PR DESCRIPTION
## Quoi

Premier maillon de la chaîne ADR-0042 (convention de date unifiée, parent #311) : `duckdb_readonly_conn` épingle le fuseau de session DuckDB à `Europe/Paris` (`SET TimeZone`) à l'ouverture de la connexion read-only.

Conséquence : les instants (`TIMESTAMPTZ`) ressortent taggés Paris et les littéraux de filtre sont interprétés en heure légale française, **déterministes quel que soit le fuseau de l'hôte** (poste local en Paris, VPS/CI en UTC). C'est l'enabler qui portera, à terme (#398), le retrait de la `FormeTemporelle` + de l'enveloppe de filtre par colonne (#391).

## Tranche neutre en sortie

Tant que la `FormeTemporelle` du loader (`convert_time_zone` + wrap de filtre #391) est encore en place, poser la session Paris **ne change aucun instant ni dtype** : le convert devient idempotent, le wrap de filtre était déjà déterministe. Vérifié par la suite complète (**889 verts**, instants `test_loaders_sur_base_dbt` inchangés).

## Test (TDD)

Le défaut DuckDB est figé au démarrage du processus (ICU lit `TZ` une fois) et cette machine est déjà en `Europe/Paris` : une assertion en process serait verte par accident. Le nouveau test force donc un **hôte étranger via sous-processus** (`TZ=UTC` vs `TZ=Europe/Paris`) et sonde un littéral de filtre **nu** (sans le wrap #391) à travers la connexion — seul moyen honnête de prouver que la session est bien épinglée Paris (RED `False`/`True` → GREEN `True`/`True`).

## Docs du cadrage (figées)

Cette tranche porte aussi les changements de doc d'ADR-0042 :
- `docs/adr/0042-convention-date-instant-jour-civil-boundary-flux.md` (nouveau)
- entrées de glossaire `core/CONTEXT.md` : *instant* / *jour civil* / *convention début-fin de journée*

ADR-0042 supersède #391 (PR #392), révise ADR-0003 (amendement #294) et ADR-0035 §1.

## Acceptance criteria (#393)

- [x] `duckdb_readonly_conn` pose `SET TimeZone='Europe/Paris'` à l'ouverture
- [x] Filtre TIMESTAMPTZ déterministe sous `TZ=UTC` et `TZ=Europe/Paris` (session pinned du loader)
- [x] Aucun changement d'instant ni de dtype (suite complète verte ; `test_loaders_sur_base_dbt` inchangé)
- [x] ADR-0042 + entrées de glossaire CONTEXT.md commités

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)
