### PR TITLE
ci: limiter le GITHUB_TOKEN à contents:read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Jeton en lecture seule : les jobs ne font que checkout + lint/mypy/pytest,
+# aucune écriture (commits, releases, comments…) n'est nécessaire.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: lint (ruff)


### PR DESCRIPTION
## Contexte

3 alertes code-scanning identiques (`actions/missing-workflow-permissions`, severity *medium*) sur `.github/workflows/ci.yml` — une par job (`lint`, `typecheck`, `test`). Le `GITHUB_TOKEN` n'a aucun bloc `permissions` explicite et hérite donc des permissions par défaut du dépôt (potentiellement larges en écriture).

## Correctif

Un seul bloc `permissions: { contents: read }` au niveau workflow. Les trois jobs ne font que `checkout` + lint/mypy/pytest — aucune écriture (commits, releases, comments…) n'est nécessaire. Un bloc au niveau workflow couvre les trois jobs et résout les trois alertes d'un coup.

Alertes : [#1](https://github.com/Energie-De-Nantes/electricore/security/code-scanning/1), [#2](https://github.com/Energie-De-Nantes/electricore/security/code-scanning/2), [#3](https://github.com/Energie-De-Nantes/electricore/security/code-scanning/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)