### PR TITLE
chore(release): 3.4.0rc2 — affinage consommation spine + loaders SELECT * (ADR-0042)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.4.0rc2] - 2026-06-21
+
+Les loaders `/flux` deviennent de **vrais `SELECT *`** (convention de date unifiée ADR-0042),
+et la branche abonnement affine sa consommation de la spine *Chronologie du contrat*.
+
+### ✨ Temps forts
+
+- **Loaders `/flux` = `SELECT *` typeless** (ADR-0042, #393→#398). La forme résiduelle (types,
+  littéraux `source`/`unite`, renames, placeholders null) et l'ancrage de date descendent dans
+  les modèles dbt `flux_*`. Convention tranchée : un **instant** est un `TIMESTAMPTZ` harmonisé
+  **au boundary `flux_*`** (R64 → instant heure-mur Paris ; R151 → instant minuit Paris **J+1**,
+  le « +1 jour » devenu natif), un **jour civil** reste un `DATE` (F15, bascules de niveau, dates
+  d'effet d'affaire). Le **fuseau de session** DuckDB est épinglé à `Europe/Paris` à la lecture
+  (`duckdb_readonly_conn`) → instants déterministes quel que soit le fuseau de l'hôte (poste/CI/VPS)
+  et filtres de date interprétés en heure de Paris, sans ancrage par colonne. Retrait de la
+  machinerie `FormeTemporelle`/`col_*`/`convert_time_zone`/enveloppe de filtre (#391).
+- **Affinage de la consommation de la spine** (ADR-0041). `detecter_points_de_rupture` force les
+  bornes FACTURATION sur le discriminant **typé non-null `type_fait`** de la spine (`SpineContrat`)
+  plutôt que sur `evenement_declencheur` (nullable) ; le filtre d'horizon de la *Chronologie des
+  relevés* passe par le même helper `_horizon_expr` que `pipeline_historique` (cohérence).
+
+### ⚠️ Changements de sortie (endpoints `/flux`, assumés)
+
+- `/flux/r64`, `/flux/r151` servent désormais des **instants** (`TIMESTAMPTZ`) ; `/flux/r151` sert
+  l'instant **J+1** harmonisé (endpoint déprécié — l'aval consomme le mart `releves`).
+- `/flux/f15` sert `date_facture`/`date_debut`/`date_fin` en **`DATE`** (jour civil), plus en instant.
+- Empreinte canonique `/releves` **stable** ; `releve_id` inchangés ; instants exacts préservés.
+
 ## [3.4.0rc1] - 2026-06-21
 
 Fin de la **descente d'assemblage d'ADR-0041** : le cœur consomme, dbt assemble. La branche

--- a/electricore/core/builds/contexte_mensuel.py
+++ b/electricore/core/builds/contexte_mensuel.py
@@ -35,7 +35,7 @@ from electricore.core.models.lignes_facture_rapprochees import LignesFactureRapp
 from electricore.core.pipelines.abonnements import pipeline_abonnements
 from electricore.core.pipelines.energie import pipeline_energie
 from electricore.core.pipelines.facturation import pipeline_facturation
-from electricore.core.pipelines.historique import horizon_par_defaut, pipeline_historique
+from electricore.core.pipelines.historique import _horizon_expr, horizon_par_defaut, pipeline_historique
 
 # Les clés sont des *catégories produit* (labels ERP, cf. LignesFacture) —
 # concept distinct des cadrans malgré l'homonymie ; seules les valeurs
@@ -117,7 +117,7 @@ def _composer(
     historique_enrichi = pipeline_historique(spine_mart, horizon=horizon)
     abonnements = pipeline_abonnements(historique_enrichi)
     # Horizon = filtre au boundary (le mart va jusqu'à une borne généreuse, ADR-0041).
-    chronologie_horizon = chronologie_mart.filter(pl.col("date_releve") <= pl.lit(horizon))
+    chronologie_horizon = chronologie_mart.filter(pl.col("date_releve") <= _horizon_expr(horizon))
     energie = pipeline_energie(chronologie_horizon)  # type: ignore[arg-type]
     # Journal des relevés utilisés (#233, ADR-0029/0038) = la MÊME source que l'énergie.
     releves_utilises = chronologie_horizon

--- a/electricore/core/pipelines/historique.py
+++ b/electricore/core/pipelines/historique.py
@@ -249,11 +249,11 @@ def detecter_points_de_rupture(spine: pl.LazyFrame) -> pl.LazyFrame:
         # Appliquer la détection d'impact abonnement avec nos expressions pures. Les bornes
         # FACTURATION (forward-fillées, donc « sans changement ») impactent toujours
         # l'abonnement : ce sont des bornes de période — on les force ici (concern de la spine).
+        # On clé sur le discriminant typé non-null `type_fait` de la spine (`SpineContrat`),
+        # pas sur le `evenement_declencheur` nullable (ADR-0041 #378).
         .with_columns(
             [
-                (expr_impacte_abonnement() | (pl.col("evenement_declencheur") == "FACTURATION")).alias(
-                    "impacte_abonnement"
-                ),
+                (expr_impacte_abonnement() | (pl.col("type_fait") == "facturation")).alias("impacte_abonnement"),
                 expr_resume_modification().alias("resume_modification"),
             ]
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.4.0rc1"
+version = "3.4.0rc2"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/tests/unit/test_expressions_historique.py
+++ b/tests/unit/test_expressions_historique.py
@@ -262,6 +262,8 @@ def test_detecter_points_de_rupture_pipeline_complet():
         "ref_situation_contractuelle": ["PDL1", "PDL1", "PDL1", "PDL1", "PDL1"],
         "date_evenement": ["2024-01-01", "2024-02-01", "2024-03-15", "2024-04-01", "2024-05-20"],
         "evenement_declencheur": ["MES", "FACTURATION", "MCT", "FACTURATION", "RES"],
+        # Discriminant typé de la spine (épine) : FACTURATION ⇒ 'facturation', sinon 'evenement'.
+        "type_fait": ["evenement", "facturation", "evenement", "facturation", "evenement"],
         "puissance_souscrite_kva": [6.0, 6.0, 9.0, 9.0, 9.0],
         "formule_tarifaire_acheminement": ["BTINFCU4", "BTINFCU4", "BTINFMU4", "BTINFMU4", "BTINFMU4"],
     }

--- a/uv.lock
+++ b/uv.lock
@@ -735,7 +735,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.4.0rc1"
+version = "3.4.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Quoi

Travail local + **bump version 3.4.0rc1 → 3.4.0rc2** pour déploiement & test.

Deux commits :

1. **`refactor(core)` — affinage de la consommation de la spine** (ADR-0041) :
   - `detecter_points_de_rupture` force les bornes FACTURATION sur le discriminant **typé non-null `type_fait`** de la spine (`== "facturation"`) au lieu de `evenement_declencheur` (nullable) ;
   - le filtre d'horizon de la *Chronologie des relevés* (`contexte_mensuel`) passe par le même helper `_horizon_expr` que `pipeline_historique` (une seule interprétation de l'horizon).
2. **`chore(release)` — bump 3.4.0rc2** (pyproject + uv.lock + CHANGELOG).

## Périmètre de la rc2 (delta depuis v3.4.0rc1)

La rc2 embarque tout ce qui a atterri sur `main` depuis rc1 :
- la chaîne **ADR-0042** (loaders `/flux` = vrais `SELECT *`, instants au boundary `flux_*`, jours civils en `DATE`, fuseau de session épinglé, #393→#398) — déjà mergée ;
- l'affinage de la spine ci-dessus (ce PR).

Détail dans `CHANGELOG.md` `[3.4.0rc2]` (avec les changements de sortie `/flux` assumés).

## Non inclus (volontairement)

- `scripts/chronologie_spine.{excalidraw,png}` (diagrammes WIP, binaire 1.5 Mo) — dis-moi si tu veux les versionner.
- `scripts/sonde_format_aes.py` (sonde jetable ADR-0040) et `.claude/` — gardés locaux.

## Vérification

Suite complète **882 passed, 23 skipped** sous `TZ=UTC` (condition CI exacte) sur la base `main` à jour. `pre-commit` (ruff + secrets) vert.

> Le tag `v3.4.0rc2` (action publiante) suit le merge — c'est ton étape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
