### PR TITLE
feat: vue facturiste — chronologie filtrable PDL/RSC + endpoint (#366, #367)

### DIFF
--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse
 from electricore.api.config import settings
 from electricore.api.routers import admin as admin_router
 from electricore.api.routers import affaires as affaires_router
+from electricore.api.routers import chronologie as chronologie_router
 from electricore.api.routers import facturation as facturation_router
 from electricore.api.routers import flux as flux_router
 from electricore.api.routers import ingestion as ingestion_router
@@ -132,6 +133,7 @@ app.include_router(releves_router.router)
 app.include_router(taxes_router.router)
 app.include_router(facturation_router.router)
 app.include_router(meta_periodes_router.router)
+app.include_router(chronologie_router.router)
 app.include_router(turpe_variable_router.router)
 app.include_router(affaires_router.router)
 

--- a/electricore/api/routers/chronologie.py
+++ b/electricore/api/routers/chronologie.py
@@ -1,0 +1,58 @@
+"""Router de la *vue facturiste* : chronologie du point / du contrat + verdicts (#367).
+
+Endpoint de **lecture** (« Odoo tire » [ADR-0027], read-only [ADR-0012], `X-API-Key`) qui rend
+la **frise complète** d'un point (`pdl`) ou d'un contrat (`rsc`) : faits (événements C15 *y
+compris hors-comptage* + relevés) tissés avec les verdicts dérivés (qualité/communication/
+énergie). Drill-down/explication du **pourquoi**, là où `/meta-periodes` est l'extrait mensuel
+valorisé — **pas de montants tarifaires** ici (différenciateur explicite).
+
+Réponse en JSON enveloppé, même convention que `/facturation/meta-periodes` et `/releves`
+(`grain` / `filters` / `pagination` / `data`).
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from electricore.api.security import get_current_api_key
+from electricore.api.services.chronologie_service import CONTRAT_VERSION, chronologie_point_ou_contrat
+
+router = APIRouter(tags=["facturation"])
+
+
+@router.get("/facturation/chronologie")
+async def get_chronologie(
+    pdl: str | None = Query(
+        None,
+        examples=["12345678901234"],
+        description="Point de livraison : toute l'histoire du PDL (RSC successives + charnières)",
+    ),
+    rsc: str | None = Query(
+        None,
+        description="Référence de situation contractuelle : une tenure bornée entrée→sortie",
+    ),
+    limit: int = Query(2000, le=10000, ge=1, description="Nombre maximum de lignes à retourner"),
+    offset: int = Query(0, ge=0, description="Nombre de lignes à ignorer (pagination)"),
+    api_key: str = Depends(get_current_api_key),
+):
+    """Frise complète d'un point (`pdl`) **ou** d'un contrat (`rsc`) en JSON enveloppé.
+
+    **Authentification requise** (`X-API-Key`). Lecture seule.
+
+    Chaque ligne porte le **fait** (événement *ou* relevé, son origine/sa nature) et, pour les
+    périodes dérivées, les **verdicts** qualité/communication/énergie associés — sans montant
+    tarifaire (turpe/cta/accise). Fournir exactement un grain (`pdl` ou `rsc`).
+    """
+    if pdl is None and rsc is None:
+        raise HTTPException(422, "Fournir un grain : `pdl` (point) ou `rsc` (contrat).")
+
+    frise = chronologie_point_ou_contrat(pdl=pdl, rsc=rsc)
+    total = frise.height
+    rows = frise.slice(offset, limit).to_dicts()
+    grain = "point" if pdl is not None else "contrat"
+    filtres = {k: v for k, v in (("pdl", pdl), ("rsc", rsc)) if v}
+    return {
+        "grain": grain,
+        "contract_version": CONTRAT_VERSION,
+        "filters": filtres or None,
+        "pagination": {"limit": limit, "offset": offset, "returned": len(rows), "total": total},
+        "data": rows,
+    }

--- a/electricore/api/services/chronologie_service.py
+++ b/electricore/api/services/chronologie_service.py
@@ -1,0 +1,219 @@
+"""Vue facturiste : *Chronologie du point / du contrat* + verdicts (#367, ADR-0039/0041).
+
+Endpoint de **lecture** (pattern « Odoo tire » [ADR-0027], read-only [ADR-0012]) qui rend
+la **frise complète** d'un point (`pdl`) ou d'un contrat (`rsc`) : les **faits** (événements
+C15 *y compris hors-comptage* — MDPRM de niveau, MCT puissance — et relevés R151/R64/C15,
+avec leur origine/nature) **tissés** avec les **verdicts dérivés** de chaque période d'énergie
+(qualité / communication / énergie). But : rendre lisible le **pourquoi** d'un mois (« borne
+manquante → incalculable », « niveau 0 → non-communicante »), là où `/meta-periodes` est
+l'extrait mensuel valorisé.
+
+**Pas de montants tarifaires** (turpe/cta/accise) : c'est le différenciateur explicite vs
+`/meta-periodes`. La frise porte l'énergie **physique** (kWh), pas son prix.
+
+S'appuie sur la reconstruction **filtrée** du `ContexteMensuel` (#366) : le périmètre est
+poussé dans DuckDB (`spine().filter(...)` / `chronologie().filter(...)`), pas de scan parc.
+
+Grain :
+- **point** (`pdl`) — toute l'histoire du PDL : RSC successives + charnières
+  (déménagement/reprise) ;
+- **contrat** (`rsc`) — une seule tenure bornée entrée→sortie.
+
+ERP-agnostique : aucun import `integrations/odoo` (ADR-0016).
+"""
+
+import datetime as dt
+
+import polars as pl
+
+from electricore.core.builds.contexte_mensuel import ContexteMensuel, contexte_du_mois_filtre
+from electricore.core.models.cadrans import CADRANS, col_index
+
+# Version du contrat exposée dans l'enveloppe. Bump sur rupture (cf. /meta-periodes).
+CONTRAT_VERSION = 1
+
+# Registres réels d'index exposés sur une ligne de relevé (cf. /meta-periodes, ADR-0038) :
+# seuls les non-nuls ressortent (jamais de cadran synthétisé).
+REGISTRES_REELS: tuple[str, ...] = tuple(col_index(c) for c in CADRANS)
+
+# Énergies physiques (kWh) portées par une ligne de période — PAS de montant tarifaire.
+COLONNES_ENERGIE: tuple[str, ...] = tuple(c.replace("index_", "energie_") for c in REGISTRES_REELS)
+
+
+def _lignes_evenements(historique: pl.LazyFrame) -> list[dict]:
+    """Faits événementiels : événements C15 (y compris hors-comptage) + bornes FACTURATION.
+
+    Chaque ligne porte la situation **au moment du fait** (puissance, FTA, niveau d'ouverture)
+    et les annotations de rupture d'abonnement (`impacte_abonnement`, `resume_modification`).
+    """
+    colonnes = [
+        "date_evenement",
+        "pdl",
+        "ref_situation_contractuelle",
+        "source",
+        "type_fait",
+        "evenement_declencheur",
+        "puissance_souscrite_kva",
+        "formule_tarifaire_acheminement",
+        "niveau_ouverture_services",
+        "impacte_abonnement",
+        "resume_modification",
+    ]
+    dispo = set(historique.collect_schema().names())
+    df = historique.select([c for c in colonnes if c in dispo]).collect()
+    lignes = []
+    for r in df.iter_rows(named=True):
+        lignes.append(
+            {
+                "type_ligne": "evenement",
+                "date": r["date_evenement"],
+                "pdl": r.get("pdl"),
+                "ref_situation_contractuelle": r.get("ref_situation_contractuelle"),
+                "source": r.get("source"),
+                "type_fait": r.get("type_fait"),
+                "evenement_declencheur": r.get("evenement_declencheur"),
+                "puissance_souscrite_kva": r.get("puissance_souscrite_kva"),
+                "formule_tarifaire_acheminement": r.get("formule_tarifaire_acheminement"),
+                "niveau_ouverture_services": r.get("niveau_ouverture_services"),
+                "impacte_abonnement": r.get("impacte_abonnement"),
+                "resume_modification": r.get("resume_modification"),
+            }
+        )
+    return lignes
+
+
+def _lignes_releves(releves: pl.LazyFrame) -> list[dict]:
+    """Faits de relevé : un relevé d'index utilisé, avec origine (périodique/événementiel),
+    nature et registres réels non nuls. Un relevé sans identité (interrogé absent) est écarté.
+    """
+    dispo = set(releves.collect_schema().names())
+    if "date_releve" not in dispo:
+        return []
+    colonnes = [
+        c
+        for c in (
+            "ref_situation_contractuelle",
+            "pdl",
+            "date_releve",
+            "ordre_index",
+            "releve_id",
+            "nature_index",
+            "source",
+            "evenement_declencheur",
+            *REGISTRES_REELS,
+        )
+        if c in dispo
+    ]
+    df = releves.select(colonnes).collect()
+    if "releve_id" in df.columns:
+        df = df.filter(pl.col("releve_id").is_not_null())
+    lignes = []
+    for r in df.iter_rows(named=True):
+        evenementiel = r.get("source") == "flux_C15"
+        ligne = {
+            "type_ligne": "releve",
+            "date": r["date_releve"],
+            "pdl": r.get("pdl"),
+            "ref_situation_contractuelle": r.get("ref_situation_contractuelle"),
+            "source": r.get("source"),
+            "releve_id": r.get("releve_id"),
+            "nature_index": r.get("nature_index"),
+            "origine_releve": "événementiel" if evenementiel else "périodique",
+            "ordre_index": r.get("ordre_index"),
+        }
+        if evenementiel and r.get("evenement_declencheur") is not None:
+            ligne["evenement_declencheur"] = r["evenement_declencheur"]
+        for registre in REGISTRES_REELS:
+            if r.get(registre) is not None:
+                ligne[registre] = r[registre]
+        lignes.append(ligne)
+    return lignes
+
+
+def _lignes_periodes_energie(energie: pl.LazyFrame) -> list[dict]:
+    """Périodes d'énergie dérivées : bornes + **verdicts** (qualité/communication) + énergie
+    physique (kWh). **Aucun** montant tarifaire (`turpe_variable_eur` écarté ici, ADR-0027).
+    """
+    dispo = set(energie.collect_schema().names())
+    if "debut" not in dispo:
+        return []
+    base = [
+        "ref_situation_contractuelle",
+        "pdl",
+        "debut",
+        "fin",
+        "nb_jours",
+        "qualite",
+        "statut_communication",
+    ]
+    colonnes = [c for c in (*base, *COLONNES_ENERGIE) if c in dispo]
+    df = energie.select(colonnes).collect()
+    lignes = []
+    for r in df.iter_rows(named=True):
+        ligne = {
+            "type_ligne": "periode_energie",
+            # La période est ancrée sur sa borne de début (point d'apparition dans la frise).
+            "date": r["debut"],
+            "pdl": r.get("pdl"),
+            "ref_situation_contractuelle": r.get("ref_situation_contractuelle"),
+            "debut": r.get("debut"),
+            "fin": r.get("fin"),
+            "nb_jours": r.get("nb_jours"),
+            "qualite": r.get("qualite"),
+            "statut_communication": r.get("statut_communication"),
+        }
+        for col in COLONNES_ENERGIE:
+            if col in dispo and r.get(col) is not None:
+                ligne[col] = r[col]
+        lignes.append(ligne)
+    return lignes
+
+
+def _tisser_frise(ctx: ContexteMensuel) -> pl.DataFrame:
+    """Tisse la frise complète depuis un `ContexteMensuel` (cœur pur du service).
+
+    Concatène les trois familles de lignes — **événements** (faits C15 + FACTURATION),
+    **relevés** (faits de lecture), **périodes d'énergie** (dérivées, avec verdicts) — et
+    les ordonne chronologiquement (`date`). Schéma hétérogène : chaque famille a ses clés ;
+    une frame `pl.DataFrame` à colonnes unionnées (valeurs absentes → null) est plus lisible
+    pour un facturier qu'une liste typée. Aucun montant tarifaire (différenciateur ADR-0027).
+    """
+    lignes = [
+        *_lignes_evenements(ctx.historique_enrichi),
+        *_lignes_releves(ctx.releves_utilises),
+        *_lignes_periodes_energie(ctx.energie),
+    ]
+    if not lignes:
+        return pl.DataFrame({"type_ligne": [], "date": []})
+    # Union des clés (schéma hétérogène) → DataFrame, puis tri chronologique stable.
+    frise = pl.DataFrame(lignes, infer_schema_length=None)
+    return frise.sort("date", maintain_order=True)
+
+
+def chronologie_point_ou_contrat(
+    pdl: str | None = None,
+    rsc: str | None = None,
+    horizon: dt.datetime | None = None,
+) -> pl.DataFrame:
+    """Frise complète d'un point (`pdl`) ou d'un contrat (`rsc`) — vue facturiste (#367).
+
+    Reconstruit le `ContexteMensuel` **filtré** (#366, prédicat poussé dans DuckDB) puis tisse
+    la frise. La résolution du `mois` du contexte ne borne que `facturation_mensuelle` (non
+    utilisée ici) : la frise couvre **toute l'histoire** jusqu'à l'horizon.
+
+    Args:
+        pdl: grain point — toute l'histoire du PDL (RSC successives + charnières).
+        rsc: grain contrat — une tenure bornée entrée→sortie.
+        horizon: borne de facturation (issue #179) ; `None` → 1er du mois courant.
+
+    Returns:
+        DataFrame de la frise (lignes hétérogènes, ordonnées par `date`).
+
+    Raises:
+        ValueError: si ni `pdl` ni `rsc` n'est fourni (un grain est requis).
+        FileNotFoundError: si la base DuckDB est absente (levée par les loaders).
+    """
+    if pdl is None and rsc is None:
+        raise ValueError("Un grain est requis : fournir `pdl` (point) ou `rsc` (contrat).")
+    ctx = contexte_du_mois_filtre(pdl=pdl, rsc=rsc, horizon=horizon)
+    return _tisser_frise(ctx)

--- a/electricore/core/builds/contexte_mensuel.py
+++ b/electricore/core/builds/contexte_mensuel.py
@@ -29,6 +29,7 @@ import polars as pl
 from pandera.typing.polars import DataFrame
 
 from electricore.core.loaders import chronologie, spine
+from electricore.core.loaders.duckdb import DuckDBQuery
 from electricore.core.models.cadrans import col_energie
 from electricore.core.models.lignes_facture import LignesFacture
 from electricore.core.models.lignes_facture_rapprochees import LignesFactureRapprochees
@@ -192,6 +193,56 @@ def contexte_du_mois(mois: str | None = None, horizon: dt.datetime | None = None
             à l'appel — leur `.lazy()` exécute la lecture immédiatement).
     """
     return charger(spine().lazy(), chronologie().lazy(), mois=mois, horizon=horizon)
+
+
+def _filtrer_point_ou_contrat(query: DuckDBQuery, pdl: str | None, rsc: str | None) -> DuckDBQuery:
+    """Pousse un filtre `pdl` et/ou `rsc` dans un loader de mart (`spine`/`chronologie`).
+
+    Le prédicat **descend dans DuckDB** : `spine()` et `chronologie()` sont des marts
+    `SELECT *` (`base_sql`), donc `.filter({...})` ajoute une clause `WHERE` paramétrée
+    exécutée côté base — pas un scan parc puis filtre Polars en aval (ADR-0039,
+    « Filtrabilité en amont »). Filtre **symétrique** : la même fonction s'applique aux
+    deux entrées (spine + chronologie), qui partagent les colonnes `pdl` /
+    `ref_situation_contractuelle`. Les deux grains sont indépendants et cumulables.
+    """
+    if pdl is not None:
+        query = query.filter({"pdl": pdl})
+    if rsc is not None:
+        query = query.filter({"ref_situation_contractuelle": rsc})
+    return query
+
+
+def contexte_du_mois_filtre(
+    pdl: str | None = None,
+    rsc: str | None = None,
+    mois: str | None = None,
+    horizon: dt.datetime | None = None,
+) -> ContexteMensuel:
+    """Reconstruit le *Contexte mensuel* d'un **seul point (PDL) ou contrat (RSC)** (#366).
+
+    Variante de `contexte_du_mois()` qui **pousse le filtre `pdl`/`rsc` au boundary de
+    chargement** : il descend dans DuckDB via `spine().filter(...)` /
+    `chronologie().filter(...)` (clause `WHERE` paramétrée), sans charger le parc entier.
+    La composition reste celle de `charger()` — le pipeline de chronologie ne change pas :
+    il est **partition-local** (`group_by`/`over` par RSC et PDL) et l'horizon est un
+    **paramètre** (#179, pas un `max()` parc), donc filtrer l'entrée à X donne un résultat
+    **identique** au run plein restreint à X (test de parité, ADR-0039).
+
+    Au moins l'un de `pdl` / `rsc` est attendu (les deux sont cumulables) ; sans filtre,
+    cette fonction reconstruit le parc entier comme `contexte_du_mois()`.
+
+    Args:
+        pdl: point de livraison à reconstruire (toute son histoire, RSC successives comprises).
+        rsc: référence de situation contractuelle (une seule tenure entrée→sortie).
+        mois: format `YYYY-MM-DD`. `None` → dernier mois disponible *du périmètre filtré*.
+        horizon: borne de facturation (issue #179) ; `None` → 1er du mois courant.
+
+    Raises:
+        FileNotFoundError: si la base DuckDB est absente (levée par les loaders).
+    """
+    spine_q = _filtrer_point_ou_contrat(spine(), pdl, rsc)
+    chronologie_q = _filtrer_point_ou_contrat(chronologie(), pdl, rsc)
+    return charger(spine_q.lazy(), chronologie_q.lazy(), mois=mois, horizon=horizon)
 
 
 @pa.check_types(lazy=True)

--- a/tests/architecture/test_meta_periodes_erp_agnostique.py
+++ b/tests/architecture/test_meta_periodes_erp_agnostique.py
@@ -1,9 +1,10 @@
-"""Garde-fou : l'endpoint méta-périodes est ERP-agnostique (ADR-0027, ADR-0016).
+"""Garde-fou : les endpoints « Odoo tire » sont ERP-agnostiques (ADR-0027, ADR-0016).
 
 Contrairement aux autres endpoints `/facturation/*` (qui lisent Odoo via `@with_odoo`),
-le router et le service des méta-périodes exposent un modèle **electricore-natif** et
-n'importent **rien** de `electricore.integrations`. Analyse statique via `ast` (couvre
-aussi les imports `TYPE_CHECKING`).
+le router et le service des **méta-périodes** et de la **chronologie facturiste** (#367)
+exposent un modèle **electricore-natif** et n'importent **rien** de
+`electricore.integrations`. Analyse statique via `ast` (couvre aussi les imports
+`TYPE_CHECKING`).
 """
 
 import ast
@@ -16,6 +17,8 @@ API_ROOT = Path(__file__).resolve().parents[2] / "electricore" / "api"
 MODULES = [
     API_ROOT / "routers" / "meta_periodes.py",
     API_ROOT / "services" / "meta_periodes_service.py",
+    API_ROOT / "routers" / "chronologie.py",
+    API_ROOT / "services" / "chronologie_service.py",
 ]
 
 
@@ -32,7 +35,7 @@ def _absolute_imports(path: Path) -> set[str]:
 
 
 @pytest.mark.parametrize("module", MODULES, ids=lambda p: p.name)
-def test_meta_periodes_n_importe_pas_integrations(module: Path) -> None:
+def test_endpoint_odoo_tire_n_importe_pas_integrations(module: Path) -> None:
     """ADR-0027 : ni le router ni le service n'importent `electricore.integrations`."""
     forbidden = sorted(
         m
@@ -40,6 +43,6 @@ def test_meta_periodes_n_importe_pas_integrations(module: Path) -> None:
         if m == "electricore.integrations" or m.startswith("electricore.integrations.")
     )
     assert not forbidden, (
-        f"{module.name} importe {forbidden} — l'endpoint méta-périodes doit rester "
+        f"{module.name} importe {forbidden} — un endpoint « Odoo tire » doit rester "
         "ERP-agnostique (ADR-0027 / ADR-0016)."
     )

--- a/tests/integration/test_chronologie_endpoint.py
+++ b/tests/integration/test_chronologie_endpoint.py
@@ -1,0 +1,297 @@
+"""Tests d'intégration de `GET /facturation/chronologie` (vue facturiste, #367).
+
+Endpoint de lecture (ADR-0027/0012) : frise complète d'un point/contrat + verdicts, **sans
+montant tarifaire**. Le seam de test est la fonction `chronologie_point_ou_contrat` référencée
+par le router (même patron que `tests/integration/test_meta_periodes_endpoint.py`) — on
+court-circuite la reconstruction DuckDB, le chemin transport + enveloppe reste réel.
+
+Couvre aussi (acceptance #367) un **point à plusieurs RSC** (changement de main) et un **point
+récemment activé** (MDPRM → verdict communication correct, post-#365) en faisant tisser le vrai
+service depuis un `ContexteMensuel` synthétique.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+from fastapi.testclient import TestClient
+
+from electricore.api.main import app
+from electricore.api.security import get_current_api_key
+from electricore.core.builds.contexte_mensuel import ContexteMensuel
+
+PARIS = ZoneInfo("Europe/Paris")
+
+
+@pytest.fixture
+def frise_synthetique() -> pl.DataFrame:
+    """Mime la sortie de `chronologie_point_ou_contrat` : frise hétérogène ordonnée."""
+    return pl.DataFrame(
+        [
+            {
+                "type_ligne": "evenement",
+                "date": datetime(2024, 1, 5, tzinfo=PARIS),
+                "pdl": "PDL_X",
+                "ref_situation_contractuelle": "REF_1",
+                "evenement_declencheur": "MES",
+                "impacte_abonnement": True,
+            },
+            {
+                "type_ligne": "periode_energie",
+                "date": datetime(2024, 1, 5, tzinfo=PARIS),
+                "pdl": "PDL_X",
+                "ref_situation_contractuelle": "REF_1",
+                "qualite": "réelle",
+                "statut_communication": "communicante",
+                "energie_base_kwh": 50.0,
+            },
+        ],
+        infer_schema_length=None,
+    )
+
+
+def test_chronologie_retourne_enveloppe_json(monkeypatch, frise_synthetique):
+    """Tracer bullet : GET par PDL sert la frise en JSON enveloppé, grain `point`."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.routers.chronologie.chronologie_point_ou_contrat",
+        lambda pdl=None, rsc=None: frise_synthetique,
+    )
+    try:
+        response = TestClient(app).get("/facturation/chronologie", params={"pdl": "PDL_X"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["grain"] == "point"
+    assert body["filters"] == {"pdl": "PDL_X"}
+    assert body["pagination"]["total"] == 2
+    types = {r["type_ligne"] for r in body["data"]}
+    assert types == {"evenement", "periode_energie"}
+
+
+def test_chronologie_par_rsc_grain_contrat(monkeypatch, frise_synthetique):
+    """Le grain contrat (`rsc`) est servi avec `grain=contrat`."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    appels: list[tuple] = []
+
+    def _capture(pdl=None, rsc=None):
+        appels.append((pdl, rsc))
+        return frise_synthetique
+
+    monkeypatch.setattr("electricore.api.routers.chronologie.chronologie_point_ou_contrat", _capture)
+    try:
+        response = TestClient(app).get("/facturation/chronologie", params={"rsc": "REF_1"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert appels == [(None, "REF_1")]
+    assert response.json()["grain"] == "contrat"
+
+
+def test_chronologie_pas_de_montant_tarifaire(monkeypatch, frise_synthetique):
+    """Différenciateur vs /meta-periodes : aucun montant tarifaire dans le payload."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.routers.chronologie.chronologie_point_ou_contrat",
+        lambda pdl=None, rsc=None: frise_synthetique,
+    )
+    try:
+        response = TestClient(app).get("/facturation/chronologie", params={"pdl": "PDL_X"})
+    finally:
+        app.dependency_overrides.clear()
+
+    payload = response.text
+    assert "turpe" not in payload
+    assert "cta_eur" not in payload
+    assert "accise" not in payload
+
+
+def test_chronologie_refuse_sans_api_key():
+    """Endpoint sécurisé : 401 sans clé."""
+    response = TestClient(app).get("/facturation/chronologie", params={"pdl": "PDL_X"})
+    assert response.status_code == 401
+
+
+def test_chronologie_exige_un_grain(monkeypatch):
+    """Sans `pdl` ni `rsc` → 422 (un grain est requis)."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    try:
+        response = TestClient(app).get("/facturation/chronologie")
+    finally:
+        app.dependency_overrides.clear()
+    assert response.status_code == 422
+
+
+def test_chronologie_pagine(monkeypatch, frise_synthetique):
+    """`limit`/`offset` tranchent ; `total` reste le total non paginé."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.routers.chronologie.chronologie_point_ou_contrat",
+        lambda pdl=None, rsc=None: frise_synthetique,
+    )
+    try:
+        response = TestClient(app).get("/facturation/chronologie", params={"pdl": "PDL_X", "limit": 1, "offset": 1})
+    finally:
+        app.dependency_overrides.clear()
+    body = response.json()
+    assert body["pagination"] == {"limit": 1, "offset": 1, "returned": 1, "total": 2}
+    assert len(body["data"]) == 1
+
+
+# =============================================================================
+# Acceptance #367 : tissage réel depuis un ContexteMensuel synthétique
+# =============================================================================
+
+
+def _ctx_multi_rsc() -> ContexteMensuel:
+    """Point PDL_X passé de REF_1 (RES) à REF_2 (CFNE) — changement de main."""
+    historique = pl.DataFrame(
+        [
+            {
+                "date_evenement": datetime(2024, 1, 5, tzinfo=PARIS),
+                "pdl": "PDL_X",
+                "ref_situation_contractuelle": "REF_1",
+                "source": "flux_C15",
+                "type_fait": "evenement",
+                "evenement_declencheur": "MES",
+                "niveau_ouverture_services": "2",
+                "impacte_abonnement": True,
+            },
+            {
+                "date_evenement": datetime(2024, 6, 1, tzinfo=PARIS),
+                "pdl": "PDL_X",
+                "ref_situation_contractuelle": "REF_1",
+                "source": "flux_C15",
+                "type_fait": "evenement",
+                "evenement_declencheur": "RES",
+                "niveau_ouverture_services": "2",
+                "impacte_abonnement": True,
+            },
+            {
+                "date_evenement": datetime(2024, 6, 2, tzinfo=PARIS),
+                "pdl": "PDL_X",
+                "ref_situation_contractuelle": "REF_2",
+                "source": "flux_C15",
+                "type_fait": "evenement",
+                "evenement_declencheur": "CFNE",
+                "niveau_ouverture_services": "2",
+                "impacte_abonnement": True,
+            },
+        ],
+        schema_overrides={"date_evenement": pl.Datetime("us", "Europe/Paris")},
+    )
+    return ContexteMensuel(
+        mois="2024-06-01",
+        historique_enrichi=historique.lazy(),
+        abonnements=pl.LazyFrame({}),
+        energie=pl.LazyFrame({}),
+        releves_utilises=pl.LazyFrame({}),
+        facturation_mensuelle=pl.DataFrame({}),
+    )
+
+
+def _ctx_recemment_active() -> ContexteMensuel:
+    """PDL_Y récemment activé : MES (niveau 2) puis MDPRM hors-comptage (toujours niveau 2),
+    une période d'énergie réelle ET communicante. Post-#365 : le verdict communication ne doit
+    PAS retomber à `non_communicante` faute de niveau forward-fillé depuis un relevé indexé.
+    """
+    historique = pl.DataFrame(
+        [
+            {
+                "date_evenement": datetime(2024, 3, 11, tzinfo=PARIS),
+                "pdl": "PDL_Y",
+                "ref_situation_contractuelle": "REF_Y",
+                "source": "flux_C15",
+                "type_fait": "evenement",
+                "evenement_declencheur": "MES",
+                "niveau_ouverture_services": "2",
+                "impacte_abonnement": True,
+            },
+            {
+                "date_evenement": datetime(2024, 3, 16, tzinfo=PARIS),
+                "pdl": "PDL_Y",
+                "ref_situation_contractuelle": "REF_Y",
+                "source": "flux_C15",
+                "type_fait": "evenement",
+                "evenement_declencheur": "MDPRM",  # hors-comptage
+                "niveau_ouverture_services": "2",
+                "impacte_abonnement": False,
+            },
+        ],
+        schema_overrides={"date_evenement": pl.Datetime("us", "Europe/Paris")},
+    )
+    energie = pl.DataFrame(
+        [
+            {
+                "pdl": "PDL_Y",
+                "ref_situation_contractuelle": "REF_Y",
+                "debut": datetime(2024, 4, 1, tzinfo=PARIS),
+                "fin": datetime(2024, 5, 1, tzinfo=PARIS),
+                "nb_jours": 30,
+                "qualite": "réelle",
+                "statut_communication": "communicante",
+                "energie_base_kwh": 120.0,
+            }
+        ],
+        schema_overrides={
+            "debut": pl.Datetime("us", "Europe/Paris"),
+            "fin": pl.Datetime("us", "Europe/Paris"),
+        },
+    )
+    return ContexteMensuel(
+        mois="2024-04-01",
+        historique_enrichi=historique.lazy(),
+        abonnements=pl.LazyFrame({}),
+        energie=energie.lazy(),
+        releves_utilises=pl.LazyFrame({}),
+        facturation_mensuelle=pl.DataFrame({}),
+    )
+
+
+def test_chronologie_point_plusieurs_rsc_via_service(monkeypatch):
+    """Acceptance : un point à plusieurs RSC trace ses deux situations (changement de main)."""
+    import electricore.api.services.chronologie_service as svc
+
+    monkeypatch.setattr(svc, "contexte_du_mois_filtre", lambda pdl=None, rsc=None, horizon=None: _ctx_multi_rsc())
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    try:
+        response = TestClient(app).get("/facturation/chronologie", params={"pdl": "PDL_X"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    rsc = {r["ref_situation_contractuelle"] for r in data if r["type_ligne"] == "evenement"}
+    assert rsc == {"REF_1", "REF_2"}
+    # Les charnières (RES sortie / CFNE entrée) sont visibles comme faits.
+    evts = {r["evenement_declencheur"] for r in data if r["type_ligne"] == "evenement"}
+    assert {"RES", "CFNE"} <= evts
+
+
+def test_chronologie_point_recemment_active_communication_correcte(monkeypatch):
+    """Acceptance post-#365 : MDPRM présent comme fait, et la période réelle reste
+    `communicante` (le verdict n'est pas faussé par un niveau périmé)."""
+    import electricore.api.services.chronologie_service as svc
+
+    monkeypatch.setattr(
+        svc, "contexte_du_mois_filtre", lambda pdl=None, rsc=None, horizon=None: _ctx_recemment_active()
+    )
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    try:
+        response = TestClient(app).get("/facturation/chronologie", params={"pdl": "PDL_Y"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    # MDPRM (hors-comptage) figure dans la frise.
+    evts = {r["evenement_declencheur"] for r in data if r["type_ligne"] == "evenement"}
+    assert "MDPRM" in evts
+    # La période d'énergie porte le verdict communication CORRECT (communicante).
+    periode = next(r for r in data if r["type_ligne"] == "periode_energie")
+    assert periode["statut_communication"] == "communicante"
+    assert periode["qualite"] == "réelle"

--- a/tests/unit/test_chronologie_service.py
+++ b/tests/unit/test_chronologie_service.py
@@ -1,0 +1,223 @@
+"""Tests du service de la vue facturiste (chronologie + verdicts, #367).
+
+`_tisser_frise` est le **cœur pur** du service : il tisse, à partir d'un `ContexteMensuel`
+(reconstruit filtré par #366), la frise complète d'un point/contrat — **faits** (événements
+C15 *y compris hors-comptage* + relevés, avec origine/nature) **+ verdicts dérivés** des
+périodes (qualité/communication/énergie). On le teste sur un contexte synthétique pour
+isoler la valeur ajoutée (tissage + projection), sans I/O DuckDB.
+
+Garde-fous d'ADR-0027/0012 portés ici :
+- **Pas de montants tarifaires** (turpe/cta/accise) dans la frise — différenciateur vs
+  `/meta-periodes` ;
+- un point à plusieurs RSC (changement de main) doit tracer ses charnières ;
+- un point récemment activé (MDPRM) doit voir son verdict communication correct (post-#365 :
+  le niveau n'est plus forward-fillé depuis les seuls relevés indexés).
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import polars as pl
+
+from electricore.api.services.chronologie_service import _tisser_frise
+from electricore.core.builds.contexte_mensuel import ContexteMensuel
+
+PARIS = ZoneInfo("Europe/Paris")
+
+
+def _ctx(*, historique: pl.DataFrame, energie: pl.DataFrame, releves: pl.DataFrame) -> ContexteMensuel:
+    """Emballe les trois frames dérivés dans un `ContexteMensuel` (les autres vides)."""
+    return ContexteMensuel(
+        mois="2024-03-01",
+        historique_enrichi=historique.lazy(),
+        abonnements=pl.LazyFrame({}),
+        energie=energie.lazy(),
+        releves_utilises=releves.lazy(),
+        facturation_mensuelle=pl.DataFrame({}),
+    )
+
+
+def _historique(lignes: list[dict]) -> pl.DataFrame:
+    return pl.DataFrame(
+        lignes,
+        schema_overrides={"date_evenement": pl.Datetime(time_unit="us", time_zone="Europe/Paris")},
+    )
+
+
+def _energie(lignes: list[dict]) -> pl.DataFrame:
+    return pl.DataFrame(
+        lignes,
+        schema_overrides={
+            "debut": pl.Datetime(time_unit="us", time_zone="Europe/Paris"),
+            "fin": pl.Datetime(time_unit="us", time_zone="Europe/Paris"),
+        },
+    )
+
+
+def _releves(lignes: list[dict]) -> pl.DataFrame:
+    return pl.DataFrame(
+        lignes,
+        schema_overrides={"date_releve": pl.Datetime(time_unit="us", time_zone="Europe/Paris")},
+    )
+
+
+# Faits minimaux d'un PDL : entrée MES, MDPRM hors-comptage, FACTURATION.
+EVT_MES = {
+    "date_evenement": datetime(2024, 1, 5, 0, 1, tzinfo=PARIS),
+    "pdl": "PDL_X",
+    "ref_situation_contractuelle": "REF_1",
+    "source": "flux_C15",
+    "type_fait": "evenement",
+    "evenement_declencheur": "MES",
+    "puissance_souscrite_kva": 6.0,
+    "formule_tarifaire_acheminement": "BTINFCU4",
+    "niveau_ouverture_services": "2",
+    "impacte_abonnement": True,
+    "resume_modification": "",
+}
+EVT_MDPRM = {
+    "date_evenement": datetime(2024, 1, 16, 0, 1, tzinfo=PARIS),
+    "pdl": "PDL_X",
+    "ref_situation_contractuelle": "REF_1",
+    "source": "flux_C15",
+    "type_fait": "evenement",
+    "evenement_declencheur": "MDPRM",  # hors-comptage (bascule niveau)
+    "puissance_souscrite_kva": 6.0,
+    "formule_tarifaire_acheminement": "BTINFCU4",
+    "niveau_ouverture_services": "2",
+    "impacte_abonnement": False,
+    "resume_modification": "",
+}
+EVT_FACT = {
+    "date_evenement": datetime(2024, 2, 1, 0, 0, tzinfo=PARIS),
+    "pdl": "PDL_X",
+    "ref_situation_contractuelle": "REF_1",
+    "source": "synthese_mensuelle",
+    "type_fait": "facturation",
+    "evenement_declencheur": "FACTURATION",
+    "puissance_souscrite_kva": 6.0,
+    "formule_tarifaire_acheminement": "BTINFCU4",
+    "niveau_ouverture_services": "2",
+    "impacte_abonnement": True,
+    "resume_modification": "",
+}
+
+PERIODE_ENERGIE = {
+    "pdl": "PDL_X",
+    "ref_situation_contractuelle": "REF_1",
+    "debut": datetime(2024, 1, 5, tzinfo=PARIS),
+    "fin": datetime(2024, 2, 1, tzinfo=PARIS),
+    "nb_jours": 27,
+    "qualite": "réelle",
+    "statut_communication": "communicante",
+    "energie_base_kwh": 50.0,
+    "energie_hp_kwh": None,
+    "energie_hc_kwh": None,
+    "turpe_variable_eur": 9.99,  # montant tarifaire : DOIT être écarté de la frise
+}
+
+RELEVE = {
+    "ref_situation_contractuelle": "REF_1",
+    "date_releve": datetime(2024, 1, 5, tzinfo=PARIS),
+    "ordre_index": False,
+    "releve_id": "abcd1234",
+    "nature_index": "réel",
+    "source": "flux_R151",
+    "evenement_declencheur": None,
+    "index_base_kwh": 100,
+}
+
+
+class TestTissageFaitsEtVerdicts:
+    def test_frise_contient_evenements_releves_et_periodes(self):
+        frise = _tisser_frise(
+            _ctx(
+                historique=_historique([EVT_MES, EVT_FACT]),
+                energie=_energie([PERIODE_ENERGIE]),
+                releves=_releves([RELEVE]),
+            )
+        )
+        types = set(frise["type_ligne"].to_list())
+        # Trois familles de lignes tissées : événement, relevé, période d'énergie.
+        assert types == {"evenement", "releve", "periode_energie"}
+
+    def test_periode_porte_les_verdicts_sans_montant_tarifaire(self):
+        frise = _tisser_frise(
+            _ctx(
+                historique=_historique([EVT_MES, EVT_FACT]),
+                energie=_energie([PERIODE_ENERGIE]),
+                releves=_releves([RELEVE]),
+            )
+        )
+        periode = frise.filter(pl.col("type_ligne") == "periode_energie").row(0, named=True)
+        # Verdicts présents.
+        assert periode["qualite"] == "réelle"
+        assert periode["statut_communication"] == "communicante"
+        # Énergie physique présente (kWh, pas un montant).
+        assert periode["energie_base_kwh"] == 50.0
+        # AUCUN montant tarifaire dans la frise (différenciateur vs /meta-periodes).
+        assert "turpe_variable_eur" not in frise.columns
+        assert "turpe_fixe_eur" not in frise.columns
+        assert "cta_eur" not in frise.columns
+
+    def test_evenement_hors_comptage_mdprm_est_present(self):
+        """Un MDPRM (hors-comptage, sans index) figure dans la frise comme fait."""
+        frise = _tisser_frise(
+            _ctx(
+                historique=_historique([EVT_MES, EVT_MDPRM, EVT_FACT]),
+                energie=_energie([PERIODE_ENERGIE]),
+                releves=_releves([RELEVE]),
+            )
+        )
+        evenements = frise.filter(pl.col("type_ligne") == "evenement")["evenement_declencheur"].to_list()
+        assert "MDPRM" in evenements
+
+    def test_releve_porte_son_origine_et_sa_nature(self):
+        frise = _tisser_frise(
+            _ctx(
+                historique=_historique([EVT_MES, EVT_FACT]),
+                energie=_energie([PERIODE_ENERGIE]),
+                releves=_releves([RELEVE]),
+            )
+        )
+        releve = frise.filter(pl.col("type_ligne") == "releve").row(0, named=True)
+        assert releve["nature_index"] == "réel"
+        assert releve["origine_releve"] == "périodique"  # source R151 → télérelevé
+
+    def test_frise_triee_chronologiquement(self):
+        frise = _tisser_frise(
+            _ctx(
+                historique=_historique([EVT_MES, EVT_MDPRM, EVT_FACT]),
+                energie=_energie([PERIODE_ENERGIE]),
+                releves=_releves([RELEVE]),
+            )
+        )
+        dates = frise["date"].to_list()
+        assert dates == sorted(dates)
+
+
+class TestPlusieursRSC:
+    """Grain point : un PDL qui change de main (REF_1 → REF_2) trace ses charnières."""
+
+    def test_les_deux_rsc_apparaissent(self):
+        evt_res = {
+            **EVT_MES,
+            "evenement_declencheur": "RES",
+            "ref_situation_contractuelle": "REF_1",
+            "date_evenement": datetime(2024, 6, 1, tzinfo=PARIS),
+        }
+        evt_cfne = {
+            **EVT_MES,
+            "evenement_declencheur": "CFNE",
+            "ref_situation_contractuelle": "REF_2",
+            "date_evenement": datetime(2024, 6, 2, tzinfo=PARIS),
+        }
+        frise = _tisser_frise(
+            _ctx(
+                historique=_historique([EVT_MES, evt_res, evt_cfne]),
+                energie=_energie([PERIODE_ENERGIE]),
+                releves=_releves([RELEVE]),
+            )
+        )
+        rsc = set(frise.filter(pl.col("type_ligne") == "evenement")["ref_situation_contractuelle"].to_list())
+        assert rsc == {"REF_1", "REF_2"}

--- a/tests/unit/test_contexte_filtre_parite.py
+++ b/tests/unit/test_contexte_filtre_parite.py
@@ -1,0 +1,302 @@
+"""Parité du *Contexte mensuel* filtré par PDL/RSC (#366, ADR-0041/ADR-0039).
+
+`contexte_du_mois_filtre()` reconstruit la chronologie d'un seul point/contrat **sans
+tourner le pipeline sur tout le parc** : le filtre `pdl`/`rsc` est poussé au boundary de
+chargement (clause `WHERE` paramétrée descendue dans DuckDB). Comme le pipeline de
+chronologie est **partition-local** (`group_by`/`over` par RSC et PDL) et que l'horizon
+est un **paramètre** (#179, jamais un `max()` parc), filtrer l'entrée à X donne un
+résultat **identique** au run plein restreint à X.
+
+Deux familles de tests :
+
+1. **Parité de composition** (`charger`) : on prouve sur des frames synthétiques
+   (substrat *spine* + *Chronologie des relevés*) que `charger(plein ∩ X)` ≡
+   `charger(plein) ∩ X` sur énergie + abonnement + méta-période. La fixture porte un
+   **deuxième PDL/RSC volumineux** dont les dates débordent le périmètre filtré : un
+   horizon dérivé d'un `max()` parc déplacerait la borne du run plein et **casserait** la
+   parité — c'est la garde explicite de l'invariant « horizon = paramètre ».
+
+2. **Poussée du prédicat** (`contexte_du_mois_filtre`) : on espionne les loaders pour
+   vérifier que `pdl`/`rsc` atteignent `spine().filter(...)` / `chronologie().filter(...)`
+   (symétrique sur les deux entrées, deux grains), donc que la base ne sert que le
+   périmètre demandé (pas de scan parc).
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import polars as pl
+
+from electricore.core.builds.contexte_mensuel import (
+    _filtrer_point_ou_contrat,
+    charger,
+)
+from electricore.core.models.cadrans import CADRANS, col_index
+
+PARIS = ZoneInfo("Europe/Paris")
+
+# Horizon FIXE : un paramètre, pas une lecture d'horloge ni un max() parc.
+HORIZON = datetime(2024, 4, 1, tzinfo=PARIS)
+
+
+def _ligne_spine(
+    *, date: datetime, pdl: str, rsc: str, source: str, type_fait: str, evt: str, puissance: float
+) -> dict:
+    """Une ligne du substrat *spine* (forme du mart `spine_contrat`)."""
+    return {
+        "date_evenement": date,
+        "pdl": pdl,
+        "ref_situation_contractuelle": rsc,
+        "source": source,
+        "type_fait": type_fait,
+        "evenement_declencheur": evt,
+        "type_evenement": "contractuel" if source == "flux_C15" else "artificiel",
+        "segment_clientele": "C5",
+        "etat_contractuel": "EN SERVICE",
+        "puissance_souscrite_kva": puissance,
+        "formule_tarifaire_acheminement": "BTINFCU4",
+        "type_compteur": "LINKY",
+        "num_compteur": "123456",
+        "categorie": None,
+        "ref_demandeur": None,
+        "id_affaire": None,
+        "niveau_ouverture_services": "2",
+        "date_changement_niveau_ouverture_services": None,
+    }
+
+
+def _spine_parc() -> pl.LazyFrame:
+    """Spine de DEUX points : PDL_A (1 RSC, petit) et PDL_B (1 RSC, dates débordantes).
+
+    PDL_B porte des FACTURATION jusqu'en mars 2025 — bien au-delà de l'horizon avril 2024.
+    Si l'horizon était dérivé d'un `max(date_evenement)` parc, le run plein bornerait PDL_A
+    à mars 2025 et la parité avec le run filtré (borné par le même horizon) tomberait.
+    """
+    lignes = [
+        # PDL_A / REF_A : entrée janvier + grille FACTURATION fév/mars 2024.
+        _ligne_spine(
+            date=datetime(2024, 1, 5, 0, 1, tzinfo=PARIS),
+            pdl="PDL_A",
+            rsc="REF_A",
+            source="flux_C15",
+            type_fait="evenement",
+            evt="MES",
+            puissance=6.0,
+        ),
+        _ligne_spine(
+            date=datetime(2024, 2, 1, 0, 0, tzinfo=PARIS),
+            pdl="PDL_A",
+            rsc="REF_A",
+            source="synthese_mensuelle",
+            type_fait="facturation",
+            evt="FACTURATION",
+            puissance=6.0,
+        ),
+        _ligne_spine(
+            date=datetime(2024, 3, 1, 0, 0, tzinfo=PARIS),
+            pdl="PDL_A",
+            rsc="REF_A",
+            source="synthese_mensuelle",
+            type_fait="facturation",
+            evt="FACTURATION",
+            puissance=6.0,
+        ),
+        # PDL_B / REF_B : un parc « volumineux » qui déborde l'horizon (jusqu'en 2025).
+        _ligne_spine(
+            date=datetime(2024, 1, 10, 0, 1, tzinfo=PARIS),
+            pdl="PDL_B",
+            rsc="REF_B",
+            source="flux_C15",
+            type_fait="evenement",
+            evt="MES",
+            puissance=9.0,
+        ),
+        _ligne_spine(
+            date=datetime(2024, 2, 1, 0, 0, tzinfo=PARIS),
+            pdl="PDL_B",
+            rsc="REF_B",
+            source="synthese_mensuelle",
+            type_fait="facturation",
+            evt="FACTURATION",
+            puissance=9.0,
+        ),
+        _ligne_spine(
+            date=datetime(2025, 3, 1, 0, 0, tzinfo=PARIS),
+            pdl="PDL_B",
+            rsc="REF_B",
+            source="synthese_mensuelle",
+            type_fait="facturation",
+            evt="FACTURATION",
+            puissance=9.0,
+        ),
+    ]
+    return pl.LazyFrame(
+        lignes,
+        schema_overrides={
+            "date_evenement": pl.Datetime(time_unit="us", time_zone="Europe/Paris"),
+            "categorie": pl.Utf8,
+            "ref_demandeur": pl.Utf8,
+            "id_affaire": pl.Utf8,
+            "date_changement_niveau_ouverture_services": pl.Date,
+        },
+    )
+
+
+def _ligne_releve(*, date: datetime, pdl: str, rsc: str, ordre: bool, index_base: int) -> dict:
+    """Une ligne de la *Chronologie des relevés* (forme du mart `chronologie_releves`)."""
+    ligne = {
+        "pdl": pdl,
+        "ref_situation_contractuelle": rsc,
+        "formule_tarifaire_acheminement": "BTINFCU4",
+        "niveau_ouverture_services": "2",
+        "date_releve": date,
+        "ordre_index": ordre,
+        "source": "flux_R151",
+        "releve_id": f"{rsc}-{date:%Y%m%d}",
+        "nature_index": "réel",
+        "evenement_declencheur": None,
+        "id_calendrier_distributeur": "DI000001",
+        "releve_manquant": False,
+    }
+    # Les 7 registres de cadran doivent exister (l'énergie shift/diff sur tous) ; seul `base`
+    # porte une valeur, les autres restent null (compteur Base).
+    for cadran in CADRANS:
+        ligne[col_index(cadran)] = index_base if cadran == "base" else None
+    return ligne
+
+
+def _chronologie_parc() -> pl.LazyFrame:
+    """Relevés des deux points. PDL_B déborde l'horizon (relevé en 2025)."""
+    lignes = [
+        # PDL_A : relevés mensuels bornant fév/mars 2024.
+        _ligne_releve(date=datetime(2024, 1, 5, tzinfo=PARIS), pdl="PDL_A", rsc="REF_A", ordre=False, index_base=100),
+        _ligne_releve(date=datetime(2024, 2, 1, tzinfo=PARIS), pdl="PDL_A", rsc="REF_A", ordre=False, index_base=150),
+        _ligne_releve(date=datetime(2024, 3, 1, tzinfo=PARIS), pdl="PDL_A", rsc="REF_A", ordre=False, index_base=210),
+        # PDL_B : déborde jusqu'en 2025.
+        _ligne_releve(date=datetime(2024, 1, 10, tzinfo=PARIS), pdl="PDL_B", rsc="REF_B", ordre=False, index_base=500),
+        _ligne_releve(date=datetime(2024, 2, 1, tzinfo=PARIS), pdl="PDL_B", rsc="REF_B", ordre=False, index_base=560),
+        _ligne_releve(date=datetime(2025, 3, 1, tzinfo=PARIS), pdl="PDL_B", rsc="REF_B", ordre=False, index_base=9000),
+    ]
+    return pl.LazyFrame(
+        lignes,
+        schema_overrides={
+            "date_releve": pl.Datetime(time_unit="us", time_zone="Europe/Paris"),
+            "ordre_index": pl.Boolean,
+            "releve_manquant": pl.Boolean,
+            # All-None mais typé String : le contrat `ChronologieReleves` exige le dtype.
+            "evenement_declencheur": pl.Utf8,
+            # Tous les registres de cadran en Int64 (kWh entiers, ADR-0034).
+            **{col_index(c): pl.Int64 for c in CADRANS},
+        },
+    )
+
+
+def _restreindre(lf: pl.LazyFrame, rsc: str) -> pl.DataFrame:
+    """Run plein restreint à une RSC, trié canoniquement pour comparaison."""
+    cols = lf.collect_schema().names()
+    df = lf.filter(pl.col("ref_situation_contractuelle") == rsc).collect()
+    tri = [c for c in ("ref_situation_contractuelle", "debut", "fin") if c in cols]
+    return df.sort(tri) if tri else df
+
+
+class TestPariteCompositionFiltree:
+    """`charger(plein ∩ X)` ≡ `charger(plein) ∩ X` sur les trois frames dérivés."""
+
+    def test_energie_abonnement_meta_identiques_pour_la_rsc_filtree(self):
+        # Run PLEIN (parc à 2 points) — horizon fixe (paramètre, jamais max() parc).
+        plein = charger(_spine_parc(), _chronologie_parc(), mois="2024-02-01", horizon=HORIZON)
+
+        # Run FILTRÉ : seul REF_A entre dans les frames (filtre au boundary de chargement).
+        filtre = charger(
+            _spine_parc().filter(pl.col("ref_situation_contractuelle") == "REF_A"),
+            _chronologie_parc().filter(pl.col("ref_situation_contractuelle") == "REF_A"),
+            mois="2024-02-01",
+            horizon=HORIZON,
+        )
+
+        # Énergie : le découpage de REF_A doit être identique des deux côtés.
+        ener_plein = _restreindre(plein.energie, "REF_A")
+        ener_filtre = filtre.energie.collect().sort(["ref_situation_contractuelle", "debut", "fin"])
+        assert ener_plein.equals(ener_filtre)
+
+        # Abonnement : idem.
+        abo_plein = _restreindre(plein.abonnements, "REF_A")
+        abo_filtre = filtre.abonnements.collect().sort(["ref_situation_contractuelle", "debut", "fin"])
+        assert abo_plein.equals(abo_filtre)
+
+        # Méta-période : la facturation mensuelle de REF_A est la même.
+        meta_plein = plein.facturation_mensuelle.filter(pl.col("ref_situation_contractuelle") == "REF_A").sort(
+            ["ref_situation_contractuelle", "debut"]
+        )
+        meta_filtre = filtre.facturation_mensuelle.sort(["ref_situation_contractuelle", "debut"])
+        assert meta_plein.equals(meta_filtre)
+
+    def test_parite_par_pdl(self):
+        """Le grain PDL fonctionne aussi (filtre sur `pdl`, pas seulement `rsc`)."""
+        plein = charger(_spine_parc(), _chronologie_parc(), mois="2024-02-01", horizon=HORIZON)
+        filtre = charger(
+            _spine_parc().filter(pl.col("pdl") == "PDL_A"),
+            _chronologie_parc().filter(pl.col("pdl") == "PDL_A"),
+            mois="2024-02-01",
+            horizon=HORIZON,
+        )
+        ener_plein = (
+            plein.energie.collect()
+            .filter(pl.col("pdl") == "PDL_A")
+            .sort(["ref_situation_contractuelle", "debut", "fin"])
+        )
+        ener_filtre = filtre.energie.collect().sort(["ref_situation_contractuelle", "debut", "fin"])
+        assert ener_plein.equals(ener_filtre)
+
+
+class TestPredicatPousseDansDuckDB:
+    """Le filtre `pdl`/`rsc` descend bien au loader (espion `.filter`)."""
+
+    def test_filtre_helper_symetrique_pdl_et_rsc(self):
+        """`_filtrer_point_ou_contrat` empile une clause par grain, sur la colonne câblée."""
+
+        class _SpyQuery:
+            def __init__(self):
+                self.filters: list[dict] = []
+
+            def filter(self, f):
+                self.filters.append(f)
+                return self
+
+        q = _filtrer_point_ou_contrat(_SpyQuery(), pdl="PDL_A", rsc="REF_A")
+        assert q.filters == [{"pdl": "PDL_A"}, {"ref_situation_contractuelle": "REF_A"}]
+
+    def test_contexte_filtre_pousse_le_predicat_sur_les_deux_entrees(self, monkeypatch):
+        """`contexte_du_mois_filtre` pousse pdl+rsc dans spine() ET chronologie() — pas de scan
+        parc puis filtre aval (les frames servies ne portent que le périmètre demandé)."""
+        import electricore.core.builds.contexte_mensuel as cm
+
+        spy: dict[str, list] = {"spine": [], "chronologie": []}
+
+        class _SpyQuery:
+            def __init__(self, nom, lf):
+                self._nom = nom
+                self._lf = lf
+
+            def filter(self, f):
+                spy[self._nom].append(f)
+                # Applique vraiment le filtre → la frame servie est restreinte (pas un scan parc).
+                col, val = next(iter(f.items()))
+                self._lf = self._lf.filter(pl.col(col) == val)
+                return self
+
+            def lazy(self):
+                return self._lf
+
+        monkeypatch.setattr(cm, "spine", lambda: _SpyQuery("spine", _spine_parc()))
+        monkeypatch.setattr(cm, "chronologie", lambda: _SpyQuery("chronologie", _chronologie_parc()))
+
+        ctx = cm.contexte_du_mois_filtre(pdl="PDL_A", rsc="REF_A", mois="2024-02-01", horizon=HORIZON)
+
+        # Le prédicat a atteint LES DEUX loaders (symétrie), pour LES DEUX grains.
+        assert spy["spine"] == [{"pdl": "PDL_A"}, {"ref_situation_contractuelle": "REF_A"}]
+        assert spy["chronologie"] == [{"pdl": "PDL_A"}, {"ref_situation_contractuelle": "REF_A"}]
+
+        # Et le contexte produit ne contient que le périmètre filtré.
+        rsc_servies = set(ctx.energie.collect()["ref_situation_contractuelle"].to_list())
+        assert rsc_servies == {"REF_A"}


### PR DESCRIPTION
Closes #366
Closes #367

Vue facturiste de la chronologie d'un point/contrat, en deux temps.

**#366** expose un filtre PDL/RSC au boundary de chargement : `contexte_du_mois_filtre`
pousse le prédicat dans DuckDB (spine()/chronologie() filter, clause WHERE
paramétrée) — pas de scan parc. Le pipeline de chronologie est inchangé
(partition-local + horizon paramétrique #179), garanti par un test de parité
« run filtré sur X ≡ run plein ∩ X » qui garde explicitement l'invariant horizon.

**#367** ajoute `GET /facturation/chronologie?pdl|rsc` (read-only, X-API-Key, JSON
enveloppé) : la frise complète d'un point/contrat tissant les faits (événements C15
y compris hors-comptage + relevés) avec les verdicts dérivés (qualité/communication/
énergie). Sans montant tarifaire — différenciateur explicite vs /meta-periodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)