### PR TITLE
fix(release): moteur publiable avec electricore-client + bump 3.4.0rc4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Smoke-test image
         run: |
           docker run --rm "${{ steps.docker_tags.outputs.smoke_tag }}" \
-            python -c "import electricore; import electricore.ingestion.runner; import dbt.cli.main; print('image OK')"
+            python -c "import electricore; import electricore.ingestion.runner; import electricore.api.main; import dbt.cli.main; print('image OK')"
 
       # Build n°2 : réhydrate le cache GHA du build n°1 (cache-from) → quasi
       # rien à reconstruire, l'essentiel du temps est l'export + le push.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.4.0rc4] - 2026-06-23
+
+Extraction du **client léger `electricore-client`** (paquet distribué séparément) et bascule
+des endpoints facturiste en **flux JSONL typé**, pour que `souscriptions_odoo` consomme l'API
+sans tirer polars/duckdb/fastapi.
+
+### ✨ Temps forts
+
+- **Paquet `electricore-client`** (httpx + pydantic seuls, `[arrow]` en extra) : modèles de
+  contrat single-source, méthodes client, garde de version par en-tête (ADR-0043, #406–#411).
+- **Endpoints facturiste en JSONL streaming** (`/facturation/chronologie`, `/facturation/meta-periodes`) :
+  métadonnées en en-têtes HTTP, plus d'enveloppe ni de pagination ; `turpe_variable` en RPC POST typé.
+- **Contrat single-source** : les routers importent les modèles depuis `electricore-client`
+  (le moteur en dépend via le workspace uv).
+- Client Arrow historique migré derrière l'extra `[arrow]` (polars en import paresseux,
+  garde de pureté en CI).
+
+### 🛠️ Release
+
+- Image Docker : `electricore-client` installé en **wheel** dans le venv (le runtime n'embarque
+  pas le source `packages/`).
+- Smoke-test de release élargi à `import electricore.api.main` (exerce réellement `electricore_client`).
+- Publication PyPI du client par tag `client-v*` (Trusted Publishing / OIDC), versionné indépendamment.
+
 ## [3.4.0rc3] - 2026-06-21
 
 La *Chronologie du contrat* devient interrogeable **par point ou par contrat**, et expose

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -23,8 +23,11 @@ ENV UV_LINK_MODE=copy \
 
 WORKDIR /app
 
-# Couche cache deps : on copie d'abord les manifestes pour profiter du cache Docker
+# Couche cache deps : manifestes + source du client. `electricore-client` est un membre
+# du workspace uv dont le moteur dépend ; uv en a besoin pour résoudre le lock gelé, même
+# avec --no-install-project. (Source minuscule : l'impact sur le cache de couche est négligeable.)
 COPY pyproject.toml uv.lock README.md ./
+COPY packages/ ./packages/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --extra ingestion --extra dbt --no-dev
 
@@ -32,6 +35,14 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY electricore/ ./electricore/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --extra ingestion --extra dbt --no-dev
+
+# `uv sync` a installé `electricore-client` en ÉDITABLE (membre du workspace, pointant vers
+# /app/packages/…). On le remplace par un vrai WHEEL installé dans le venv : ainsi l'image
+# runtime n'embarque PAS le source `packages/` (seul le moteur reste servi depuis son source).
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv build packages/electricore-client --wheel --out-dir /tmp/wheels \
+ && uv pip install --python /app/.venv/bin/python --no-deps --reinstall \
+        /tmp/wheels/electricore_client-*.whl
 
 # =============================================================================
 # Stage 2 — runtime : image légère sans outils de build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.4.0rc3"
+version = "3.4.0rc4"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}
@@ -48,7 +48,7 @@ dependencies = [
     # Client léger distribué séparément (workspace local) : le moteur en dépend
     # comme source unique des modèles de contrat, même s'il n'en importe les
     # modèles qu'aux slices d'endpoint (#406+).
-    "electricore-client",
+    "electricore-client>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.4.0rc3"
+version = "3.4.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Pourquoi

PR #412 a couplé le moteur à `electricore-client` (membre du workspace uv) **sans adapter le chemin de release** — un trou que ni les 907 tests verts ni le gate n'ont vu (les tests tournent dans le workspace dev ; **l'image Docker n'est jamais buildée hors release**). Sur `main`, le Dockerfile ne copie pas `packages/` → `uv sync --frozen` casserait au build d'image, et le wheel moteur PyPI déclarait `electricore-client` sans pin (ininstallable, client pas encore publié).

Cette PR rend le moteur **publiable** et bumpe en **3.4.0rc4**.

## Changements

- **Dockerfile** — copie `packages/` (membre workspace requis par le lock gelé) puis installe `electricore-client` en **WHEEL** dans le venv. L'image runtime n'embarque donc **pas** le source `packages/` (choix « wheel » ; le moteur, lui, reste servi depuis son source comme avant).
- **release.yml** — le smoke-test importe désormais `electricore.api.main`, ce qui **exerce réellement `electricore_client`** (le smoke précédent — `import electricore` seul — n'aurait pas vu le client manquant dans l'image).
- **pyproject** — pin `electricore-client>=0.1.0` (résoluble sur PyPI une fois `client-v0.1.0` publié).
- **bump 3.4.0rc3 → 3.4.0rc4** + CHANGELOG + `uv.lock`.

## Validé / non validé ici

- ✅ `uv lock` + `uv sync --frozen` passent (cohérence lock↔pyproject — ce que fait le build Docker).
- ⚠️ **Le build de l'image Docker lui-même n'est pas validable en sandbox.** Les deux lignes ajoutées au Dockerfile (copy `packages/` + build/install wheel) sont le pattern standard, mais leur vrai test est le **workflow de release au tag `v3.4.0rc4`** (build → smoke `import electricore.api.main` → push). Si le wheel est mal installé, la release échoue proprement (aucun impact prod) plutôt que de pousser une image cassée.

## Ordre de release

1. **Avant** ce merge ou en parallèle : tag `client-v0.1.0` → publie `electricore-client 0.1.0` sur PyPI (valide aussi le pending Trusted Publisher).
2. Merger cette PR.
3. Tag `v3.4.0rc4` → release moteur (le smoke importe le client, donc le gate est réel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
