### PR TITLE
fix(notebooks): le lanceur charge le .env (ELECTRICORE_API_URL/KEY) — suite #415

### DIFF
--- a/electricore/operator_launcher.py
+++ b/electricore/operator_launcher.py
@@ -76,6 +76,26 @@ def _manquantes_odoo() -> list[str]:
     return []
 
 
+def charger_env() -> None:
+    """Charge le `.env` à la racine du dépôt dans `os.environ` (précédence préservée).
+
+    Les creds Odoo passent par pydantic-settings (`_env_file`), mais
+    `ELECTRICORE_API_URL`/`ELECTRICORE_API_KEY` sont lues en direct via `os.getenv`
+    (ici et dans les notebooks). Sans ce chargement, un opérateur qui remplit `.env`
+    resterait « manquant ». Comme les apps marimo tournent dans le MÊME process
+    uvicorn lancé par `main()`, ce seul chargement les rend visibles à la fois pour
+    la validation et pour les notebooks.
+
+    `override=False` : une vraie variable d'env-système l'emporte toujours sur le
+    `.env` (précédence documentée, ADR-0024). `FICHIER_ENV is None` (seam de test)
+    → on ne fait rien.
+    """
+    from dotenv import load_dotenv
+
+    if runtime.FICHIER_ENV is not None:
+        load_dotenv(runtime.FICHIER_ENV, override=False)
+
+
 def valider_environnement() -> None:
     """Valide l'environnement requis ; sinon imprime un message clair et sort (non-nul).
 
@@ -138,7 +158,8 @@ def construire_app(directory: str | Path, *, prefixe: str = _PREFIXE_APPS):
 
 
 def main() -> None:
-    """Point d'entrée `electricore-notebooks` : valide, sert, ouvre le navigateur."""
+    """Point d'entrée `electricore-notebooks` : charge le .env, valide, sert, ouvre le navigateur."""
+    charger_env()
     valider_environnement()
 
     dossier = dossier_notebooks()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ notebooks = [
     "marimo>=0.23.0",  # pre-auth RCE fix (CVE-2026-39987)
     "altair>=5.5.0,<6.0.0",
     "plotly[express]>=6.2.0",
+    "python-dotenv>=1.0.0",  # charger_env() : .env → os.environ pour ELECTRICORE_API_URL/KEY (déjà transitif via pydantic-settings)
 ]
 # Linéarisation des flux en dbt (ADR-0020, prototype branche dbt).
 dbt = [

--- a/tests/unit/test_operator_launcher.py
+++ b/tests/unit/test_operator_launcher.py
@@ -7,12 +7,14 @@ Couvre deux seams :
 Le smoke navigateur/serveur est une vérif MANUELLE (non automatisée).
 """
 
+import os
 from pathlib import Path
 
 import pytest
 
 from electricore.config import runtime
 from electricore.operator_launcher import (
+    charger_env,
     construire_app,
     dossier_notebooks,
     url_navigateur,
@@ -87,6 +89,47 @@ def test_message_nomme_la_variable_et_son_role(monkeypatch, capsys):
     captured = capsys.readouterr()
     sortie = captured.out + captured.err
     assert "ELECTRICORE_API_KEY" in sortie
+
+
+# --- Seam : chargement du .env dans os.environ (précédence env-système > .env) ---
+
+
+def test_charger_env_charge_le_fichier_dans_environ(monkeypatch, tmp_path):
+    """`charger_env()` rend les vars du .env visibles dans os.environ.
+
+    Les notebooks et la validation lisent ELECTRICORE_API_URL/KEY via os.getenv :
+    sans ce chargement, un opérateur qui remplit .env reste « manquant ».
+    """
+    monkeypatch.delenv("ELECTRICORE_API_URL", raising=False)
+    fichier = tmp_path / ".env"
+    fichier.write_text("ELECTRICORE_API_URL=https://depuis-le-fichier.example\n")
+    monkeypatch.setattr(runtime, "FICHIER_ENV", fichier)
+
+    charger_env()
+
+    assert os.environ.get("ELECTRICORE_API_URL") == "https://depuis-le-fichier.example"
+
+
+def test_charger_env_ne_surcharge_pas_l_env_systeme(monkeypatch, tmp_path):
+    """L'env-système l'emporte sur le .env (précédence documentée, override=False)."""
+    monkeypatch.setenv("ELECTRICORE_API_URL", "https://depuis-le-systeme.example")
+    fichier = tmp_path / ".env"
+    fichier.write_text("ELECTRICORE_API_URL=https://depuis-le-fichier.example\n")
+    monkeypatch.setattr(runtime, "FICHIER_ENV", fichier)
+
+    charger_env()
+
+    assert os.environ.get("ELECTRICORE_API_URL") == "https://depuis-le-systeme.example"
+
+
+def test_charger_env_sans_fichier_ne_fait_rien(monkeypatch):
+    """Seam de test : FICHIER_ENV None → aucun chargement, aucune erreur."""
+    monkeypatch.delenv("ELECTRICORE_API_URL", raising=False)
+    monkeypatch.setattr(runtime, "FICHIER_ENV", None)
+
+    charger_env()  # ne doit pas lever
+
+    assert os.environ.get("ELECTRICORE_API_URL") is None
 
 
 # --- Seam : résolution du dossier embarqué + construction de l'app ASGI ---

--- a/uv.lock
+++ b/uv.lock
@@ -775,6 +775,7 @@ notebooks = [
     { name = "altair" },
     { name = "marimo" },
     { name = "plotly", extra = ["express"] },
+    { name = "python-dotenv" },
 ]
 viz = [
     { name = "altair" },
@@ -821,6 +822,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=23.0.1,<24.0.0" },
     { name = "pycryptodome", marker = "extra == 'ingestion'", specifier = ">=3.23.0,<4.0.0" },
     { name = "pydantic-settings", specifier = ">=2.14.1" },
+    { name = "python-dotenv", marker = "extra == 'notebooks'", specifier = ">=1.0.0" },
     { name = "python-telegram-bot", specifier = ">=21.0" },
     { name = "starlette", specifier = ">=0.49.1" },
     { name = "uvicorn", specifier = ">=0.35.0,<0.36.0" },


### PR DESCRIPTION
Suite de #415 (mergé) — **bugfix du lanceur opérateur `electricore-notebooks`**.

## Le bug

#415 a livré le lanceur, mais les creds n'étaient **pas tous** chargés depuis le `.env` :

| Config | Lecture | Venait du `.env` ? |
|---|---|---|
| Creds Odoo (`runtime.odoo()`) | pydantic-settings `_env_file` | ✅ |
| `ELECTRICORE_API_URL` / `KEY` | `os.getenv` (launcher **et** notebooks) | ❌ |

Rien ne faisait `load_dotenv` → un opérateur qui remplit le `.env` voyait quand même « `ELECTRICORE_API_URL` manquante ». Ça casse la promesse « remplis **un** `.env`, lance ».

## Le fix

- `charger_env()` (testé) appelé en **tout premier** dans `main()`, avant la validation : `load_dotenv(runtime.FICHIER_ENV, override=False)`. Comme les apps marimo tournent dans le même process uvicorn, les vars deviennent visibles pour la validation **et** les notebooks.
- `override=False` → une vraie variable d'env-système l'emporte toujours sur le `.env` (précédence ADR-0024 préservée). No-op si `FICHIER_ENV is None` (seam de test).
- `python-dotenv>=1.0.0` ajouté explicite à l'extra `[notebooks]` (déjà transitif via pydantic-settings).
- 3 tests unitaires : `.env` temp → `os.environ` ; var système non écrasée ; `FICHIER_ENV None` = no-op.

→ **L'opérateur ne remplit qu'un seul `.env` à la racine du dépôt** (creds Odoo **et** vars API).

Notebooks intouchés. `uv sync --frozen` OK ; 15 tests launcher verts. **Pont transitoire** — à retirer avec le reste à l'arrivée de `souscriptions_odoo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
