### PR TITLE
fix(notebooks): re-synchroniser facturation sur le contrat fact_mois + garde anti-drift (#417)

### DIFF
--- a/notebooks/facturation.py
+++ b/notebooks/facturation.py
@@ -20,7 +20,6 @@ with app.setup:
 
     from datetime import date
 
-    from electricore.integrations.odoo import OdooReader, lignes_factures_du_mois
     from electricore_client.arrow import ElectricoreArrowClient as ElectricoreClient
 
     # Configuration du logging
@@ -64,9 +63,9 @@ def _():
     mo.md(r"""
     # Mois cible
 
-    Toutes les requêtes (Odoo + Enedis) portent sur ce mois (cf. ADR-0014 :
-    `lignes_factures_du_mois` retourne toutes les lignes du mois avec les flags
-    `a_facturer` / `a_supprimer`, sans dépendre de l'état de facturation actuel).
+    Toutes les requêtes portent sur ce mois. `client.facturation(mois)` retourne le
+    rapprochement Odoo × Enedis du mois avec les flags `a_facturer` / `a_supprimer`
+    (calculés côté serveur, cf. ADR-0014), sans dépendre de l'état de facturation actuel.
     """)
     return
 
@@ -77,58 +76,6 @@ def _():
     mois_input = mo.ui.text(label="Mois (YYYY-MM-DD)", value=_today.isoformat())
     mois_input
     return (mois_input,)
-
-
-@app.cell(hide_code=True)
-def _():
-    mo.md(r"""
-    # Récupération des données Odoo
-
-    `OdooReader` reste utilisé en notebook pour les colonnes non exposées par
-    l'API (sale_order_id, invoice_ids) et la persistance via `OdooWriter`
-    (cf. ADR-0012).
-    """)
-    return
-
-
-@app.cell
-def _(mois_input):
-    with OdooReader(config=config) as _odoo:
-        lignes_odoo_df = (
-            lignes_factures_du_mois(_odoo, mois=mois_input.value)
-            .filter(pl.col("name_product_category").is_in(["Abonnements", "HP", "HC", "Base"]))
-            .collect()
-            .select(
-                [
-                    "sale_order_id",
-                    "name",
-                    "x_pdl",
-                    "x_lisse",
-                    "x_ref_situation_contractuelle",
-                    "invoice_ids",
-                    "invoice_line_ids",
-                    "quantity",
-                    "name_product_product",
-                    "name_account_move",
-                    "name_product_category",
-                    "a_facturer",
-                    "a_supprimer",
-                ]
-            )
-        )
-    lignes_a_facturer_df = lignes_odoo_df.filter(pl.col("a_facturer"))
-    lignes_a_supprimer = lignes_odoo_df.filter(pl.col("a_supprimer"))
-    mo.vstack(
-        [
-            mo.md(
-                f"**{len(lignes_odoo_df)}** lignes du mois · "
-                f"**{len(lignes_a_facturer_df)}** à facturer · "
-                f"**{len(lignes_a_supprimer)}** à supprimer"
-            ),
-            mo.ui.table(lignes_odoo_df),
-        ]
-    )
-    return (lignes_a_facturer_df,)
 
 
 @app.cell(hide_code=True)
@@ -186,9 +133,9 @@ def _():
     # Réconciliation Enedis → Odoo
 
     `fact_mois` (= `lignes_facture_rapprochees`) contient déjà le rapprochement
-    par `invoice_line_ids`. Plus besoin de joindre côté client : on enrichit
-    juste avec les colonnes Odoo non exposées par l'API (`sale_order_id`,
-    `invoice_ids`).
+    par `invoice_line_ids` **et** les identifiants Odoo passe-plat
+    (`sale_order_id`, `invoice_ids`, `x_lisse`), conservés par `rapprocher`.
+    Aucune lecture Odoo séparée : tout vient de l'API.
     """)
     return
 
@@ -255,9 +202,9 @@ def _(fact_mois, filtre_a_injecter):
                     [
                         "name_account_move",
                         "x_pdl",
-                        "name_product_category",
+                        "categorie_produit",
                         "name_product_product",
-                        "quantity",
+                        "quantite",
                         "quantite_enedis",
                         "memo_puissance",
                     ]
@@ -308,25 +255,18 @@ def _():
 
 
 @app.cell
-def _(fact_mois, lignes_a_facturer_df, taux_verification):
+def _(fact_mois, taux_verification):
     import numpy as np
 
-    # Côté Odoo : sale_order_id + x_lisse, unique par RSC
-    _odoo_df = lignes_a_facturer_df.select(["sale_order_id", "x_lisse", "x_ref_situation_contractuelle"]).unique()
-    # Côté Enedis : qualité par RSC (déduplication car fact_mois a 1 ligne / invoice_line).
+    # fact_mois porte déjà sale_order_id / x_lisse / qualite / ref_situation_contractuelle
+    # (passe-plat de `rapprocher`) → 1 ligne par order après déduplication. L'ancienne
+    # lecture Odoo directe + jointure sur la RSC était redondante (#417).
     # « à jour » ≡ énergie calculable (ADR-0033 : ancien data_complete=True ⇒ qualite ≠ incalculable).
-    _enedis_df = fact_mois.select(["qualite", "ref_situation_contractuelle"]).unique()
+    _orders = fact_mois.select(["sale_order_id", "x_lisse", "qualite", "ref_situation_contractuelle"]).unique()
 
-    _df = (
-        _odoo_df.join(
-            _enedis_df,
-            left_on="x_ref_situation_contractuelle",
-            right_on="ref_situation_contractuelle",
-            how="left",
-        )
-        .with_columns(((pl.col("qualite") != "incalculable") | pl.col("x_lisse")).alias("a_jour"))
-        .with_columns(pl.Series("rand", np.random.rand(len(_odoo_df))))
-    )
+    _df = _orders.with_columns(
+        ((pl.col("qualite") != "incalculable") | pl.col("x_lisse")).alias("a_jour")
+    ).with_columns(pl.Series("rand", np.random.rand(len(_orders))))
 
     orders_records = (
         _df.with_columns(
@@ -367,23 +307,10 @@ def _():
 
 
 @app.cell
-def _(fact_mois, lignes_a_facturer_df):
-    # Côté Odoo : invoice_ids unique par RSC
-    _odoo_df = lignes_a_facturer_df.select(["invoice_ids", "x_ref_situation_contractuelle"]).unique()
-
-    # Côté Enedis : 1 ligne par RSC avec debut/fin/turpe/compteur (dédoublonnage : fact_mois a 1 ligne / invoice_line)
-    _enedis_df = fact_mois.select(
-        [
-            "ref_situation_contractuelle",
-            "debut",
-            "fin",
-            "turpe_fixe_eur",
-            "turpe_variable_eur",
-            "num_compteur",
-            "type_compteur",
-        ]
-    ).unique()
-
+def _(fact_mois):
+    # fact_mois porte déjà invoice_ids + debut/fin/turpe/compteur par invoice_line
+    # (passe-plat de `rapprocher`). Déduplication sur (invoice_ids × RSC) → 1 ligne par
+    # facture ; l'ancienne lecture Odoo directe + jointure sur la RSC était redondante (#417).
     _to_rename = {
         "invoice_ids": "id",
         "turpe": "x_turpe",
@@ -394,12 +321,19 @@ def _(fact_mois, lignes_a_facturer_df):
     }
 
     _df = (
-        _odoo_df.join(
-            _enedis_df,
-            left_on="x_ref_situation_contractuelle",
-            right_on="ref_situation_contractuelle",
-            how="left",
+        fact_mois.select(
+            [
+                "invoice_ids",
+                "ref_situation_contractuelle",
+                "debut",
+                "fin",
+                "turpe_fixe_eur",
+                "turpe_variable_eur",
+                "num_compteur",
+                "type_compteur",
+            ]
         )
+        .unique()
         .with_columns(
             [
                 (pl.col("turpe_fixe_eur") + pl.col("turpe_variable_eur")).alias("turpe"),
@@ -407,7 +341,7 @@ def _(fact_mois, lignes_a_facturer_df):
                 pl.col("fin").dt.strftime("%Y-%m-%d"),
             ]
         )
-        .drop(["turpe_fixe_eur", "turpe_variable_eur", "x_ref_situation_contractuelle"])
+        .drop(["turpe_fixe_eur", "turpe_variable_eur", "ref_situation_contractuelle"])
         .rename(mapping=_to_rename)
     )
     invoices_records = _df.to_dicts()

--- a/tests/integration/test_operator_notebooks_bundle.py
+++ b/tests/integration/test_operator_notebooks_bundle.py
@@ -59,6 +59,37 @@ def test_garde_de_securite_des_notebooks_intacte(nom):
     assert "OdooWriter(config=config" in source
 
 
+# Noms de colonnes RETIRÉS de la sortie de `lignes_factures_du_mois` par le refactor
+# breaking `ecaa930` (wire-up facturation api/services) : `x_ref_situation_contractuelle`
+# → `ref_situation_contractuelle`, `name_product_category` → `categorie_produit`. Le
+# notebook `facturation.py` consomme `fact_mois` (`client.facturation`), qui porte les
+# noms RENOMMÉS via le passe-plat de `rapprocher`. Référencer un nom pré-rename = le
+# drift qui a cassé le notebook 13 jours sans détection (#417). Ces deux noms n'ont
+# aucun homonyme légitime dans `facturation.py` (à la différence de `quantity`/`a_facturer`,
+# qui sont des champs d'écriture Odoo valides) → ils sont sûrement interdits.
+_COLONNES_PRE_RENAME_INTERDITES_FACTURATION = (
+    "name_product_category",
+    "x_ref_situation_contractuelle",
+)
+
+
+@pytest.mark.parametrize("colonne_retiree", _COLONNES_PRE_RENAME_INTERDITES_FACTURATION)
+def test_facturation_ne_reference_pas_de_colonne_pre_rename(colonne_retiree):
+    """`facturation.py` ne référence que les noms post-rename du contrat `fact_mois` (#417).
+
+    Anti-drift : un refactor `core` qui renomme une sortie consommée par le notebook
+    doit casser CE test, pas l'opérateur. Garde **purement statique** (texte source) —
+    n'exécute jamais le notebook, n'instancie aucun `OdooWriter`, n'ouvre aucune
+    connexion Odoo (cf. la garde de sécurité ci-dessus : zéro écriture en prod).
+    """
+    source = (_RACINE / "notebooks" / "facturation.py").read_text()
+    assert colonne_retiree not in source, (
+        f"`facturation.py` référence `{colonne_retiree}`, retiré de la sortie de "
+        f"`lignes_factures_du_mois` (refactor api/services). Utiliser le nom post-rename "
+        f"porté par `fact_mois` (`client.facturation`) — cf. #417."
+    )
+
+
 @pytest.mark.slow
 def test_wheel_contient_les_notebooks_operateur(tmp_path: Path):
     """`uv build --wheel` produit un wheel electricore contenant les 3 notebooks."""


### PR DESCRIPTION
Closes #417 — suite du pont opérateur transitoire #414.

## Le bug

`notebooks/facturation.py` cassé depuis le refactor **breaking** `ecaa930` (11/06, wire-up facturation api/services) : la sortie de `lignes_factures_du_mois` a été renommée (`ref_situation_contractuelle` / `categorie_produit` / `quantite`) et `a_facturer`/`a_supprimer` déplacés au core, **sans toucher le notebook** → `ColumnNotFoundError`. Cassé **13 jours sans détection** (aucun test ne lance les notebooks ; le pont #414 est ce qui l'a enfin exercé).

## Le fix : supprimer la double-lecture Odoo, pas la rafistoler

Le notebook lisait Odoo **deux fois** : en direct via `lignes_factures_du_mois` **et** via `client.facturation`. La lecture directe était **redondante** — `rapprocher` passe `sale_order_id` / `invoice_ids` / `x_lisse` en passe-plat, donc `fact_mois` les porte déjà.

→ cellule directe supprimée, `orders_records` / `invoices_records` re-pointés sur `fact_mois.filter(a_facturer)` (la jointure sur la RSC s'effondre : même source), noms d'aperçu (`categorie_produit`, `quantite`) + docstrings corrigés. **Le notebook lit Odoo une seule fois, via l'API. Net −35 lignes.**

> Méta-périodes (ADR-0027) écartées : feed ERP-agnostique **sans IDs Odoo** = destination future `souscriptions_odoo` ; ce notebook **écrit** dans Odoo → besoin des IDs que seul `/facturation/detail.arrow` porte.

## Garde anti-drift (TDD)

`test_operator_notebooks_bundle.py` : garde **statique** (RED sur le notebook cassé → GREEN après fix) interdisant les noms pré-rename dans `facturation.py`. ⚠️ **Purement textuelle** — n'exécute jamais le notebook, n'instancie aucun `OdooWriter`, n'ouvre aucune connexion Odoo. **Aucun test de ces notebooks ne touche un serveur réel.**

## Validation

- RED→GREEN garde ; **916 passed / 28 skipped** (les échecs `ingestion` venaient de l'extra manquant dans le venv frais du worktree — **99 verts** après `uv sync --extra ingestion --extra dbt`, sans aucune modif de code) ; `ruff check .` clean ; notebook = Python valide (`py_compile`) ; garde de sécurité (simulation `value=True` + `mo.stop`) **intacte**.
- ⚠️ **RESTE hors CI/sandbox — smoke Odoo manuel à faire AVANT merge** (Virgile / agent Odoo-MCP, l'agent ne peut pas l'exécuter) : `uv run electricore-notebooks` → `/apps/facturation` s'affiche **sans** `ColumnNotFoundError`, `print(fact_mois.columns)` confirme `sale_order_id` / `invoice_ids` / `x_lisse`, mode simulation coché (aucune écriture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
