### PR TITLE
Secrets-as-code : chiffrement SOPS + age (remplace le .env)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,28 @@ jobs:
         # sans lui, les tests dbt sont skippés (importorskip).
         run: uv sync --locked --extra ingestion --extra dbt --group test
 
+      # sops + age : binaires statiques pinnés (mêmes versions que l'image, cf.
+      # deploy/docker/Dockerfile) pour que le test de déchiffrement à l'entrypoint
+      # (ADR-0044, tests/integration/test_entrypoint_dechiffrement.py) tourne pour
+      # de VRAI en CI au lieu de se skipper.
+      - name: Installer sops + age (déchiffrement secrets, ADR-0044)
+        run: |
+          set -euo pipefail
+          SOPS_VERSION=3.9.4
+          SOPS_SHA256=5488e32bc471de7982ad895dd054bbab3ab91c417a118426134551e9626e4e85
+          AGE_VERSION=1.2.1
+          AGE_SHA256=7df45a6cc87d4da11cc03a539a7470c15b1041ab2b396af088fe9990f7c79d50
+          curl -fsSL -o /tmp/sops "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          echo "${SOPS_SHA256}  /tmp/sops" | sha256sum -c -
+          sudo install -m 0755 /tmp/sops /usr/local/bin/sops
+          curl -fsSL -o /tmp/age.tgz "https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz"
+          echo "${AGE_SHA256}  /tmp/age.tgz" | sha256sum -c -
+          tar -xzf /tmp/age.tgz -C /tmp
+          sudo install -m 0755 /tmp/age/age /usr/local/bin/age
+          sudo install -m 0755 /tmp/age/age-keygen /usr/local/bin/age-keygen
+          sops --version
+          age --version
+
       - name: Run tests
         run: uv run --group test pytest
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -21,6 +21,9 @@ paths = [
     # Fixtures .env de tests deploy/ (déjà annotées `# gitleaks:allow` en ligne,
     # listées ici pour robustesse si l'annotation en ligne ne couvre pas tout).
     '''deploy/tests/fixtures/env-valid''',
+    # Fake-binaries des tests deploy-shell (secrets-as-code) — le fake `sops` émet un
+    # dotenv clair FACTICE (valeurs de test, ne protègent rien).
+    '''deploy/tests/fixtures/fake_bin/sops''',
 ]
 # Clé age privée de test (la regex couvre la valeur exacte committée).
 regexes = [

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,12 +18,19 @@ paths = [
     '''tests/fixtures/sops/secrets\.env\.clair''',
     # Le test bout-en-bout asserte les valeurs factices déchiffrées (API_KEY, etc.).
     '''tests/integration/test_entrypoint_dechiffrement\.py''',
+    # Fixtures d'isolation multi-destinataires (#420) : 3 paires age de test + clair
+    # source + ciphertext, toutes à valeurs FACTICES.
+    '''tests/fixtures/sops/multi/.*''',
+    '''tests/integration/test_sops_isolation_multi_destinataires\.py''',
     # Fixtures .env de tests deploy/ (déjà annotées `# gitleaks:allow` en ligne,
     # listées ici pour robustesse si l'annotation en ligne ne couvre pas tout).
     '''deploy/tests/fixtures/env-valid''',
     # Fake-binaries des tests deploy-shell (secrets-as-code) — le fake `sops` émet un
     # dotenv clair FACTICE (valeurs de test, ne protègent rien).
     '''deploy/tests/fixtures/fake_bin/sops''',
+    # Scaffolding d'exemple providers/ (#420) : destinataires + secrets FACTICES,
+    # clairement marqués (.example).
+    '''deploy/providers/example/.*''',
 ]
 # Clé age privée de test (la regex couvre la valeur exacte committée).
 regexes = [

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -25,14 +25,16 @@ paths = [
     # Fixtures .env de tests deploy/ (déjà annotées `# gitleaks:allow` en ligne,
     # listées ici pour robustesse si l'annotation en ligne ne couvre pas tout).
     '''deploy/tests/fixtures/env-valid''',
-    # Fake-binaries des tests deploy-shell (secrets-as-code) — le fake `sops` émet un
-    # dotenv clair FACTICE (valeurs de test, ne protègent rien).
-    '''deploy/tests/fixtures/fake_bin/sops''',
+    # Fake-binaries des tests deploy-shell (secrets-as-code) : le fake `sops` émet un
+    # dotenv FACTICE et le fake `docker` émet une paire age FACTICE (age-keygen stub) —
+    # valeurs de test, ne protègent rien.
+    '''deploy/tests/fixtures/fake_bin/.*''',
     # Scaffolding d'exemple providers/ (#420) : destinataires + secrets FACTICES,
     # clairement marqués (.example).
     '''deploy/providers/example/.*''',
 ]
-# Clé age privée de test (la regex couvre la valeur exacte committée).
-regexes = [
-    '''AGE-SECRET-KEY-1[0-9A-Z]+''',
-]
+# Pas de `regexes` d'allowlist : les `paths` ci-dessus couvrent déjà toutes les clés age
+# de TEST committées. Une regex `AGE-SECRET-KEY-…` globale OU-erait avec les `paths`
+# (gitleaks v8) et désactiverait la détection des clés age privées dans TOUT le dépôt —
+# précisément la classe de secret que cette feature introduit (ADR-0044). La détection
+# reste donc active partout ailleurs ; n'ajoute pas de `regexes` ici.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,28 @@
+# Configuration gitleaks du dépôt — étend les règles par défaut et allowliste les
+# secrets de TEST qui ne protègent rien de réel (ADR-0044 §9).
+#
+# Sans cette allowlist, la clé age privée de test committée et la fixture
+# `secrets.env` chiffrée (valeurs FACTICES) font sonner gitleaks (Palier 0, scan
+# de secrets en pre-commit). Conséquence assumée et explicitement documentée.
+
+# Repart des règles par défaut de gitleaks (sinon on remplace tout le jeu de règles).
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Fixtures de test SOPS+age — secrets factices, ne protègent rien (ADR-0044 §9)."
+paths = [
+    # Paire age de TEST + fixtures de secrets (clair source + ciphertext SOPS).
+    '''tests/fixtures/sops/test_age\.key''',
+    '''tests/fixtures/sops/secrets\.env''',
+    '''tests/fixtures/sops/secrets\.env\.clair''',
+    # Le test bout-en-bout asserte les valeurs factices déchiffrées (API_KEY, etc.).
+    '''tests/integration/test_entrypoint_dechiffrement\.py''',
+    # Fixtures .env de tests deploy/ (déjà annotées `# gitleaks:allow` en ligne,
+    # listées ici pour robustesse si l'annotation en ligne ne couvre pas tout).
+    '''deploy/tests/fixtures/env-valid''',
+]
+# Clé age privée de test (la regex couvre la valeur exacte committée).
+regexes = [
+    '''AGE-SECRET-KEY-1[0-9A-Z]+''',
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,11 +242,22 @@ déchiffrement. La bonne clé est **sélectionnée par essai** (oracle PKCS7 + m
 ZIP), sans aucune date ni notion de protocole — AES-128 et AES-256 sont le même schéma,
 la longueur de clé est auto-sélectionnée.
 
-Procédure de rotation :
+Procédure de rotation (secrets-as-code, ADR-0044) — en prod, le trousseau vit dans le
+`secrets.env` **chiffré** du provider, plus dans un `.env` édité sur la box :
 1. Obtenir la nouvelle clé Enedis
-2. L'ajouter au trousseau sous un nouveau label (`AES__TROUSSEAU__<nouveau>__KEY`, plus `__IV` seulement si Enedis en fournit un — schéma IV-fixe ; sans IV ⇒ IV-préfixé, ADR-0040)
-3. Relancer le pipeline — chaque fichier déchiffre avec la clé qui marche, par essai
+2. Sur la machine admin, édition chiffrée in-place : `sops providers/<slug>/secrets.env`,
+   ajouter un nouveau label (`AES__TROUSSEAU__<nouveau>__KEY`, plus `__IV` seulement si Enedis
+   en fournit un — schéma IV-fixe ; sans IV ⇒ IV-préfixé, ADR-0040)
+3. Commit → push → `reconfigure` sur la box (pull + déchiffre + restart) — chaque fichier
+   déchiffre avec la clé qui marche, par essai
 4. Retirer une vieille clé seulement quand plus aucune archive chiffrée avec elle n'est (re)téléchargeable
+
+> **`sops updatekeys` ≠ rotation de secret** (ADR-0044) : `updatekeys` (ex. ajout d'une box
+> via `deploy/add-provider.sh`) ne rote que l'**enveloppe** (destinataires age). Une clé qui a
+> pu **fuiter** doit être changée **à la source** (nouvelle clé Enedis), pas juste re-wrappée.
+
+(Dev local non-conteneur : `uv run` lit toujours `.env`/env système directement —
+pydantic-settings — non concerné par SOPS.)
 
 L'échec de déchiffrement n'est plus silencieux : un flux qui a des fichiers mais **0**
 déchiffrement réussi fait passer le job à `failed` → la surveillance bot alerte

--- a/deploy/add-provider.sh
+++ b/deploy/add-provider.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# add-provider.sh — ajoute un destinataire age à un provider et re-chiffre l'enveloppe.
+#
+# Outil ADMIN (machine admin, dépôt de déploiement privé), PAS sur le VPS. Il :
+#   1. ajoute une clé age publique (box, ou nouvelle clé admin) aux destinataires du
+#      .sops.yaml du provider (idempotent) ;
+#   2. lance `sops updatekeys` → re-chiffre l'ENVELOPPE de secrets.env vers le nouveau
+#      jeu de destinataires (sans changer les valeurs).
+#
+# Isolation cryptographique (ADR-0044 §6) : une box n'est destinataire que de SON
+# provider → elle ne déchiffre que les siens. La CI n'est JAMAIS destinataire.
+#
+# ⚠️ Distinction cruciale (ADR-0044) : `updatekeys` ne rote que l'ENVELOPPE. Si un
+#    secret a pu fuiter, le changer AUSSI à la source — updatekeys ne le protège pas.
+#
+# Usage :
+#   deploy/add-provider.sh --provider-dir providers/<slug> --age-pubkey age1xxxx…
+#   deploy/add-provider.sh --provider-dir providers/<slug> --age-pubkey age1xxxx… --no-updatekeys
+#
+# Les tests deploy-shell sourcent ce fichier (guard main_add_provider) et stubbent
+# `sops` en fake-binary (motif maison).
+
+SOPS_BIN="${SOPS_BIN:-sops}"
+
+usage_add_provider() {
+    cat <<'EOF'
+Usage: add-provider.sh --provider-dir <dir> --age-pubkey <age1…> [--no-updatekeys]
+
+  --provider-dir <dir>   Dossier du provider (contient .sops.yaml + secrets.env)
+  --age-pubkey <key>     Clé age PUBLIQUE à ajouter aux destinataires (box ou admin)
+  --no-updatekeys        N'exécute pas `sops updatekeys` (ajoute juste le destinataire)
+  -h, --help             Cette aide
+
+Cf. ADR-0044 (secrets-as-code), docs/deploiement.md.
+EOF
+}
+
+# parse_add_provider_args "$@" — remplit OPT_PROVIDER_DIR, OPT_AGE_PUBKEY, OPT_NO_UPDATEKEYS.
+parse_add_provider_args() {
+    OPT_PROVIDER_DIR=""
+    OPT_AGE_PUBKEY=""
+    OPT_NO_UPDATEKEYS=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --provider-dir) OPT_PROVIDER_DIR="${2:-}"; shift 2 ;;
+            --age-pubkey)   OPT_AGE_PUBKEY="${2:-}"; shift 2 ;;
+            --no-updatekeys) OPT_NO_UPDATEKEYS=1; shift ;;
+            -h|--help)      usage_add_provider; exit 0 ;;
+            *) echo "Argument inconnu : $1" >&2; return 2 ;;
+        esac
+    done
+    [[ -n "$OPT_PROVIDER_DIR" ]] || { echo "--provider-dir manquant" >&2; return 1; }
+    [[ -n "$OPT_AGE_PUBKEY" ]]   || { echo "--age-pubkey manquant" >&2; return 1; }
+    [[ "$OPT_AGE_PUBKEY" =~ ^age1[0-9a-z]+$ ]] || { echo "--age-pubkey ne ressemble pas à une clé age (age1…) : $OPT_AGE_PUBKEY" >&2; return 1; }
+    return 0
+}
+
+# add_recipient_to_sops <sops_yaml> <age_pubkey>
+# Ajoute <age_pubkey> à la liste des destinataires age du .sops.yaml (idempotent :
+# no-op si déjà présent). Insère sous le 1er bloc `- age:` rencontré, en respectant
+# l'indentation de la 1re entrée existante. Renvoie 0 si OK.
+add_recipient_to_sops() {
+    local sops_yaml="$1"
+    local pubkey="$2"
+    [[ -r "$sops_yaml" ]] || { echo "fichier .sops.yaml introuvable : $sops_yaml" >&2; return 1; }
+    if grep -qF "$pubkey" "$sops_yaml"; then
+        echo "destinataire déjà présent (idempotent) : $pubkey" >&2
+        return 0
+    fi
+    # Indentation des entrées age existantes (1re ligne `- age1…` après la clé `age:`,
+    # qui peut être en tête de bloc `      - age:` ou `age:`). On repère l'entrée
+    # `- age1…` existante et on reprend son indentation pour aligner la nouvelle.
+    local indent
+    indent=$(grep -oE '^[[:space:]]*- age1[0-9a-z]+' "$sops_yaml" | head -1 | sed -E 's/- age1.*//')
+    [[ -n "$indent" ]] || indent="          "  # repli : 10 espaces (sous key_groups/age:)
+    local tmp; tmp=$(mktemp)
+    # Insère la nouvelle entrée juste après la ligne qui ouvre le bloc age (`age:`),
+    # qu'elle soit `age:` seule ou `- age:` (item de key_groups).
+    awk -v key="$pubkey" -v ind="$indent" '
+        { print }
+        !done && /^[[:space:]]*(-[[:space:]]+)?age:[[:space:]]*$/ { print ind "- " key; done=1 }
+    ' "$sops_yaml" > "$tmp"
+    mv "$tmp" "$sops_yaml"
+    echo "destinataire ajouté : $pubkey" >&2
+}
+
+# updatekeys_provider <provider_dir>
+# Lance `sops updatekeys` sur secrets.env du provider → re-chiffre l'enveloppe vers le
+# nouveau jeu de destinataires. Suppose le .sops.yaml à jour et la clé admin disponible.
+updatekeys_provider() {
+    local provider_dir="$1"
+    local secrets="${provider_dir}/secrets.env"
+    [[ -f "$secrets" ]] || { echo "secrets.env introuvable : $secrets" >&2; return 1; }
+    # --yes : non-interactif. sops lit .sops.yaml du dossier courant du fichier.
+    ( cd "$provider_dir" && "$SOPS_BIN" updatekeys --yes secrets.env )
+}
+
+# add_provider <provider_dir> <age_pubkey> <run_updatekeys>
+# Orchestration : ajoute le destinataire puis (si demandé) re-chiffre l'enveloppe.
+add_provider() {
+    local provider_dir="$1"
+    local pubkey="$2"
+    local run_updatekeys="${3:-1}"
+    add_recipient_to_sops "${provider_dir}/.sops.yaml" "$pubkey" || return 1
+    if [[ "$run_updatekeys" == "1" ]]; then
+        updatekeys_provider "$provider_dir" || return 1
+    else
+        echo "updatekeys sauté (--no-updatekeys)" >&2
+    fi
+}
+
+main_add_provider() {
+    set -euo pipefail
+    parse_add_provider_args "$@" || { usage_add_provider; exit 2; }
+    local run=1; [[ "$OPT_NO_UPDATEKEYS" -eq 1 ]] && run=0
+    add_provider "$OPT_PROVIDER_DIR" "$OPT_AGE_PUBKEY" "$run"
+    echo "✓ provider mis à jour : ${OPT_PROVIDER_DIR}"
+    echo "  Rappel (ADR-0044) : updatekeys ne rote que l'enveloppe — un secret qui a"
+    echo "  pu fuiter doit AUSSI être changé à la source. Pense à commit + push."
+}
+
+# Guard : exécute main_add_provider seulement si lancé, pas sourcé (tests).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main_add_provider "$@"
+fi

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -75,6 +75,25 @@ RUN curl -fsSL -o /tmp/duckdb.zip \
  && chmod +x /usr/local/bin/duckdb \
  && rm /tmp/duckdb.zip
 
+# sops + age : déchiffrement des secrets à l'entrypoint (ADR-0044). Binaires statiques
+# pinnés + vérifiés par checksum, même motif que supercronic/duckdb ci-dessus.
+ARG SOPS_VERSION=3.9.4
+ARG SOPS_SHA256=5488e32bc471de7982ad895dd054bbab3ab91c417a118426134551e9626e4e85
+RUN curl -fsSL -o /usr/local/bin/sops \
+        "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" \
+ && echo "${SOPS_SHA256}  /usr/local/bin/sops" | sha256sum -c - \
+ && chmod +x /usr/local/bin/sops
+
+ARG AGE_VERSION=1.2.1
+ARG AGE_SHA256=7df45a6cc87d4da11cc03a539a7470c15b1041ab2b396af088fe9990f7c79d50
+RUN curl -fsSL -o /tmp/age.tgz \
+        "https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz" \
+ && echo "${AGE_SHA256}  /tmp/age.tgz" | sha256sum -c - \
+ && tar -xzf /tmp/age.tgz -C /tmp \
+ && mv /tmp/age/age /tmp/age/age-keygen /usr/local/bin/ \
+ && chmod +x /usr/local/bin/age /usr/local/bin/age-keygen \
+ && rm -rf /tmp/age /tmp/age.tgz
+
 # Utilisateur non-root
 RUN groupadd --system --gid 1000 electricore \
  && useradd --system --uid 1000 --gid electricore --home-dir /app --shell /usr/sbin/nologin electricore
@@ -86,6 +105,11 @@ COPY --from=builder --chown=electricore:electricore /app/.venv /app/.venv
 COPY --chown=electricore:electricore electricore/ ./electricore/
 COPY --chown=electricore:electricore deploy/docker/backup_duckdb.sh /app/deploy/docker/backup_duckdb.sh
 RUN chmod +x /app/deploy/docker/backup_duckdb.sh
+
+# Entrypoint de déchiffrement SOPS+age (ADR-0044) — installé sur le PATH comme
+# `electricore-entrypoint`. Il s'intercale après tini : `tini -- electricore-entrypoint <cmd…>`.
+COPY deploy/docker/entrypoint.sh /usr/local/bin/electricore-entrypoint
+RUN chmod +x /usr/local/bin/electricore-entrypoint
 
 # Volumes pour les données (DuckDB et backups)
 RUN mkdir -p /data /backups \
@@ -99,10 +123,12 @@ ENV PATH="/app/.venv/bin:${PATH}" \
 
 USER electricore
 
-# tini comme PID 1 — propagation correcte des signaux (SIGTERM lors d'un compose down)
-ENTRYPOINT ["/usr/bin/tini", "--"]
+# tini comme PID 1 — propagation correcte des signaux (SIGTERM lors d'un compose down).
+# Puis electricore-entrypoint déchiffre les secrets SOPS+age (ADR-0044) avant d'exec
+# la commande du service. Échappatoire dev/test : ELECTRICORE_DECRYPT=off.
+ENTRYPOINT ["/usr/bin/tini", "--", "electricore-entrypoint"]
 
 # Pas de CMD : chaque service docker-compose définit son propre `command`.
-# Exemples :
+# Exemples (la commande est exec'd APRÈS déchiffrement par electricore-entrypoint) :
 #   - API : ["uvicorn", "electricore.api.main:app", "--host", "0.0.0.0", "--port", "8001"]
 #   - ETL : ["supercronic", "/etc/cron/crontab"]

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,23 +1,33 @@
 # ElectriCore — stack VPS reproductible.
 #
-# Layout attendu (cf. ADR-0017) :
+# Layout attendu (cf. ADR-0017, ADR-0044 secrets-as-code) :
 #   /srv/<slug>/                       ← home du user système de l'instance
-#   ├── .env                           ← secrets (source unique)
+#   ├── age.key                        ← clé age PRIVÉE de la box (600, ne sort jamais)
+#   ├── ssh_deploy_key                 ← clé SSH RO du dépôt de déploiement privé (600)
+#   ├── config.env                     ← config CLAIRE versionnée (substitutions compose + non-secret)
+#   ├── providers/<slug>/              ← copie pull du dépôt privé (config.env + secrets.env chiffré)
+#   │   ├── config.env
+#   │   └── secrets.env                ← credentials CHIFFRÉS (SOPS + age)
 #   ├── backups/                       ← bind-mount des snapshots DuckDB
 #   └── deploy/docker/
 #       ├── docker-compose.yml         ← ce fichier
 #       ├── Caddyfile
 #       └── crontab
 #
-# Invocation : depuis `deploy/docker/`, lancer avec --env-file pour que les
-# substitutions `${...}` ci-dessous résolvent les valeurs du .env racine :
+# Secrets (ADR-0044) : plus de `.env` en clair. La config claire arrive via
+# `env_file: ../../config.env` ; les CREDENTIALS sont déchiffrés DANS le process
+# par l'entrypoint de l'image (`electricore-entrypoint`, SOPS+age) à partir du
+# `secrets.env` chiffré + de la clé age, tous deux montés RO. Jamais de clair sur disque.
 #
-#   docker compose --env-file ../../.env up -d
+# Invocation : depuis `deploy/docker/`, lancer avec --env-file pour que les
+# substitutions `${...}` ci-dessous résolvent les valeurs du config.env racine :
+#
+#   docker compose --env-file ../../config.env up -d
 #
 # Sans --env-file, Compose chercherait un .env dans le cwd (deploy/docker/) et
 # tomberait sur les défauts (ELECTRICORE_VERSION=latest, BACKUPS_PATH=./backups
-# côté deploy/docker/). Les vars dans les conteneurs (env_file: ../../.env) ne
-# sont PAS utilisées pour les substitutions du compose lui-même — c'est une
+# côté deploy/docker/). Les vars dans les conteneurs (env_file: ../../config.env)
+# ne sont PAS utilisées pour les substitutions du compose lui-même — c'est une
 # subtilité Compose qui justifie l'invocation explicite.
 #
 # Documentation complète : docs/deploiement.md
@@ -35,12 +45,19 @@ services:
       - --port
       - "8001"
     env_file:
-      - ../../.env
+      - ../../config.env
     environment:
       DUCKDB_PATH: /data/flux_enedis_pipeline.duckdb
+      # Secrets SOPS+age (ADR-0044) : l'entrypoint déchiffre secrets.env avec la clé age.
+      SOPS_AGE_KEY_FILE: /run/secrets/age.key
+      SECRETS_ENV_FILE: /run/secrets/secrets.env
     volumes:
       - duckdb_data:/data
-      # Mode "fichiers collocés" : décommenter et adapter si SFTP__URL=file://... dans .env
+      # Secrets montés en lecture seule (ADR-0044) : la clé age privée de la box et
+      # le secrets.env chiffré (pull du dépôt privé dans providers/<slug>/).
+      - ../../age.key:/run/secrets/age.key:ro
+      - ../../providers/${INSTANCE_SLUG:-electricore}/secrets.env:/run/secrets/secrets.env:ro
+      # Mode "fichiers collocés" : décommenter et adapter si SFTP__URL=file://... dans secrets.env
       # - /var/enedis:/var/enedis:ro
     expose:
       - "8001"
@@ -64,12 +81,18 @@ services:
       - -passthrough-logs
       - /etc/cron/crontab
     env_file:
-      - ../../.env
+      - ../../config.env
     environment:
       DUCKDB_PATH: /data/flux_enedis_pipeline.duckdb
       TZ: Europe/Paris
+      # Secrets SOPS+age (ADR-0044) : l'entrypoint déchiffre secrets.env (SFTP/AES).
+      SOPS_AGE_KEY_FILE: /run/secrets/age.key
+      SECRETS_ENV_FILE: /run/secrets/secrets.env
     volumes:
       - duckdb_data:/data
+      # Secrets montés en lecture seule (ADR-0044).
+      - ../../age.key:/run/secrets/age.key:ro
+      - ../../providers/${INSTANCE_SLUG:-electricore}/secrets.env:/run/secrets/secrets.env:ro
       # Bind-mount des backups (cf. ADR-0017). Côté host, le dossier est owned
       # par uid 1000 (le user `electricore` du conteneur). Le user système
       # de l'instance (`<slug>`) doit être ajouté au groupe 1000 par le script

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -44,6 +44,9 @@ fi
 # `sops exec-env FILE CMD` exécute CMD via `sh -c` (un seul argument-commande, pas
 # de positionnels). On re-sérialise donc l'argv d'origine en une chaîne shell sûre
 # (quoting POSIX) pour la `exec` telle quelle, sans jamais écrire de fichier clair.
+# Le `exec` EN TÊTE de la chaîne-commande est essentiel : il remplace le `sh -c` de
+# sops par le process de service, pour que tini propage SIGTERM jusqu'à lui — sinon le
+# signal s'arrêterait au wrapper `sh` et `compose down` traînerait jusqu'au timeout.
 _quote_argv() {
     for a in "$@"; do
         printf "'%s' " "$(printf '%s' "$a" | sed "s/'/'\\\\''/g")"

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# electricore-entrypoint — déchiffre les secrets SOPS+age puis exec la commande (ADR-0044 §2-§3).
+#
+# Place dans l'image juste après tini :   tini -- electricore-entrypoint <commande…>
+# Le déchiffrement se fait DANS l'environnement du process (`sops exec-env`), jamais
+# en fichier clair, puis `exec` la commande (uvicorn / supercronic). La voie exec-env
+# gère les noms de variables DYNAMIQUES du trousseau AES (AES__TROUSSEAU__<label>__KEY,
+# ADR-0037) sans énumération.
+#
+# Variables d'environnement :
+#   SECRETS_ENV_FILE     chemin du `secrets.env` chiffré (défaut /run/secrets/secrets.env)
+#   SOPS_AGE_KEY_FILE    chemin de la clé age privée (lu par sops ; défaut /run/secrets/age.key)
+#   ELECTRICORE_DECRYPT  =off → bypass total (dev/test conteneur, ADR-0044 §3)
+#
+# Repli = ÉCHEC DUR (ADR-0044 §3) : pas de retombée silencieuse sur un run sans secrets
+# (qui serait une API sans API_KEY, une ingestion sans SFTP/AES — une mauvaise config masquée).
+
+set -eu
+
+SECRETS_ENV_FILE="${SECRETS_ENV_FILE:-/run/secrets/secrets.env}"
+SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-/run/secrets/age.key}"
+export SOPS_AGE_KEY_FILE
+
+# Échappatoire explicite et documentée (ADR-0044 §3) : dev/test conteneur sans secrets.
+if [ "${ELECTRICORE_DECRYPT:-}" = "off" ]; then
+    echo "electricore-entrypoint: ELECTRICORE_DECRYPT=off → déchiffrement contourné." >&2
+    exec "$@"
+fi
+
+# Fail-fast (ADR-0044 §3) : sans clé age NI fichier chiffré, on échoue bruyamment.
+if [ ! -f "$SECRETS_ENV_FILE" ]; then
+    echo "electricore-entrypoint: secrets SOPS requis introuvables." >&2
+    echo "  fichier chiffré attendu : ${SECRETS_ENV_FILE} (absent)" >&2
+    echo "  monter le secrets.env chiffré, ou poser ELECTRICORE_DECRYPT=off (dev/test)." >&2
+    exit 1
+fi
+if [ ! -f "$SOPS_AGE_KEY_FILE" ]; then
+    echo "electricore-entrypoint: secrets SOPS requis, aucune clé age." >&2
+    echo "  clé age attendue : ${SOPS_AGE_KEY_FILE} (absente)" >&2
+    echo "  monter la clé age (RO), ou poser ELECTRICORE_DECRYPT=off (dev/test)." >&2
+    exit 1
+fi
+
+# `sops exec-env FILE CMD` exécute CMD via `sh -c` (un seul argument-commande, pas
+# de positionnels). On re-sérialise donc l'argv d'origine en une chaîne shell sûre
+# (quoting POSIX) pour la `exec` telle quelle, sans jamais écrire de fichier clair.
+_quote_argv() {
+    for a in "$@"; do
+        printf "'%s' " "$(printf '%s' "$a" | sed "s/'/'\\\\''/g")"
+    done
+}
+
+exec sops exec-env "$SECRETS_ENV_FILE" "exec $(_quote_argv "$@")"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -29,7 +29,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_BASE_URL_DEFAULT="${INSTALL_BASE_URL:-https://raw.githubusercontent.com/Energie-De-Nantes/electricore/main/deploy}"
-LIB_FILES=(log cli validate os system user harden config env_validate dns stack ingestion)
+LIB_FILES=(log cli validate os system user harden config env_validate secrets dns stack ingestion)
 
 # fetch_lib_files <base_url> <target_dir>
 # Télécharge les helpers `${LIB_FILES[@]}` depuis <base_url> vers <target_dir>.
@@ -120,6 +120,10 @@ main() {
 
     parse_args "$@" || { usage; exit 2; }
 
+    # Secrets-as-code (ADR-0044) ajoute 2 étapes (identité box + pull) à la place de
+    # l'édition .env → le compteur d'étapes s'ajuste pour rester juste.
+    [[ -n "${OPT_DEPLOY_REPO:-}" ]] && LOG_TOTAL_STEPS=15
+
     validate_slug "$OPT_SLUG" || die "slug invalide : '$OPT_SLUG' (attendu [a-z0-9-]+, 2-32 chars)"
     validate_domain "$OPT_DOMAIN" || die "domaine invalide : '$OPT_DOMAIN'"
     [[ -z "$OPT_EMAIL" || "$OPT_EMAIL" =~ ^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]+$ ]] \
@@ -131,14 +135,17 @@ main() {
     CADDYFILE="${DOCKER_DIR}/Caddyfile"
 
     # ─── Détection mode reconfigure ─────────────────────────────────────────
+    # En secrets-as-code (ADR-0044), la box ne porte plus de .env mais une clé age :
+    # sa présence atteste un install antérieur (2e temps de l'onboarding = reconfigure).
+    AGE_KEY_FILE="${HOME_DIR}/age.key"
     MODE_RECONFIGURE=0
-    if [[ -f "$ENV_FILE" ]]; then
+    if [[ -f "$ENV_FILE" || -f "$AGE_KEY_FILE" ]]; then
         MODE_RECONFIGURE=1
     fi
-    # Garde-fou ADR-0017 : si /srv/<slug> existe sans .env, on est dans un état
-    # inconnu (peut-être un user système qui s'appelle aussi <slug>). Refus poli.
+    # Garde-fou ADR-0017 : si /srv/<slug> existe sans .env NI clé age, on est dans un
+    # état inconnu (peut-être un user système qui s'appelle aussi <slug>). Refus poli.
     if [[ -d "$HOME_DIR" && "$MODE_RECONFIGURE" -eq 0 ]]; then
-        die "Le dossier ${HOME_DIR} existe mais ne contient pas de .env." \
+        die "Le dossier ${HOME_DIR} existe mais ne contient ni .env ni clé age (age.key)." \
             "État ambigu — choisir un autre slug ou supprimer ${HOME_DIR} à la main."
     fi
 
@@ -195,54 +202,101 @@ main() {
 
     # ─── Étape 7 : config files ─────────────────────────────────────────────
     log_step "Téléchargement config (tag ${OPT_VERSION})"
-    download_config_files "$OPT_VERSION" "$HOME_DIR"
+    # En secrets-as-code (--deploy-repo) : pas de .env téléchargé, la config claire
+    # arrive par le dépôt (providers/<slug>/config.env, ADR-0044).
+    skip_env=0; [[ -n "$OPT_DEPLOY_REPO" ]] && skip_env=1
+    download_config_files "$OPT_VERSION" "$HOME_DIR" "$skip_env"
     chown_instance_home "$OPT_SLUG"
 
     # ─── Étape 8 : substitutions ────────────────────────────────────────────
     log_step "Patch des templates (slug + domaine + email)"
-    substitute_env "$ENV_FILE" "$OPT_SLUG" "$OPT_VERSION"
     substitute_caddyfile "$CADDYFILE" "$OPT_DOMAIN" "$OPT_EMAIL"
     if [[ -z "$OPT_EMAIL" ]]; then
         log_warn "email Let's Encrypt non fourni — placeholder conservé dans ${CADDYFILE}." \
                  "Éditer à la main avant de mettre en prod."
     fi
 
-    # ─── Étape 9 : édition .env + validation ────────────────────────────────
-    log_step "Configuration .env (édition + validation)"
-    if [[ "$MODE_RECONFIGURE" -eq 1 ]]; then
-        backup="${ENV_FILE}.bak.$(date +%Y%m%dT%H%M%SZ)"
-        cp -p "$ENV_FILE" "$backup"
-        chown "$OPT_SLUG:$OPT_SLUG" "$backup"
-        log_info "backup du .env existant → ${backup}"
-    fi
-    if [[ -n "$OPT_ENV_FROM" ]]; then
-        [[ -r "$OPT_ENV_FROM" ]] || die "--env-from : fichier illisible : $OPT_ENV_FROM"
-        cp "$OPT_ENV_FROM" "$ENV_FILE"
-        chown "$OPT_SLUG:$OPT_SLUG" "$ENV_FILE"
-        chmod 600 "$ENV_FILE"
-        log_info "chargement depuis $OPT_ENV_FROM"
+    # ─── Étape 9 : secrets-as-code (ADR-0044) OU legacy .env ────────────────
+    if [[ -n "$OPT_DEPLOY_REPO" ]]; then
+        # ── Secrets-as-code : identité de la box + auto-pull + déchiffrement ──
+        log_step "Identité de la box (age + SSH deploy key)"
+        if pubs=$(generate_box_identities "$OPT_SLUG"); then
+            age_pub=$(printf '%s\n' "$pubs" | sed -n 's/^AGE_PUBLIC_KEY=//p')
+            ssh_pub=$(printf '%s\n' "$pubs" | sed -n 's/^SSH_DEPLOY_PUBKEY=//p')
+        else
+            die "Génération des identités de la box échouée (image ${SECRETS_IMAGE} indisponible ?)."
+        fi
+
+        log_step "Pull du dépôt de déploiement privé"
+        if ! pull_deploy_repo "$OPT_DEPLOY_REPO" "$OPT_SLUG"; then
+            # Onboarding EN DEUX TEMPS (ADR-0044 §4) : la deploy key SSH doit être
+            # enregistrée comme deploy key RO avant que le pull réussisse.
+            print_onboarding_pending "$OPT_SLUG" "$OPT_DOMAIN" "$age_pub" "$ssh_pub"
+            _CLEAN_EXIT=1
+            return 0
+        fi
+
+        log_step "Validation du split config/secret + déchiffrement"
+        config_env="${HOME_DIR}/config.env"
+        secrets_env="${HOME_DIR}/providers/${OPT_SLUG}/secrets.env"
+        age_key="${HOME_DIR}/age.key"
+        if errs=$(validate_config_env "$config_env" "$OPT_SLUG"); then
+            log_ok "config.env valide"
+        else
+            log_err "config.env invalide :"; printf '%s\n' "$errs" | sed 's/^/     - /'
+            die "Corrige providers/${OPT_SLUG}/config.env dans le dépôt, pousse, puis relance reconfigure."
+        fi
+        if ! box_can_decrypt "$OPT_SLUG"; then
+            # La box a sa clé + le ciphertext, mais ne déchiffre pas → sa clé age publique
+            # n'est pas (encore) destinataire dans .sops.yaml. 2e temps de l'onboarding.
+            print_onboarding_pending "$OPT_SLUG" "$OPT_DOMAIN" "$age_pub" "$ssh_pub"
+            die "La box ne déchiffre pas encore : enregistre sa clé age comme destinataire (.sops.yaml + sops updatekeys), pousse, puis relance reconfigure."
+        fi
+        if errs=$(validate_secrets_env "$secrets_env" "$age_key"); then
+            log_ok "secrets.env déchiffré et valide"
+        else
+            log_err "secrets.env invalide (après déchiffrement) :"; printf '%s\n' "$errs" | sed 's/^/     - /'
+            die "Corrige les secrets dans le dépôt (sops providers/${OPT_SLUG}/secrets.env), pousse, puis relance reconfigure."
+        fi
     else
-        log_info "ouverture de $ENV_FILE dans \${EDITOR:-nano}…"
-    fi
-    while true; do
-        if [[ -z "$OPT_ENV_FROM" ]]; then
-            sudo -u "$OPT_SLUG" "${EDITOR:-nano}" "$ENV_FILE"
+        # ── Legacy .env (migration / tests) : édition + validation monolithique ──
+        substitute_env "$ENV_FILE" "$OPT_SLUG" "$OPT_VERSION"
+        log_step "Configuration .env (édition + validation)"
+        if [[ "$MODE_RECONFIGURE" -eq 1 ]]; then
+            backup="${ENV_FILE}.bak.$(date +%Y%m%dT%H%M%SZ)"
+            cp -p "$ENV_FILE" "$backup"
+            chown "$OPT_SLUG:$OPT_SLUG" "$backup"
+            log_info "backup du .env existant → ${backup}"
         fi
-        if errs=$(validate_env_file "$ENV_FILE" "$OPT_SLUG"); then
-            log_ok ".env valide"
-            strip_validation_error_block "$ENV_FILE"
-            chmod 600 "$ENV_FILE"
-            break
-        fi
-        log_err ".env invalide :"
-        printf '%s\n' "$errs" | sed 's/^/     - /'
         if [[ -n "$OPT_ENV_FROM" ]]; then
-            die ".env fourni invalide, abandon."
+            [[ -r "$OPT_ENV_FROM" ]] || die "--env-from : fichier illisible : $OPT_ENV_FROM"
+            cp "$OPT_ENV_FROM" "$ENV_FILE"
+            chown "$OPT_SLUG:$OPT_SLUG" "$ENV_FILE"
+            chmod 600 "$ENV_FILE"
+            log_info "chargement depuis $OPT_ENV_FROM"
+        else
+            log_info "ouverture de $ENV_FILE dans \${EDITOR:-nano}…"
         fi
-        prepend_errors_to_env "$ENV_FILE" "$errs"
-        log_warn "ré-ouverture de l'éditeur dans 2s…"
-        sleep 2
-    done
+        while true; do
+            if [[ -z "$OPT_ENV_FROM" ]]; then
+                sudo -u "$OPT_SLUG" "${EDITOR:-nano}" "$ENV_FILE"
+            fi
+            if errs=$(validate_env_file "$ENV_FILE" "$OPT_SLUG"); then
+                log_ok ".env valide"
+                strip_validation_error_block "$ENV_FILE"
+                chmod 600 "$ENV_FILE"
+                break
+            fi
+            log_err ".env invalide :"
+            printf '%s\n' "$errs" | sed 's/^/     - /'
+            if [[ -n "$OPT_ENV_FROM" ]]; then
+                die ".env fourni invalide, abandon."
+            fi
+            prepend_errors_to_env "$ENV_FILE" "$errs"
+            log_warn "ré-ouverture de l'éditeur dans 2s…"
+            sleep 2
+        done
+    fi
 
     # ─── Étape 10 : DNS ─────────────────────────────────────────────────────
     log_step "Vérification DNS"

--- a/deploy/lib/cli.sh
+++ b/deploy/lib/cli.sh
@@ -17,8 +17,11 @@ Options :
   --email <addr>         Email pour les notifications Let's Encrypt
                          (défaut: laisse le placeholder du Caddyfile, à éditer)
   --version <tag>        Tag GHCR à déployer (défaut: latest)
+  --deploy-repo <url>    Dépôt de déploiement PRIVÉ (secrets-as-code, ADR-0044) d'où
+                         pull providers/<slug>/{config.env,secrets.env}. La box y accède
+                         via sa deploy key SSH RO (générée à l'install).
   --env-from <file>      Charge un .env pré-rempli au lieu d'ouvrir l'éditeur
-                         (utile pour les tests e2e et déploiements scriptés)
+                         (legacy/migration ; utile pour les tests e2e et scripts)
   --skip-dns             N'attend pas la propagation DNS (test local)
   --no-harden            Saute tout le durcissement VPS (ADR-0031)
   --no-sshd              Durcit mais ne verrouille pas sshd (garde root SSH actif)
@@ -41,6 +44,7 @@ parse_args() {
     OPT_ADMIN_PUBKEY=""
     OPT_EMAIL=""
     OPT_VERSION="latest"
+    OPT_DEPLOY_REPO=""
     OPT_ENV_FROM=""
     OPT_SKIP_DNS=0
     OPT_NO_HARDEN=0
@@ -55,6 +59,7 @@ parse_args() {
             --admin-pubkey) OPT_ADMIN_PUBKEY="${2:-}"; shift 2 ;;
             --email)        OPT_EMAIL="${2:-}"; shift 2 ;;
             --version)      OPT_VERSION="${2:-}"; shift 2 ;;
+            --deploy-repo)  OPT_DEPLOY_REPO="${2:-}"; shift 2 ;;
             --env-from)     OPT_ENV_FROM="${2:-}"; shift 2 ;;
             --skip-dns)     OPT_SKIP_DNS=1; shift ;;
             --no-harden)    OPT_NO_HARDEN=1; shift ;;

--- a/deploy/lib/config.sh
+++ b/deploy/lib/config.sh
@@ -18,18 +18,23 @@ map_version_to_git_ref() {
     esac
 }
 
-# download_config_files <version> <home_dir>
+# download_config_files <version> <home_dir> [<skip_env>]
 # Télécharge depuis le tag <version> vers <home_dir>/{.env,deploy/docker/*}.
 # Idempotent : si .env existe déjà, on ne l'écrase pas (mode reconfigure).
+# Si <skip_env>=1 (secrets-as-code, ADR-0044) : on ne télécharge AUCUN .env — la
+# config claire arrive via le dépôt de déploiement (providers/<slug>/config.env).
 download_config_files() {
     local version="$1"
     local home="$2"
+    local skip_env="${3:-0}"
     local docker_dir="${home}/deploy/docker"
     local ref; ref=$(map_version_to_git_ref "$version")
     local base="${CONFIG_BASE_URL}/${ref}/deploy/docker"
     install -d "$docker_dir"
-    # .env : ne pas écraser si présent (rerun)
-    if [[ ! -f "${home}/.env" ]]; then
+    # .env : ne pas écraser si présent (rerun) ; ne pas créer du tout en secrets-as-code.
+    if [[ "$skip_env" == "1" ]]; then
+        log_skip ".env non téléchargé (secrets-as-code : config.env vient du dépôt)"
+    elif [[ ! -f "${home}/.env" ]]; then
         curl -fsSL "${base}/.env.example" -o "${home}/.env"
         log_ok ".env téléchargé depuis ${version}"
     else
@@ -55,6 +60,8 @@ download_config_files() {
 # par les valeurs réelles. `--version` étant la source de vérité de la version
 # Docker à pin, on évite de devoir l'éditer à la main dans le step EDITOR.
 # Préserve l'ownership du fichier (sed -i peut le casser).
+# NB (ADR-0044) : ces trois clés sont TOUTES côté config CLAIRE → cette fonction
+# écrit aussi bien le legacy `.env` que le `config.env` du split secrets-as-code.
 substitute_env() {
     local env_file="$1"
     local slug="$2"

--- a/deploy/lib/env_validate.sh
+++ b/deploy/lib/env_validate.sh
@@ -112,7 +112,7 @@ validate_config_env() {
 
     # Garde-fou anti-fuite : un credential n'a RIEN à faire dans config.env (clair).
     local leaked
-    leaked=$(grep -oE '^[[:space:]]*(API_KEY|API_KEYS|SFTP__URL|TELEGRAM_BOT_TOKEN|AES__TROUSSEAU__|ODOO__(PASSWORD|API_KEY))' "$file" 2>/dev/null | head -1)
+    leaked=$(grep -oE '^[[:space:]]*(API_KEY|API_KEYS|SFTP__URL|TELEGRAM_BOT_TOKEN|AES__TROUSSEAU__|ODOO_(TEST|PROD)_PASSWORD)' "$file" 2>/dev/null | head -1)
     [[ -z "$leaked" ]] || \
         errors+=("secret en clair détecté dans config.env (« ${leaked} ») — il doit vivre dans secrets.env chiffré")
 

--- a/deploy/lib/env_validate.sh
+++ b/deploy/lib/env_validate.sh
@@ -169,8 +169,11 @@ validate_secrets_plaintext() {
 }
 
 # validate_secrets_env <secrets_file> <age_keyfile>
-# Déchiffre <secrets_file> (SOPS+age) avec <age_keyfile> EN MÉMOIRE (jamais sur disque)
-# et valide le clair via `validate_secrets_plaintext`. 0 si OK, 1 sinon (erreurs stdout).
+# Déchiffre <secrets_file> (SOPS+age) avec <age_keyfile> et valide le clair via
+# `validate_secrets_plaintext`. 0 si OK, 1 sinon (erreurs stdout). NB : chemin de
+# validation côté MACHINE ADMIN à la (re)config — PAS le runtime (l'entrypoint
+# `sops exec-env` n'écrit, lui, jamais de clair). Ici le clair transite par un tmp 0600
+# shreddé immédiatement (cf. plus bas pourquoi un fichier et pas un pipe).
 validate_secrets_env() {
     local file="$1"
     local keyfile="$2"
@@ -181,12 +184,16 @@ validate_secrets_env() {
         echo "déchiffrement SOPS échoué (clé age non destinataire ? fichier corrompu ?)"
         return 1
     fi
-    # On valide via un tmp en mémoire (mktemp puis suppression immédiate).
+    # validate_secrets_plaintext relit son argument plusieurs fois (un read_env_var/grep
+    # par variable) → une substitution de process (pipe à lecture unique) ne convient pas.
+    # Le clair touche donc un tmp 0600 (mktemp), shreddé immédiatement après validation.
+    # (Pas de trap de nettoyage ici : install.sh possède déjà un `trap … INT TERM` au
+    #  niveau process qu'on ne doit pas écraser depuis une fonction de lib.)
     local tmp; tmp=$(mktemp)
     printf '%s\n' "$plaintext" > "$tmp"
     local rc=0 out
     out=$(validate_secrets_plaintext "$tmp") || rc=1
-    rm -f "$tmp"
+    shred -u "$tmp" 2>/dev/null || rm -f "$tmp"
     [[ -n "$out" ]] && printf '%s\n' "$out"
     return "$rc"
 }

--- a/deploy/lib/env_validate.sh
+++ b/deploy/lib/env_validate.sh
@@ -81,6 +81,116 @@ validate_env_file() {
     return 0
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Split config/secret (ADR-0044) : le `.env` monolithique se scinde en deux.
+#   config.env  (clair, versionné)  — config NON secrète + substitutions compose
+#   secrets.env (chiffré SOPS+age)  — UNIQUEMENT des credentials
+# Le validateur ci-dessus (`validate_env_file`) reste pour la migration ; les deux
+# fonctions ci-dessous valident chaque moitié.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# validate_config_env <config_file> <expected_slug>
+# Valide la moitié CLAIRE : INSTANCE_SLUG (matche), ELECTRICORE_VERSION et
+# BACKUPS_PATH présents. AUCUN secret ici (sinon erreur — un secret en clair dans
+# config.env est une fuite). Imprime les erreurs sur stdout ; 0 si OK, 1 sinon.
+validate_config_env() {
+    local file="$1"
+    local expected_slug="$2"
+    local errors=()
+
+    [[ -r "$file" ]] || { echo "config.env introuvable : $file"; return 1; }
+
+    local slug version backups
+    slug=$(read_env_var "$file" INSTANCE_SLUG)
+    version=$(read_env_var "$file" ELECTRICORE_VERSION)
+    backups=$(read_env_var "$file" BACKUPS_PATH)
+
+    [[ "$slug" == "$expected_slug" ]] || \
+        errors+=("INSTANCE_SLUG='${slug}' ne matche pas le slug attendu '${expected_slug}'")
+    [[ -n "$version" ]] || errors+=("ELECTRICORE_VERSION manquant (substitution compose)")
+    [[ -n "$backups" ]] || errors+=("BACKUPS_PATH manquant (substitution compose)")
+
+    # Garde-fou anti-fuite : un credential n'a RIEN à faire dans config.env (clair).
+    local leaked
+    leaked=$(grep -oE '^[[:space:]]*(API_KEY|API_KEYS|SFTP__URL|TELEGRAM_BOT_TOKEN|AES__TROUSSEAU__|ODOO__(PASSWORD|API_KEY))' "$file" 2>/dev/null | head -1)
+    [[ -z "$leaked" ]] || \
+        errors+=("secret en clair détecté dans config.env (« ${leaked} ») — il doit vivre dans secrets.env chiffré")
+
+    if [[ ${#errors[@]} -gt 0 ]]; then
+        printf '%s\n' "${errors[@]}"
+        return 1
+    fi
+    return 0
+}
+
+# validate_secrets_plaintext <plaintext_file>
+# Valide la moitié SECRÈTE déjà DÉCHIFFRÉE (dotenv en clair, jamais sur disque en prod) :
+# API_KEY, SFTP__URL, trousseau AES présents et valides. Réutilise les règles AES de
+# `validate_env_file`. Imprime les erreurs sur stdout ; 0 si OK, 1 sinon.
+validate_secrets_plaintext() {
+    local file="$1"
+    local errors=()
+
+    [[ -r "$file" ]] || { echo "secrets (clair) introuvable : $file"; return 1; }
+
+    local api_key sftp
+    api_key=$(read_env_var "$file" API_KEY)
+    sftp=$(read_env_var "$file" SFTP__URL)
+
+    validate_api_key "$api_key" || \
+        errors+=("API_KEY manquant ou trop court (≥ 32 caractères requis)")
+    validate_url "$sftp" || \
+        errors+=("SFTP__URL invalide (attendu sftp://… ou file://…) : '${sftp}'")
+
+    local labels label key iv
+    mapfile -t labels < <(
+        grep -oE '^[[:space:]]*AES__TROUSSEAU__.+__KEY[[:space:]]*=' "$file" 2>/dev/null \
+            | sed -E 's/^[[:space:]]*AES__TROUSSEAU__(.+)__KEY[[:space:]]*=.*/\1/' | sort -u
+    )
+    if [[ ${#labels[@]} -eq 0 ]]; then
+        errors+=("trousseau AES vide : ajoutez au moins une clé AES__TROUSSEAU__<label>__KEY (hex 32 ou 64)")
+    else
+        for label in "${labels[@]}"; do
+            key=$(read_env_var "$file" "AES__TROUSSEAU__${label}__KEY")
+            iv=$(read_env_var "$file" "AES__TROUSSEAU__${label}__IV")
+            if ! validate_aes_key "$key"; then
+                errors+=("AES__TROUSSEAU__${label}__KEY absent ou pas en hex 32/64 chars")
+            elif [[ -n "$iv" ]] && ! validate_aes_iv "$iv"; then
+                errors+=("AES__TROUSSEAU__${label}__IV présent mais pas en hex 32/64 (retire-le pour le schéma IV-préfixé AES-256)")
+            fi
+        done
+    fi
+
+    if [[ ${#errors[@]} -gt 0 ]]; then
+        printf '%s\n' "${errors[@]}"
+        return 1
+    fi
+    return 0
+}
+
+# validate_secrets_env <secrets_file> <age_keyfile>
+# Déchiffre <secrets_file> (SOPS+age) avec <age_keyfile> EN MÉMOIRE (jamais sur disque)
+# et valide le clair via `validate_secrets_plaintext`. 0 si OK, 1 sinon (erreurs stdout).
+validate_secrets_env() {
+    local file="$1"
+    local keyfile="$2"
+    [[ -r "$file" ]]    || { echo "secrets.env introuvable : $file"; return 1; }
+    [[ -r "$keyfile" ]] || { echo "clé age introuvable : $keyfile"; return 1; }
+    local plaintext
+    if ! plaintext=$(SOPS_AGE_KEY_FILE="$keyfile" sops decrypt --input-type dotenv --output-type dotenv "$file" 2>/dev/null); then
+        echo "déchiffrement SOPS échoué (clé age non destinataire ? fichier corrompu ?)"
+        return 1
+    fi
+    # On valide via un tmp en mémoire (mktemp puis suppression immédiate).
+    local tmp; tmp=$(mktemp)
+    printf '%s\n' "$plaintext" > "$tmp"
+    local rc=0 out
+    out=$(validate_secrets_plaintext "$tmp") || rc=1
+    rm -f "$tmp"
+    [[ -n "$out" ]] && printf '%s\n' "$out"
+    return "$rc"
+}
+
 # strip_validation_error_block <env_file>
 # Supprime le bloc d'erreurs (marqueurs VALIDATION-ERROR-BLOCK-BEGIN/END et
 # son contenu) du .env, quand la validation vient de réussir. Idempotent :

--- a/deploy/lib/secrets.sh
+++ b/deploy/lib/secrets.sh
@@ -1,0 +1,168 @@
+# shellcheck shell=bash
+# Secrets-as-code (ADR-0044) : génération des deux identités de la box (age + SSH),
+# pull du dépôt de déploiement privé, validation du split config/secret.
+#
+# Toutes les commandes externes (docker, git, age) sont appelées PAR LEUR NOM (via
+# le PATH) → les tests `deploy/tests/` les stubbent en fake-binaries (motif maison).
+#
+# Décisions clés (ADR-0044) :
+#   §4 — chaque box génère SA paire age + SA paire SSH ; les clés PRIVÉES naissent sur
+#        la box et n'en sortent jamais (/srv/<slug>/, 600). L'opérateur enregistre les
+#        deux PUBLIQUES (age → destinataire .sops.yaml ; SSH → deploy key RO).
+#        Génération VIA L'IMAGE (age-keygen / ssh-keygen embarqués) → zéro dép hôte.
+#   §5 — le ciphertext arrive par auto-pull : la box clone/pull le dépôt privé via sa
+#        deploy key RO et lit providers/<slug>/{config.env,secrets.env}.
+
+# Image runtime par défaut (porte age + ssh-keygen + sops).
+SECRETS_IMAGE="${SECRETS_IMAGE:-ghcr.io/energie-de-nantes/electricore:latest}"
+# Commandes externes, surchargeable pour les tests.
+DOCKER_BIN="${DOCKER_BIN:-docker}"
+GIT_BIN="${GIT_BIN:-git}"
+# Racine des homes d'instance (/srv en prod, ADR-0017). Surchargeable pour les tests.
+SRV_BASE="${SRV_BASE:-/srv}"
+
+# generate_age_identity <home>
+# Génère la paire age de la box VIA L'IMAGE (age-keygen), écrit la clé privée dans
+# <home>/age.key (600), et imprime la clé PUBLIQUE sur stdout. Idempotent : si
+# <home>/age.key existe déjà, on ne régénère pas (on re-dérive juste la pub).
+generate_age_identity() {
+    local home="$1"
+    local keyfile="${home}/age.key"
+    if [[ -f "$keyfile" ]]; then
+        log_skip "clé age déjà présente (${keyfile}) — conservée" >&2
+    else
+        # age-keygen écrit la clé privée sur stdout (+ la pub en commentaire) et la
+        # pub sur stderr. On capture la privée via l'image, sans jamais l'exposer.
+        "$DOCKER_BIN" run --rm "$SECRETS_IMAGE" age-keygen 2>/dev/null > "$keyfile" \
+            || { log_err "échec age-keygen via l'image" >&2; return 1; }
+        chmod 600 "$keyfile"
+        log_ok "paire age générée (${keyfile}, 600)" >&2
+    fi
+    age_public_key "$keyfile"
+}
+
+# age_public_key <keyfile>
+# Dérive la clé publique age depuis la clé privée VIA L'IMAGE (age-keygen -y).
+age_public_key() {
+    local keyfile="$1"
+    "$DOCKER_BIN" run --rm -v "${keyfile}:/age.key:ro" "$SECRETS_IMAGE" \
+        age-keygen -y /age.key 2>/dev/null
+}
+
+# generate_ssh_deploy_identity <home>
+# Génère la paire SSH de la box VIA L'IMAGE (ssh-keygen ed25519), clé privée dans
+# <home>/ssh_deploy_key (600), et imprime la clé PUBLIQUE sur stdout. Idempotent.
+generate_ssh_deploy_identity() {
+    local home="$1"
+    local keyfile="${home}/ssh_deploy_key"
+    if [[ -f "$keyfile" ]]; then
+        log_skip "clé SSH de déploiement déjà présente (${keyfile}) — conservée" >&2
+    else
+        # ssh-keygen écrit keyfile + keyfile.pub. On le lance dans l'image, le home
+        # monté en RW pour récupérer les deux fichiers.
+        "$DOCKER_BIN" run --rm -v "${home}:/out" "$SECRETS_IMAGE" \
+            ssh-keygen -t ed25519 -N '' -C "deploy-key" -f /out/ssh_deploy_key \
+            >/dev/null 2>&1 \
+            || { log_err "échec ssh-keygen via l'image" >&2; return 1; }
+        chmod 600 "$keyfile"
+        [[ -f "${keyfile}.pub" ]] && chmod 644 "${keyfile}.pub"
+        log_ok "paire SSH de déploiement générée (${keyfile}, 600)" >&2
+    fi
+    cat "${keyfile}.pub"
+}
+
+# generate_box_identities <slug>
+# Génère les DEUX identités de la box et imprime les deux clés publiques sous une
+# forme parlante pour l'opérateur (à enregistrer : age → destinataire ; SSH → deploy key).
+# Renvoie 0 si OK. La sortie « publique » va sur stdout (capturable), les logs sur stderr.
+generate_box_identities() {
+    local slug="$1"
+    local home="${SRV_BASE}/${slug}"
+    local age_pub ssh_pub
+    age_pub=$(generate_age_identity "$home") || return 1
+    ssh_pub=$(generate_ssh_deploy_identity "$home") || return 1
+    chown "$slug:$slug" "${home}/age.key" "${home}/ssh_deploy_key" "${home}/ssh_deploy_key.pub" 2>/dev/null || true
+    printf 'AGE_PUBLIC_KEY=%s\n' "$age_pub"
+    printf 'SSH_DEPLOY_PUBKEY=%s\n' "$ssh_pub"
+}
+
+# pull_deploy_repo <repo_url> <slug>
+# Clone (ou pull si déjà cloné) le dépôt de déploiement PRIVÉ via la deploy key RO de
+# la box, dans /srv/<slug>/deploy-repo, puis expose providers/<slug>/ à la racine du
+# home (symlink ou copie) là où le compose l'attend (../../providers/<slug>/).
+# La deploy key est de faible valeur (ADR-0044 §5) : elle ne donne accès qu'à du
+# ciphertext, inutile sans la clé age.
+pull_deploy_repo() {
+    local repo_url="$1"
+    local slug="$2"
+    local home="${SRV_BASE}/${slug}"
+    local repo_dir="${home}/deploy-repo"
+    local deploy_key="${home}/ssh_deploy_key"
+    [[ -f "$deploy_key" ]] || { log_err "deploy key absente (${deploy_key}) — génère d'abord l'identité." >&2; return 1; }
+    # GIT_SSH_COMMAND épingle la clé RO et coupe l'interactivité (StrictHostKeyChecking).
+    local git_ssh="ssh -i ${deploy_key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+    if [[ -d "${repo_dir}/.git" ]]; then
+        GIT_SSH_COMMAND="$git_ssh" "$GIT_BIN" -C "$repo_dir" pull --ff-only \
+            || { log_err "git pull du dépôt de déploiement a échoué" >&2; return 1; }
+        log_ok "dépôt de déploiement mis à jour (${repo_dir})" >&2
+    else
+        GIT_SSH_COMMAND="$git_ssh" "$GIT_BIN" clone "$repo_url" "$repo_dir" \
+            || { log_err "git clone du dépôt de déploiement a échoué" >&2; return 1; }
+        log_ok "dépôt de déploiement cloné (${repo_dir})" >&2
+    fi
+    # Le compose attend ../../providers/<slug>/{config.env,secrets.env}. On relie le
+    # dossier providers/ du dépôt à la racine du home → ${home}/providers/<slug>/ résout.
+    local providers_src="${repo_dir}/providers"
+    [[ -d "${providers_src}/${slug}" ]] || { log_err "providers/${slug}/ absent du dépôt de déploiement." >&2; return 1; }
+    ln -sfn "$providers_src" "${home}/providers"
+    # Le config.env CLAIR (substitutions compose) est tiré à la racine du home pour
+    # `docker compose --env-file ../../config.env` (cf. stack.sh::compose_up).
+    if [[ -f "${providers_src}/${slug}/config.env" ]]; then
+        cp "${providers_src}/${slug}/config.env" "${home}/config.env"
+    fi
+    log_ok "providers/${slug}/ relié depuis le dépôt (${home}/providers → ${providers_src})" >&2
+}
+
+# print_onboarding_pending <slug> <domain> <age_pub> <ssh_pub>
+# Affiche le message d'onboarding EN DEUX TEMPS (ADR-0044 §4) : les deux clés
+# publiques à enregistrer + la marche à suivre, puis comment finir avec reconfigure.
+print_onboarding_pending() {
+    local slug="$1" domain="$2" age_pub="$3" ssh_pub="$4"
+    cat <<EOF
+
+  ${_C_BOLD}Onboarding en deux temps — la box ${slug} attend l'enregistrement de ses clés.${_C_RESET}
+
+  La box a généré ses DEUX identités (clés privées en /srv/${slug}/, 600, elles
+  ne quittent jamais la box). Enregistre maintenant les DEUX clés PUBLIQUES :
+
+  1) Clé age PUBLIQUE → destinataire .sops.yaml du dépôt de déploiement
+     (puis: sops updatekeys providers/${slug}/secrets.env ; commit ; push)
+
+       ${age_pub}
+
+  2) Clé SSH PUBLIQUE → deploy key EN LECTURE SEULE du dépôt de déploiement
+
+       ${ssh_pub}
+
+  Une fois les deux enregistrées et poussées, termine l'onboarding :
+
+       sudo bash install.sh --slug ${slug} --domain ${domain} --deploy-repo <url>
+
+  (reconfigure : la box pull le ciphertext, déchiffre, et démarre la stack.)
+
+EOF
+}
+
+# box_can_decrypt <slug>
+# Vrai (0) si la box est capable de déchiffrer : clé age présente ET secrets.env présent
+# ET la clé age publique de la box est destinataire (le déchiffrement réussit). On teste
+# le déchiffrement RÉEL d'au moins une valeur (sops decrypt --extract impossible sans
+# clé → on tente un decrypt complet, silencieux). Sert au garde-fou onboarding 2 temps.
+box_can_decrypt() {
+    local slug="$1"
+    local home="${SRV_BASE}/${slug}"
+    local keyfile="${home}/age.key"
+    local secrets="${home}/providers/${slug}/secrets.env"
+    [[ -f "$keyfile" && -f "$secrets" ]] || return 1
+    SOPS_AGE_KEY_FILE="$keyfile" sops decrypt --input-type dotenv --output-type dotenv "$secrets" >/dev/null 2>&1
+}

--- a/deploy/lib/stack.sh
+++ b/deploy/lib/stack.sh
@@ -3,17 +3,19 @@
 # La stack est exécutée en tant que <slug> (membre du groupe docker).
 
 # compose_up <slug>
-# Lance `docker compose --env-file ../../.env up -d` depuis /srv/<slug>/deploy/docker/
+# Lance `docker compose --env-file ../../config.env up -d` depuis /srv/<slug>/deploy/docker/
 # en tant que <slug>. Le `--env-file` est requis pour que les substitutions
 # ${INSTANCE_SLUG}/${BACKUPS_PATH}/${ELECTRICORE_VERSION} soient résolues
-# (cf. commentaire en tête de docker-compose.yml).
+# (cf. commentaire en tête de docker-compose.yml). Depuis ADR-0044, la source des
+# substitutions est `config.env` (clair) — plus de `.env` ; les credentials vivent
+# dans `secrets.env` (chiffré, déchiffré par l'entrypoint de l'image).
 compose_up() {
     local slug="$1"
     local home="/srv/${slug}"
     # On utilise `sudo -u` pour matcher l'uid host du user (cohérence permissions
     # bind-mount). Note : le user <slug> est dans le groupe docker (cf. user.sh).
     sudo -u "$slug" -- bash -c \
-        "cd '${home}/deploy/docker' && docker compose --env-file ../../.env up -d"
+        "cd '${home}/deploy/docker' && docker compose --env-file ../../config.env up -d"
 }
 
 # wait_for_health <slug> [<max_retries>] [<delay_seconds>]

--- a/deploy/providers/example/.sops.yaml.example
+++ b/deploy/providers/example/.sops.yaml.example
@@ -1,0 +1,29 @@
+# EXEMPLE — règles SOPS pour un provider (ADR-0044). À COPIER dans le dépôt de
+# déploiement PRIVÉ sous providers/<slug>/.sops.yaml, puis remplacer les destinataires
+# FACTICES par les VRAIES clés publiques (admin + box). NE JAMAIS committer ce fichier
+# tel quel dans un dépôt avec de vrais secrets : ces clés sont des PLACEHOLDERS.
+#
+# Isolation CRYPTOGRAPHIQUE multi-cible (ADR-0044 §6) : chaque secrets.env n'est chiffré
+# QUE pour les destinataires de SA règle. Une box n'est destinataire que de SON provider
+# → elle ne peut pas déchiffrer ceux des autres. L'isolation n'est pas une convention de
+# dossiers, c'est la liste de destinataires.
+#
+# Destinataires (ADR-0044 §6) :
+#   - admin  : TOUJOURS, dans CHAQUE règle (récupération, rotation, edition).
+#   - box    : la clé age publique de la box qui sert ce provider.
+#   - la CI n'est JAMAIS destinataire (elle build des images publiques sans secret —
+#     elle ne déchiffre jamais ; cf. NOTE plus bas).
+
+creation_rules:
+  # Le chiffrement cible les fichiers secrets.env de ce provider.
+  - path_regex: secrets\.env$
+    key_groups:
+      - age:
+          # FACTICE — clé publique age de l'ADMIN (toujours destinataire).
+          - age1adminFACTICExxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx00
+          # FACTICE — clé publique age de la BOX qui sert ce provider.
+          - age1boxFACTICExxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx11
+
+# NOTE — la CI n'est PAS destinataire (ADR-0044 §6). Elle ne déchiffre jamais : elle
+# build des images publiques sans secret, garanties par le scan d'image. N'ajoute
+# JAMAIS de clé « CI » ici.

--- a/deploy/providers/example/README.md
+++ b/deploy/providers/example/README.md
@@ -1,0 +1,37 @@
+# Exemple de scaffolding `providers/<slug>/` (secrets-as-code, ADR-0044)
+
+> **Ceci est un EXEMPLE clairement marqué.** electricore (public, AGPL) ne porte que
+> le **mécanisme + le scaffolding** ([ADR-0044](../../../docs/adr/0044-secrets-as-code-sops-age.md) §6).
+> Les **vrais** secrets, le **vrai** `.sops.yaml` et les **vraies** clés publiques
+> vivent dans un **dépôt de déploiement privé séparé** — jamais ici. Les destinataires
+> ci-dessous sont **FACTICES**.
+
+Forme multi-cible adoptée dès une seule instance (ADR-0044 §7) : chaque fournisseur a
+son dossier `providers/<slug>/` dans le dépôt privé, avec sa propre liste de
+destinataires → **isolation cryptographique** (une box ne déchiffre que les siens).
+
+## Fichiers
+
+| Fichier | Rôle | Versionné | Chiffré |
+|---|---|---|---|
+| `.sops.yaml` | destinataires age (admin **toujours** + box) | oui | non |
+| `config.env` | config CLAIRE (substitutions compose + non-secret) | oui | non |
+| `secrets.env` | credentials | oui | **oui** (SOPS + age) |
+
+Les `*.example` ici sont des **gabarits**. Dans le dépôt privé, on les copie sans le
+suffixe `.example`, on remplace les valeurs FACTICES, et on chiffre `secrets.env`.
+
+## Ajouter un provider / une box
+
+Utilise [`deploy/add-provider.sh`](../../add-provider.sh) : il ajoute un destinataire
+(clé age publique d'une box) à `.sops.yaml` et lance `sops updatekeys` pour **re-chiffrer
+l'enveloppe** de `secrets.env` vers le nouveau jeu de destinataires.
+
+> **Distinction cruciale** (ADR-0044) : `sops updatekeys` ne rote que l'**enveloppe**
+> (le re-wrap de la clé de données). Si un secret a pu **fuiter**, le changer **AUSSI à
+> la source** (nouvelle clé Enedis, nouveau token, etc.) — `updatekeys` ne le protège pas.
+
+## La CI n'est jamais destinataire
+
+La CI build des images publiques **sans secret** (garanties par le scan d'image) : elle
+ne déchiffre jamais. N'ajoute **jamais** de clé « CI » à un `.sops.yaml` (ADR-0044 §6).

--- a/deploy/providers/example/config.env.example
+++ b/deploy/providers/example/config.env.example
@@ -1,0 +1,18 @@
+# EXEMPLE — config.env d'un provider (ADR-0044). CLAIR, versionné, AUCUN secret.
+# À copier dans le dépôt de déploiement privé sous providers/<slug>/config.env et
+# adapter. Porte la config NON secrète + les substitutions ${...} de docker compose.
+#
+# ⚠️ AUCUN credential ici (API_KEY, SFTP__URL, AES__TROUSSEAU__*, TELEGRAM_BOT_TOKEN,
+#    ODOO__PASSWORD…) — ils vivent dans secrets.env (chiffré). Le validateur d'install
+#    (validate_config_env) REFUSE un secret en clair dans config.env.
+
+# ── Identité de l'instance ──────────────────────────────────────────────────
+INSTANCE_SLUG=example
+# Tag d'image GHCR à épingler (substitution compose ${ELECTRICORE_VERSION}).
+ELECTRICORE_VERSION=latest
+# Chemin host des backups (substitution compose ${BACKUPS_PATH}).
+BACKUPS_PATH=/srv/example/backups
+
+# ── Config non-secrète optionnelle ──────────────────────────────────────────
+# Environnement Odoo (métadonnée non secrète ; les credentials sont dans secrets.env).
+ODOO_ENV=prod

--- a/deploy/providers/example/config.env.example
+++ b/deploy/providers/example/config.env.example
@@ -3,7 +3,7 @@
 # adapter. Porte la config NON secrète + les substitutions ${...} de docker compose.
 #
 # ⚠️ AUCUN credential ici (API_KEY, SFTP__URL, AES__TROUSSEAU__*, TELEGRAM_BOT_TOKEN,
-#    ODOO__PASSWORD…) — ils vivent dans secrets.env (chiffré). Le validateur d'install
+#    ODOO_PROD_PASSWORD…) — ils vivent dans secrets.env (chiffré). Le validateur d'install
 #    (validate_config_env) REFUSE un secret en clair dans config.env.
 
 # ── Identité de l'instance ──────────────────────────────────────────────────

--- a/deploy/providers/example/secrets.env.example
+++ b/deploy/providers/example/secrets.env.example
@@ -20,10 +20,12 @@ API_KEY=remplacer_par_une_cle_d_au_moins_32_caracteres_factice
 TELEGRAM_BOT_TOKEN=000000:FACTICE_TELEGRAM_TOKEN
 
 # ── Odoo (bloc de connexion) ────────────────────────────────────────────────
-ODOO__URL=https://odoo.example
-ODOO__DB=odoo_factice
-ODOO__USERNAME=bot@example
-ODOO__PASSWORD=mot_de_passe_factice
+# Préfixe ODOO_<ENV>_ aligné sur ODOO_ENV de config.env (ici prod → ODOO_PROD_*).
+# C'est ce que lit runtime.odoo() ; ODOO__* (sans env) ne serait jamais pris en compte.
+ODOO_PROD_URL=https://odoo.example
+ODOO_PROD_DB=odoo_factice
+ODOO_PROD_USERNAME=bot@example
+ODOO_PROD_PASSWORD=mot_de_passe_factice
 
 # ── Trousseau AES Enedis (ADR-0037/ADR-0040) ────────────────────────────────
 # Labels DYNAMIQUES choisis par l'opérateur ; injectés sans énumération par

--- a/deploy/providers/example/secrets.env.example
+++ b/deploy/providers/example/secrets.env.example
@@ -1,0 +1,34 @@
+# EXEMPLE — secrets.env d'un provider (ADR-0044), montré EN CLAIR à titre pédagogique.
+# Dans le dépôt de déploiement privé, ce fichier vit CHIFFRÉ (SOPS + age) sous
+# providers/<slug>/secrets.env. NE JAMAIS committer ce contenu en clair avec de
+# VRAIES valeurs : ci-dessous, tout est FACTICE / placeholder.
+#
+# Pour produire le vrai secrets.env chiffré, sur la machine admin :
+#   sops encrypt --input-type dotenv --output-type dotenv \
+#       secrets.env.clair > providers/<slug>/secrets.env
+# (SOPS chiffre les VALEURS, laisse les NOMS de champs en clair → diffs Git lisibles.)
+#
+# Contenu = UNIQUEMENT des credentials.
+
+# ── SFTP Enedis (mot de passe embarqué dans l'URL) ──────────────────────────
+SFTP__URL=sftp://USER_FACTICE:PASS_FACTICE@sftp.enedis.example:22/exports
+
+# ── API electricore ─────────────────────────────────────────────────────────
+API_KEY=remplacer_par_une_cle_d_au_moins_32_caracteres_factice
+
+# ── Bot Telegram (tourne dans le process API) ───────────────────────────────
+TELEGRAM_BOT_TOKEN=000000:FACTICE_TELEGRAM_TOKEN
+
+# ── Odoo (bloc de connexion) ────────────────────────────────────────────────
+ODOO__URL=https://odoo.example
+ODOO__DB=odoo_factice
+ODOO__USERNAME=bot@example
+ODOO__PASSWORD=mot_de_passe_factice
+
+# ── Trousseau AES Enedis (ADR-0037/ADR-0040) ────────────────────────────────
+# Labels DYNAMIQUES choisis par l'opérateur ; injectés sans énumération par
+# l'entrypoint (sops exec-env). __IV optionnel : absent ⇒ schéma IV-préfixé (AES-256).
+AES__TROUSSEAU__aes256_2026__KEY=00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff
+# AES-128 historique (schéma IV-fixe) : clé + IV fournis par Enedis.
+AES__TROUSSEAU__aes128_2024__KEY=00112233445566778899aabbccddeeff
+AES__TROUSSEAU__aes128_2024__IV=ffeeddccbbaa99887766554433221100

--- a/deploy/tests/fixtures/fake_bin/docker
+++ b/deploy/tests/fixtures/fake_bin/docker
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Fake `docker` pour les tests de secrets.sh (ADR-0044) — simule `docker run … <tool>`.
+# On n'a PAS de vrai Docker en CI deploy-shell : on imite juste les sous-commandes
+# qu'appelle secrets.sh (age-keygen, age-keygen -y, ssh-keygen). Trace les appels
+# dans $FAKE_DOCKER_LOG si défini.
+[[ -n "${FAKE_DOCKER_LOG:-}" ]] && printf '%s\n' "$*" >> "$FAKE_DOCKER_LOG"
+
+# Sauter les flags `run --rm [-v src:dst[:ro]]* <image>` pour atteindre la commande.
+args=("$@")
+i=0
+# avance jusqu'après l'image (1er token qui ne commence pas par '-' après 'run',
+# en sautant les valeurs de -v). Simplification : on cherche le 1er token connu.
+tool=""
+mount_src=""
+while [[ $i -lt ${#args[@]} ]]; do
+    case "${args[$i]}" in
+        -v) mount_src="${args[$((i+1))]%%:*}"; i=$((i+2)); continue ;;
+        age-keygen|ssh-keygen) tool="${args[$i]}"; break ;;
+    esac
+    i=$((i+1))
+done
+
+case "$tool" in
+    age-keygen)
+        # `age-keygen -y /age.key` → imprime une pub factice déterministe ;
+        # `age-keygen` seul → imprime une clé privée factice (format age) sur stdout.
+        if [[ "${args[$((i+1))]:-}" == "-y" ]]; then
+            echo "age1faketestpublickeyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxq9"
+        else
+            echo "# created: fake"
+            echo "# public key: age1faketestpublickeyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxq9"
+            echo "AGE-SECRET-KEY-1FAKETESTPRIVATEKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        fi
+        ;;
+    ssh-keygen)
+        # `ssh-keygen … -f /out/ssh_deploy_key` → écrit privée + .pub dans le mount.
+        out="${mount_src}/ssh_deploy_key"
+        echo "FAKE-OPENSSH-PRIVATE-KEY" > "$out"
+        echo "ssh-ed25519 AAAAFAKEDEPLOYKEY deploy-key" > "${out}.pub"
+        ;;
+    *)
+        echo "fake docker: commande non simulée ($*)" >&2; exit 1 ;;
+esac

--- a/deploy/tests/fixtures/fake_bin/git
+++ b/deploy/tests/fixtures/fake_bin/git
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Fake `git` pour les tests de secrets.sh (ADR-0044) — simule clone/pull du dépôt
+# de déploiement privé sans réseau. Trace les appels dans $FAKE_GIT_LOG si défini.
+# Le contenu du dépôt simulé est posé par le test dans $FAKE_GIT_SRC.
+[[ -n "${FAKE_GIT_LOG:-}" ]] && printf '%s\n' "$*" >> "$FAKE_GIT_LOG"
+
+cmd="$1"; shift || true
+case "$cmd" in
+    clone)
+        # `git clone <url> <dest>` → recopie $FAKE_GIT_SRC dans <dest>.
+        dest="${*: -1}"
+        mkdir -p "$dest"
+        cp -r "${FAKE_GIT_SRC:?FAKE_GIT_SRC requis}/." "$dest/"
+        mkdir -p "${dest}/.git"   # marque "cloné" pour les pulls suivants
+        ;;
+    -C)
+        # `git -C <repo> pull --ff-only` → no-op succès (déjà à jour).
+        :
+        ;;
+    *)
+        echo "fake git: commande non simulée ($cmd $*)" >&2; exit 1 ;;
+esac

--- a/deploy/tests/fixtures/fake_bin/sops
+++ b/deploy/tests/fixtures/fake_bin/sops
@@ -1,17 +1,28 @@
 #!/usr/bin/env bash
-# Fake `sops` pour les tests de secrets.sh / env_validate.sh (ADR-0044).
-# `sops decrypt … <file>` → si $FAKE_SOPS_FAIL=1, échoue (clé non destinataire) ;
-# sinon imprime un dotenv clair factice (valide pour validate_secrets_plaintext).
+# Fake `sops` pour les tests de secrets.sh / env_validate.sh / add-provider.sh (ADR-0044).
+# Sous-commandes simulées :
+#   decrypt … <file>      → si $FAKE_SOPS_FAIL=1, échoue ; sinon imprime un dotenv clair.
+#   updatekeys [--yes] f  → trace l'appel (re-wrap d'enveloppe) ; succès no-op.
 [[ -n "${FAKE_SOPS_LOG:-}" ]] && printf '%s\n' "$*" >> "$FAKE_SOPS_LOG"
 
-if [[ "${FAKE_SOPS_FAIL:-0}" == "1" ]]; then
-    echo "fake sops: échec déchiffrement (clé non destinataire)" >&2
-    exit 1
-fi
-
-# Émet un clair factice cohérent (utilisé par validate_secrets_env).
-cat <<'EOF'
+sub="${1:-}"
+case "$sub" in
+    updatekeys)
+        # Re-chiffrement d'enveloppe simulé : succès silencieux.
+        exit 0
+        ;;
+    decrypt|"")
+        if [[ "${FAKE_SOPS_FAIL:-0}" == "1" ]]; then
+            echo "fake sops: échec déchiffrement (clé non destinataire)" >&2
+            exit 1
+        fi
+        # Émet un clair factice cohérent (utilisé par validate_secrets_env).
+        cat <<'EOF'
 API_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 SFTP__URL=sftp://user:pass@host.fr:22/exports
 AES__TROUSSEAU__demo__KEY=00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff
 EOF
+        ;;
+    *)
+        echo "fake sops: sous-commande non simulée ($sub)" >&2; exit 1 ;;
+esac

--- a/deploy/tests/fixtures/fake_bin/sops
+++ b/deploy/tests/fixtures/fake_bin/sops
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Fake `sops` pour les tests de secrets.sh / env_validate.sh (ADR-0044).
+# `sops decrypt … <file>` → si $FAKE_SOPS_FAIL=1, échoue (clé non destinataire) ;
+# sinon imprime un dotenv clair factice (valide pour validate_secrets_plaintext).
+[[ -n "${FAKE_SOPS_LOG:-}" ]] && printf '%s\n' "$*" >> "$FAKE_SOPS_LOG"
+
+if [[ "${FAKE_SOPS_FAIL:-0}" == "1" ]]; then
+    echo "fake sops: échec déchiffrement (clé non destinataire)" >&2
+    exit 1
+fi
+
+# Émet un clair factice cohérent (utilisé par validate_secrets_env).
+cat <<'EOF'
+API_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+SFTP__URL=sftp://user:pass@host.fr:22/exports
+AES__TROUSSEAU__demo__KEY=00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff
+EOF

--- a/deploy/tests/fixtures/fake_lib/secrets.sh
+++ b/deploy/tests/fixtures/fake_lib/secrets.sh
@@ -1,0 +1,1 @@
+# stub secrets

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -357,6 +357,11 @@ tmp_cfg=$(mktemp)
 printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nAPI_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n' > "$tmp_cfg"
 assert_fail "validate_config_env refuse un secret en clair (API_KEY)" validate_config_env "$tmp_cfg" "edn"
 rm -f "$tmp_cfg"
+# Idem pour un credential Odoo (ODOO_<ENV>_PASSWORD, le vrai nom lu par runtime.odoo)
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nODOO_PROD_PASSWORD=secret_factice\n' > "$tmp_cfg"
+assert_fail "validate_config_env refuse un secret en clair (ODOO_PROD_PASSWORD)" validate_config_env "$tmp_cfg" "edn"
+rm -f "$tmp_cfg"
 # config.env manquant version → échec
 tmp_cfg=$(mktemp); printf 'INSTANCE_SLUG=edn\nBACKUPS_PATH=/srv/edn/backups\n' > "$tmp_cfg"
 assert_fail "validate_config_env exige ELECTRICORE_VERSION" validate_config_env "$tmp_cfg" "edn"

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -39,6 +39,11 @@ source "${LIB_DIR}/../harden.sh"
 # shellcheck source=../unharden.sh
 source "${LIB_DIR}/../unharden.sh"
 
+# `add-provider.sh` (outil admin secrets-as-code, ADR-0044) — guard
+# `main_add_provider` ; expose parse_add_provider_args + add_recipient_to_sops + add_provider.
+# shellcheck source=../add-provider.sh
+source "${LIB_DIR}/../add-provider.sh"
+
 PASS=0; FAIL=0
 ok() { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
 ko() { printf '  \033[31m✗\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
@@ -417,6 +422,38 @@ PATH="${FAKE_BIN}:$PATH" FAKE_SOPS_FAIL=1 validate_secrets_env "${secrets_root}/
 
 unset SRV_BASE
 rm -rf "$secrets_root"
+
+echo
+echo "→ add-provider.sh (parse + add_recipient + add_provider, fake sops)"
+# parse_add_provider_args : exige --provider-dir + --age-pubkey (format age1…)
+( parse_add_provider_args --provider-dir providers/edn --age-pubkey age1abcdef >/dev/null 2>&1
+  [[ "$OPT_PROVIDER_DIR" == "providers/edn" && "$OPT_AGE_PUBKEY" == "age1abcdef" && "$OPT_NO_UPDATEKEYS" == "0" ]]
+) && ok "parse_add_provider_args: --provider-dir + --age-pubkey" || ko "parse_add_provider_args minimal"
+assert_fail "parse_add_provider_args: --age-pubkey manquant" parse_add_provider_args --provider-dir providers/edn
+assert_fail "parse_add_provider_args: clé non-age rejetée"   parse_add_provider_args --provider-dir p --age-pubkey "ssh-ed25519 AAAA"
+( parse_add_provider_args --provider-dir p --age-pubkey age1zzz --no-updatekeys >/dev/null 2>&1
+  [[ "$OPT_NO_UPDATEKEYS" == "1" ]]
+) && ok "parse_add_provider_args: --no-updatekeys" || ko "parse_add_provider_args --no-updatekeys"
+
+# add_recipient_to_sops : insère un destinataire, idempotent au 2e appel.
+prov=$(mktemp -d)
+cp "${LIB_DIR}/../providers/example/.sops.yaml.example" "${prov}/.sops.yaml"
+add_recipient_to_sops "${prov}/.sops.yaml" "age1nouvelleboxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" >/dev/null 2>&1
+grep -q "age1nouvelleboxxx" "${prov}/.sops.yaml" && ok "add_recipient_to_sops: destinataire inséré" || ko "destinataire non inséré"
+add_recipient_to_sops "${prov}/.sops.yaml" "age1nouvelleboxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" >/dev/null 2>&1
+n=$(grep -c "age1nouvelleboxxx" "${prov}/.sops.yaml")
+assert_eq "$n" "1" "add_recipient_to_sops: idempotent (1 seule occurrence après 2 appels)"
+# L'admin (destinataire FACTICE toujours présent) survit à l'ajout.
+grep -q "age1adminFACTICE" "${prov}/.sops.yaml" && ok "add_recipient_to_sops: admin (toujours destinataire) préservé" || ko "admin effacé"
+
+# add_provider : ajoute + updatekeys (fake sops) ; --no-updatekeys saute le re-chiffrement.
+printf '#ENC[fake]\n' > "${prov}/secrets.env"
+PATH="${FAKE_BIN}:$PATH" SOPS_BIN=sops add_provider "$prov" "age1autreboxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy" 1 >/dev/null 2>&1 \
+    && ok "add_provider: ajoute destinataire + updatekeys (fake sops réussit)" || ko "add_provider a échoué"
+grep -q "age1autreboxyyy" "${prov}/.sops.yaml" && ok "add_provider: 2e destinataire bien ajouté" || ko "2e destinataire absent"
+PATH="${FAKE_BIN}:$PATH" SOPS_BIN=sops add_provider "$prov" "age1encoreunboxzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz" 0 >/dev/null 2>&1 \
+    && ok "add_provider: --no-updatekeys ajoute sans re-chiffrer" || ko "add_provider --no-updatekeys"
+rm -rf "$prov"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="${SCRIPT_DIR}/../lib"
 FIXTURES_DIR="${SCRIPT_DIR}/fixtures"
 
+# shellcheck source=../lib/log.sh
+source "${LIB_DIR}/log.sh"
 # shellcheck source=../lib/validate.sh
 source "${LIB_DIR}/validate.sh"
 # shellcheck source=../lib/os.sh
@@ -16,6 +18,8 @@ source "${LIB_DIR}/cli.sh"
 source "${LIB_DIR}/config.sh"
 # shellcheck source=../lib/env_validate.sh
 source "${LIB_DIR}/env_validate.sh"
+# shellcheck source=../lib/secrets.sh
+source "${LIB_DIR}/secrets.sh"
 # shellcheck source=../lib/harden.sh
 source "${LIB_DIR}/harden.sh"
 
@@ -142,6 +146,13 @@ echo "→ cli.sh / parse_args"
   [[ "$OPT_VERSION" == "1.7.0" && "$OPT_SSH_PUBKEY" == "ssh-ed25519 AAAA" && "$OPT_SKIP_DNS" == "1" ]]
 ) && ok "parse_args avec --version --ssh-pubkey --skip-dns" || ko "parse_args options complètes"
 
+# --deploy-repo (secrets-as-code, ADR-0044)
+( parse_args --slug edn --domain edn.fr >/dev/null 2>&1; [[ -z "$OPT_DEPLOY_REPO" ]] ) \
+    && ok "parse_args: --deploy-repo vide par défaut" || ko "parse_args OPT_DEPLOY_REPO défaut"
+( parse_args --slug edn --domain edn.fr --deploy-repo "git@example.test:org/deploy.git" >/dev/null 2>&1
+  [[ "$OPT_DEPLOY_REPO" == "git@example.test:org/deploy.git" ]]
+) && ok "parse_args: --deploy-repo capturé" || ko "parse_args --deploy-repo"
+
 assert_fail "parse_args sans --slug"      parse_args --domain edn.fr
 assert_fail "parse_args sans --domain"    parse_args --slug edn
 assert_fail "parse_args flag inconnu"     parse_args --slug edn --domain edn.fr --foo
@@ -211,8 +222,8 @@ echo
 echo "→ install.sh / fetch_lib_files"
 tmp_target=$(mktemp -d)
 fetch_lib_files "file://${FIXTURES_DIR}/fake_lib" "$tmp_target"
-[[ -f "${tmp_target}/log.sh" && -f "${tmp_target}/cli.sh" && -f "${tmp_target}/config.sh" && -f "${tmp_target}/harden.sh" ]] \
-    && ok "fetch_lib_files: les 12 helpers sont téléchargés au 1er appel" \
+[[ -f "${tmp_target}/log.sh" && -f "${tmp_target}/cli.sh" && -f "${tmp_target}/config.sh" && -f "${tmp_target}/secrets.sh" && -f "${tmp_target}/harden.sh" ]] \
+    && ok "fetch_lib_files: les 13 helpers sont téléchargés au 1er appel" \
     || ko "fetch_lib_files: helpers manquants après 1er appel"
 # 2e appel idempotent (les fichiers existent déjà, doit re-télécharger sans erreur)
 fetch_lib_files "file://${FIXTURES_DIR}/fake_lib" "$tmp_target"
@@ -327,6 +338,85 @@ strip_validation_error_block "$tmp_env"
 grep -q "^INSTANCE_SLUG=edn$" "$tmp_env" && ok "strip: INSTANCE_SLUG survit" || ko "strip: INSTANCE_SLUG effacé"
 grep -q "^API_KEY=" "$tmp_env" && ok "strip: API_KEY survit" || ko "strip: API_KEY effacé"
 rm -f "$tmp_env"
+
+echo
+echo "→ env_validate.sh / split config/secret (ADR-0044)"
+# config.env valide (slug + version + backups, AUCUN secret)
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nODOO_ENV=prod\n' > "$tmp_cfg"
+assert_ok   "validate_config_env (config claire valide)"   validate_config_env "$tmp_cfg" "edn"
+assert_fail "validate_config_env (slug mismatch)"          validate_config_env "$tmp_cfg" "autre"
+rm -f "$tmp_cfg"
+# Garde-fou anti-fuite : un secret dans config.env doit faire échouer
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nAPI_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n' > "$tmp_cfg"
+assert_fail "validate_config_env refuse un secret en clair (API_KEY)" validate_config_env "$tmp_cfg" "edn"
+rm -f "$tmp_cfg"
+# config.env manquant version → échec
+tmp_cfg=$(mktemp); printf 'INSTANCE_SLUG=edn\nBACKUPS_PATH=/srv/edn/backups\n' > "$tmp_cfg"
+assert_fail "validate_config_env exige ELECTRICORE_VERSION" validate_config_env "$tmp_cfg" "edn"
+rm -f "$tmp_cfg"
+
+# Secrets (clair) : API_KEY + SFTP + trousseau AES
+tmp_sec=$(mktemp)
+printf 'API_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nSFTP__URL=sftp://u:p@h.fr:22/x\nAES__TROUSSEAU__demo__KEY=00112233445566778899aabbccddeeff\n' > "$tmp_sec"
+assert_ok   "validate_secrets_plaintext (secrets clairs valides)" validate_secrets_plaintext "$tmp_sec"
+rm -f "$tmp_sec"
+# Trousseau vide → échec
+tmp_sec=$(mktemp); printf 'API_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nSFTP__URL=sftp://u:p@h.fr:22/x\n' > "$tmp_sec"
+assert_fail "validate_secrets_plaintext refuse trousseau AES vide" validate_secrets_plaintext "$tmp_sec"
+rm -f "$tmp_sec"
+
+echo
+echo "→ secrets.sh (fake-binaries docker/git/sops)"
+FAKE_BIN="${FIXTURES_DIR}/fake_bin"
+# Sandbox d'instance jetable : SRV_BASE pointe sur un tmp, fake docker/git/sops sur PATH.
+secrets_root=$(mktemp -d)
+export SRV_BASE="$secrets_root"
+install -d "${secrets_root}/edn"
+
+# generate_box_identities : génère age.key + ssh_deploy_key (600) + imprime les 2 pubs.
+out=$(PATH="${FAKE_BIN}:$PATH" DOCKER_BIN=docker generate_box_identities edn 2>/dev/null)
+grep -q "^AGE_PUBLIC_KEY=age1" <<<"$out" && ok "generate_box_identities: imprime la clé age publique" || ko "pas de AGE_PUBLIC_KEY"
+grep -q "^SSH_DEPLOY_PUBKEY=ssh-ed25519" <<<"$out" && ok "generate_box_identities: imprime la deploy key SSH publique" || ko "pas de SSH_DEPLOY_PUBKEY"
+[[ -f "${secrets_root}/edn/age.key" ]] && ok "generate_box_identities: clé age privée écrite" || ko "age.key absent"
+[[ -f "${secrets_root}/edn/ssh_deploy_key" ]] && ok "generate_box_identities: deploy key privée écrite" || ko "ssh_deploy_key absent"
+perm=$(stat -c '%a' "${secrets_root}/edn/age.key" 2>/dev/null)
+assert_eq "$perm" "600" "generate_box_identities: age.key en 600 (clé privée, ne sort jamais)"
+# Idempotent : 2e appel ne régénère pas (clé conservée)
+key_before=$(cat "${secrets_root}/edn/age.key")
+PATH="${FAKE_BIN}:$PATH" generate_box_identities edn >/dev/null 2>&1
+key_after=$(cat "${secrets_root}/edn/age.key")
+assert_eq "$key_after" "$key_before" "generate_box_identities: idempotent (clé privée conservée au 2e run)"
+
+# pull_deploy_repo : clone le dépôt privé simulé, relie providers/, tire config.env.
+git_src=$(mktemp -d)
+install -d "${git_src}/providers/edn"
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\n' > "${git_src}/providers/edn/config.env"
+printf '#ENC[fake-ciphertext]\n' > "${git_src}/providers/edn/secrets.env"
+PATH="${FAKE_BIN}:$PATH" FAKE_GIT_SRC="$git_src" GIT_BIN=git \
+    pull_deploy_repo "git@example.test:org/deploy.git" edn >/dev/null 2>&1
+[[ -L "${secrets_root}/edn/providers" ]] && ok "pull_deploy_repo: providers/ relié (symlink)" || ko "providers/ non relié"
+[[ -f "${secrets_root}/edn/providers/edn/secrets.env" ]] && ok "pull_deploy_repo: secrets.env accessible via providers/<slug>/" || ko "secrets.env inaccessible"
+[[ -f "${secrets_root}/edn/config.env" ]] && ok "pull_deploy_repo: config.env clair tiré à la racine du home" || ko "config.env non tiré"
+rm -rf "$git_src"
+
+# box_can_decrypt : vrai si clé + secrets présents ET sops réussit ; faux si sops échoue.
+PATH="${FAKE_BIN}:$PATH" FAKE_SOPS_FAIL=0 box_can_decrypt edn \
+    && ok "box_can_decrypt: vrai quand sops déchiffre (clé destinataire)" || ko "box_can_decrypt devait réussir"
+PATH="${FAKE_BIN}:$PATH" FAKE_SOPS_FAIL=1 box_can_decrypt edn \
+    && ko "box_can_decrypt: devait échouer si sops échoue (clé non destinataire)" \
+    || ok "box_can_decrypt: faux quand sops échoue (deux temps — pas encore destinataire)"
+
+# validate_secrets_env : déchiffre via (fake) sops puis valide le clair.
+PATH="${FAKE_BIN}:$PATH" validate_secrets_env "${secrets_root}/edn/providers/edn/secrets.env" "${secrets_root}/edn/age.key" >/dev/null 2>&1 \
+    && ok "validate_secrets_env: déchiffre + valide le clair (fake sops)" || ko "validate_secrets_env a échoué"
+PATH="${FAKE_BIN}:$PATH" FAKE_SOPS_FAIL=1 validate_secrets_env "${secrets_root}/edn/providers/edn/secrets.env" "${secrets_root}/edn/age.key" >/dev/null 2>&1 \
+    && ko "validate_secrets_env: devait échouer si déchiffrement KO" \
+    || ok "validate_secrets_env: échec propre si le déchiffrement KO"
+
+unset SRV_BASE
+rm -rf "$secrets_root"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then

--- a/docs/adr/0037-trousseau-cles-aes-n-cles-selection-par-essai.md
+++ b/docs/adr/0037-trousseau-cles-aes-n-cles-selection-par-essai.md
@@ -89,6 +89,12 @@ L'agrégation succès/échec par resource vit au niveau runner (il orchestre dé
   puis resync — l'escalade signalera tout segment encore sans clé.
 - [ADR-0008](0008-rotation-cles-aes.md) **superseded**.
 
+> **Procédure de rotation révisée par [ADR-0044](0044-secrets-as-code-sops-age.md)** : le trousseau ne
+> vit plus dans un `.env` édité sur la box mais dans le `secrets.env` **chiffré** du provider. Rotation :
+> `sops providers/<slug>/secrets.env` (édition chiffrée in-place, ajout d'un label) → commit → push →
+> `reconfigure` (la box pull + déchiffre + restart). **Distinction cruciale** : `sops updatekeys` ne rote
+> que l'**enveloppe** (destinataires) ; une clé AES qui a pu fuiter doit être changée **à la source**.
+
 ## Statut
 
 Accepté (grill 18/06/2026). Supersède [ADR-0008](0008-rotation-cles-aes.md). Porté par

--- a/docs/adr/0040-schema-dechiffrement-aes-iv-prefixe.md
+++ b/docs/adr/0040-schema-dechiffrement-aes-iv-prefixe.md
@@ -82,6 +82,10 @@ d'ADR-0037 (trousseau N-clés, sélection par essai, escalade per-flux, rupture 
 - **Migration `.env` EDN** : ajouter `AES__TROUSSEAU__aes256_2026__KEY=<64hex>` **sans** `__IV` ; garder
   les labels AES-128 (avec IV) pour relire les archives. *Quels flux ont basculé* (R64 seul vs tous) se
   confirme à la sonde — sans incidence sur le design (le trial couvre un parc mixte).
+
+  > **Révisé par [ADR-0044](0044-secrets-as-code-sops-age.md)** : depuis secrets-as-code, ce label
+  > AES-256 (sans `__IV`) s'ajoute non plus dans un `.env` clair mais dans le `secrets.env` **chiffré**
+  > du provider : `sops providers/<slug>/secrets.env` → commit → push → `reconfigure`.
 - Glossaire : [`electricore/ingestion/CONTEXT.md`](../../electricore/ingestion/CONTEXT.md) — terme
   **« Schéma de déchiffrement »** ajouté, l'entrée *Trousseau* corrigée (la bascule **change de schéma**,
   pas seulement de longueur de clé).

--- a/docs/adr/0044-secrets-as-code-sops-age.md
+++ b/docs/adr/0044-secrets-as-code-sops-age.md
@@ -3,8 +3,8 @@
 ## Statut
 
 Accepté (grill 25/06/2026, `/grill-with-docs`). S'appuie sur [ADR-0011](0011-deploiement-vps-docker.md)
-(stack docker compose), [ADR-0017](0017-layout-srv-slug.md) (layout `/srv/<slug>/`),
-[ADR-0031](0031-durcissement-vps.md) (durcissement), [ADR-0015](0015-deploiement-multi-instance.md)
+(stack docker compose), [ADR-0017](0017-layout-deploiement-srv-slug.md) (layout `/srv/<slug>/`),
+[ADR-0031](0031-durcissement-ssh-vps-utilisateur-ops.md) (durcissement), [ADR-0015](0015-deploiement-multi-instance.md)
 (multi-instance), [ADR-0024](0024-trois-registres-de-savoir.md)/[ADR-0025](0025-registre-runtime-pydantic-settings.md)
 (registre runtime). **Révise la procédure de rotation** d'[ADR-0037](0037-trousseau-cles-aes-n-cles-selection-par-essai.md)
 et [ADR-0040](0040-schema-dechiffrement-aes-iv-prefixe.md) (« éditer le `.env` » → éditer le `secrets.env`
@@ -12,7 +12,7 @@ chiffré). Porté par la chaîne d'issues *secrets-as-code* (à créer via `/to-
 
 ## Contexte
 
-Aujourd'hui les secrets vivent en clair dans `/srv/<slug>/.env` ([ADR-0017](0017-layout-srv-slug.md)) :
+Aujourd'hui les secrets vivent en clair dans `/srv/<slug>/.env` ([ADR-0017](0017-layout-deploiement-srv-slug.md)) :
 source unique, montée dans les conteneurs (`env_file:`) et lue par `docker compose --env-file` pour ses
 substitutions `${...}`. Ce fichier est **édité à la main** à l'install, **jamais versionné**, et n'existe
 **que** sur le VPS — perdre la box, c'est perdre les secrets ; aucun historique, aucune revue, aucune

--- a/docs/adr/0044-secrets-as-code-sops-age.md
+++ b/docs/adr/0044-secrets-as-code-sops-age.md
@@ -1,0 +1,168 @@
+# Secrets-as-code : chiffrement SOPS + age, déchiffrement en image, identité par instance
+
+## Statut
+
+Accepté (grill 25/06/2026, `/grill-with-docs`). S'appuie sur [ADR-0011](0011-deploiement-vps-docker.md)
+(stack docker compose), [ADR-0017](0017-layout-srv-slug.md) (layout `/srv/<slug>/`),
+[ADR-0031](0031-durcissement-vps.md) (durcissement), [ADR-0015](0015-deploiement-multi-instance.md)
+(multi-instance), [ADR-0024](0024-trois-registres-de-savoir.md)/[ADR-0025](0025-registre-runtime-pydantic-settings.md)
+(registre runtime). **Révise la procédure de rotation** d'[ADR-0037](0037-trousseau-cles-aes-n-cles-selection-par-essai.md)
+et [ADR-0040](0040-schema-dechiffrement-aes-iv-prefixe.md) (« éditer le `.env` » → éditer le `secrets.env`
+chiffré). Porté par la chaîne d'issues *secrets-as-code* (à créer via `/to-issues`).
+
+## Contexte
+
+Aujourd'hui les secrets vivent en clair dans `/srv/<slug>/.env` ([ADR-0017](0017-layout-srv-slug.md)) :
+source unique, montée dans les conteneurs (`env_file:`) et lue par `docker compose --env-file` pour ses
+substitutions `${...}`. Ce fichier est **édité à la main** à l'install, **jamais versionné**, et n'existe
+**que** sur le VPS — perdre la box, c'est perdre les secrets ; aucun historique, aucune revue, aucune
+récupération. La cible est un déploiement **multi-instance** (un VPS par fournisseur à terme,
+[ADR-0015](0015-deploiement-multi-instance.md)).
+
+**Modèle de menace, cadré honnêtement.** Sur une box unique, la clé de déchiffrement vit sur la **même
+box** que la donnée : SOPS **seul** ne protège donc **pas** du vol à froid (snapshot hébergeur, backup qui
+fuite) — la clé est dans le snapshot aussi. Le gain **immédiat** de SOPS n'est pas la confidentialité au
+repos, c'est :
+
+1. **secrets-as-code** — secrets versionnés, revus en diff, récupérables (le `.env` à la main disparaît) ;
+2. **isolation cryptographique multi-cible** — un dépôt, N fournisseurs, une box ne déchiffre que les siens ;
+3. **substrat** — la couche sur laquelle la vraie protection au repos (LUKS + Tang/NBDE, *hors scope*) se
+   branchera plus tard : la clé age deviendra ce que Tang garde.
+
+La portée de cet ADR est **« remplacer le `.env` »**. Le chiffrement au repos du disque / des backups
+(LUKS, Tang, `age` sur les dumps), l'isolation `raw.db`/`serve.db` et le durcissement DuckDB de l'API sont
+des concerns **distincts**, suivis séparément (cf. *Alternatives écartées*).
+
+## Décision
+
+### 1. SOPS + age, deux fichiers (secret / config séparés)
+
+Le `.env` se scinde en deux, parce que `docker compose` résout ses substitutions `${...}` (tags d'image,
+chemins de volume) **côté hôte, avant tout conteneur** — il ne peut pas lire du ciphertext :
+
+- **`config.env`** (clair, versionné) : vars de substitution compose (`ELECTRICORE_VERSION`,
+  `BACKUPS_PATH`) + config non-secrète (`INSTANCE_SLUG`, `ODOO_ENV`, métadonnées API).
+- **`secrets.env`** (chiffré SOPS) : **uniquement** des credentials — `SFTP__URL` (mot de passe embarqué),
+  trousseau `AES__TROUSSEAU__*`, `API_KEY` / `API_KEYS`, `TELEGRAM_BOT_TOKEN`, bloc de connexion `ODOO_*`.
+  SOPS chiffre les **valeurs** et laisse les **noms de champs** en clair → diffs Git lisibles.
+
+### 2. Déchiffrement en image, à l'entrypoint (`sops exec-env`)
+
+L'image electricore embarque `sops` + `age` (binaires statiques, ~15 Mo). Un entrypoint déchiffre
+`secrets.env` **dans l'environnement du process** (`sops exec-env`) puis `exec` la commande
+(uvicorn / supercronic) — **jamais de fichier en clair**. Décisif : cette voie gère les **noms de
+variables dynamiques** du trousseau AES (`AES__TROUSSEAU__<label>__KEY`, `<label>` choisi par l'opérateur
+à chaque rotation, [ADR-0037](0037-trousseau-cles-aes-n-cles-selection-par-essai.md)) **sans
+énumération**. Toute approche qui énumère les secrets un par un (passthrough compose `environment:`) est
+**éliminée** par là : elle ne sait pas exprimer un nom de var inconnu d'avance.
+
+### 3. Fail-fast, pas de double chemin
+
+Un conteneur sans clé age **ni** fichier chiffré ⇒ l'entrypoint **échoue bruyamment** (« secrets SOPS
+requis, aucune clé age »), il ne **retombe pas** silencieusement sur un run sans secrets (qui serait une
+API sans `API_KEY`, une ingestion sans SFTP/AES — une mauvaise config masquée). Le mécanisme de déchiffrement
+reste celui du §2 ; seul son **repli** est un échec dur, pas un passthrough. Le dev **non-conteneur**
+(`uv run`) lit `.env` directement via pydantic-settings et **n'est pas concerné**. Échappatoire conteneur
+dev/test **explicite et documentée** (`ELECTRICORE_DECRYPT=off`, ou clé de test montée).
+`runtime.valider()` reste en **défense en profondeur**, derrière l'entrypoint.
+
+### 4. L'identité vit par instance, générée sur la box
+
+Chaque box génère **deux** paires à l'install : une paire **age** (déchiffrement) et une paire **SSH**
+(lecture du dépôt de déploiement, cf. §5). Les deux clés **privées naissent sur la box et ne la quittent
+jamais** (`/srv/<slug>/`, `600`, montées RO dans les conteneurs). L'opérateur enregistre les deux clés
+**publiques** : la age pub comme **destinataire `.sops.yaml`**, la SSH pub comme **deploy key en lecture
+seule** du dépôt privé. Mort de la box ⇒ on **forge une identité neuve** + `sops updatekeys` — **pas de
+récupération de clé** (forger est déjà bon marché). Coût **assumé** : onboarding **en deux temps** (la age
+pub doit être destinataire avant que la box puisse déchiffrer), donc l'install « stack qui tourne à la fin »
+d'aujourd'hui se scinde.
+
+### 5. Le ciphertext arrive par auto-pull (GitOps)
+
+La box **clone/pull** le dépôt de déploiement **privé** via sa deploy key RO et y lit
+`providers/<slug>/{config.env,secrets.env}`. La deploy key est de **faible valeur** : elle ne donne accès
+qu'à du **ciphertext**, inutile sans la clé age — toute la sécurité repose sur la clé age, jamais sur le
+transport. Cadence : **on-demand** (étape `reconfigure` / commande dédiée) en v1 ; le cron auto-pull est
+**différé** (ne pas pull une livraison de secrets cassée sans surveillance).
+
+### 6. Frontière de dépôt : mécanisme public, secrets privés
+
+electricore (public, AGPL) ne porte **que le mécanisme + le scaffolding** : entrypoint, Dockerfile
+(`sops`/`age`), câblage compose, génération des clés dans `install.sh` (**via l'image**, zéro dép hôte),
+`add-provider.sh`, et un **exemple clairement marqué** au format multi-cible `providers/<slug>/`
+(`.sops.yaml.example`, `secrets.env.example`, `config.env.example`, destinataires **factices**). Les
+**vrais** secrets, le **vrai** `.sops.yaml` et les clés publiques vivent dans un **dépôt de déploiement
+privé séparé** (jamais dans electricore). Destinataires `.sops.yaml` = **admin (toujours, dans chaque
+règle)** + **chaque box** ; **la CI n'est pas destinataire** (elle build des images publiques sans secret,
+garanties par le scan d'image — elle ne déchiffre jamais). L'isolation entre instances est
+**cryptographique** (la clé d'une box n'est pas destinataire d'une autre), pas une convention de dossiers.
+
+### 7. Forme multi-cible adoptée maintenant (là où c'est gratuit)
+
+Le scaffolding est structuré `providers/<slug>/` **dès une seule instance** : les primitives d'isolation
+(destinataires par cible dans `.sops.yaml`) sont gratuites à adopter et évitent un **refactor artificiel**
+plus tard. Seule la **machinerie de flotte coûteuse** (un dépôt privé par fournisseur, CI de flotte) est
+différée jusqu'à ce que l'isolation devienne une exigence contractuelle.
+
+### 8. Bascule forcée à la prochaine release
+
+Pas de double chemin **opérateur** maintenu : la release qui introduit SOPS fait migrer l'instance vivante
+(EDN) dans une **fenêtre planifiée**. Migration, par box : `age-keygen` + deploy key sur la box ; scinder
+le `.env` vivant en `config.env` + `secrets.env` ; chiffrer `secrets.env` **sur la machine admin** (l'unique
+manipulation de secrets en clair, **jamais committée**) ; pousser ; enregistrer les deux pubs ; `reconfigure`
+→ la box pull + déchiffre ; **vérifier** ; **puis** supprimer le `.env` en clair.
+
+### 9. Tests : clé de test committée + fixture ciphertext
+
+Une paire age de **test committée** (`tests/fixtures/`) + un `secrets.env` fixture **chiffré à valeurs
+factices** → test **déterministe** du déchiffrement bout-en-bout contre un **vrai** `sops`/`age` ; fail-fast
+testé en **omettant** la clé. Conséquence à absorber : la clé privée de test **fait sonner gitleaks**
+(détection de secrets, Palier 0) → une **entrée d'allowlist** explicite (elle ne protège rien de réel). Les
+tests shell de `deploy/` suivent le **motif fake-binary** déjà en place (`deploy/tests/fixtures/fake_lib`).
+
+## Alternatives écartées
+
+- **OpenBao / Vault** (coffre central, secrets dynamiques, OIDC) — **différé**, pas rejeté : surdimensionné
+  pour ~6 secrets et une instance (un coffre HA pour si peu est un anti-pattern asso). SOPS+age est le 90/10 ;
+  la trajectoire connue est *SOPS-age → OpenBao transit + identité OIDC* quand la flotte le justifie.
+- **Déchiffrement côté hôte** (tmpfs `env_file`, ou `sops exec-env` enveloppant `docker compose`) — écarté :
+  le passthrough compose ne sait pas exprimer les **noms dynamiques** du trousseau AES (§2) ; la variante
+  tmpfs laisse du clair en RAM et déporte la logique dans le shell `deploy/`. L'image porte déjà l'identité
+  runtime ; l'entrypoint en image est self-contained et portable.
+- **Admin forge la clé de la box / la conserve (chiffrée-admin) dans le dépôt** — écarté : la clé privée
+  transiterait (machine admin → box) ou vivrait à un endroit de plus, alors que forger une identité neuve à
+  la mort de la box est **déjà** bon marché (`add-provider` + `updatekeys`) — la récupération de clé n'a pas
+  de valeur. (Choix opérateur au grill : la box est seule maître de sa clé privée.)
+- **Migration opt-in / double chemin permanent** — écarté : un passthrough silencieux masque une box prod
+  qui tournerait sans secrets, et c'est exactement le double chemin qu'on ne veut pas maintenir (§3, §8).
+- **Chiffrement natif DuckDB, `age` sur les backups, isolation `raw.db`/`serve.db`, durcissement DuckDB de
+  l'API, LUKS/Tang** — **hors scope** de « remplacer le `.env` » : concerns distincts (vol à froid, surface
+  API), suivis comme follow-ups indépendants.
+
+## Conséquences
+
+- **Image electricore** : +`sops`+`age` (~15 Mo statiques) + `entrypoint.sh` (déchiffre-ou-échoue). Le dev
+  non-conteneur reste intact.
+- **`docker-compose.yml`** : `api` + `ingestion-scheduler` montent la clé age (RO) + le `secrets.env` chiffré
+  + `SOPS_AGE_KEY_FILE` ; `env_file:` passe de `.env` à `config.env` ; `caddy` inchangé (aucun secret).
+  Le **bot** tourne dans le process API ([ADR-0025](0025-registre-runtime-pydantic-settings.md)) → son token
+  est dans `secrets.env`, déchiffré par l'entrypoint de l'API.
+- **`deploy/install.sh` + `deploy/lib/`** : génération des deux paires (via l'image), onboarding en deux
+  temps, deploy key + clone du dépôt privé, `env_validate` adapté au split. `substitute_env` écrit
+  désormais `config.env`.
+- **`runtime.py` / app Python : inchangés** — l'env-système peuplé par l'entrypoint gagne déjà sur `.env`
+  (précédence native pydantic-settings) ; le `config.env` arrive via `env_file:` ; l'absence du `.env`
+  racine dans le conteneur est un no-op.
+- **Procédure de rotation** ([ADR-0037](0037-trousseau-cles-aes-n-cles-selection-par-essai.md) §migration,
+  [ADR-0040](0040-schema-dechiffrement-aes-iv-prefixe.md) §migration, `CLAUDE.md`, `docs/configuration.md`) :
+  « éditer le `.env` » → `sops providers/<slug>/secrets.env` (édition chiffrée in-place) → commit → pull →
+  restart ; retrait d'une box / rotation admin → `sops updatekeys`. **Distinction cruciale** : `updatekeys`
+  ne rote que l'**enveloppe** ; si un secret a pu fuiter, le changer **aussi à la source**.
+- **Nouveau dépôt privé de déploiement** à créer et peupler (runbook opérateur, **hors PR**).
+
+## Glossaire
+
+Pas de `CONTEXT.md` deploy créé : SOPS / age / destinataire sont des outils **généraux**, pas du vocabulaire
+métier electricore (les `CONTEXT.md` existants sont des glossaires métier). Les rares termes propres au
+projet (`config.env` vs `secrets.env`, dépôt de déploiement, identité par instance) sont définis **en
+contexte** dans cet ADR. À réévaluer si un glossaire ops émerge.

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -624,12 +624,21 @@ Enedis rote périodiquement ses clés (et en change la longueur : AES-128 → AE
 Le **trousseau** porte un nombre arbitraire de clés labellisées ; la bonne est
 sélectionnée par essai (aucune date, aucun protocole).
 
-### Procédure (via le mode reconfigure)
+### Procédure (secrets-as-code, ADR-0044)
+
+Depuis [ADR-0044](adr/0044-secrets-as-code-sops-age.md), le trousseau AES vit dans le
+`secrets.env` **chiffré** du provider — plus dans un `.env` édité sur la box. La rotation
+se fait donc **sur la machine admin**, par édition chiffrée in-place :
 
 1. Recevoir la nouvelle clé Enedis.
-2. Relancer le script : `sudo bash /srv/<slug>/deploy/install.sh --slug <slug> --domain <slug>.electricore.fr`.
-3. L'éditeur s'ouvre sur `.env`. **Ajouter** la nouvelle clé au trousseau sous un
-   nouveau label, sans retirer les anciennes :
+2. Sur la machine admin (dépôt de déploiement privé), éditer **in-place** le secrets
+   chiffré (SOPS ouvre l'éditeur sur le clair, re-chiffre à la fermeture) :
+
+   ```bash
+   sops providers/<slug>/secrets.env
+   ```
+
+   **Ajouter** la nouvelle clé au trousseau sous un nouveau label, sans retirer les anciennes :
 
    ```
    # AES-256 (depuis juin 2026) : Enedis ne fournit QUE la clé, sans IV → pas de __IV.
@@ -640,8 +649,14 @@ sélectionnée par essai (aucune date, aucun protocole).
    AES__TROUSSEAU__aes128_2024__IV=ancien_iv_hex
    ```
 
-4. Sauvegarder, fermer l'éditeur. Le script valide, restart la stack, lance
-   une ingestion test pour confirmer que le trousseau déchiffre tout.
+3. Commit + push le `secrets.env` (re-chiffré).
+4. Sur la box, `reconfigure` (pull + déchiffre + restart) :
+
+   ```bash
+   ssh ops@<vps>
+   sudo bash /srv/<slug>/deploy/install.sh --slug <slug> --domain <slug>.electricore.fr \
+       --deploy-repo git@github.com:org/electricore-deploy-prive.git
+   ```
 
 Les logs `[<label>]` indiquent quelle clé a déchiffré quel fichier. Si un flux a des
 fichiers mais **0** déchiffrement réussi, le job passe à `failed` et le bot alerte
@@ -649,6 +664,11 @@ fichiers mais **0** déchiffrement réussi, le job passe à `failed` et le bot a
 
 Retirer une vieille clé seulement quand plus aucune archive chiffrée avec elle
 n'est (re)téléchargeable depuis le SFTP.
+
+> **`sops updatekeys` ≠ rotation de secret** (ADR-0044) : `updatekeys` ne rote que
+> l'**enveloppe** (re-wrap vers le jeu de destinataires, ex. ajout d'une box via
+> [`add-provider.sh`](../deploy/add-provider.sh)). Si une **clé AES a pu fuiter**, il
+> faut la changer **à la source** (nouvelle clé Enedis) — `updatekeys` ne la protège pas.
 
 ## Sauvegarde et restauration
 

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -345,7 +345,7 @@ La box ne peut **pas déchiffrer** tant que sa clé age publique n'est pas desti
 ssh ops@<vps>
 sudo bash /srv/<slug>/deploy/install.sh \
     --slug <slug> --domain <slug>.electricore.fr \
-    --deploy-repo git@github.com:org/electricore-deploy-prive.git
+    --deploy-repo git@github.com:Energie-De-Nantes/electricore-secrets.git
 # → AGE_PUBLIC_KEY=age1…   (à enregistrer comme destinataire .sops.yaml)
 # → SSH_DEPLOY_PUBKEY=ssh-ed25519 …   (à enregistrer comme deploy key RO du dépôt)
 ```
@@ -361,7 +361,7 @@ Côté **machine admin**, dans le dépôt de déploiement privé :
 # 2e temps — reconfigure : la box pull le ciphertext, déchiffre, démarre la stack.
 sudo bash /srv/<slug>/deploy/install.sh \
     --slug <slug> --domain <slug>.electricore.fr \
-    --deploy-repo git@github.com:org/electricore-deploy-prive.git
+    --deploy-repo git@github.com:Energie-De-Nantes/electricore-secrets.git
 ```
 
 À ce 2e temps, le script : pull `providers/<slug>/{config.env,secrets.env}` via la
@@ -655,7 +655,7 @@ se fait donc **sur la machine admin**, par édition chiffrée in-place :
    ```bash
    ssh ops@<vps>
    sudo bash /srv/<slug>/deploy/install.sh --slug <slug> --domain <slug>.electricore.fr \
-       --deploy-repo git@github.com:org/electricore-deploy-prive.git
+       --deploy-repo git@github.com:Energie-De-Nantes/electricore-secrets.git
    ```
 
 Les logs `[<label>]` indiquent quelle clé a déchiffré quel fichier. Si un flux a des

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -298,6 +298,103 @@ Couvre les cas :
 > En mode reconfigure, un `lib/` co-localisé complet est en plus re-téléchargé.
 > Override possible via `INSTALL_BASE_URL` pour pinner sur un tag spécifique en dev.
 
+## Secrets-as-code (SOPS + age, ADR-0044)
+
+Depuis [ADR-0044](adr/0044-secrets-as-code-sops-age.md), les secrets ne vivent plus
+en clair dans `/srv/<slug>/.env` : ils sont **versionnés chiffrés** (SOPS + age) dans
+un **dépôt de déploiement privé**, et **déchiffrés dans le process** par l'entrypoint
+de l'image (`electricore-entrypoint`) au démarrage — jamais de fichier clair sur disque.
+
+Le `.env` se scinde en deux :
+
+| Fichier | Contenu | Versionné | Chiffré |
+|---|---|---|---|
+| `config.env` | config NON secrète + substitutions compose (`INSTANCE_SLUG`, `ELECTRICORE_VERSION`, `BACKUPS_PATH`, `ODOO_ENV`…) | oui | non (clair) |
+| `secrets.env` | **uniquement** des credentials (`SFTP__URL`, trousseau `AES__TROUSSEAU__*`, `API_KEY`/`API_KEYS`, `TELEGRAM_BOT_TOKEN`, bloc `ODOO_*`) | oui | **oui** (SOPS + age) |
+
+`docker compose` résout ses substitutions `${...}` **côté hôte avant tout conteneur**
+→ il lui faut du clair, d'où `config.env` séparé. Les credentials, eux, sont déchiffrés
+**dans** le conteneur par l'entrypoint.
+
+### Deux identités, générées sur la box
+
+Chaque box génère **deux** paires de clés à l'install, **via l'image** (zéro dépendance
+hôte : `age` et `ssh-keygen` sont embarqués) :
+
+- une paire **age** (déchiffrement des secrets) — privée dans `/srv/<slug>/age.key` ;
+- une paire **SSH** (lecture du dépôt de déploiement) — privée dans `/srv/<slug>/ssh_deploy_key`.
+
+Les **clés privées naissent sur la box et ne la quittent jamais** (`600`, montées RO
+dans les conteneurs). L'opérateur enregistre les deux **publiques** : la age pub comme
+**destinataire `.sops.yaml`**, la SSH pub comme **deploy key en lecture seule** du dépôt.
+
+La deploy key SSH est de **faible valeur** : elle ne donne accès qu'à du **ciphertext**,
+inutile sans la clé age. Toute la sécurité repose sur la clé age, jamais sur le transport.
+
+> **Mort de la box** ⇒ on **forge une identité neuve** (`add-provider.sh` + `sops updatekeys`),
+> pas de récupération de clé (forger est déjà bon marché). La clé privée d'une box ne
+> transite jamais.
+
+### Onboarding en deux temps
+
+La box ne peut **pas déchiffrer** tant que sa clé age publique n'est pas destinataire
+`.sops.yaml`. L'install se fait donc **en deux temps** :
+
+```bash
+# 1er temps — la box génère ses identités et IMPRIME les deux clés publiques, puis s'arrête.
+ssh ops@<vps>
+sudo bash /srv/<slug>/deploy/install.sh \
+    --slug <slug> --domain <slug>.electricore.fr \
+    --deploy-repo git@github.com:org/electricore-deploy-prive.git
+# → AGE_PUBLIC_KEY=age1…   (à enregistrer comme destinataire .sops.yaml)
+# → SSH_DEPLOY_PUBKEY=ssh-ed25519 …   (à enregistrer comme deploy key RO du dépôt)
+```
+
+Côté **machine admin**, dans le dépôt de déploiement privé :
+
+1. ajouter la **age pub** aux destinataires de `providers/<slug>/.sops.yaml` (cf.
+   [`add-provider.sh`](../deploy/add-provider.sh)), puis `sops updatekeys providers/<slug>/secrets.env` ;
+2. enregistrer la **SSH pub** comme **deploy key RO** du dépôt (réglages GitHub/GitLab) ;
+3. commit + push.
+
+```bash
+# 2e temps — reconfigure : la box pull le ciphertext, déchiffre, démarre la stack.
+sudo bash /srv/<slug>/deploy/install.sh \
+    --slug <slug> --domain <slug>.electricore.fr \
+    --deploy-repo git@github.com:org/electricore-deploy-prive.git
+```
+
+À ce 2e temps, le script : pull `providers/<slug>/{config.env,secrets.env}` via la
+deploy key, **valide le split** (config claire sans secret ; secrets déchiffrables et
+valides), puis démarre la stack. Si la box ne déchiffre pas encore (age pub pas encore
+destinataire), il **réaffiche** les pubs et **échoue proprement** sans rien démarrer.
+
+### Runbook de migration EDN (bascule forcée)
+
+Migration de l'instance vivante (EDN) du `.env` en clair vers secrets-as-code, dans une
+**fenêtre planifiée** (pas de double chemin maintenu, ADR-0044 §8). L'unique manipulation
+de secrets en clair se fait **sur la machine admin** et **n'est jamais committée**.
+
+1. **Box** — générer les identités (1er temps ci-dessus) avec `--deploy-repo`. Noter les
+   deux pubs. (La box garde son `.env` vivant intact pour l'instant.)
+2. **Machine admin** — scinder le `.env` vivant récupéré de la box en deux :
+   - `config.env` ← `INSTANCE_SLUG`, `ELECTRICORE_VERSION`, `BACKUPS_PATH`, config non-secrète ;
+   - `secrets.env.clair` ← `SFTP__URL`, `AES__TROUSSEAU__*`, `API_KEY`/`API_KEYS`,
+     `TELEGRAM_BOT_TOKEN`, `ODOO_*`.
+3. **Machine admin** — chiffrer **sur place**, jamais committer le clair :
+   ```bash
+   sops encrypt --input-type dotenv --output-type dotenv \
+       secrets.env.clair > providers/<slug>/secrets.env
+   shred -u secrets.env.clair    # détruire le clair
+   ```
+   (`.sops.yaml` du provider porte déjà l'admin + la box comme destinataires.)
+4. **Machine admin** — committer `providers/<slug>/{config.env,secrets.env}` + pousser ;
+   enregistrer la SSH pub comme deploy key RO.
+5. **Box** — `reconfigure` (2e temps) : pull + déchiffre + démarre.
+6. **Vérifier** : `curl https://<slug>.electricore.fr/health` OK, une ingestion test OK.
+7. **Puis seulement** : supprimer le `.env` en clair de la box (`shred -u /srv/<slug>/.env`).
+   La bascule est **forcée** : tant que `.env` traîne, on n'a pas fini.
+
 ## Durcissement du VPS
 
 Depuis [ADR-0031](adr/0031-durcissement-ssh-vps-utilisateur-ops.md), `install.sh`

--- a/tests/fixtures/sops/multi/admin.key
+++ b/tests/fixtures/sops/multi/admin.key
@@ -1,0 +1,5 @@
+# Paire age de TEST (admin) — committée, ne protège RIEN (ADR-0044 §9).
+# Sert au test d'isolation cryptographique multi-destinataires (#420).
+# created: 2026-06-25T01:56:10+02:00
+# public key: age12ppazl946mtjd32qvs2ac6sg7e29h29gsslsszg85wser4hsuq6sssh7r9
+AGE-SECRET-KEY-1QAN6QYYWHA0YQLHX0Y0G3SG4NCLGG4SKAHMU75DGCJ9JNZ43FQ5QVSTFDV

--- a/tests/fixtures/sops/multi/box.key
+++ b/tests/fixtures/sops/multi/box.key
@@ -1,0 +1,5 @@
+# Paire age de TEST (box) — committée, ne protège RIEN (ADR-0044 §9).
+# Sert au test d'isolation cryptographique multi-destinataires (#420).
+# created: 2026-06-25T01:56:10+02:00
+# public key: age1ylcxt6nec737ad857dvrdw3fx3jqsu34zue8euc82vsuac0effzs6z0u0k
+AGE-SECRET-KEY-1K3UZ3AAE0G46G2SCDQMRGMUHDF6AS4GAHY88PRUNNVZAJG8U44FSA0EZ63

--- a/tests/fixtures/sops/multi/outsider.key
+++ b/tests/fixtures/sops/multi/outsider.key
@@ -1,0 +1,5 @@
+# Paire age de TEST (outsider) — committée, ne protège RIEN (ADR-0044 §9).
+# Sert au test d'isolation cryptographique multi-destinataires (#420).
+# created: 2026-06-25T01:56:10+02:00
+# public key: age12q9r7wsjz8a0y2mz5790ljw89kf2n7ezg5f2yapvpzw6q5a7t5rs5fep6u
+AGE-SECRET-KEY-1EZ3XP4DTC9CKXUV8YLJSGXXR4XTNGKPF77M4UEAQMURZVCYTRSPS4Y68VN

--- a/tests/fixtures/sops/multi/secrets.env
+++ b/tests/fixtures/sops/multi/secrets.env
@@ -1,0 +1,11 @@
+API_KEY=ENC[AES256_GCM,data:TG28v602VhvYX0yQzrgMFcJtMlSFjGN/WHmGXVDKGt9092zUq+e+Pw==,iv:QMrpoKQ2Wwlx53FhImb+T8wvZPNj2Gr9mRnWSMmn4ns=,tag:0G2sI+v9OQKK81v8THEV5w==,type:str]
+SFTP__URL=ENC[AES256_GCM,data:aqrs4CTnSG7r8jKa7rbCaowjgmR9sg==,iv:Nd+jCrXUYkPmM5QNDWpXtPAidjDx+X8zcShuyh05BnU=,tag:XTQoJERIqDTR+f9PzNj4hw==,type:str]
+AES__TROUSSEAU__demo__KEY=ENC[AES256_GCM,data:fPr7VLZ+3WFlLvLGXt0QMQDUaQCmQYjZ8oG2aM2vSro=,iv:R7JrcruZiYAQ8Tw8L6PLOaFFQpdhlffVphYi79v7E9A=,tag:OD7M2biGq4CgLjciF2iY3Q==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvZnV3QndqMFNBMG5zWHh4\nR0czVU9wMzZ3TWY5MTBGbjFoelBJa3gySWtjCjZZZ0pGYVM4aWZ5NXlOa280STNa\nUzQ5RVpNTW1XOTJURmFIVTVnUWhUam8KLS0tIGx6NzliU0sweXJ6SVV1dWhtWk53\ncmhCcTN6akxZYjNYUnRwemJsanlLU2cKS66LiVY/LE25tvGq2l8/pACT6bapdRmr\nR8f2EqSzoZwE5WV1jj2FmvpcOaEL+lPrLOo3eB6rLQMyVTYpQ8KwEA==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age12ppazl946mtjd32qvs2ac6sg7e29h29gsslsszg85wser4hsuq6sssh7r9
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJVXRieWJRUHJUR2Y5ZGtt\nK296TFlQYVZtYUVXRVhZMmhBZjlQcVBCZmcwCkd4UWtOUW41NWJMblFmajNkRWlr\na0lDV2dVYThCb2hQZkVsbkZLYmVMVEkKLS0tIHZDam9qT0U0cC9QcjRvSW91RXNo\nWEt6emJaWElMRjZ1Mnk0UzRLV01PVUEK0gwTZD+3rFQVZeyR5IUgbrS5WEo1GCBe\nQvTssFcpb7QpJXWXChYeOMk0R8pTkFU7GhxyHFvrpeuG81n5W7eBJQ==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_recipient=age1ylcxt6nec737ad857dvrdw3fx3jqsu34zue8euc82vsuac0effzs6z0u0k
+sops_lastmodified=2026-06-24T23:56:22Z
+sops_mac=ENC[AES256_GCM,data:ZWHH2BlNIU+WLk8h3YbKsUx09/m61A8e+/R+ZqY8ez52LfumWKUc6vkikZo9P2KEW/aKgi/nyUr54qnr4Jjj6UIHT3ihSzAG8ns+gKvkBnSYnVdUSqsn4DMidtIWQ2h5YhOT0LVo/92qria2K/KahEh5kZKHsS2go871XpoBlfA=,iv:Lpmw8ocXBLXFOtwXVGsP0v3mKQKCcB7LhtpWn1yd59I=,tag:27giGAcfFjgIWLYl299PiQ==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.9.4

--- a/tests/fixtures/sops/multi/secrets.env.clair
+++ b/tests/fixtures/sops/multi/secrets.env.clair
@@ -1,0 +1,3 @@
+API_KEY=multi_recipient_factice_secret_value_xyz
+SFTP__URL=sftp://u:p@h.test:22/x
+AES__TROUSSEAU__demo__KEY=00112233445566778899aabbccddeeff

--- a/tests/fixtures/sops/secrets.env
+++ b/tests/fixtures/sops/secrets.env
@@ -1,0 +1,20 @@
+#ENC[AES256_GCM,data:HLqG8+2vdu1vodz2bIexYy2sDL3K9PXCxmjUs7GWTBSE7iB7K8RmD1Y/oOqE7v8psckk9JBFwamLivTdh2+Qym05+WtOZ8lB1ftfvni6xbwrab8NO5z3YQ==,iv:HCOqObwzXgQToTSTfpJX12IesOwzQf+6jnr5tSicllk=,tag:M/1hj63LkGDB4gP+GBi/8Q==,type:comment]
+#ENC[AES256_GCM,data:Mj6z0agFLYcJ7V9bxSWMQom+RotKnyOVq6odWKuukvgNPNpqLFKXWlmvUZm+YqYAskj+2Eq0o3cP9oTQAtFnLNvh3DqRa47mjWVCfbw=,iv:avjwE2iSChEOuaMBljWg1eTBhBxO5FgnREeXBUrX368=,tag:5WqtYyOVN0hcsX3ZAqF9oQ==,type:comment]
+#ENC[AES256_GCM,data:f4Ky8Htl4jKJ5esahvME0KaoUB+9hb1Du/Sj2C1U1N9Qh1EpcyT/7aPCwDaRTx2/bOZP9Wf6snRdnqC32m+Kw3cAlncofs0H4O10zWIg4xVSVwerFg==,iv:ZFLD/rbK3Nklcg2bBLxJdtick1QDUvv6abNMKgGXYao=,tag:Wf2UzSjASnAff3YeHq7QwA==,type:comment]
+#
+#ENC[AES256_GCM,data:lJS0Uatt9EL1yTBmH7BejuXnlJp9l/JHLP8nupnq9+Qf0KhbYf/JGISi1OW9o5FTCQANlGnGDJTWO6VFv6RpdOaEQXN26vzZWkBoiEUIab6z8Kfrgg==,iv:FOdo10z0W5wcWTPs/6vnnAnKzw7ZS39JqnTaVmmQ9eE=,tag:g7mk2Y5NtU20O76m+Eb2/w==,type:comment]
+#ENC[AES256_GCM,data:+LTF+02GhBJS1YLJ3ym8oqM0u2nq4K/d2/haiV83kJIctwcCgi3PvAnjIvATxySjIZ49plG53cG6/ZMQB50PchHK755ZOx//ynzbQZUCYQ==,iv:InHJVvaTwci5jW/TLhZNgQprDXAOp6nFExLWvRzcZ+w=,tag:w833eO5HQs0X6PX2q3N6RA==,type:comment]
+SFTP__URL=ENC[AES256_GCM,data:MPBmGnflG50y9NEsSC2IPqakTzayfSq24qySfmNBhWZideNPphrEMpzj+oS+,iv:0G4/e6g+789qGLySS69yYfkTjMjCYTiQKbcgstro9yY=,tag:zOe8nJIhu6ELgcDXw3BPHw==,type:str]
+API_KEY=ENC[AES256_GCM,data:kIuQPpkUCq7XQvP+Vi81MOZeSd1dFyOcHFQtq4wNlXuJ57DPWA==,iv:VXR24hAWetCccPSLHBfsOlpVG7D9Cz+QLtnGaJykawk=,tag:PNemxP5nTMFfso101F4cIQ==,type:str]
+TELEGRAM_BOT_TOKEN=ENC[AES256_GCM,data:6tDqukuQ720DQT33bGEoRLwSDayMkhOMlIKOPhq0Gnh0txcUjTx8,iv:6+m52sysssl27sCLtIJGr7jBJpUMj6/p6n0rNAmWC8A=,tag:0cfG/RteWT7bmsSS78eBAQ==,type:str]
+ODOO__URL=ENC[AES256_GCM,data:uVbuaPYrbx5VB75ThJN+/qvV1ccx/02gng==,iv:y4PJfJXB2D+yHOdvByS11GNK/K6LHfzG+JV5l5O6HTg=,tag:xc5Jsf2+xNlLvlrPUJgC8w==,type:str]
+ODOO__DB=ENC[AES256_GCM,data:tFLDuAPGSvQK,iv:d1rqwNzeC3dFeguyT8staOxUgMqNchi+/w41bW7xFEY=,tag:m6JKoUdBXVOOO5WAgY6haQ==,type:str]
+ODOO__USERNAME=ENC[AES256_GCM,data:9tYuflouZIpZ6h+m9SbFOA==,iv:s73T/5yFNWRAL4GqVUtG6jPKnd0BI2S6KrpJ7u2UcnU=,tag:kRduy4dH2Lla7UAEkGw3EA==,type:str]
+ODOO__PASSWORD=ENC[AES256_GCM,data:TZlauN7Cg8A0rsR4MsfHNuzqcCt5,iv:XBMu1W1tgZ6iDL/5bH6fATYv4PivJoax/Yfw8GXVe54=,tag:PqWnKAH6DnyVlq6dUayEcg==,type:str]
+AES__TROUSSEAU__demo__KEY=ENC[AES256_GCM,data:W3T9GHaRS+WgtdLQtFo1ShM6OO17c5Cwft1lcKj8ItlPjx+5x2xR8sJPqR5iOaAgzN1RPzY6gMBgFp+Io/0agw==,iv:v+uttkx6+Jmnn1X3rvMgP3VsB8/cqqu39SyoKONRdbs=,tag:8qRIVmurNhMhL9gDuX42Ew==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHRUtueGdGRHBCdWFKTW1i\nalk0aGRmZytpNTFPMW9QVGUxd2lrSm5OOG1rCmdHNDBwd1dpWFFhcUdJYUtxSVVp\nQUo5RnBSVlZNdGFLVG02S2RjbExLdGcKLS0tIHdmNVRhbWhLVm9xUm0yRjhLemo1\nNGJGUnRDREFySmp3MDdZVkUraVBiaGcKcLON9kORpKLfhAtq+UbBrpubaYEB20WP\nGrAfAr2Tj7Q/AxrMMLuy12sgHQVLYJ03MRf2qR7VjVyJXSeW6jAuKA==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1ha9l748w5hw2jaweedu2ksepcxy2nw5ccmlvsa9ydvz6lt7pwu9sswzn2v
+sops_lastmodified=2026-06-24T23:33:36Z
+sops_mac=ENC[AES256_GCM,data:C4sKPFK1l0ihfoCv5ydhCH0wtpwbFZ3MdRBSpN421Lnfi4FVyFhgoD7Tksji14bnlTJMx4OR8mc7kuKEch0XuiW5g4+NMwEwgdf/7PteKHdXFZfUWPNhcGNkZIZUv7zt+yChLs+IIo4ATHQ9c3YFbiuC4fgNHZDTIeLdUo8TQjQ=,iv:kzyhp5Oo/v073nmoo5zH/hdG79a72ZS3TAg19KM9D4w=,tag:AWEgh94oPafotgGo6J0Vmw==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.9.4

--- a/tests/fixtures/sops/secrets.env.clair
+++ b/tests/fixtures/sops/secrets.env.clair
@@ -1,0 +1,14 @@
+# Fixture de secrets EN CLAIR — valeurs FACTICES, jamais de vrai secret (ADR-0044 §9).
+# C'est la source chiffrée en `secrets.env` (SOPS + age) à destination de la
+# clé de test `test_age.key`. Sert uniquement au test de déchiffrement bout-en-bout.
+#
+# Le label `demo` du trousseau AES est DYNAMIQUE (choisi par l'opérateur, ADR-0037) :
+# la voie `sops exec-env` l'injecte SANS énumération, ce que le test vérifie.
+SFTP__URL=sftp://user:pass@sftp.example.test:22/exports
+API_KEY=test_api_key_factice_0123456789abcdef
+TELEGRAM_BOT_TOKEN=000000:FACTICE_TELEGRAM_TOKEN_POUR_TEST
+ODOO__URL=https://odoo.example.test
+ODOO__DB=odoo_test
+ODOO__USERNAME=bot@example.test
+ODOO__PASSWORD=factice_odoo_password
+AES__TROUSSEAU__demo__KEY=00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff

--- a/tests/fixtures/sops/test_age.key
+++ b/tests/fixtures/sops/test_age.key
@@ -1,0 +1,6 @@
+# Paire age de TEST — committée volontairement (ADR-0044 §9).
+# Elle ne protège RIEN de réel : elle ne sert qu'à déchiffrer la fixture
+# `secrets.env` (valeurs factices) dans le test bout-en-bout du déchiffrement.
+# gitleaks:allow — clé privée de test, allowlistée explicitement (cf. .gitleaks.toml).
+# public key: age1ha9l748w5hw2jaweedu2ksepcxy2nw5ccmlvsa9ydvz6lt7pwu9sswzn2v
+AGE-SECRET-KEY-19SHDVTJGR45059QHAFSD2GASYH4XGTN7L3DGPDY9PDKVYRM9UE2QV8HEW4

--- a/tests/integration/test_entrypoint_dechiffrement.py
+++ b/tests/integration/test_entrypoint_dechiffrement.py
@@ -1,0 +1,105 @@
+"""Test bout-en-bout du déchiffrement SOPS+age à l'entrypoint (ADR-0044, issue #418).
+
+On exécute le VRAI `deploy/docker/entrypoint.sh` contre un VRAI `sops`/`age` (pas
+de mock) : la fixture `secrets.env` (valeurs FACTICES) est chiffrée à la clé de test
+committée `tests/fixtures/sops/test_age.key`. On vérifie :
+
+- chemin nominal : les credentials atterrissent dans l'env du process exec'd,
+  Y COMPRIS un nom de variable DYNAMIQUE `AES__TROUSSEAU__demo__KEY` (ADR-0037),
+  ce qui prouve l'absence d'énumération (la voie `sops exec-env`, ADR-0044 §2) ;
+- fail-fast : sans clé age, l'entrypoint échoue bruyamment (ADR-0044 §3) ;
+- fail-fast : sans fichier chiffré, idem ;
+- échappatoire : `ELECTRICORE_DECRYPT=off` contourne le déchiffrement (ADR-0044 §3).
+
+Si `sops`/`age` ne sont pas sur le PATH, le test se skip (l'image et la CI les
+embarquent ; cf. Dockerfile + .github/workflows/ci.yml).
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+ENTRYPOINT = _REPO_ROOT / "deploy" / "docker" / "entrypoint.sh"
+FIXTURES = _REPO_ROOT / "tests" / "fixtures" / "sops"
+AGE_KEY = FIXTURES / "test_age.key"
+SECRETS_ENV = FIXTURES / "secrets.env"
+
+# Outils requis pour le test bout-en-bout (vrai déchiffrement, pas de mock).
+sops_present = shutil.which("sops") is not None
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not sops_present, reason="sops/age absents du PATH (embarqués par l'image + CI)"),
+]
+
+
+def _run_entrypoint(args, *, env_extra=None):
+    """Lance l'entrypoint avec `args` (la commande à exec) et renvoie le CompletedProcess."""
+    env = dict(os.environ)
+    env.setdefault("SECRETS_ENV_FILE", str(SECRETS_ENV))
+    env.setdefault("SOPS_AGE_KEY_FILE", str(AGE_KEY))
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        ["sh", str(ENTRYPOINT), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_dechiffre_et_injecte_les_credentials():
+    """Chemin nominal : les secrets factices sont dans l'env de la commande exec'd."""
+    cp = _run_entrypoint(["sh", "-c", "echo API_KEY=$API_KEY; echo SFTP=$SFTP__URL; echo ODOO=$ODOO__URL"])
+    assert cp.returncode == 0, cp.stderr
+    assert "API_KEY=test_api_key_factice_0123456789abcdef" in cp.stdout
+    assert "SFTP=sftp://user:pass@sftp.example.test:22/exports" in cp.stdout
+    assert "ODOO=https://odoo.example.test" in cp.stdout
+
+
+def test_injecte_un_nom_de_variable_dynamique_du_trousseau_aes():
+    """Le label AES `demo` est DYNAMIQUE : injecté sans énumération (ADR-0037/§2)."""
+    cp = _run_entrypoint(["sh", "-c", "echo DEMO=$AES__TROUSSEAU__demo__KEY"])
+    assert cp.returncode == 0, cp.stderr
+    assert "DEMO=00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff" in cp.stdout
+
+
+def test_fail_fast_sans_cle_age():
+    """Sans clé age : échec dur, message clair, la commande ne tourne pas (ADR-0044 §3)."""
+    cp = _run_entrypoint(
+        ["sh", "-c", "echo NE_DOIT_PAS_TOURNER"],
+        env_extra={"SOPS_AGE_KEY_FILE": "/nonexistent-age.key"},
+    )
+    assert cp.returncode != 0
+    assert "NE_DOIT_PAS_TOURNER" not in cp.stdout
+    assert "aucune clé age" in cp.stderr.lower()
+
+
+def test_fail_fast_sans_fichier_chiffre():
+    """Sans secrets.env chiffré : échec dur (ADR-0044 §3)."""
+    cp = _run_entrypoint(
+        ["sh", "-c", "echo NE_DOIT_PAS_TOURNER"],
+        env_extra={"SECRETS_ENV_FILE": "/nonexistent-secrets.env"},
+    )
+    assert cp.returncode != 0
+    assert "NE_DOIT_PAS_TOURNER" not in cp.stdout
+    assert "introuvable" in cp.stderr.lower()
+
+
+def test_bypass_electricore_decrypt_off():
+    """`ELECTRICORE_DECRYPT=off` contourne le déchiffrement (échappatoire dev/test)."""
+    cp = _run_entrypoint(
+        ["sh", "-c", "echo contourne_ok"],
+        env_extra={
+            "ELECTRICORE_DECRYPT": "off",
+            # Même sans secrets valides, le bypass doit aboutir.
+            "SOPS_AGE_KEY_FILE": "/nonexistent-age.key",
+            "SECRETS_ENV_FILE": "/nonexistent-secrets.env",
+        },
+    )
+    assert cp.returncode == 0, cp.stderr
+    assert "contourne_ok" in cp.stdout

--- a/tests/integration/test_sops_isolation_multi_destinataires.py
+++ b/tests/integration/test_sops_isolation_multi_destinataires.py
@@ -1,0 +1,62 @@
+"""Isolation cryptographique multi-destinataires SOPS+age (ADR-0044 §6, issue #420).
+
+Un `secrets.env` chiffré pour DEUX destinataires (admin + box) :
+- se déchiffre avec la clé de l'UN **ou** de l'AUTRE (chaque box destinataire lit) ;
+- ÉCHOUE avec une clé NON destinataire (outsider) — la box d'un autre provider ne
+  peut pas le déchiffrer. L'isolation entre instances est cryptographique, pas une
+  convention de dossiers.
+
+Test contre un VRAI `sops`/`age` (clés + ciphertext committés à valeurs FACTICES).
+Se skip si `sops` n'est pas sur le PATH (image + CI l'embarquent).
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+MULTI = _REPO_ROOT / "tests" / "fixtures" / "sops" / "multi"
+SECRETS_ENV = MULTI / "secrets.env"
+
+sops_present = shutil.which("sops") is not None
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not sops_present, reason="sops/age absents du PATH (embarqués par l'image + CI)"),
+]
+
+
+def _decrypt_with(keyfile: Path):
+    """Tente `sops decrypt` avec <keyfile> comme clé age. Renvoie le CompletedProcess."""
+    return subprocess.run(
+        [
+            "sops",
+            "decrypt",
+            "--input-type",
+            "dotenv",
+            "--output-type",
+            "dotenv",
+            str(SECRETS_ENV),
+        ],
+        env={"SOPS_AGE_KEY_FILE": str(keyfile), "PATH": os.environ["PATH"]},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize("recipient", ["admin", "box"])
+def test_chaque_destinataire_dechiffre(recipient):
+    """Le ciphertext se déchiffre avec la clé de CHAQUE destinataire (admin OU box)."""
+    cp = _decrypt_with(MULTI / f"{recipient}.key")
+    assert cp.returncode == 0, cp.stderr
+    assert "API_KEY=multi_recipient_factice_secret_value_xyz" in cp.stdout
+
+
+def test_non_destinataire_echoue():
+    """Une clé NON destinataire (autre provider) NE déchiffre PAS — isolation crypto."""
+    cp = _decrypt_with(MULTI / "outsider.key")
+    assert cp.returncode != 0
+    assert "multi_recipient_factice_secret_value_xyz" not in cp.stdout


### PR DESCRIPTION
Secrets-as-code (SOPS + age) — remplace le `.env` en clair sur le VPS (**ADR-0044**).

L'image embarque `sops`+`age` et déchiffre `secrets.env` à l'entrypoint (`sops exec-env`, jamais de clair sur disque ; gère les labels AES dynamiques du trousseau sans énumération ; **fail-fast** sinon, `ELECTRICORE_DECRYPT=off` pour le dev). Onboarding opérateur **en deux temps** : la box génère ses deux identités (age + SSH deploy key) via l'image, l'**auto-pull** GitOps tire le ciphertext d'un dépôt privé, le split `config.env` (clair) / `secrets.env` (chiffré) est validé. Scaffolding **multi-cible** `providers/<slug>/` + `add-provider.sh` (`sops updatekeys`) avec **isolation cryptographique** entre instances. Migration EDN (bascule forcée) documentée.

Conception complète : `docs/adr/0044-secrets-as-code-sops-age.md`.

**Tests** : 933 passed, 26 skipped (extras `viz`/`odoo` absents en CI) ; harnais shell `deploy/` : 145 passed. Le déchiffrement réel (`sops`+`age`) et l'isolation multi-destinataires sont couverts par des tests d'intégration pytest ; le job CI `test` installe `sops`+`age`.

⚠️ **Non vérifié en sandbox** : le **build + démarrage de l'image Docker** (pas de Docker dispo). Le câblage Dockerfile/compose/entrypoint est validé par parse + checksums `sops`/`age` confirmés sur les artefacts GitHub, mais un **smoke test conteneur réel** reste à faire côté opérateur avant merge. Le **dépôt de déploiement privé** (vrais secrets + vrai `.sops.yaml` + clés) est un runbook opérateur, hors PR.

Closes #418
Closes #419
Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)
