### PR TITLE
fix(docker): build l'image avec les notebooks force-inclus du wheel (#414)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,11 @@ htmlcov/
 
 # Notebooks et données locales (jamais embarqués dans l'image)
 notebooks/
+# … sauf les 3 notebooks opérateur force-inclus dans le wheel electricore (pont #414) :
+# hatchling exige leur source à l'install de la racine (cf. Dockerfile, étape builder).
+!notebooks/accueil.py
+!notebooks/facturation.py
+!notebooks/injection_rsc.py
 *.duckdb
 *.duckdb.wal
 *.csv

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -33,6 +33,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Couche projet : on copie le code et on l'installe dans le venv
 COPY electricore/ ./electricore/
+# Les notebooks opérateur sont force-inclus dans le wheel electricore (pont #414,
+# → electricore/_operator_notebooks/) : hatchling exige leur source présente à l'install
+# de la racine. Sans eux, `uv sync` casse (FileNotFoundError: Forced include not found).
+COPY notebooks/accueil.py notebooks/facturation.py notebooks/injection_rsc.py ./notebooks/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --extra ingestion --extra dbt --no-dev
 


### PR DESCRIPTION
L'image Docker de `main` ne build plus depuis le pont notebooks (#414, commit `2bf1f11`).

## Cause

`pyproject.toml` force-inclut `notebooks/{accueil,facturation,injection_rsc}.py` dans le wheel `electricore` (`electricore/_operator_notebooks/`). À l'install de la racine, hatchling **exige la source** de ces fichiers (`recurse_forced_files`). Or :
- le `Dockerfile` ne copiait pas `notebooks/` ;
- `.dockerignore` excluait `notebooks/` (« jamais embarqués dans l'image »).

→ `uv sync` casse au build : `FileNotFoundError: Forced include not found: /app/notebooks/accueil.py`.

L'image était donc cassée **sur main depuis #414**, jamais détecté : **la CI ne build pas l'image** (lint / test / typecheck / CodeQL seulement). Surfacé par le smoke test conteneur de la PR secrets-as-code (#422, mergée), premier build d'image depuis le pont.

## Fix (9 lignes, 2 fichiers)

- `Dockerfile` : `COPY` des 3 notebooks force-inclus juste avant le `uv sync` qui installe la racine.
- `.dockerignore` : whiteliste **uniquement** ces 3 fichiers — le reste de `notebooks/` (demos, validations…) reste hors image, intention préservée.

## Vérifié localement (smoke test conteneur réel, ce que la CI ne fait pas)

- `docker build` ✅ (34/34, checksums sops/age OK)
- Déchiffrement nominal SOPS+age dans l'image ✅ (y compris un label AES **dynamique** `AES__TROUSSEAU__demo__KEY`)
- Fail-fast sans clé age ✅ (exit 1, « aucune clé age »)
- `decrypt → exec → import electricore.api.main` ✅

## Suivi suggéré (hors PR)

Ajouter un job `docker build` (idéalement + smoke test entrypoint) à la CI, pour que cette classe de casse ne repasse plus inaperçue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)