### PR TITLE
fix(release): le smoke d'image bypasse l'entrypoint SOPS (ELECTRICORE_DECRYPT=off)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,9 +138,13 @@ jobs:
             --only-verified \
             --fail
 
+      # ELECTRICORE_DECRYPT=off : ce smoke vérifie l'IMPORTABILITÉ de l'image, pas le
+      # déchiffrement. Sans bypass, l'entrypoint SOPS+age (ADR-0044) fail-fast car aucun
+      # secrets.env/clé age n'est monté → exit 1. Le déchiffrement réel est couvert par
+      # tests/integration/test_entrypoint_dechiffrement.py.
       - name: Smoke-test image
         run: |
-          docker run --rm "${{ steps.docker_tags.outputs.smoke_tag }}" \
+          docker run --rm -e ELECTRICORE_DECRYPT=off "${{ steps.docker_tags.outputs.smoke_tag }}" \
             python -c "import electricore; import electricore.ingestion.runner; import electricore.api.main; import dbt.cli.main; print('image OK')"
 
       # Build n°2 : réhydrate le cache GHA du build n°1 (cache-from) → quasi


### PR DESCRIPTION
Second volet de la réparation du chemin image Docker (après #433 qui a réparé le **build**). Celui-ci répare le **smoke de release**.

## Cause

Depuis l'entrypoint secrets-as-code (#422 / ADR-0044), l'image a un `ENTRYPOINT` qui **fail-fast** si aucun `secrets.env` chiffré ni clé age n'est monté (ADR-0044 §3). Or l'étape `Smoke-test image` de `release.yml` fait :

```
docker run --rm "$smoke_tag" python -c "import …"
```

sans rien monter → l'entrypoint sort en **exit 1** (« secrets SOPS requis introuvables ») **avant** d'exécuter le `python -c`. La prochaine release aurait donc cassé à l'étape Smoke-test, juste après le build.

#422 a ajouté l'entrypoint mais n'a pas mis à jour `release.yml`.

## Fix (1 ligne utile)

`docker run --rm -e ELECTRICORE_DECRYPT=off …` : ce smoke vérifie l'**importabilité** de l'image, pas le déchiffrement. Le déchiffrement réel est couvert par `tests/integration/test_entrypoint_dechiffrement.py`. `ELECTRICORE_DECRYPT=off` est l'échappatoire documentée de l'ADR-0044 §3.

## Vérifié localement

| commande | résultat |
|---|---|
| `docker run image python -c …` (actuel) | ❌ exit 1, « secrets SOPS requis introuvables » |
| `docker run -e ELECTRICORE_DECRYPT=off image python -c …` | ✅ `image OK` |

Avec #433 (build) **et** cette PR (smoke), le chemin release-image est de nouveau vert de bout en bout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)