### PR TITLE
feat(api): jsonl_response (validate-then-stream) + adopt in both JSONL endpoints (#426, #427)

### DIFF
--- a/electricore/api/routers/chronologie.py
+++ b/electricore/api/routers/chronologie.py
@@ -12,39 +12,14 @@ métadonnées (`contract_version`, `grain`) remontent dans les en-têtes. Le mod
 **single-sourcé** dans `electricore_client`.
 """
 
-import datetime as dt
-from collections.abc import Iterator
-
 from electricore_client.models import valider_ligne_chronologie
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi.responses import StreamingResponse
 
 from electricore.api.security import get_current_api_key
+from electricore.api.serializers.jsonl import jsonl_response
 from electricore.api.services.chronologie_service import CONTRAT_VERSION, chronologie_point_ou_contrat
 
 router = APIRouter(tags=["facturation"])
-
-MEDIA_TYPE_JSONL = "application/jsonl"
-
-
-def _stringifier_dates(ligne: dict) -> dict:
-    """Rend les `datetime`/`date` de la ligne en ISO8601 (le contrat porte des `str`)."""
-    return {
-        clef: (valeur.isoformat() if isinstance(valeur, (dt.datetime, dt.date)) else valeur)
-        for clef, valeur in ligne.items()
-    }
-
-
-def _lignes_jsonl(rows: list[dict]) -> Iterator[bytes]:
-    """Valide chaque ligne via l'union discriminée et l'émet comme une ligne JSONL.
-
-    Les clés à valeur nulle sont retirées (un registre/une énergie nul n'est jamais
-    émis, conformément au service) avant la résolution de l'union.
-    """
-    for row in rows:
-        propres = {clef: valeur for clef, valeur in _stringifier_dates(row).items() if valeur is not None}
-        ligne = valider_ligne_chronologie(propres)
-        yield (ligne.model_dump_json(exclude_none=True) + "\n").encode()
 
 
 @router.get("/facturation/chronologie")
@@ -79,7 +54,9 @@ async def get_chronologie(
         raise HTTPException(422, "Fournir un grain : `pdl` (point) ou `rsc` (contrat).")
 
     frise = chronologie_point_ou_contrat(pdl=pdl, rsc=rsc)
-    rows = frise.to_dicts()
     grain = "point" if pdl is not None else "contrat"
     headers = {"X-Contract-Version": str(CONTRAT_VERSION), "X-Grain": grain}
-    return StreamingResponse(_lignes_jsonl(rows), media_type=MEDIA_TYPE_JSONL, headers=headers)
+    # `omettre_les_nuls=True` : clés nulles retirées avant la résolution de l'union discriminée
+    # (registre/énergie nul jamais émis) + `exclude_none` au dump. Validate-then-stream (#427)
+    # → une ligne hors-contrat fait un 500 atomique avant tout octet.
+    return jsonl_response(frise, valider=valider_ligne_chronologie, headers=headers, omettre_les_nuls=True)

--- a/electricore/api/routers/meta_periodes.py
+++ b/electricore/api/routers/meta_periodes.py
@@ -10,40 +10,17 @@ de réponse. Les modèles de ligne (`PeriodeMeta`/`ObjetReleve`) sont **single-s
 `electricore_client` — le router les importe, ne les redéfinit pas.
 """
 
-import datetime as dt
-from collections.abc import Iterator
 from typing import Annotated
 
 # Modèles single-sourcés dans le paquet client (ADR-0043).
 from electricore_client.models import PeriodeMeta
 from fastapi import APIRouter, Depends, Query
-from fastapi.responses import StreamingResponse
 
 from electricore.api.security import get_current_api_key
+from electricore.api.serializers.jsonl import jsonl_response
 from electricore.api.services.meta_periodes_service import CONTRAT_VERSION, meta_periodes
 
 router = APIRouter(tags=["facturation"])
-
-MEDIA_TYPE_JSONL = "application/jsonl"
-
-
-def _stringifier_dates(ligne: dict) -> dict:
-    """Rend les `datetime`/`date` de la ligne en ISO8601 (le contrat porte des `str`)."""
-    return {
-        clef: (valeur.isoformat() if isinstance(valeur, (dt.datetime, dt.date)) else valeur)
-        for clef, valeur in ligne.items()
-    }
-
-
-def _lignes_jsonl(rows: list[dict]) -> Iterator[bytes]:
-    """Construit un `PeriodeMeta` par ligne et l'émet comme une ligne JSONL.
-
-    La construction par modèle **valide** chaque ligne (le serveur ne peut pas servir
-    une ligne hors-contrat) et normalise la sérialisation (alias, types).
-    """
-    for row in rows:
-        periode = PeriodeMeta.model_validate(_stringifier_dates(row))
-        yield (periode.model_dump_json() + "\n").encode()
 
 
 @router.get("/facturation/meta-periodes")
@@ -74,9 +51,10 @@ async def get_meta_periodes(
     Odoo construit/upsert ses `souscription.periode` à partir de ce flux.
     """
     mois_resolu, df = meta_periodes(mois=mois, rsc=rsc)
-    rows = df.to_dicts()
     headers = {
         "X-Contract-Version": str(CONTRAT_VERSION),
         "X-Mois": mois_resolu,
     }
-    return StreamingResponse(_lignes_jsonl(rows), media_type=MEDIA_TYPE_JSONL, headers=headers)
+    # Validate-then-stream (#426) : `jsonl_response` valide toutes les lignes en amont, donc
+    # une ligne hors-contrat fait un 500 atomique avant tout octet (pas un 200 tronqué).
+    return jsonl_response(df, valider=PeriodeMeta.model_validate, headers=headers)

--- a/electricore/api/serializers/jsonl.py
+++ b/electricore/api/serializers/jsonl.py
@@ -1,0 +1,74 @@
+"""Sérialiseur JSONL partagé `jsonl_response` (validate-then-stream, ADR-0043, #426).
+
+Possède le format de fil des endpoints JSONL (`application/jsonl`, une ligne = un modèle
+de contrat sérialisé) **et** la garantie d'atomicité : toutes les lignes sont construites
+et **validées en amont**, donc une ligne hors-contrat lève *avant* que le premier octet ne
+parte. Le consommateur (`electricore-client` → Odoo, ADR-0027) reçoit alors un **500 propre,
+zéro ligne appliquée** — et re-rejoue le mois — au lieu d'un 200 tronqué en cours de flux.
+
+Réutilisé par `/facturation/meta-periodes` et `/facturation/chronologie` : chacun passe son
+validateur de ligne (`PeriodeMeta.model_validate` / `valider_ligne_chronologie`) et ses
+en-têtes. Le flag `omettre_les_nuls` (défaut **off**) couvre la sémantique chronologie
+(clés nulles retirées avant résolution de l'union discriminée + `exclude_none` au dump).
+"""
+
+import datetime as dt
+import logging
+from collections.abc import Callable
+
+import polars as pl
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+MEDIA_TYPE_JSONL = "application/jsonl"
+
+
+def _stringifier_dates(ligne: dict) -> dict:
+    """Rend les `datetime`/`date` de la ligne en ISO8601 (le contrat porte des `str`)."""
+    return {
+        clef: (valeur.isoformat() if isinstance(valeur, (dt.datetime, dt.date)) else valeur)
+        for clef, valeur in ligne.items()
+    }
+
+
+def jsonl_response(
+    df: pl.DataFrame,
+    *,
+    valider: Callable[[dict], BaseModel],
+    headers: dict[str, str],
+    omettre_les_nuls: bool = False,
+) -> StreamingResponse:
+    """Construit, valide et streame un DataFrame en JSONL (`application/jsonl`).
+
+    Validate-then-stream : toutes les lignes sont matérialisées en `list[bytes]` avant la
+    réponse, donc une ligne hors-contrat lève (et l'appel échoue) *avant* tout octet émis.
+
+    Args:
+        df: Lignes à émettre (une ligne = une ligne JSONL). Parcouru via `iter_rows(named=True)`.
+        valider: Validateur de ligne `dict -> BaseModel` (construit/valide la ligne).
+        headers: En-têtes de réponse (métadonnées : `X-Contract-Version`, `X-Mois`/`X-Grain`…).
+        omettre_les_nuls: Si vrai, retire les clés nulles *avant* validation et sérialise avec
+            `exclude_none=True` (sémantique chronologie : registre/énergie nul jamais émis).
+    """
+    lignes: list[bytes] = []
+    for row in df.iter_rows(named=True):
+        brut = _stringifier_dates(row)
+        if omettre_les_nuls:
+            brut = {clef: valeur for clef, valeur in brut.items() if valeur is not None}
+        try:
+            modele = valider(brut)
+        except Exception as exc:
+            # Le corps 500 générique de FastAPI ne fuit rien : on logge ici de quoi
+            # diagnostiquer en prod *quelle* ligne était hors-contrat, puis on propage
+            # (le mois entier échoue, zéro ligne appliquée côté consommateur).
+            logger.error(
+                "Ligne hors-contrat (ref_situation_contractuelle=%s) : %s",
+                row.get("ref_situation_contractuelle"),
+                exc,
+            )
+            raise
+        lignes.append((modele.model_dump_json(exclude_none=omettre_les_nuls) + "\n").encode())
+
+    return StreamingResponse(iter(lignes), media_type=MEDIA_TYPE_JSONL, headers=headers)

--- a/electricore/api/serializers/jsonl.py
+++ b/electricore/api/serializers/jsonl.py
@@ -59,14 +59,14 @@ def jsonl_response(
             brut = {clef: valeur for clef, valeur in brut.items() if valeur is not None}
         try:
             modele = valider(brut)
-        except Exception as exc:
+        except Exception:
             # Le corps 500 générique de FastAPI ne fuit rien : on logge ici de quoi
             # diagnostiquer en prod *quelle* ligne était hors-contrat, puis on propage
             # (le mois entier échoue, zéro ligne appliquée côté consommateur).
-            logger.error(
-                "Ligne hors-contrat (ref_situation_contractuelle=%s) : %s",
+            # `logger.exception` attache la trace (et l'erreur pydantic qui nomme le champ).
+            logger.exception(
+                "Ligne hors-contrat (ref_situation_contractuelle=%s)",
                 row.get("ref_situation_contractuelle"),
-                exc,
             )
             raise
         lignes.append((modele.model_dump_json(exclude_none=omettre_les_nuls) + "\n").encode())

--- a/notebooks/accueil.py
+++ b/notebooks/accueil.py
@@ -11,8 +11,11 @@ with app.setup:
 def _():
     mo.md(
         "## Notebooks opérateur\n\n"
-        "- [Facturation mensuelle](/apps/facturation)\n"
-        "- [Injection RSC](/apps/injection_rsc)\n"
+        "Suis l'ordre d'usage :\n\n"
+        "1. [Injection RSC](/apps/injection_rsc) — réconcilie les RSC du mois\n"
+        "2. [Facturation mensuelle](/apps/facturation)\n\n"
+        "La facturation **dépend** de la réconciliation RSC du mois : lance d'abord "
+        "l'injection RSC, puis la facturation.\n"
     )
     return
 

--- a/tests/integration/test_chronologie_endpoint.py
+++ b/tests/integration/test_chronologie_endpoint.py
@@ -141,6 +141,37 @@ def test_chronologie_pas_de_montant_tarifaire(monkeypatch, frise_synthetique):
     assert "accise" not in payload
 
 
+def test_chronologie_ligne_hors_contrat_500_atomique(monkeypatch):
+    """Une ligne hors-contrat (`type_ligne` hors de l'union discriminée) fait un **500 propre**
+    *avant* tout octet — pas un 200 tronqué en cours de flux (validate-then-stream, #427)."""
+    frise_cassee = pl.DataFrame(
+        [
+            {
+                "type_ligne": "bidon",  # hors union evenement|releve|periode_energie
+                "date": datetime(2024, 1, 5, tzinfo=PARIS),
+                "pdl": "PDL_X",
+                "ref_situation_contractuelle": "REF_1",
+            }
+        ],
+        infer_schema_length=None,
+    )
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    monkeypatch.setattr(
+        "electricore.api.routers.chronologie.chronologie_point_ou_contrat",
+        lambda pdl=None, rsc=None: frise_cassee,
+    )
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/facturation/chronologie", params={"pdl": "PDL_X"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 500
+    # Le flux n'a pas commencé : pas de données de frise dans le corps.
+    assert not response.headers["content-type"].startswith("application/jsonl")
+    assert "type_ligne" not in response.text
+
+
 def test_chronologie_refuse_sans_api_key():
     """Endpoint sécurisé : 401 sans clé."""
     response = TestClient(app).get("/facturation/chronologie", params={"pdl": "PDL_X"})

--- a/tests/integration/test_meta_periodes_endpoint.py
+++ b/tests/integration/test_meta_periodes_endpoint.py
@@ -149,6 +149,29 @@ def test_meta_periodes_lignes_valident_le_modele(monkeypatch, meta_periodes_synt
     assert periodes[1].releves_utilises == []
 
 
+def test_meta_periodes_ligne_hors_contrat_500_atomique(monkeypatch, meta_periodes_synthetiques):
+    """Une ligne hors-contrat (champ requis retiré) fait un **500 propre** *avant* tout octet —
+    pas un 200 tronqué en cours de flux (validate-then-stream, #426). Le consommateur n'applique
+    alors aucune ligne et re-rejoue le mois."""
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    # On retire un champ requis du contrat (`source_hash`) → la validation échoue en amont.
+    df_casse = meta_periodes_synthetiques.drop("source_hash")
+    monkeypatch.setattr(
+        "electricore.api.routers.meta_periodes.meta_periodes",
+        lambda mois=None, rsc=None: ("2026-05-01", df_casse),
+    )
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/facturation/meta-periodes")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 500
+    # Le flux n'a pas commencé : aucune ligne JSONL (pas de données de contrat) n'a fuité.
+    assert not response.headers["content-type"].startswith("application/jsonl")
+    assert "ref_situation_contractuelle" not in response.text
+
+
 def test_meta_periodes_refuse_sans_api_key():
     """Endpoint sécurisé : 401 sans clé."""
     response = TestClient(app).get("/facturation/meta-periodes")

--- a/tests/integration/test_operator_notebooks_bundle.py
+++ b/tests/integration/test_operator_notebooks_bundle.py
@@ -90,6 +90,57 @@ def test_facturation_ne_reference_pas_de_colonne_pre_rename(colonne_retiree):
     )
 
 
+# --- Accueil : ordre d'usage explicite (réconciliation RSC → facturation, #423) ---
+# Garde purement statique sur la source de `accueil.py` (page de liens, sans
+# exécution ni Odoo). Un opérateur qui lance `facturation` AVANT d'avoir réconcilié
+# les RSC du mois obtient un 503 « ingestion en cours » trompeur (la vraie cause :
+# `ref_situation_contractuelle` NULL refusé par `LignesFacture`). L'accueil doit
+# désamorcer le piège en présentant l'ordre d'usage.
+_LIEN_RECONCILIATION_RSC = "/apps/injection_rsc"
+_LIEN_FACTURATION = "/apps/facturation"
+
+
+def test_accueil_presente_reconciliation_rsc_avant_facturation():
+    """`accueil.py` liste la réconciliation RSC AVANT la facturation (ordre d'usage, #423)."""
+    source = (_RACINE / "notebooks" / "accueil.py").read_text()
+    assert _LIEN_RECONCILIATION_RSC in source and _LIEN_FACTURATION in source
+    assert source.index(_LIEN_RECONCILIATION_RSC) < source.index(_LIEN_FACTURATION), (
+        "L'accueil doit présenter la réconciliation RSC (injection_rsc) avant la "
+        "facturation : la facturation dépend des RSC réconciliées (#423)."
+    )
+
+
+def test_accueil_explique_la_dependance_facturation_rsc():
+    """`accueil.py` énonce que la facturation DÉPEND de la réconciliation RSC (#423).
+
+    Sans cette phrase, l'opérateur qui voit le 503 « ingestion en cours » attend une
+    ingestion sans rapport au lieu de lancer la réconciliation. La garde vérifie la
+    présence d'un énoncé de dépendance, pas une formulation exacte (survie au reword).
+    """
+    source = (_RACINE / "notebooks" / "accueil.py").read_text().lower()
+    assert "dépend" in source, (
+        "L'accueil doit énoncer explicitement que la facturation dépend de la réconciliation RSC préalable (#423)."
+    )
+
+
+def test_accueil_numerote_les_etapes_dans_l_ordre():
+    """`accueil.py` numérote les deux étapes : 1. réconciliation RSC, 2. facturation (#423).
+
+    La numérotation rend la séquence d'usage non-ambiguë. Les marqueurs `"N. "`
+    (chiffre-point-espace) évitent toute collision avec la chaîne de version
+    (`"0.21.1"`) ; les positions sont ancrées sur les URLs des liens (survie au
+    renommage des libellés).
+    """
+    source = (_RACINE / "notebooks" / "accueil.py").read_text()
+    assert "1. " in source and "2. " in source, "L'accueil doit numéroter les étapes (#423)."
+    assert (
+        source.index("1. ")
+        < source.index(_LIEN_RECONCILIATION_RSC)
+        < source.index("2. ")
+        < source.index(_LIEN_FACTURATION)
+    ), "Étape 1 = réconciliation RSC, étape 2 = facturation, dans cet ordre (#423)."
+
+
 @pytest.mark.slow
 def test_wheel_contient_les_notebooks_operateur(tmp_path: Path):
     """`uv build --wheel` produit un wheel electricore contenant les 3 notebooks."""

--- a/tests/unit/test_jsonl_response.py
+++ b/tests/unit/test_jsonl_response.py
@@ -1,0 +1,132 @@
+"""Le sérialiseur partagé `jsonl_response` (validate-then-stream, #426).
+
+Construit et **valide toutes les lignes JSONL en amont** : une ligne hors-contrat lève
+*avant* que le premier octet ne parte (500 atomique, zéro ligne appliquée côté consommateur)
+plutôt qu'en cassant un flux déjà committé en 200. Le format de fil (`application/jsonl`,
+une ligne = un modèle sérialisé) et la stringification des dates sont possédés par le helper ;
+les deux endpoints JSONL (méta-périodes, chronologie) lui passent leur validateur de ligne.
+"""
+
+import asyncio
+import datetime as dt
+import json
+import logging
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from electricore.api.serializers.jsonl import MEDIA_TYPE_JSONL, jsonl_response
+
+PARIS = ZoneInfo("Europe/Paris")
+
+
+class _Ligne(BaseModel):
+    """Modèle de ligne minimal pour exercer le helper générique."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    ref_situation_contractuelle: str
+    debut: str
+    valeur: int
+    note: str | None = None
+    # Champ requis (non-optionnel) *avec* défaut : un `None` explicite casse la
+    # validation s'il n'est pas retiré au préalable — exerce `omettre_les_nuls`.
+    categorie: str = "defaut"
+
+
+def _corps(response) -> bytes:
+    """Draine le corps streamé (StreamingResponse) en bytes."""
+
+    async def _collect() -> bytes:
+        chunks = [c async for c in response.body_iterator]
+        return b"".join(c if isinstance(c, bytes) else c.encode() for c in chunks)
+
+    return asyncio.run(_collect())
+
+
+def _lignes(response) -> list[dict]:
+    return [json.loads(ligne) for ligne in _corps(response).decode().splitlines() if ligne.strip()]
+
+
+def test_happy_path_streame_des_lignes_jsonl_validees():
+    """Tracer bullet : chaque ligne du DataFrame est validée et émise en JSONL."""
+    df = pl.DataFrame(
+        {
+            "ref_situation_contractuelle": ["RSC-1", "RSC-2"],
+            "debut": [dt.datetime(2026, 5, 1, tzinfo=PARIS), dt.datetime(2026, 5, 1, tzinfo=PARIS)],
+            "valeur": [10, 20],
+        }
+    )
+
+    response = jsonl_response(df, valider=_Ligne.model_validate, headers={"X-Contract-Version": "9"})
+
+    assert response.media_type == MEDIA_TYPE_JSONL
+    assert response.headers["X-Contract-Version"] == "9"
+
+    lignes = _lignes(response)
+    assert len(lignes) == 2
+    assert lignes[0]["ref_situation_contractuelle"] == "RSC-1"
+    assert lignes[0]["valeur"] == 10
+    # Les dates sont stringifiées en ISO8601 (le contrat porte des `str`).
+    assert lignes[0]["debut"] == "2026-05-01T00:00:00+02:00"
+
+
+def test_ligne_hors_contrat_leve_avant_de_streamer():
+    """Validate-then-stream : une ligne hors-contrat fait lever l'appel lui-même
+    (avant tout octet), pas le générateur de flux déjà committé en 200."""
+    df = pl.DataFrame(
+        {
+            "ref_situation_contractuelle": ["RSC-1", "RSC-BAD"],
+            "debut": [dt.datetime(2026, 5, 1, tzinfo=PARIS), dt.datetime(2026, 5, 1, tzinfo=PARIS)],
+            # 2e ligne : `valeur` non coercible en int → champ requis invalide.
+            "valeur": ["10", "pas-un-entier"],
+        }
+    )
+
+    with pytest.raises(ValidationError):
+        jsonl_response(df, valider=_Ligne.model_validate, headers={})
+
+
+def test_omettre_les_nuls_retire_les_clefs_nulles_avant_validation_et_au_dump():
+    """`omettre_les_nuls=True` retire les clés nulles *avant* la validation (le défaut
+    s'applique) et sérialise avec `exclude_none` (sémantique chronologie)."""
+    df = pl.DataFrame(
+        {
+            "ref_situation_contractuelle": ["RSC-1"],
+            "debut": [dt.datetime(2026, 5, 1, tzinfo=PARIS)],
+            "valeur": [10],
+            "note": [None],
+            "categorie": [None],  # None contre un champ `str` requis (avec défaut)
+        }
+    )
+
+    # Sans le flag : `categorie=None` casse la validation (None vs str non-optionnel).
+    with pytest.raises(ValidationError):
+        jsonl_response(df, valider=_Ligne.model_validate, headers={})
+
+    # Avec le flag : clés nulles retirées avant validation (défaut appliqué) ET au dump.
+    response = jsonl_response(df, valider=_Ligne.model_validate, headers={}, omettre_les_nuls=True)
+    lignes = _lignes(response)
+    assert lignes[0]["categorie"] == "defaut"
+    assert "note" not in lignes[0]  # null omis au dump (exclude_none)
+
+
+def test_logge_la_ref_et_lerreur_sur_ligne_hors_contrat(caplog):
+    """Sur échec, le serveur logge la `ref_situation_contractuelle` fautive + l'erreur
+    pydantic (le corps 500 générique de FastAPI ne fuit rien — prod doit diagnostiquer)."""
+    df = pl.DataFrame(
+        {
+            "ref_situation_contractuelle": ["RSC-CASSEE"],
+            "debut": [dt.datetime(2026, 5, 1, tzinfo=PARIS)],
+            "valeur": ["pas-un-entier"],
+        }
+    )
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValidationError):
+            jsonl_response(df, valider=_Ligne.model_validate, headers={})
+
+    assert "RSC-CASSEE" in caplog.text
+    assert "valeur" in caplog.text  # l'erreur pydantic nomme le champ fautif


### PR DESCRIPTION
## What

Closes #426
Closes #427

A shared `jsonl_response` serializer that **validates every row before the response starts**, adopted in both JSONL endpoints (`/facturation/meta-periodes`, `/facturation/chronologie`) to close the mid-stream-break bug on each.

## Why

Both endpoints validated each row *inside* the `StreamingResponse` generator — after HTTP 200 + headers were already committed. A single off-contract row (missing/null required field, type mismatch, or an unknown `type_ligne`) broke the stream mid-flight. The consumer (`electricore-client` → Odoo, ADR-0027) got a **partially-applied month** plus an opaque transport error (`httpx.RemoteProtocolError`), all under a 200.

`jsonl_response` does **validate-then-stream**: it builds and validates all JSONL lines up front, so a bad row raises *before the first byte ships* → a clean **atomic 500**, zero rows applied, consumer re-runs the month. Because the month is already fully materialized, pre-validating costs nothing (peak memory actually falls: the intermediate `to_dicts()` `list[dict]` is dropped in favor of a compact `list[bytes]`, fed via `iter_rows(named=True)`).

## How

- **`electricore/api/serializers/jsonl.py`** — new `jsonl_response(df, *, valider, headers, omettre_les_nuls=False)`. Owns date-stringification + the `application/jsonl` media type. `omettre_les_nuls` (default **off**) strips null keys *before* validation and dumps with `exclude_none=True` — the chronologie discriminated-union semantics. On failure, logs the offending `ref_situation_contractuelle` + the pydantic error (FastAPI's generic 500 body leaks nothing).
- **`/facturation/meta-periodes`** (#426) — adopts the helper (`PeriodeMeta.model_validate`); duplicated `_stringifier_dates`/`_lignes_jsonl` removed. Wire output (JSONL lines + `X-Contract-Version`/`X-Mois`) unchanged.
- **`/facturation/chronologie`** (#427) — adopts the helper with `omettre_les_nuls=True` (`valider_ligne_chronologie`); duplicated trio removed. Wire output (`exclude_none` semantics + `X-Contract-Version`/`X-Grain`) unchanged. The grain check (`pdl` XOR `rsc` → 422) stays in the router.

## Tests

- Helper unit tests (`tests/unit/test_jsonl_response.py`): happy path yields validated JSONL lines; off-contract row raises *before* returning the response; `omettre_les_nuls` strips nulls pre-validation + at dump; failure logs the offending ref + error.
- Integration: each endpoint with an off-contract row (service patched) returns a clean **500**, not a truncated 200; no contract data leaks in the body.
- Existing happy-path tests for both endpoints pass unchanged.

> Note: this branch currently also carries #423 (`feat(notebooks): accueil …`) because `origin/main` did not yet include it at branch time; the diff cleans up once #423 merges. The pre-existing `test_operator_launcher` failure (missing `marimo._server` / `viz` extra) is unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
