### PR TITLE
ci: build + smoke-test l'image Docker sur les PR via workflow réutilisable (#435)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,22 @@ jobs:
       - name: Lancer les tests du client (les tests Arrow se skippent sans polars)
         run: |
           /tmp/client-venv/bin/python -m pytest packages/electricore-client/tests -q
+
+  deploy-tests:
+    name: deploy shell tests (bash, fake-binaries)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # Couvre les helpers deploy/lib/ + deploy/docker/smoke.sh (secrets-as-code,
+      # ADR-0044 ; smoke d'image, #435). Bash pur, fake-binaires docker/git/sops,
+      # zéro dépendance → ces logiques d'infra étaient jusqu'ici hors-CI.
+      - name: Run deploy unit tests
+        run: bash deploy/tests/unit.sh
+
+  # Build + scan + smoke de l'image Docker sur CHAQUE PR (#435) — via le workflow
+  # réutilisable partagé avec release.yml. `push` reste à false : seul release.yml pousse.
+  docker-image:
+    name: docker image (build + smoke)
+    permissions:
+      contents: read
+    uses: ./.github/workflows/docker-image.yml

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,93 @@
+name: Docker image (build + smoke)
+
+# Workflow RÉUTILISABLE (issue #435). Build l'image, la scanne (TruffleHog) puis la
+# FUME (deploy/docker/smoke.sh : importabilité + déchiffrement) — et seulement si
+# `push: true` (release), la pousse vers GHCR en réhydratant le cache du build n°1.
+#
+# Appelé par :
+#   - ci.yml      (PR)  → push=false : build + scan + smoke, RIEN n'est poussé.
+#   - release.yml (tag) → push=true  : idem + push n°2 vers ghcr.io.
+#
+# Source unique du gate « build → scan → smoke → push » (avant #435 il vivait inline
+# dans release.yml, donc jamais exercé sur les PR — d'où des casses build/smoke restées
+# invisibles jusqu'au tag de release). Deux temps : on ne fait pas load+push dans le
+# même build (load = image locale, push = export direct ; ils ne cohabitent pas de
+# façon fiable sur un seul builder). La séquence garantit l'invariant : rien n'est
+# poussé tant que l'image n'a pas été scannée ET fumée.
+#
+# Pas de bloc `permissions:` ici : le workflow hérite des permissions que LUI DÉLÈGUE
+# l'appelant (ci.yml → contents:read ; release.yml/image → +packages:write pour le push).
+
+on:
+  workflow_call:
+    inputs:
+      push:
+        description: "Pousser l'image vers GHCR après le gate (release uniquement)."
+        type: boolean
+        default: false
+      push_tags:
+        description: "Tags GHCR à pousser (séparés par des virgules) — requis si push=true."
+        type: string
+        default: ""
+
+jobs:
+  build-smoke:
+    name: build + scan + smoke
+    runs-on: ubuntu-latest
+    env:
+      # Tag LOCAL du build n°1 (chargé dans le démon Docker, jamais poussé tel quel).
+      SMOKE_TAG: electricore:ci-smoke
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GHCR
+        if: ${{ inputs.push }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      # Build n°1 : le vrai build. Charge l'image en local (load) pour le gate
+      # ci-dessous et alimente le cache GHA (cache-to) que le push n°2 réutilisera.
+      - name: Build image (n°1 — local, sans push, pour le gate scan + smoke)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: ${{ env.SMOKE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image for verified secrets (TruffleHog)
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            trufflesecurity/trufflehog:latest \
+            docker --image "${SMOKE_TAG}" \
+            --only-verified \
+            --fail
+
+      # Fume l'image : importabilité (entrypoint SOPS contourné, #434) + déchiffrement
+      # RÉEL (entrypoint SOPS + fixtures de test → label AES dynamique injecté, #435).
+      - name: Smoke-test image (importabilité + déchiffrement)
+        run: bash deploy/docker/smoke.sh "${SMOKE_TAG}"
+
+      # Build n°2 : réhydrate le cache GHA du build n°1 (cache-from) → quasi rien à
+      # reconstruire ; l'essentiel du temps est l'export + le push. Release uniquement.
+      - name: Push image vers GHCR (n°2 — cache du n°1 réhydraté, quasi gratuit)
+        if: ${{ inputs.push }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ inputs.push_tags }}
+          cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,89 +72,46 @@ jobs:
             ${PRERELEASE_FLAG} \
             dist/*.tar.gz dist/*.whl
 
-      # ---------------------------------------------------------------
-      # Image Docker → ghcr.io (en parallèle de la publication PyPI)
-      #
-      # Gate « build → scan → push » en deux temps (cf. les deux étapes
-      # build-push-action plus bas) :
-      #   1. build local (load: true, push: false) → image dans le démon
-      #      Docker, scannée (TruffleHog) puis fumée (import) AVANT tout push ;
-      #   2. push vers ghcr.io seulement si le gate passe, en réhydratant le
-      #      cache GHA du build n°1 (donc quasi gratuit).
-      # On ne fait pas load + push dans le même step : load = image locale,
-      # push = export direct vers le registre, les deux ne cohabitent pas de
-      # façon fiable sur un seul builder. La séquence garantit l'invariant :
-      # rien n'est poussé tant que l'image n'a pas été scannée et fumée.
-      # ---------------------------------------------------------------
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Login to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute Docker tags
-        id: docker_tags
+  # ---------------------------------------------------------------
+  # Image Docker → ghcr.io (en parallèle de la publication PyPI)
+  #
+  # Le gate « build → scan → smoke → push » vit désormais dans le workflow
+  # réutilisable docker-image.yml (#435), partagé avec ci.yml — qui le fait
+  # tourner sur CHAQUE PR (push=false). Ici on calcule les tags du release puis
+  # on appelle ce même workflow avec push=true.
+  # ---------------------------------------------------------------
+  docker_meta:
+    name: Compute Docker tags
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tags: ${{ steps.compute.outputs.tags }}
+    steps:
+      - name: Compute tags (pré-release ne touche ni :latest ni :MAJOR.MINOR)
+        id: compute
         run: |
+          set -euo pipefail
           OWNER="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
           V="${GITHUB_REF_NAME#v}"
           MAJOR_MINOR="${V%.*}"
-          if [[ "${{ steps.release_type.outputs.is_prerelease }}" == "true" ]]; then
-            # Pré-release : on ne touche ni `:latest` ni `:MAJOR.MINOR` pour ne pas
-            # rediriger les déploiements stables vers la rc/dev.
-            TAGS="ghcr.io/${OWNER}/electricore:${V}"
-          else
+          if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            # Stable : :latest + :MAJOR.MINOR + :version exacte.
             TAGS="ghcr.io/${OWNER}/electricore:${V},ghcr.io/${OWNER}/electricore:${MAJOR_MINOR},ghcr.io/${OWNER}/electricore:latest"
+          else
+            # Pré-release : seulement :version exacte (ne pas rediriger les déploiements
+            # stables vers la rc/dev).
+            TAGS="ghcr.io/${OWNER}/electricore:${V}"
           fi
-          {
-            echo "tags=${TAGS}"
-            echo "smoke_tag=ghcr.io/${OWNER}/electricore:${V}"
-          } >> "$GITHUB_OUTPUT"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
-      # Build n°1 : le vrai build (0% cache, lent). Charge l'image en local
-      # pour le gate ci-dessous et alimente le cache GHA (cache-to) que le
-      # push réutilisera.
-      - name: Build image (n°1 — local, sans push, pour le gate scan + smoke)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: deploy/docker/Dockerfile
-          push: false
-          load: true
-          platforms: linux/amd64
-          tags: ${{ steps.docker_tags.outputs.smoke_tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Scan image for verified secrets (TruffleHog)
-        run: |
-          docker run --rm \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            trufflesecurity/trufflehog:latest \
-            docker --image ${{ steps.docker_tags.outputs.smoke_tag }} \
-            --only-verified \
-            --fail
-
-      # ELECTRICORE_DECRYPT=off : ce smoke vérifie l'IMPORTABILITÉ de l'image, pas le
-      # déchiffrement. Sans bypass, l'entrypoint SOPS+age (ADR-0044) fail-fast car aucun
-      # secrets.env/clé age n'est monté → exit 1. Le déchiffrement réel est couvert par
-      # tests/integration/test_entrypoint_dechiffrement.py.
-      - name: Smoke-test image
-        run: |
-          docker run --rm -e ELECTRICORE_DECRYPT=off "${{ steps.docker_tags.outputs.smoke_tag }}" \
-            python -c "import electricore; import electricore.ingestion.runner; import electricore.api.main; import dbt.cli.main; print('image OK')"
-
-      # Build n°2 : réhydrate le cache GHA du build n°1 (cache-from) → quasi
-      # rien à reconstruire, l'essentiel du temps est l'export + le push.
-      - name: Push image vers GHCR (n°2 — cache du n°1 réhydraté, quasi gratuit)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: deploy/docker/Dockerfile
-          push: true
-          platforms: linux/amd64
-          tags: ${{ steps.docker_tags.outputs.tags }}
-          cache-from: type=gha
+  image:
+    name: Build, scan, smoke & push image
+    needs: docker_meta
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      push: true
+      push_tags: ${{ needs.docker_meta.outputs.tags }}

--- a/deploy/docker/smoke.sh
+++ b/deploy/docker/smoke.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# smoke.sh — fume une image electricore DÉJÀ buildée (issue #435).
+#
+# Deux vérifications, contre l'IMAGE (pas le seul script entrypoint) :
+#   1. Importabilité : l'image démarre et les modules de tête s'importent. On contourne
+#      l'entrypoint SOPS (ELECTRICORE_DECRYPT=off) — sinon il fail-fast faute de secrets
+#      montés (#434, ADR-0044 §3) et le smoke échouerait pour une mauvaise raison.
+#   2. Déchiffrement : monté avec les fixtures SOPS de test, l'entrypoint déchiffre et
+#      injecte un label AES DYNAMIQUE (AES__TROUSSEAU__demo__KEY, ADR-0037) — le scénario
+#      de tests/integration/test_entrypoint_dechiffrement.py, mais contre l'image.
+#
+# Usage :   deploy/docker/smoke.sh <image-tag>
+#
+# Surcharges de test (motif maison, cf. deploy/lib/secrets.sh) :
+#   DOCKER_BIN           binaire docker (défaut: docker ; les tests le stubbent)
+#   SMOKE_FIXTURES_DIR   dossier des fixtures SOPS (défaut: tests/fixtures/sops du repo)
+
+# Commandes externes + emplacements, surchargeables pour les tests (pas de set -e ici :
+# ce fichier est SOURCÉ par deploy/tests/unit.sh ; errexit est posé dans le guard `main`).
+DOCKER_BIN="${DOCKER_BIN:-docker}"
+_SMOKE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Racine du repo résolue en absolu (sans `..` : `docker -v` monte mal les chemins relatifs).
+_REPO_ROOT="$(cd "${_SMOKE_DIR}/../.." && pwd)"
+SMOKE_FIXTURES_DIR="${SMOKE_FIXTURES_DIR:-${_REPO_ROOT}/tests/fixtures/sops}"
+
+# Modules de tête dont l'échec d'import = image cassée (même liste que release.yml).
+_SMOKE_IMPORTS='import electricore; import electricore.ingestion.runner; import electricore.api.main; import dbt.cli.main'
+
+# smoke_importabilite <tag> : l'image s'importe (entrypoint SOPS contourné).
+smoke_importabilite() {
+    local tag="$1"
+    "$DOCKER_BIN" run --rm -e ELECTRICORE_DECRYPT=off "$tag" \
+        python -c "$_SMOKE_IMPORTS"
+}
+
+# smoke_dechiffrement <tag> : monté avec les fixtures SOPS, l'entrypoint injecte le
+# label AES dynamique. On n'inspecte QUE le code de sortie : la commande dans le
+# conteneur (`test -n`) échoue si le label n'a pas été injecté → l'entrypoint n'a pas
+# déchiffré. C'est le scénario de test_entrypoint_dechiffrement.py, contre l'image.
+smoke_dechiffrement() {
+    local tag="$1"
+    "$DOCKER_BIN" run --rm \
+        -v "${SMOKE_FIXTURES_DIR}/secrets.env:/run/secrets/secrets.env:ro" \
+        -v "${SMOKE_FIXTURES_DIR}/test_age.key:/run/secrets/age.key:ro" \
+        "$tag" \
+        sh -c 'test -n "${AES__TROUSSEAU__demo__KEY:-}"'
+}
+
+# smoke_image <tag> : lance les deux fumées, rapporte chaque verdict, échoue si l'une casse.
+smoke_image() {
+    local tag="${1:-}"
+    if [[ -z "$tag" ]]; then
+        echo "usage: smoke.sh <image-tag>" >&2
+        return 2
+    fi
+    local rc=0
+    if smoke_importabilite "$tag"; then
+        echo "smoke: importabilité OK"
+    else
+        echo "smoke: ÉCHEC importabilité (l'image ne démarre/importe pas)" >&2
+        rc=1
+    fi
+    if smoke_dechiffrement "$tag"; then
+        echo "smoke: déchiffrement OK (label AES dynamique injecté)"
+    else
+        echo "smoke: ÉCHEC déchiffrement (entrypoint SOPS n'a pas injecté le label)" >&2
+        rc=1
+    fi
+    return "$rc"
+}
+
+main_smoke() {
+    set -euo pipefail
+    smoke_image "$@"
+}
+
+# Guard : exécute main_smoke seulement si lancé (`bash smoke.sh …`), pas sourcé (tests).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main_smoke "$@"
+fi

--- a/deploy/tests/fixtures/fake_bin/docker
+++ b/deploy/tests/fixtures/fake_bin/docker
@@ -15,7 +15,7 @@ mount_src=""
 while [[ $i -lt ${#args[@]} ]]; do
     case "${args[$i]}" in
         -v) mount_src="${args[$((i+1))]%%:*}"; i=$((i+2)); continue ;;
-        age-keygen|ssh-keygen) tool="${args[$i]}"; break ;;
+        age-keygen|ssh-keygen|python|python3|sh) tool="${args[$i]}"; break ;;
     esac
     i=$((i+1))
 done
@@ -37,6 +37,19 @@ case "$tool" in
         out="${mount_src}/ssh_deploy_key"
         echo "FAKE-OPENSSH-PRIVATE-KEY" > "$out"
         echo "ssh-ed25519 AAAAFAKEDEPLOYKEY deploy-key" > "${out}.pub"
+        ;;
+    python|python3)
+        # smoke d'importabilité (smoke.sh) : l'image importe les modules de tête.
+        # FAKE_SMOKE_IMPORT_FAIL=1 simule une image cassée (import KO).
+        [[ "${FAKE_SMOKE_IMPORT_FAIL:-0}" == "1" ]] && { echo "fake docker: import KO" >&2; exit 1; }
+        echo "fake docker: import OK"
+        ;;
+    sh)
+        # smoke de déchiffrement (smoke.sh) : simule l'entrypoint SOPS qui injecte le
+        # label AES puis exec la commande de test. FAKE_SMOKE_DECRYPT_FAIL=1 simule le
+        # fail-fast de l'entrypoint (pas de secrets déchiffrés → label absent).
+        [[ "${FAKE_SMOKE_DECRYPT_FAIL:-0}" == "1" ]] && { echo "fake docker: entrypoint fail-fast" >&2; exit 1; }
+        exit 0
         ;;
     *)
         echo "fake docker: commande non simulée ($*)" >&2; exit 1 ;;

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -44,6 +44,11 @@ source "${LIB_DIR}/../unharden.sh"
 # shellcheck source=../add-provider.sh
 source "${LIB_DIR}/../add-provider.sh"
 
+# `smoke.sh` (fume l'image Docker buildée, issue #435) — guard `main_smoke` ;
+# expose smoke_image + smoke_importabilite + smoke_dechiffrement.
+# shellcheck source=../docker/smoke.sh
+source "${LIB_DIR}/../docker/smoke.sh"
+
 PASS=0; FAIL=0
 ok() { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
 ko() { printf '  \033[31m✗\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
@@ -414,6 +419,51 @@ SOPS_EX="${LIB_DIR}/../providers/example/.sops.yaml.example"
 n_age=$(grep -cE '^[[:space:]]*- age1' "$SOPS_EX")
 assert_eq "$n_age" "3" ".sops.yaml.example: 3 destinataires (admin ops + escrow + box)"
 grep -qi "escrow" "$SOPS_EX" && ok ".sops.yaml.example: clé escrow modélisée + commentée" || ko "escrow absent du modèle"
+
+echo
+echo "→ smoke.sh (fume l'image Docker — fake docker)"
+# Fixtures SOPS factices : le fake docker ne les lit pas (il simule l'entrypoint),
+# elles n'ont qu'à exister pour les montages `-v`.
+SMOKE_FIX=$(mktemp -d); : > "${SMOKE_FIX}/secrets.env"; : > "${SMOKE_FIX}/test_age.key"
+PATH="${FAKE_BIN}:$PATH" DOCKER_BIN=docker SMOKE_FIXTURES_DIR="$SMOKE_FIX" \
+    assert_ok "smoke_image: image saine (import + déchiffrement OK) → succès" \
+    smoke_image "electricore:test"
+
+# Importabilité cassée → échec qui NOMME la vérification fautive.
+out=$(PATH="${FAKE_BIN}:$PATH" DOCKER_BIN=docker SMOKE_FIXTURES_DIR="$SMOKE_FIX" \
+    FAKE_SMOKE_IMPORT_FAIL=1 smoke_image "electricore:test" 2>&1); rc=$?
+[[ "$rc" -ne 0 ]] && ok "smoke_image: import cassé → exit non-zero" || ko "smoke_image: import cassé devait échouer"
+grep -qi "importabilité" <<<"$out" && ok "smoke_image: import cassé → message nomme l'importabilité" || ko "smoke_image: message d'échec import manquant"
+
+# Déchiffrement cassé (entrypoint fail-fast) → échec qui NOMME la vérification fautive.
+out=$(PATH="${FAKE_BIN}:$PATH" DOCKER_BIN=docker SMOKE_FIXTURES_DIR="$SMOKE_FIX" \
+    FAKE_SMOKE_DECRYPT_FAIL=1 smoke_image "electricore:test" 2>&1); rc=$?
+[[ "$rc" -ne 0 ]] && ok "smoke_image: déchiffrement cassé → exit non-zero" || ko "smoke_image: déchiffrement cassé devait échouer"
+grep -qi "déchiffrement" <<<"$out" && ok "smoke_image: déchiffrement cassé → message nomme le déchiffrement" || ko "smoke_image: message d'échec déchiffrement manquant"
+
+# Sans tag → erreur d'usage explicite (exit 2, distinct d'un échec de fumée).
+( smoke_image >/dev/null 2>&1 ); rc=$?
+[[ "$rc" -eq 2 ]] && ok "smoke_image: sans tag → exit 2 (usage)" || ko "smoke_image: sans tag devait être exit 2 (got $rc)"
+
+# Détails PORTEURS (régression silencieuse = faux échec en CI) : on trace les appels docker.
+SMOKE_LOG=$(mktemp)
+PATH="${FAKE_BIN}:$PATH" DOCKER_BIN=docker SMOKE_FIXTURES_DIR="$SMOKE_FIX" FAKE_DOCKER_LOG="$SMOKE_LOG" \
+    smoke_image "electricore:test" >/dev/null 2>&1
+# L'import DOIT contourner l'entrypoint SOPS, sinon il fail-fast → faux échec (#434, ADR-0044 §3).
+grep -q -- '-e ELECTRICORE_DECRYPT=off' "$SMOKE_LOG" \
+    && ok "smoke_image: l'import contourne l'entrypoint (ELECTRICORE_DECRYPT=off, #434)" \
+    || ko "smoke_image: l'import ne pose pas ELECTRICORE_DECRYPT=off"
+# Le déchiffrement DOIT monter les deux secrets aux chemins attendus par l'entrypoint,
+# sinon il fail-fast (chemins par défaut /run/secrets/{secrets.env,age.key}).
+grep -Eq -- '-v [^ ]*/secrets\.env:/run/secrets/secrets\.env:ro' "$SMOKE_LOG" \
+    && ok "smoke_image: déchiffrement monte secrets.env → /run/secrets/secrets.env" \
+    || ko "smoke_image: secrets.env non monté au bon chemin"
+grep -Eq -- '-v [^ ]*/test_age\.key:/run/secrets/age\.key:ro' "$SMOKE_LOG" \
+    && ok "smoke_image: déchiffrement monte la clé age → /run/secrets/age.key" \
+    || ko "smoke_image: clé age non montée au bon chemin"
+rm -f "$SMOKE_LOG"
+
+rm -rf "$SMOKE_FIX"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then


### PR DESCRIPTION
## Pourquoi

Le gate Docker « build → scan → smoke → push » ne vivait qu'**inline dans `release.yml`**, donc n'était **jamais exercé sur les PR**. Résultat : deux casses latentes accumulées sur `main` sans détection jusqu'au tag de release — le build (#433) et le smoke entrypoint SOPS (#434), trouvées seulement en buildant l'image à la main. C'est l'objet de #435.

## Ce que fait cette PR

**1. Workflow réutilisable `.github/workflows/docker-image.yml`** — source unique du gate, appelé par :
- `ci.yml` (PR) → `push=false` : **build + scan (TruffleHog) + smoke**, rien n'est poussé ;
- `release.yml` (tag) → `push=true` : idem **+ push GHCR** (build n°2, cache GHA réhydraté).

`release.yml` perd son bloc docker inline ; un petit job `docker_meta` calcule les tags et l'`image` (reusable) les pousse. Le job `release` (PyPI + GitHub release) est **inchangé**.

**2. Smoke extrait dans `deploy/docker/smoke.sh`** (logique testable, réutilisée par le workflow et lançable à la main) et **renforcé** — deux vérifications contre l'**image** :
- *importabilité* : `electricore` / `ingestion.runner` / `api.main` / `dbt.cli.main` s'importent (entrypoint contourné, `ELECTRICORE_DECRYPT=off`, #434) ;
- *déchiffrement* (option 3 de #435) : l'entrypoint SOPS, monté avec les fixtures de test, **injecte le label AES dynamique** `AES__TROUSSEAU__demo__KEY` — le scénario de `tests/integration/test_entrypoint_dechiffrement.py`, mais contre l'image au lieu du seul script.

**3. `deploy/docker/smoke.sh` est testé** (TDD) par `deploy/tests/unit.sh` via le fake `docker` maison : import OK/KO, déchiffrement OK/KO, usage sans tag, **+ gardes** sur le `ELECTRICORE_DECRYPT=off` de l'import et les montages `/run/secrets/{secrets.env,age.key}` (régression silencieuse de l'un = faux échec en CI). Ces gardes ont été vérifiées *sensibles* (cassent quand on retire le détail).

**4. `ci.yml` lance désormais `deploy/tests/unit.sh`** (job `deploy-tests`). La logique d'infra `deploy/` (secrets-as-code, ADR-0044) était jusqu'ici **entièrement hors-CI** — c'est un petit ajout de périmètre, signalé ici pour validation.

## À savoir pour la revue

- **Docker n'est pas dispo dans mon environnement** : la partie YAML n'a pas pu être exécutée localement. Son vrai test, c'est le **run CI de cette PR même** (le job `docker-image` build l'image pour de vrai + smoke). Le noyau testable — `smoke.sh` — est lui couvert en local (141 tests deploy verts, fake docker).
- Permissions : `docker-image.yml` **n'a pas de bloc `permissions`** → il hérite de la délégation de l'appelant (`ci.yml` : `contents:read` ; `release.yml`/`image` : `+packages:write`). Pas de risque « le workflow réutilisable demande plus que l'appelant ».
- Aucune source Python touchée.

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
