### PR TITLE
fix(api): validate /flux/{table}/info name upstream + parameterize get_table_info SQL (#428)

### DIFF
--- a/electricore/api/routers/flux.py
+++ b/electricore/api/routers/flux.py
@@ -10,7 +10,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from electricore.api.decorators import arrow_endpoint, xlsx_endpoint
 from electricore.api.security import get_current_api_key
 from electricore.api.services import duckdb_service
-from electricore.core.loaders.duckdb import DuckDBLockError
 
 router = APIRouter(tags=["flux"])
 
@@ -112,15 +111,16 @@ async def get_table_info(table_name: str, api_key: str = Depends(get_current_api
     Returns:
         Dict avec les métadonnées de la table (colonnes, types, nombre de lignes)
     """
-    try:
-        return duckdb_service.get_table_info(table_name)
-    except DuckDBLockError:
-        # Base verrouillée par l'ingestion ≠ table inconnue — laisser le
-        # handler d'app répondre 503 « ingestion en cours » (#171).
-        raise
-    except Exception:
-        available_tables = duckdb_service.list_tables()
-        raise HTTPException(404, f"Table '{table_name}' non trouvée. Tables disponibles: {available_tables}")
+    # Validation **en amont** (#428) : le nom est confronté aux tables physiquement
+    # présentes (`list_tables()`, le même ensemble que les routes data et le menu bot)
+    # *avant* toute requête de métadonnées. Un nom inconnu (ou porteur de quote) est
+    # ainsi rejeté en 404 sans jamais atteindre le SQL — l'unique f-string piloté par
+    # l'utilisateur est neutralisé au bord. `DuckDBLockError` (ingestion en cours) levée
+    # par `list_tables`/`get_table_info` remonte au handler d'app (503, #171).
+    disponibles = duckdb_service.list_tables()
+    if table_name not in disponibles:
+        raise HTTPException(404, f"Table '{table_name}' non trouvée. Tables disponibles: {disponibles}")
+    return duckdb_service.get_table_info(table_name)
 
 
 # `/flux/{table_name}` (JSON) déclaré APRÈS les routes plus spécifiques pour que

--- a/electricore/api/services/duckdb_service.py
+++ b/electricore/api/services/duckdb_service.py
@@ -23,7 +23,7 @@ SCHEMA = "flux_enedis"
 _IDENTIFIANT_SQL = re.compile(r"^[a-z0-9_]+$")
 
 
-def _garde_identifiant(identifiant: str) -> str:
+def _valider_identifiant_sql(identifiant: str) -> str:
     """Rejette tout identifiant SQL hors `^[a-z0-9_]+$` (interpolé, donc non-bindable)."""
     if not _IDENTIFIANT_SQL.match(identifiant):
         raise ValueError(f"Identifiant SQL non autorisé : {identifiant!r}")
@@ -98,7 +98,7 @@ def get_table_info(table_name: str, *, prefix: str = "flux_", date_column: str |
     """
     # Nom physique interpolé dans `COUNT(*)`/`max()` (positions d'identifiant non-bindables) :
     # gardé en amont, avant toute connexion (l'injection ne touche jamais le moteur).
-    physical = _garde_identifiant(f"{prefix}{table_name}")
+    physical = _valider_identifiant_sql(f"{prefix}{table_name}")
     colonne_date = date_column or COLONNE_DATE_METIER.get(table_name)
     with duckdb_readonly_conn(runtime.duckdb().chemin) as conn:
         # Nombre de lignes
@@ -120,7 +120,7 @@ def get_table_info(table_name: str, *, prefix: str = "flux_", date_column: str |
         if colonne_date and any(c["name"] == colonne_date for c in columns):
             # `colonne_date` est un identifiant (interpolé dans `max()`) : il vient déjà d'une
             # colonne réelle de la table, on le garde quand même par cohérence (non-bindable).
-            colonne_date = _garde_identifiant(colonne_date)
+            colonne_date = _valider_identifiant_sql(colonne_date)
             max_val = conn.execute(f"SELECT max({colonne_date}) FROM {SCHEMA}.{physical}").fetchone()[0]
             if max_val is not None:
                 derniere_date = str(max_val)[:10]

--- a/electricore/api/services/duckdb_service.py
+++ b/electricore/api/services/duckdb_service.py
@@ -4,6 +4,7 @@ Fonctions pures pour lire les tables de flux Enedis.
 """
 
 import logging
+import re
 from datetime import UTC, datetime
 
 import duckdb
@@ -14,6 +15,20 @@ from electricore.core.loaders.duckdb import duckdb_readonly_conn
 logger = logging.getLogger(__name__)
 
 SCHEMA = "flux_enedis"
+
+# Garde d'identifiant SQL (#428) : les positions d'identifiant non-bindables (nom de table
+# dans `COUNT(*)`/`max()`, colonne de date) n'opèrent que sur un nom validé. Défense en
+# profondeur, en plus de la validation au bord (`/flux/{table_name}/info` confronte le nom
+# à `list_tables()` avant d'appeler ce service).
+_IDENTIFIANT_SQL = re.compile(r"^[a-z0-9_]+$")
+
+
+def _garde_identifiant(identifiant: str) -> str:
+    """Rejette tout identifiant SQL hors `^[a-z0-9_]+$` (interpolé, donc non-bindable)."""
+    if not _IDENTIFIANT_SQL.match(identifiant):
+        raise ValueError(f"Identifiant SQL non autorisé : {identifiant!r}")
+    return identifiant
+
 
 # Colonne de date métier par table — la fraîcheur (#158) est le max de cette
 # colonne (date de relevé / d'événement / de facture), pas la date d'ingestion.
@@ -81,25 +96,31 @@ def get_table_info(table_name: str, *, prefix: str = "flux_", date_column: str |
     Returns:
         Dict avec table, schema, count, columns, derniere_date
     """
-    physical = f"{prefix}{table_name}"
+    # Nom physique interpolé dans `COUNT(*)`/`max()` (positions d'identifiant non-bindables) :
+    # gardé en amont, avant toute connexion (l'injection ne touche jamais le moteur).
+    physical = _garde_identifiant(f"{prefix}{table_name}")
     colonne_date = date_column or COLONNE_DATE_METIER.get(table_name)
     with duckdb_readonly_conn(runtime.duckdb().chemin) as conn:
         # Nombre de lignes
         count = conn.execute(f"SELECT COUNT(*) FROM {SCHEMA}.{physical}").fetchone()[0]
 
-        # Colonnes avec leurs types
-        columns_result = conn.execute(f"""
-            SELECT column_name, data_type
-            FROM information_schema.columns
-            WHERE table_schema = '{SCHEMA}'
-            AND table_name = '{physical}'
-            ORDER BY ordinal_position
-        """).fetchall()
+        # Colonnes avec leurs types — `schema` + nom de table **liés** (comme `get_freshness`),
+        # aucune valeur dérivée de l'utilisateur n'est interpolée dans un littéral SQL.
+        columns_result = conn.execute(
+            "SELECT column_name, data_type "
+            "FROM information_schema.columns "
+            "WHERE table_schema = ? AND table_name = ? "
+            "ORDER BY ordinal_position",
+            [SCHEMA, physical],
+        ).fetchall()
 
         columns = [{"name": col[0], "type": col[1]} for col in columns_result]
 
         derniere_date = None
         if colonne_date and any(c["name"] == colonne_date for c in columns):
+            # `colonne_date` est un identifiant (interpolé dans `max()`) : il vient déjà d'une
+            # colonne réelle de la table, on le garde quand même par cohérence (non-bindable).
+            colonne_date = _garde_identifiant(colonne_date)
             max_val = conn.execute(f"SELECT max({colonne_date}) FROM {SCHEMA}.{physical}").fetchone()[0]
             if max_val is not None:
                 derniere_date = str(max_val)[:10]

--- a/notebooks/accueil.py
+++ b/notebooks/accueil.py
@@ -11,8 +11,11 @@ with app.setup:
 def _():
     mo.md(
         "## Notebooks opérateur\n\n"
-        "- [Facturation mensuelle](/apps/facturation)\n"
-        "- [Injection RSC](/apps/injection_rsc)\n"
+        "Suis l'ordre d'usage :\n\n"
+        "1. [Injection RSC](/apps/injection_rsc) — réconcilie les RSC du mois\n"
+        "2. [Facturation mensuelle](/apps/facturation)\n\n"
+        "La facturation **dépend** de la réconciliation RSC du mois : lance d'abord "
+        "l'injection RSC, puis la facturation.\n"
     )
     return
 

--- a/tests/integration/test_flux_endpoint_extension_suffix.py
+++ b/tests/integration/test_flux_endpoint_extension_suffix.py
@@ -159,6 +159,12 @@ def test_flux_json_endpoint_still_works(client, monkeypatch, df_flux_synthetique
 
 def test_flux_info_endpoint_still_at_segment_path(client, monkeypatch):
     """`GET /flux/{table_name}/info` reste en segment (métadonnée, pas un format)."""
+    # Depuis #428, `/info` valide le nom via `list_tables()` *avant* `get_table_info` :
+    # on substitue les deux seams (sinon `list_tables` ouvre la vraie base, absente en CI).
+    monkeypatch.setattr(
+        "electricore.api.services.duckdb_service.list_tables",
+        lambda: ["c15"],
+    )
     monkeypatch.setattr(
         "electricore.api.services.duckdb_service.get_table_info",
         lambda name: {"table": f"flux_{name}", "schema": "flux_enedis", "count": 0, "columns": []},

--- a/tests/integration/test_flux_info_validation.py
+++ b/tests/integration/test_flux_info_validation.py
@@ -14,6 +14,7 @@ from fastapi.testclient import TestClient
 from electricore.api.main import app
 from electricore.api.security import get_current_api_key
 from electricore.api.services import duckdb_service
+from electricore.config import runtime
 
 
 @pytest.fixture
@@ -34,7 +35,11 @@ def base_flux(tmp_path, monkeypatch):
     conn.execute("CREATE TABLE flux_enedis.flux_c15 (pdl VARCHAR, date_evenement TIMESTAMP)")
     conn.execute("INSERT INTO flux_enedis.flux_c15 VALUES ('pdl1', '2026-06-01 00:00:00')")
     conn.close()
-    monkeypatch.setenv("DUCKDB_PATH", str(base))
+    # On substitue l'accessor `runtime.duckdb` (pas un `setenv`) : le cache `lru_cache`
+    # peut être réchauffé sur le chemin par défaut pendant la mise en place de `client`,
+    # *avant* ce fixture — un `setenv` serait alors ignoré (vert en local où la base par
+    # défaut existe, rouge en CI). Le `setattr` est insensible au cache et à l'ordre.
+    monkeypatch.setattr(runtime, "duckdb", lambda: runtime.Duckdb(chemin=base))
     return base
 
 

--- a/tests/integration/test_flux_info_validation.py
+++ b/tests/integration/test_flux_info_validation.py
@@ -1,0 +1,82 @@
+"""Tests d'intégration : `GET /flux/{table_name}/info` valide le nom **en amont** (#428).
+
+Le nom de table est validé contre les tables physiquement présentes (`list_tables()` — le
+même ensemble que les routes data servent et que le menu bot affiche) *avant* toute requête
+de métadonnées. Un nom inconnu (ou porteur de quote) renvoie un 404 propre qui nomme les
+tables disponibles — levé **en amont**, pas en exécutant du SQL puis en attrapant l'erreur.
+Ferme le seul chemin SQL f-string piloté par l'utilisateur.
+"""
+
+import duckdb
+import pytest
+from fastapi.testclient import TestClient
+
+from electricore.api.main import app
+from electricore.api.security import get_current_api_key
+from electricore.api.services import duckdb_service
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def base_flux(tmp_path, monkeypatch):
+    """Base DuckDB réelle avec un flux `c15` — `list_tables()` renvoie réellement `['c15']`."""
+    base = tmp_path / "flux.duckdb"
+    conn = duckdb.connect(str(base))
+    conn.execute("CREATE SCHEMA flux_enedis")
+    conn.execute("CREATE TABLE flux_enedis.flux_c15 (pdl VARCHAR, date_evenement TIMESTAMP)")
+    conn.execute("INSERT INTO flux_enedis.flux_c15 VALUES ('pdl1', '2026-06-01 00:00:00')")
+    conn.close()
+    monkeypatch.setenv("DUCKDB_PATH", str(base))
+    return base
+
+
+@pytest.fixture
+def espion_get_table_info(monkeypatch):
+    """Enregistre les appels à `get_table_info` pour prouver le court-circuit en amont."""
+    appels: list = []
+    reel = duckdb_service.get_table_info
+
+    def _espion(*args, **kwargs):
+        appels.append((args, kwargs))
+        return reel(*args, **kwargs)
+
+    monkeypatch.setattr(duckdb_service, "get_table_info", _espion)
+    return appels
+
+
+def test_nom_inconnu_valide_en_amont_sans_lancer_de_sql(client, base_flux, espion_get_table_info):
+    """Tracer bullet : un flux inconnu → 404 nommant les tables, **sans** lire les métadonnées
+    (validé en amont, pas en exécutant du SQL puis en attrapant l'erreur)."""
+    response = client.get("/flux/totalement_inexistant/info")
+
+    assert response.status_code == 404
+    assert "c15" in response.json()["detail"]
+    # Aucune requête de métadonnées n'a été lancée : la validation a court-circuité.
+    assert espion_get_table_info == []
+
+
+def test_nom_porteur_de_quote_404_sans_toucher_le_sql(client, base_flux, espion_get_table_info):
+    """Un nom porteur de quote (`c15'--`) → 404 propre **avant** tout SQL : il n'atteint
+    jamais le moteur (injection close au bord), pas un 500/erreur SQL attrapée."""
+    response = client.get("/flux/c15'--/info")
+
+    assert response.status_code == 404
+    assert espion_get_table_info == []
+
+
+def test_nom_valide_200_avec_metadonnees(client, base_flux):
+    """Un nom présent (`c15`) → 200 avec les métadonnées de la table."""
+    response = client.get("/flux/c15/info")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["table"] == "flux_c15"
+    assert payload["count"] == 1

--- a/tests/integration/test_operator_notebooks_bundle.py
+++ b/tests/integration/test_operator_notebooks_bundle.py
@@ -90,6 +90,57 @@ def test_facturation_ne_reference_pas_de_colonne_pre_rename(colonne_retiree):
     )
 
 
+# --- Accueil : ordre d'usage explicite (réconciliation RSC → facturation, #423) ---
+# Garde purement statique sur la source de `accueil.py` (page de liens, sans
+# exécution ni Odoo). Un opérateur qui lance `facturation` AVANT d'avoir réconcilié
+# les RSC du mois obtient un 503 « ingestion en cours » trompeur (la vraie cause :
+# `ref_situation_contractuelle` NULL refusé par `LignesFacture`). L'accueil doit
+# désamorcer le piège en présentant l'ordre d'usage.
+_LIEN_RECONCILIATION_RSC = "/apps/injection_rsc"
+_LIEN_FACTURATION = "/apps/facturation"
+
+
+def test_accueil_presente_reconciliation_rsc_avant_facturation():
+    """`accueil.py` liste la réconciliation RSC AVANT la facturation (ordre d'usage, #423)."""
+    source = (_RACINE / "notebooks" / "accueil.py").read_text()
+    assert _LIEN_RECONCILIATION_RSC in source and _LIEN_FACTURATION in source
+    assert source.index(_LIEN_RECONCILIATION_RSC) < source.index(_LIEN_FACTURATION), (
+        "L'accueil doit présenter la réconciliation RSC (injection_rsc) avant la "
+        "facturation : la facturation dépend des RSC réconciliées (#423)."
+    )
+
+
+def test_accueil_explique_la_dependance_facturation_rsc():
+    """`accueil.py` énonce que la facturation DÉPEND de la réconciliation RSC (#423).
+
+    Sans cette phrase, l'opérateur qui voit le 503 « ingestion en cours » attend une
+    ingestion sans rapport au lieu de lancer la réconciliation. La garde vérifie la
+    présence d'un énoncé de dépendance, pas une formulation exacte (survie au reword).
+    """
+    source = (_RACINE / "notebooks" / "accueil.py").read_text().lower()
+    assert "dépend" in source, (
+        "L'accueil doit énoncer explicitement que la facturation dépend de la réconciliation RSC préalable (#423)."
+    )
+
+
+def test_accueil_numerote_les_etapes_dans_l_ordre():
+    """`accueil.py` numérote les deux étapes : 1. réconciliation RSC, 2. facturation (#423).
+
+    La numérotation rend la séquence d'usage non-ambiguë. Les marqueurs `"N. "`
+    (chiffre-point-espace) évitent toute collision avec la chaîne de version
+    (`"0.21.1"`) ; les positions sont ancrées sur les URLs des liens (survie au
+    renommage des libellés).
+    """
+    source = (_RACINE / "notebooks" / "accueil.py").read_text()
+    assert "1. " in source and "2. " in source, "L'accueil doit numéroter les étapes (#423)."
+    assert (
+        source.index("1. ")
+        < source.index(_LIEN_RECONCILIATION_RSC)
+        < source.index("2. ")
+        < source.index(_LIEN_FACTURATION)
+    ), "Étape 1 = réconciliation RSC, étape 2 = facturation, dans cet ordre (#423)."
+
+
 @pytest.mark.slow
 def test_wheel_contient_les_notebooks_operateur(tmp_path: Path):
     """`uv build --wheel` produit un wheel electricore contenant les 3 notebooks."""

--- a/tests/integration/test_verrou_duckdb_503.py
+++ b/tests/integration/test_verrou_duckdb_503.py
@@ -49,12 +49,17 @@ class TestVerrouPendantIngestion:
         assert "ingestion en cours" in response.json()["detail"].lower()
 
     def test_info_repond_503_pas_un_faux_404(self, client, monkeypatch):
-        """Le verrou ne doit pas être maquillé en « Table non trouvée »."""
+        """Le verrou ne doit pas être maquillé en « Table non trouvée ».
 
-        def _verrou(table_name):
+        Depuis #428, la 1re lecture du chemin `/info` est `list_tables` (validation du nom
+        en amont) ; sous verrou, c'est elle qui lève `DuckDBLockError` → 503 via le handler
+        d'app, sans dégénérer en faux 404.
+        """
+
+        def _verrou(*args, **kwargs):
             raise DuckDBLockError("IO Error: Conflicting lock is held")
 
-        monkeypatch.setattr("electricore.api.services.duckdb_service.get_table_info", _verrou)
+        monkeypatch.setattr("electricore.api.services.duckdb_service.list_tables", _verrou)
         response = client.get("/flux/r151/info")
 
         assert response.status_code == 503

--- a/tests/unit/test_duckdb_service_fraicheur.py
+++ b/tests/unit/test_duckdb_service_fraicheur.py
@@ -46,6 +46,14 @@ def test_table_sans_colonne_date_connue_reste_servie(base_flux):
     assert info["count"] == 0
 
 
+def test_get_table_info_rejette_un_nom_porteur_dinjection(base_flux):
+    """Défense en profondeur (#428) : un nom dont l'identifiant physique sort de
+    `^[a-z0-9_]+$` est rejeté (`ValueError`) *avant* tout SQL — les positions
+    d'identifiant non-bindables (`COUNT(*)` / `max()`) ne peuvent pas porter d'injection."""
+    with pytest.raises(ValueError):
+        duckdb_service.get_table_info("c15'; DROP TABLE flux_c15; --")
+
+
 def test_get_table_info_pour_mart_sans_prefixe_flux(base_flux):
     """Le mart `releves` (table sans préfixe `flux_`, #264) est interrogeable.
 


### PR DESCRIPTION
## What

Closes #428

`GET /flux/{table_name}/info` now validates its table name **upstream** and the metadata SQL is **parameterized** — closing the one user-controlled f-string SQL path and giving `/info` the same name-validation the data routes already have.

## Why

The route interpolated the raw URL segment into `flux_{table_name}` and into the SQL, then relied on a broad `except Exception → 404` to absorb bad names as cryptic SQL errors. A quote-bearing name (`c15'--`) actually reached the engine before erroring. Sibling flux **data** routes already validate names at the boundary, and `get_freshness` already binds its parameters — this aligns `/info` with both.

## How

- **Route (`routers/flux.py`)** — validates `table_name` against `list_tables()` (the physically-present flux tables) **before** any metadata read. Unknown / quote-bearing names → clean 404 listing the available tables, raised upstream, never touching SQL. The broad catch-all is removed; `DuckDBLockError` (ingestion en cours) raised by `list_tables`/`get_table_info` still surfaces as **503** via the app handler (#171).
- **Service (`services/duckdb_service.py`)** — `get_table_info` binds `schema` + table name in the `information_schema` lookup (matching `get_freshness`); no user-derived value lands in a SQL string literal. The un-bindable identifier positions (`COUNT(*)` / `max(date)` table + date column) are backed by a cheap `^[a-z0-9_]+$` guard that raises **before** any connection (defense in depth). `/releves/info` (hardcoded `"releves"` literal) is unaffected.

### Validation source: `list_tables()`, not the short-name registry

The issue text suggested validating "via the registry (`FluxInconnu`/`flux()`)". But `/info` operates on **physical** table names (`c15`, `f12_detail`, `f15_detail`, `r15_acc`, …) which diverge from `FLUX_DESCRIPTORS` keys (`c15`, `f15`, `affaires`, …), and the bot's `/flux stats` calls `/info` with those physical names. Validating via the registry would 404 `f12_detail`/`f15_detail`/`r15_acc` (a bot regression) and `f15` maps to physical `flux_f15_detail` (a pre-existing mismatch). `list_tables()` closes the injection seam and gives the clean upstream 404 with **zero regression** — confirmed with @virgile before implementing.

## Tests

- `tests/integration/test_flux_info_validation.py` (real temp DB so `list_tables()` is real): unknown name → 404 listing tables **without** any metadata read (spy on `get_table_info`); quote-bearing `c15'--` → 404 **before** touching SQL; valid `c15` → 200 with metadata.
- `tests/unit/test_duckdb_service_fraicheur.py`: `get_table_info` rejects an injection-bearing name with `ValueError` before any SQL.
- `tests/integration/test_verrou_duckdb_503.py`: lock path still → 503 (updated for the new flow — `list_tables` is now the first DB touch, so it carries the lock; previously depended on a local dev DB and would have broken in CI).

> The pre-existing `test_operator_launcher` failure (missing `marimo._server` / `viz` extra) is unrelated. This branch carries #423 in its diff until #423 merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
