### PR TITLE
chore(release): 3.4.0rc5 — secrets-as-code (SOPS+age) + convention noms env + retire .env legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,63 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.4.0rc5] - 2026-06-25
+
+**Secrets-as-code** : les secrets de déploiement quittent le `.env` en clair pour un
+chiffrement **SOPS + age** versionné dans un dépôt privé, déchiffré dans l'image à
+l'exécution. Convention de noms d'environnement unifiée `<DOMAINE>__<CHAMP>`, identité/accès
+des secrets modélisés, et retrait du chemin d'installation `.env` legacy — un seul cutover
+(ADR-0044 / ADR-0046).
+
+### ✨ Temps forts
+
+- **Secrets-as-code SOPS + age** (ADR-0044, #418–#420) : `config.env` (clair, versionné) +
+  `secrets.env` (chiffré SOPS+age) ; déchiffrement à l'entrypoint de l'image (`sops exec-env`,
+  **fail-fast** sans clé, bypass dev `ELECTRICORE_DECRYPT=off`) ; chaque box génère ses deux
+  identités (clé age + deploy key SSH) ; onboarding **en deux temps** + auto-pull GitOps ;
+  scaffolding multi-cible `providers/<slug>/` + `add-provider.sh` + procédure de rotation.
+- **Convention de noms `<DOMAINE>__<CHAMP>`** (ADR-0046, #436) sur les domaines runtime
+  (`SFTP`/`AES` déjà conformes ; `DUCKDB__PATH`, `API__TITLE/VERSION/DESCRIPTION`, `BOT__*`),
+  avec un **test de parité de frontière** (les noms lus par le runtime == ceux des exemples deploy).
+- **Trousseau API étiqueté** (#438) : `API__TROUSSEAU__<consommateur>__KEY` — une clé par
+  consommateur (révocation ciblée + attribution dans les logs via le label) ; clé dédiée pour
+  le scheduler d'ingestion in-conteneur.
+- **Bloc Odoo unique** `ODOO__{URL,DB,USERNAME,PASSWORD}` (#439) — suppression du sélecteur
+  test/prod (`ODOO_ENV`/`_SelecteurOdoo`) ; clôture de #190 (Odoo read-only). no-ERP préservé.
+- **Clé admin d'escrow** (#437) : deux destinataires admin distincts (opérationnel + escrow
+  hors-ligne), destinataires permanents de chaque règle SOPS — plus de point unique de
+  défaillance sur l'autorité de déchiffrement au re-keying.
+- **Frontière JSONL durcie** (#426–#428) : helper `jsonl_response` (valide-puis-streame), adopté
+  par `/facturation/meta-periodes` et `/facturation/chronologie` (corrige une coupure en plein
+  flux) ; validation amont de `/flux/{table}/info` + SQL `get_table_info` paramétré.
+- **Chronologie dbt normalisée** (#431/#432) : `chronologie_releves` = mart mince + vue star-join ;
+  loaders `spine()`/`chronologie()` dés-abrégés (vocabulaire « Chronologie du périmètre »).
+- **Lanceur opérateur `electricore-notebooks`** (#414/#423) : validation env + app ASGI marimo,
+  page d'accueil, notebooks force-inclus dans le wheel (pont transitoire avant `souscriptions_odoo`).
+
 ### 🗑️ Suppressions (Breaking Changes)
 
-#### Modules supprimés
+- **Chemin d'installation `.env` legacy retiré** (ADR-0044 §8) : `--deploy-repo` devient
+  **obligatoire** ; `install.sh` ne télécharge ni n'édite plus de `.env`
+  (`deploy/docker/.env.example`, `validate_env_file`, la boucle d'édition et `--env-from`
+  supprimés). Le split `config.env`/`secrets.env` est le **seul** chemin d'installation.
+- **Variables d'environnement renommées** : `DUCKDB_PATH` → `DUCKDB__PATH`,
+  `API_TITLE/VERSION/DESCRIPTION` → `API__*`, `TELEGRAM_*` → `BOT__*`, bloc Odoo → `ODOO__*`,
+  et bare `API_KEY`/`API_KEYS` → `API__TROUSSEAU__<consommateur>__KEY`. Infra/compose
+  (`INSTANCE_SLUG`, `ELECTRICORE_VERSION`, `BACKUPS_PATH`) restent plats.
 - `electricore.core.loaders.parquet` (`charger_releves` / `charger_historique`) → derniers
   chargeurs Parquet pré-DuckDB, sans appelant (moteur, tests, notebooks). Le chargement passe
   désormais par les query builders DuckDB et les loaders Polars qui lisent les marts dbt. Le
   contrat Pandera `RelevéIndex` est conservé (toujours utilisé par les validateurs de flux
   DuckDB et `pipeline_energie`). #429
+
+### 🛠️ Release / CI
+
+- **CI : build + smoke-test de l'image Docker sur les PR** (#435) via workflow réutilisable —
+  plus seulement au tag de release ; rattrape les casses build (notebooks force-inclus) et
+  entrypoint (smoke SOPS) avant qu'elles n'atteignent `main`.
+- Smoke de release : bypass de l'entrypoint SOPS (`ELECTRICORE_DECRYPT=off`) ; image construite
+  avec les notebooks force-inclus du wheel (#414).
 
 ## [3.4.0rc4] - 2026-06-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.4.0rc4"
+version = "3.4.0rc5"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.4.0rc4"
+version = "3.4.0rc5"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Bump **v3.4.0rc4 → v3.4.0rc5**. Première release qui embarque le mécanisme **secrets-as-code** complet — c'est la version à déployer pour basculer la box EDN.

## Contenu (39 commits depuis v3.4.0rc4)
- **Secrets-as-code SOPS + age** (ADR-0044, #418–#420) : déchiffrement à l'entrypoint (fail-fast), split `config.env`/`secrets.env`, identités box (age + deploy key), onboarding 2-temps + auto-pull, scaffolding `providers/<slug>/` + `add-provider.sh` + rotation.
- **Convention `<DOMAINE>__<CHAMP>` + identité/accès** (ADR-0046, #436–#439, #437) : trousseau API étiqueté, bloc Odoo unique, clé d'escrow, test de parité de frontière.
- **Retire du chemin `.env` legacy** (ADR-0044 §8) : `--deploy-repo` obligatoire, plus d'éditeur `.env`.
- Frontière JSONL durcie (#426–#428), chronologie dbt normalisée (#431/#432), CI build+smoke image sur PR (#435), lanceur notebooks opérateur (#414/#423), retrait loaders Parquet morts (#429).

## Changements
- `pyproject.toml` + `uv.lock` : `3.4.0rc4` → `3.4.0rc5` (`uv lock --check` ✅)
- `CHANGELOG.md` : section `[3.4.0rc5]` consolidée

## Après merge (humain)
1. **Taguer `v3.4.0rc5`** → déclenche le build + smoke de l'image GHCR (action publiante).
2. Remplir le dépôt privé `electricore-secrets` (clé d'escrow hors-ligne, destinataires, secrets EDN chiffrés).
3. Basculer la box EDN via le runbook secrets-as-code (`reconfigure --deploy-repo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)