### PR TITLE
fix(config): normaliser ODOO__URL (trim + dé-quote + schéma) au chargement (#454)

### DIFF
--- a/electricore/config/runtime.py
+++ b/electricore/config/runtime.py
@@ -14,21 +14,27 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
-from pydantic import Field, ValidationError
+from pydantic import Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class ConfigurationManquante(ValueError):
-    """Variables d'environnement manquantes, groupées par domaine.
+    """Variables d'environnement manquantes — ou présentes mais malformées —, groupées par domaine.
 
     Sous-classe `ValueError` pour rester compatible avec les `except ValueError`
-    historiques (façade `charger_config_odoo`).
+    historiques (façade `charger_config_odoo`). `invalides` porte les messages des
+    valeurs présentes mais rejetées par un validateur (ex. `ODOO__URL` mal formé,
+    #454) — sinon le motif précis se perdrait derrière un simple « manquante ».
     """
 
-    def __init__(self, manquantes: dict[str, list[str]]):
+    def __init__(self, manquantes: dict[str, list[str]], invalides: list[str] | None = None):
         self.manquantes = manquantes
+        self.invalides = invalides or []
         details = " ; ".join(f"[{domaine}] {', '.join(noms)}" for domaine, noms in manquantes.items())
-        super().__init__(f"Configuration manquante : {details}")
+        message = f"Configuration manquante : {details}"
+        if self.invalides:
+            message += " | invalides : " + " ; ".join(self.invalides)
+        super().__init__(message)
 
 
 def _nom_var(prefixe: str, loc: tuple) -> str:
@@ -42,7 +48,8 @@ def _instancier(domaine: str, classe: type[BaseSettings], prefixe: str, **kwargs
         return classe(_env_file=FICHIER_ENV, **kwargs)
     except ValidationError as exc:
         noms = [_nom_var(prefixe, err["loc"]) for err in exc.errors()]
-        raise ConfigurationManquante({domaine: noms}) from exc
+        invalides = [err["msg"] for err in exc.errors() if err["type"] != "missing"]
+        raise ConfigurationManquante({domaine: noms}, invalides=invalides) from exc
 
 
 # Fichier .env ancré sur la racine du dépôt (None = désactivé, seam de test).
@@ -114,6 +121,24 @@ class Aes(BaseSettings):
         return [(label, *paire.octets(label)) for label, paire in self.trousseau.items()]
 
 
+def _normaliser_url(valeur: str, *, var: str) -> str:
+    """Trim + dé-quote + exige un schéma http(s) (#454).
+
+    En prod, `sops exec-env` exporte les valeurs dotenv **verbatim**, guillemets
+    compris — là où le `.env` lu en dev passe par python-dotenv qui les retire. Un
+    `ODOO__URL="https://…"` (guillemets dans le secret) atteint alors `ServerProxy`
+    tel quel : `urlsplit` lit le schéma `"https` ≠ `http`/`https` et lève
+    « unsupported XML-RPC protocol » (503 cryptique). On retire l'espace et les
+    guillemets appariés, et on rejette tôt un schéma absent avec un message clair.
+    """
+    url = valeur.strip()
+    if len(url) >= 2 and url[0] == url[-1] and url[0] in "\"'":
+        url = url[1:-1].strip()
+    if not url.startswith(("http://", "https://")):
+        raise ValueError(f"{var} doit commencer par http:// ou https:// (reçu : {valeur!r})")
+    return url
+
+
 class Odoo(BaseSettings):
     """Domaine odoo : connexion XML-RPC read-only (ADR-0012), bloc unique ODOO__*.
 
@@ -127,6 +152,11 @@ class Odoo(BaseSettings):
     db: str
     username: str
     password: str
+
+    @field_validator("url")
+    @classmethod
+    def _url_normalisee(cls, valeur: str) -> str:
+        return _normaliser_url(valeur, var="ODOO__URL")
 
 
 def _version_package() -> str:

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -126,6 +126,27 @@ class TestDomaineOdoo:
             "password": "secret",
         }
 
+    @pytest.mark.parametrize(
+        "brut",
+        [
+            '"https://odoo.example"',  # guillemets doubles (sops exec-env les passe verbatim, #454)
+            "'https://odoo.example'",  # guillemets simples
+            "  https://odoo.example  ",  # espaces parasites
+            '  "https://odoo.example"  ',  # espaces + guillemets
+        ],
+    )
+    def test_url_normalisee_trim_et_dequote(self, monkeypatch, brut):
+        """Une `ODOO__URL` entre guillemets / avec espaces est nettoyée au chargement (#454)."""
+        monkeypatch.setenv("ODOO__URL", brut)
+        assert runtime.odoo().url == "https://odoo.example"
+
+    def test_url_sans_schema_signalee_clairement(self, monkeypatch):
+        """Un schéma absent ne tombe plus en 503 cryptique : message explicite nommant ODOO__URL."""
+        monkeypatch.setenv("ODOO__URL", "odoo.example")
+        with pytest.raises(runtime.ConfigurationManquante) as exc:
+            runtime.odoo()
+        assert "ODOO__URL doit commencer par http:// ou https://" in str(exc.value)
+
     def test_no_erp_bloc_absent(self, monkeypatch):
         """Odoo absent (no-ERP, ADR-0022) : non configuré + manquantes listées en ODOO__*."""
         for champ in ("URL", "DB", "USERNAME", "PASSWORD"):


### PR DESCRIPTION
## Problème

`/facturation/check/odoo` renvoie **503 « unsupported XML-RPC protocol »** en prod (image 3.4.0rc5, secrets-as-code) alors que `ODOO__URL` commence bien par `https://`.

## Cause (confirmée par repro)

Le message « unsupported XML-RPC protocol » de `xmlrpc.client.ServerProxy` n'apparaît **que** quand `urlsplit` ne trouve pas de schéma `http`/`https`. Repro ciblé :

| Valeur atteignant `ServerProxy` | Résultat |
|---|---|
| `https://odoo…` | ✅ OK |
| ` https://odoo…` (espace en tête) | ✅ toléré |
| `"https://odoo…"` (guillemets doubles) | ❌ **unsupported XML-RPC protocol** |
| `'https://odoo…'` (guillemets simples) | ❌ **unsupported XML-RPC protocol** |
| `odoo…` (schéma absent) | ❌ **unsupported XML-RPC protocol** |

⇒ le coupable, ce sont des **guillemets** autour de la valeur (un espace seul est toléré).

**Pourquoi c'est un bug prod-only** : en dev, pydantic lit le `.env` via python-dotenv qui **retire les guillemets**. En prod, `entrypoint.sh` fait `sops exec-env`, qui exporte les valeurs dotenv **verbatim, guillemets compris** ; pydantic lit alors `os.environ` sans dé-quoter → le `"` arrive jusqu'à `ServerProxy`. L'opérateur a naturellement écrit `ODOO__URL="https://…"` (guillemets) dans le `secrets.env`.

## Correctif

`runtime.Odoo` normalise l'URL au chargement (`field_validator`) :
- **trim** + retrait des **guillemets appariés** (le vrai bug prod → la valeur citée fonctionne désormais) ;
- **exigence d'un schéma http(s)** avec un message explicite si absent.

`ConfigurationManquante` remonte en plus les motifs des valeurs **présentes-mais-malformées** (`invalides`), au lieu de les masquer derrière un simple « manquante » — l'erreur de schéma devient lisible via `_instancier`.

## Tests

- `ODOO__URL` entre guillemets (simples/doubles) / avec espaces → normalisée en `https://odoo.example` ;
- schéma absent → `ConfigurationManquante` avec message explicite nommant `ODOO__URL`.

## Acceptance criteria

- [x] Cause réelle identifiée (guillemets autour de la valeur, passés verbatim par `sops exec-env`)
- [x] `ODOO__URL` normalisé (trim + dé-quote) **et** validé (schéma http/https) au chargement config, message explicite
- [ ] (option) garde deploy `validate_secrets_plaintext` — laissée hors périmètre (collision avec le WIP secrets-as-code sur `env_validate.sh`) ; à traiter séparément
- [x] test couvrant `ODOO__URL` entre guillemets / avec espace

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)