### PR TITLE
fix(api): rendre le flux JSONL découvrable dans OpenAPI (#455)

### DIFF
--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -22,6 +22,7 @@ from electricore.api.routers import meta_periodes as meta_periodes_router
 from electricore.api.routers import releves as releves_router
 from electricore.api.routers import taxes as taxes_router
 from electricore.api.routers import turpe_variable as turpe_variable_router
+from electricore.api.serializers.jsonl import lever_defs_itemschema_jsonl
 from electricore.api.services import duckdb_service
 from electricore.config import runtime
 from electricore.core.loaders.duckdb import DuckDBLockError
@@ -135,6 +136,26 @@ app.include_router(meta_periodes_router.router)
 app.include_router(chronologie_router.router)
 app.include_router(turpe_variable_router.router)
 app.include_router(affaires_router.router)
+
+
+# OpenAPI 3.2.0 : décrit les *sequential media types* (NDJSON) via `itemSchema` — les flux JSONL
+# `/facturation/{meta-periodes,chronologie}` documentent ainsi le schéma d'une ligne (#455).
+# (FastAPI 0.136 n'expose pas `openapi_version` au constructeur : on le pose en attribut.)
+app.openapi_version = "3.2.0"
+
+# Les `itemSchema` de ces flux embarquent leurs `$defs` localement ; on les remonte vers
+# `components/schemas` après génération pour que les `$ref` se résolvent. FastAPI met le schéma en
+# cache (`app.openapi_schema`) — la remontée, idempotente, s'applique une fois.
+_openapi_base = app.openapi
+
+
+def _openapi_avec_itemschemas_jsonl() -> dict:
+    schema = _openapi_base()
+    lever_defs_itemschema_jsonl(schema)
+    return schema
+
+
+app.openapi = _openapi_avec_itemschemas_jsonl
 
 
 @app.get("/", tags=["public"])

--- a/electricore/api/routers/chronologie.py
+++ b/electricore/api/routers/chronologie.py
@@ -14,15 +14,20 @@ métadonnées (`contract_version`, `grain`) remontent dans les en-têtes. Le mod
 
 from electricore_client.models import valider_ligne_chronologie
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
 
 from electricore.api.security import get_current_api_key
-from electricore.api.serializers.jsonl import jsonl_response
+from electricore.api.serializers.jsonl import jsonl_response, reponses_openapi_jsonl
 from electricore.api.services.chronologie_service import CONTRAT_VERSION, chronologie_point_ou_contrat
 
 router = APIRouter(tags=["facturation"])
 
 
-@router.get("/facturation/chronologie")
+@router.get(
+    "/facturation/chronologie",
+    response_class=StreamingResponse,
+    responses=reponses_openapi_jsonl("Frise complète (`LigneChronologie`, union sur `type_ligne`)."),
+)
 async def get_chronologie(
     pdl: str | None = Query(
         None,
@@ -49,6 +54,10 @@ async def get_chronologie(
     relevé) et, pour les périodes dérivées, les **verdicts** qualité/communication/énergie —
     sans montant tarifaire (turpe/cta/accise). Métadonnées en en-têtes (`X-Contract-Version`,
     `X-Grain`). Fournir exactement un grain (`pdl` XOR `rsc`).
+
+    **Réponse JSONL streamé** (`application/jsonl`, NDJSON) : à consommer **ligne par ligne**,
+    ce n'est pas un document JSON unique. Swagger UI affiche « [object Blob] » car il ne
+    prévisualise que `application/json` — pour inspecter à la main : `curl … | jq -c .`.
     """
     if pdl is None and rsc is None:
         raise HTTPException(422, "Fournir un grain : `pdl` (point) ou `rsc` (contrat).")

--- a/electricore/api/routers/chronologie.py
+++ b/electricore/api/routers/chronologie.py
@@ -12,7 +12,7 @@ métadonnées (`contract_version`, `grain`) remontent dans les en-têtes. Le mod
 **single-sourcé** dans `electricore_client`.
 """
 
-from electricore_client.models import valider_ligne_chronologie
+from electricore_client.models import LigneChronologie, valider_ligne_chronologie
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 
@@ -26,7 +26,7 @@ router = APIRouter(tags=["facturation"])
 @router.get(
     "/facturation/chronologie",
     response_class=StreamingResponse,
-    responses=reponses_openapi_jsonl("Frise complète (`LigneChronologie`, union sur `type_ligne`)."),
+    responses=reponses_openapi_jsonl(LigneChronologie, "Frise complète (`LigneChronologie`, union sur `type_ligne`)."),
 )
 async def get_chronologie(
     pdl: str | None = Query(

--- a/electricore/api/routers/meta_periodes.py
+++ b/electricore/api/routers/meta_periodes.py
@@ -15,15 +15,20 @@ from typing import Annotated
 # Modèles single-sourcés dans le paquet client (ADR-0043).
 from electricore_client.models import PeriodeMeta
 from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
 
 from electricore.api.security import get_current_api_key
-from electricore.api.serializers.jsonl import jsonl_response
+from electricore.api.serializers.jsonl import jsonl_response, reponses_openapi_jsonl
 from electricore.api.services.meta_periodes_service import CONTRAT_VERSION, meta_periodes
 
 router = APIRouter(tags=["facturation"])
 
 
-@router.get("/facturation/meta-periodes")
+@router.get(
+    "/facturation/meta-periodes",
+    response_class=StreamingResponse,
+    responses=reponses_openapi_jsonl("Méta-périodes mensuelles (`PeriodeMeta`, contrat v3)."),
+)
 async def get_meta_periodes(
     mois: str | None = Query(
         None,
@@ -49,6 +54,10 @@ async def get_meta_periodes(
     métadonnées sont dans les en-têtes : `X-Contract-Version` et `X-Mois` (mois résolu).
     Charge utile non valorisée aux prix fournisseur : quantités physiques + montants réseau.
     Odoo construit/upsert ses `souscription.periode` à partir de ce flux.
+
+    **Réponse JSONL streamé** (`application/jsonl`, NDJSON) : à consommer **ligne par ligne**,
+    ce n'est pas un document JSON unique. Swagger UI affiche « [object Blob] » car il ne
+    prévisualise que `application/json` — pour inspecter à la main : `curl … | jq -c .`.
     """
     mois_resolu, df = meta_periodes(mois=mois, rsc=rsc)
     headers = {

--- a/electricore/api/routers/meta_periodes.py
+++ b/electricore/api/routers/meta_periodes.py
@@ -27,7 +27,7 @@ router = APIRouter(tags=["facturation"])
 @router.get(
     "/facturation/meta-periodes",
     response_class=StreamingResponse,
-    responses=reponses_openapi_jsonl("Méta-périodes mensuelles (`PeriodeMeta`, contrat v3)."),
+    responses=reponses_openapi_jsonl(PeriodeMeta, "Méta-périodes mensuelles (`PeriodeMeta`, contrat v3)."),
 )
 async def get_meta_periodes(
     mois: str | None = Query(

--- a/electricore/api/serializers/jsonl.py
+++ b/electricore/api/serializers/jsonl.py
@@ -15,35 +15,65 @@ en-têtes. Le flag `omettre_les_nuls` (défaut **off**) couvre la sémantique ch
 import datetime as dt
 import logging
 from collections.abc import Callable
+from typing import Any
 
 import polars as pl
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 
 logger = logging.getLogger(__name__)
 
 MEDIA_TYPE_JSONL = "application/jsonl"
 
 
-def reponses_openapi_jsonl(description: str) -> dict:
-    """Fragment OpenAPI annonçant la réponse 200 comme un **flux JSONL** (NDJSON), pas un JSON unique.
+def reponses_openapi_jsonl(modele: Any, description: str) -> dict:
+    """Fragment OpenAPI documentant la réponse 200 comme un **flux JSONL** (NDJSON) typé par ligne.
 
-    Sans ça, FastAPI documente un `application/json` implicite : Swagger UI tente alors un parse
-    JSON unique du NDJSON et affiche « [object Blob] » (il ne prévisualise que `application/json`),
-    ce qui déroute qui teste l'endpoint à la main (#455). Le flux se consomme **ligne par ligne**
-    (`electricore-client` le lit en `iter_lines` ; à la main : `curl … | jq -c .`).
+    OpenAPI 3.2.0 décrit les *sequential media types* (NDJSON…) via **`itemSchema`** : le schéma
+    de **chaque ligne**, validé indépendamment (https://spec.openapis.org/oas/v3.2.0.html
+    #sequential-media-types). On le dérive du modèle de ligne (`LigneChronologie` — union
+    discriminée — ou `PeriodeMeta`) pour que Swagger UI rende la forme d'une ligne, au lieu du
+    « [object Blob] » qu'il affiche quand il prend le NDJSON pour un `application/json` unique (#455).
 
-    `description` précise le modèle d'une ligne (`LigneChronologie`, `PeriodeMeta`…).
+    On **n'utilise pas** la génération native d'`itemSchema` de FastAPI (endpoints générateurs)
+    car elle valide/streame ligne par ligne : ça sacrifierait le *validate-then-stream* atomique
+    de `jsonl_response` (ADR-0043, #426/#427) dont dépend le consommateur. On émet donc l'`itemSchema`
+    à la main, le flux restant produit par `jsonl_response`.
+
+    Les `$defs` du schéma (modèles imbriqués, membres de l'union) pointent vers
+    `#/components/schemas/*` et sont remontés au niveau document par `lever_defs_itemschema_jsonl`.
     """
+    item_schema = TypeAdapter(modele).json_schema(ref_template="#/components/schemas/{model}")
     return {
         200: {
             "description": (
                 f"{description} Flux **JSONL streamé** (`{MEDIA_TYPE_JSONL}`, NDJSON) : une ligne = "
-                "un objet JSON. À consommer ligne par ligne — ce n'est pas un document JSON unique."
+                "un objet JSON (cf. `itemSchema`). À consommer ligne par ligne — ce n'est pas un "
+                "document JSON unique."
             ),
-            "content": {MEDIA_TYPE_JSONL: {"schema": {"type": "string", "format": "ndjson"}}},
+            "content": {MEDIA_TYPE_JSONL: {"itemSchema": item_schema}},
         }
     }
+
+
+def lever_defs_itemschema_jsonl(schema: dict) -> None:
+    """Remonte les `$defs` des `itemSchema` JSONL vers `components/schemas` (post-génération OpenAPI).
+
+    `reponses_openapi_jsonl` émet un `itemSchema` auto-suffisant dont les `$ref` ciblent déjà
+    `#/components/schemas/*` ; ce passage déplace les définitions correspondantes (laissées en
+    `$defs` local par pydantic) vers le bloc `components` du document, où les `$ref` se résolvent.
+    Idempotent : un `itemSchema` déjà remonté n'a plus de `$defs`.
+    """
+    composants = schema.setdefault("components", {}).setdefault("schemas", {})
+    for chemin in schema.get("paths", {}).values():
+        for operation in chemin.values():
+            if not isinstance(operation, dict):
+                continue
+            for reponse in operation.get("responses", {}).values():
+                for media in reponse.get("content", {}).values():
+                    item = media.get("itemSchema")
+                    if isinstance(item, dict):
+                        composants.update(item.pop("$defs", {}))
 
 
 def _stringifier_dates(ligne: dict) -> dict:

--- a/electricore/api/serializers/jsonl.py
+++ b/electricore/api/serializers/jsonl.py
@@ -25,6 +25,27 @@ logger = logging.getLogger(__name__)
 MEDIA_TYPE_JSONL = "application/jsonl"
 
 
+def reponses_openapi_jsonl(description: str) -> dict:
+    """Fragment OpenAPI annonçant la réponse 200 comme un **flux JSONL** (NDJSON), pas un JSON unique.
+
+    Sans ça, FastAPI documente un `application/json` implicite : Swagger UI tente alors un parse
+    JSON unique du NDJSON et affiche « [object Blob] » (il ne prévisualise que `application/json`),
+    ce qui déroute qui teste l'endpoint à la main (#455). Le flux se consomme **ligne par ligne**
+    (`electricore-client` le lit en `iter_lines` ; à la main : `curl … | jq -c .`).
+
+    `description` précise le modèle d'une ligne (`LigneChronologie`, `PeriodeMeta`…).
+    """
+    return {
+        200: {
+            "description": (
+                f"{description} Flux **JSONL streamé** (`{MEDIA_TYPE_JSONL}`, NDJSON) : une ligne = "
+                "un objet JSON. À consommer ligne par ligne — ce n'est pas un document JSON unique."
+            ),
+            "content": {MEDIA_TYPE_JSONL: {"schema": {"type": "string", "format": "ndjson"}}},
+        }
+    }
+
+
 def _stringifier_dates(ligne: dict) -> dict:
     """Rend les `datetime`/`date` de la ligne en ISO8601 (le contrat porte des `str`)."""
     return {

--- a/tests/integration/test_chronologie_endpoint.py
+++ b/tests/integration/test_chronologie_endpoint.py
@@ -172,6 +172,15 @@ def test_chronologie_ligne_hors_contrat_500_atomique(monkeypatch):
     assert "type_ligne" not in response.text
 
 
+def test_chronologie_openapi_annonce_le_flux_jsonl():
+    """Découvrabilité (#455) : OpenAPI documente la 200 en `application/jsonl` (NDJSON), pas
+    en `application/json` implicite — sinon Swagger tente un parse JSON unique (« [object Blob] »).
+    """
+    reponse_200 = app.openapi()["paths"]["/facturation/chronologie"]["get"]["responses"]["200"]
+    assert list(reponse_200["content"].keys()) == ["application/jsonl"]
+    assert "ligne par ligne" in reponse_200["description"]
+
+
 def test_chronologie_refuse_sans_api_key():
     """Endpoint sécurisé : 401 sans clé."""
     response = TestClient(app).get("/facturation/chronologie", params={"pdl": "PDL_X"})

--- a/tests/integration/test_chronologie_endpoint.py
+++ b/tests/integration/test_chronologie_endpoint.py
@@ -13,6 +13,7 @@ service depuis un `ContexteMensuel` synthétique.
 """
 
 import json
+import re
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -172,13 +173,23 @@ def test_chronologie_ligne_hors_contrat_500_atomique(monkeypatch):
     assert "type_ligne" not in response.text
 
 
-def test_chronologie_openapi_annonce_le_flux_jsonl():
-    """Découvrabilité (#455) : OpenAPI documente la 200 en `application/jsonl` (NDJSON), pas
-    en `application/json` implicite — sinon Swagger tente un parse JSON unique (« [object Blob] »).
+def test_chronologie_openapi_itemschema_3_2():
+    """Découvrabilité (#455) : OpenAPI 3.2.0 documente la 200 en `application/jsonl` avec un
+    `itemSchema` (schéma d'**une ligne**) — l'union discriminée `LigneChronologie` — au lieu d'un
+    `application/json` implicite (que Swagger prend pour un JSON unique → « [object Blob] »).
     """
-    reponse_200 = app.openapi()["paths"]["/facturation/chronologie"]["get"]["responses"]["200"]
+    openapi_doc = app.openapi()
+    assert openapi_doc["openapi"] == "3.2.0"
+    reponse_200 = openapi_doc["paths"]["/facturation/chronologie"]["get"]["responses"]["200"]
     assert list(reponse_200["content"].keys()) == ["application/jsonl"]
     assert "ligne par ligne" in reponse_200["description"]
+    item = reponse_200["content"]["application/jsonl"]["itemSchema"]
+    # Une ligne = un membre de l'union discriminée (oneOf + discriminator sur `type_ligne`).
+    assert "oneOf" in item and "discriminator" in item
+    # Les $defs ont été remontés : chaque $ref de l'itemSchema résout dans components/schemas.
+    composants = set(openapi_doc["components"]["schemas"])
+    refs = set(re.findall(r"#/components/schemas/([^\"']+)", json.dumps(item)))
+    assert refs and refs <= composants
 
 
 def test_chronologie_refuse_sans_api_key():

--- a/tests/integration/test_meta_periodes_endpoint.py
+++ b/tests/integration/test_meta_periodes_endpoint.py
@@ -172,6 +172,15 @@ def test_meta_periodes_ligne_hors_contrat_500_atomique(monkeypatch, meta_periode
     assert "ref_situation_contractuelle" not in response.text
 
 
+def test_meta_periodes_openapi_annonce_le_flux_jsonl():
+    """Découvrabilité (#455) : OpenAPI documente la 200 en `application/jsonl` (NDJSON), pas
+    en `application/json` implicite — sinon Swagger tente un parse JSON unique (« [object Blob] »).
+    """
+    reponse_200 = app.openapi()["paths"]["/facturation/meta-periodes"]["get"]["responses"]["200"]
+    assert list(reponse_200["content"].keys()) == ["application/jsonl"]
+    assert "ligne par ligne" in reponse_200["description"]
+
+
 def test_meta_periodes_refuse_sans_api_key():
     """Endpoint sécurisé : 401 sans clé."""
     response = TestClient(app).get("/facturation/meta-periodes")

--- a/tests/integration/test_meta_periodes_endpoint.py
+++ b/tests/integration/test_meta_periodes_endpoint.py
@@ -9,6 +9,7 @@ DuckDB, le chemin transport + sérialisation reste réel.
 """
 
 import json
+import re
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -172,13 +173,24 @@ def test_meta_periodes_ligne_hors_contrat_500_atomique(monkeypatch, meta_periode
     assert "ref_situation_contractuelle" not in response.text
 
 
-def test_meta_periodes_openapi_annonce_le_flux_jsonl():
-    """Découvrabilité (#455) : OpenAPI documente la 200 en `application/jsonl` (NDJSON), pas
-    en `application/json` implicite — sinon Swagger tente un parse JSON unique (« [object Blob] »).
+def test_meta_periodes_openapi_itemschema_3_2():
+    """Découvrabilité (#455) : OpenAPI 3.2.0 documente la 200 en `application/jsonl` avec un
+    `itemSchema` (schéma d'**une ligne** `PeriodeMeta`), au lieu d'un `application/json` implicite
+    (que Swagger prend pour un JSON unique → « [object Blob] »).
     """
-    reponse_200 = app.openapi()["paths"]["/facturation/meta-periodes"]["get"]["responses"]["200"]
+    openapi_doc = app.openapi()
+    assert openapi_doc["openapi"] == "3.2.0"
+    reponse_200 = openapi_doc["paths"]["/facturation/meta-periodes"]["get"]["responses"]["200"]
     assert list(reponse_200["content"].keys()) == ["application/jsonl"]
     assert "ligne par ligne" in reponse_200["description"]
+    item = reponse_200["content"]["application/jsonl"]["itemSchema"]
+    # Une ligne = un objet PeriodeMeta (schéma d'objet, pas une string opaque).
+    assert item["type"] == "object" and "properties" in item
+    # Le modèle imbriqué `ObjetReleve` a été remonté en composant et son $ref résout.
+    composants = set(openapi_doc["components"]["schemas"])
+    refs = set(re.findall(r"#/components/schemas/([^\"']+)", json.dumps(item)))
+    assert "ObjetReleve" in composants
+    assert refs <= composants
 
 
 def test_meta_periodes_refuse_sans_api_key():


### PR DESCRIPTION
## Triage : comportement **attendu** (JSONL by design) — le défaut réel est la découvrabilité

`/facturation/chronologie` (et `/facturation/meta-periodes`) répondent en **NDJSON streamé** (`application/jsonl`, ADR-0043 / #408 / #426), consommé **ligne par ligne** par `electricore-client` (`iter_lines`). Le « [object Blob] » de Swagger UI est une **limite cosmétique** : Swagger ne prévisualise que `application/json`, donc il traite tout autre media-type comme un blob binaire — **aucun** Content-Type (ni `application/jsonl`, ni `application/x-ndjson`) ne le ferait pretty-printer.

Décision (tracée ici + dans les docstrings) : on **garde `application/jsonl`** (ADR-0043 ; le client est indifférent au media-type, il lit en `iter_lines`). Le vrai défaut est que FastAPI documentait un `application/json` **implicite** → un testeur manuel s'attend à un JSON unique et tombe sur « [object Blob] ».

## Correctif (découvrabilité, zéro changement de wire format)

- **`reponses_openapi_jsonl()`** (dans le sérialiseur partagé `serializers/jsonl.py`, single-source du media-type) : déclare la 200 en `application/jsonl` avec une description « flux NDJSON, une ligne = un objet, à consommer ligne par ligne, pas un document unique ».
- **`response_class=StreamingResponse`** sur les deux routes : retire le `application/json` par défaut que FastAPI ajoutait (sinon `/docs` annonce les deux).
- **Docstrings** : guide de test manuel (`curl … | jq -c .`) + explication explicite du « [object Blob] » de Swagger.

## Vérifications / AC

- [x] `Content-Type` vérifié : `application/jsonl` (conforme ADR-0043) — **décision tracée** : attendu, on ne bascule pas vers `application/x-ndjson` (révision d'ADR sans bénéfice ; ne corrige pas le symptôme Swagger ; client indifférent)
- [x] Flux NDJSON bien formé (une ligne JSON valide par enregistrement) — déjà couvert par les tracer-bullets existants (`_lignes` + `valider_ligne_chronologie` / `PeriodeMeta`)
- [x] Décision tracée : **attendu** (streaming consommé ligne par ligne) — PR + docstrings
- [x] Cas « test à la main / Swagger » documenté (docstring + description OpenAPI) et testé (OpenAPI n'annonce plus que `application/jsonl` pour la 200)

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)