### PR TITLE
fix(deploy): --version = override local du tag en secrets-as-code (#460)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -244,6 +244,16 @@ main() {
         log_err "config.env invalide :"; printf '%s\n' "$errs" | sed 's/^/     - /'
         die "Corrige providers/${OPT_SLUG}/config.env dans le dépôt, pousse, puis relance reconfigure."
     fi
+    # Override LOCAL de la version (#460) : `--version` pilote le tag d'image déployé même
+    # en secrets-as-code, SANS toucher au dépôt secrets (la version n'est pas un secret,
+    # c'est un paramètre de déploiement — ADR-0044). Appliqué APRÈS le pull : le config.env
+    # du dépôt reste la baseline GitOps (reconfigure sans --version = version pinée). Le pull
+    # ré-écrit config.env à chaque reconfigure → l'override est ré-appliqué à chaque fois.
+    if [[ "${OPT_VERSION_EXPLICIT:-0}" -eq 1 ]]; then
+        repo_version=$(read_env_var "$config_env" ELECTRICORE_VERSION)
+        override_config_version "$config_env" "$OPT_VERSION"
+        log_warn "ELECTRICORE_VERSION overridé localement : ${OPT_VERSION} (dépôt : ${repo_version}) — non versionné, propre à cette box."
+    fi
     if ! box_can_decrypt "$OPT_SLUG"; then
         # La box a sa clé + le ciphertext, mais ne déchiffre pas → sa clé age publique
         # n'est pas (encore) destinataire dans .sops.yaml. 2e temps de l'onboarding.
@@ -299,12 +309,18 @@ main() {
         ssh_recap="  SSH (admin)      ssh ops@${OPT_DOMAIN}   ← root SSH désactivé
   SSH (service)    ssh ${OPT_SLUG}@${OPT_DOMAIN}"
     fi
+    # Tag d'image effectivement déployé : lu dans le config.env que compose utilise pour
+    # ses substitutions (et qui a pu être overridé localement par --version, #460). On le
+    # surface pour lever toute ambiguïté entre version pinée du dépôt et override de box.
+    effective_version=$(read_env_var "${HOME_DIR}/config.env" ELECTRICORE_VERSION)
+    [[ -n "$effective_version" ]] || effective_version="$OPT_VERSION"
     cat <<EOF
 
   ${_C_GREEN}${_C_BOLD}✓ Instance ${OPT_SLUG} opérationnelle.${_C_RESET}
 
   URL              https://${OPT_DOMAIN}
   /health          curl https://${OPT_DOMAIN}/health
+  Image            ghcr.io/energie-de-nantes/electricore:${effective_version}
 ${ssh_recap}
   Logs             sudo -u ${OPT_SLUG} docker compose -f ${DOCKER_DIR}/docker-compose.yml logs -f
   Stop/Start       sudo -u ${OPT_SLUG} docker compose -f ${DOCKER_DIR}/docker-compose.yml {down,up -d}
@@ -317,8 +333,11 @@ ${ssh_recap}
     - Secrets versionnés chiffrés dans le dépôt de déploiement — rien de sensible à
       sauvegarder côté box (la clé age ${AGE_KEY_FILE} se régénère, cf. clé d'escrow)
 
-  Pour reconfigurer plus tard (rotation clés AES, bump version, etc.) :
+  Pour reconfigurer plus tard (rotation clés AES, pull baseline du dépôt, etc.) :
     sudo bash $0 --slug ${OPT_SLUG} --domain ${OPT_DOMAIN} --deploy-repo ${OPT_DEPLOY_REPO}
+
+  Pour déployer un autre tag d'image sans toucher au dépôt secrets (#460) :
+    sudo bash $0 --slug ${OPT_SLUG} --domain ${OPT_DOMAIN} --deploy-repo ${OPT_DEPLOY_REPO} --version <tag>
 
 EOF
 

--- a/deploy/lib/cli.sh
+++ b/deploy/lib/cli.sh
@@ -20,7 +20,11 @@ Options :
                          (défaut: copie depuis ~root/.ssh/authorized_keys)
   --email <addr>         Email pour les notifications Let's Encrypt
                          (défaut: laisse le placeholder du Caddyfile, à éditer)
-  --version <tag>        Tag GHCR à déployer (défaut: latest)
+  --version <tag>        Tag GHCR à déployer. OVERRIDE LOCAL du tag pinné dans le
+                         config.env du dépôt (#460) : pilote l'image déployée sans
+                         éditer le dépôt secrets (la version est un paramètre de
+                         déploiement, pas un secret). Sans --version → version pinée
+                         du dépôt = baseline GitOps (défaut: latest si non pinée).
   --skip-dns             N'attend pas la propagation DNS (test local)
   --no-harden            Saute tout le durcissement VPS (ADR-0031)
   --no-sshd              Durcit mais ne verrouille pas sshd (garde root SSH actif)
@@ -34,8 +38,9 @@ EOF
 }
 
 # parse_args "$@" — remplit les vars globales OPT_SLUG, OPT_DOMAIN, OPT_DEPLOY_REPO,
-# OPT_SSH_PUBKEY, OPT_ADMIN_PUBKEY, OPT_EMAIL, OPT_VERSION, OPT_SKIP_DNS, OPT_NO_HARDEN,
-# OPT_NO_SSHD, OPT_NO_FAIL2BAN, OPT_NO_UNATTENDED. Renvoie 0 si OK, 1 si erreur.
+# OPT_SSH_PUBKEY, OPT_ADMIN_PUBKEY, OPT_EMAIL, OPT_VERSION, OPT_VERSION_EXPLICIT,
+# OPT_SKIP_DNS, OPT_NO_HARDEN, OPT_NO_SSHD, OPT_NO_FAIL2BAN, OPT_NO_UNATTENDED.
+# Renvoie 0 si OK, 1 si erreur.
 parse_args() {
     OPT_SLUG=""
     OPT_DOMAIN=""
@@ -43,6 +48,10 @@ parse_args() {
     OPT_ADMIN_PUBKEY=""
     OPT_EMAIL=""
     OPT_VERSION="latest"
+    # Distingue « --version passé explicitement » de la valeur par défaut « latest » :
+    # seul un --version explicite déclenche l'override local du tag pinné (#460). Sans
+    # ce flag, on ne pourrait pas savoir s'il faut respecter la baseline GitOps du dépôt.
+    OPT_VERSION_EXPLICIT=0
     OPT_DEPLOY_REPO=""
     OPT_SKIP_DNS=0
     OPT_NO_HARDEN=0
@@ -56,7 +65,7 @@ parse_args() {
             --ssh-pubkey)   OPT_SSH_PUBKEY="${2:-}"; shift 2 ;;
             --admin-pubkey) OPT_ADMIN_PUBKEY="${2:-}"; shift 2 ;;
             --email)        OPT_EMAIL="${2:-}"; shift 2 ;;
-            --version)      OPT_VERSION="${2:-}"; shift 2 ;;
+            --version)      OPT_VERSION="${2:-}"; OPT_VERSION_EXPLICIT=1; shift 2 ;;
             --deploy-repo)  OPT_DEPLOY_REPO="${2:-}"; shift 2 ;;
             --skip-dns)     OPT_SKIP_DNS=1; shift ;;
             --no-harden)    OPT_NO_HARDEN=1; shift ;;

--- a/deploy/lib/config.sh
+++ b/deploy/lib/config.sh
@@ -44,6 +44,23 @@ download_config_files() {
     log_ok "fichiers compose téléchargés dans ${docker_dir}/"
 }
 
+# override_config_version <config_file> <version>
+# Réécrit UNIQUEMENT ELECTRICORE_VERSION dans <config_file> (config.env), en laissant
+# tout le reste intact (INSTANCE_SLUG, BACKUPS_PATH, ODOO_ENV…). C'est l'override LOCAL
+# du tag d'image en secrets-as-code (#460) : `--version` pilote l'image effectivement
+# déployée sans muter la baseline GitOps tirée du dépôt — la version est un PARAMÈTRE
+# de déploiement, pas un secret (ADR-0044). À distinguer du `substitute_caddyfile`
+# (patch de templates) : ici on réécrit une seule clé d'un fichier déjà validé.
+# Préserve l'ownership du fichier (sed -i peut le casser).
+# Pré-condition : ELECTRICORE_VERSION est présent (garanti par validate_config_env).
+override_config_version() {
+    local config_file="$1"
+    local version="$2"
+    local owner; owner=$(stat -c '%u:%g' "$config_file" 2>/dev/null || echo "")
+    sed -i "s|^ELECTRICORE_VERSION=.*|ELECTRICORE_VERSION=${version}|" "$config_file"
+    [[ -n "$owner" ]] && chown "$owner" "$config_file" 2>/dev/null || true
+}
+
 # substitute_caddyfile <file> <domain> [<email>]
 # Remplace le placeholder de domaine et optionnellement l'email.
 substitute_caddyfile() {

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -156,6 +156,14 @@ echo "→ cli.sh / parse_args"
   [[ "$OPT_VERSION" == "1.7.0" && "$OPT_SSH_PUBKEY" == "ssh-ed25519 AAAA" && "$OPT_SKIP_DNS" == "1" ]]
 ) && ok "parse_args avec --version --ssh-pubkey --skip-dns" || ko "parse_args options complètes"
 
+# Override local du tag (#460) : OPT_VERSION_EXPLICIT distingue --version passé du défaut.
+( parse_args --slug edn --domain edn.fr --deploy-repo "git@example.test:org/deploy.git" >/dev/null 2>&1
+  [[ "$OPT_VERSION_EXPLICIT" == "0" ]]
+) && ok "parse_args: OPT_VERSION_EXPLICIT=0 sans --version (baseline GitOps)" || ko "parse_args OPT_VERSION_EXPLICIT défaut"
+( parse_args --slug edn --domain edn.fr --deploy-repo "git@example.test:org/deploy.git" --version 3.4.0rc6 >/dev/null 2>&1
+  [[ "$OPT_VERSION_EXPLICIT" == "1" && "$OPT_VERSION" == "3.4.0rc6" ]]
+) && ok "parse_args: OPT_VERSION_EXPLICIT=1 avec --version (override local)" || ko "parse_args OPT_VERSION_EXPLICIT avec --version"
+
 # --deploy-repo est OBLIGATOIRE depuis le cutover secrets-as-code (ADR-0044 §8)
 assert_fail "parse_args sans --deploy-repo" parse_args --slug edn --domain edn.fr
 ( parse_args --slug edn --domain edn.fr --deploy-repo "git@example.test:org/deploy.git" >/dev/null 2>&1
@@ -264,6 +272,21 @@ grep -q "ops@edn.fr" "$tmp_caddy" && ok "substitute_caddyfile: email" || ko "sub
 ! grep -q "electricore.exemple.fr" "$tmp_caddy" && ok "substitute_caddyfile: pas de placeholder résiduel" \
     || ko "substitute_caddyfile placeholder résiduel"
 rm -f "$tmp_caddy"
+
+echo
+echo "→ config.sh / override_config_version (override local du tag, #460)"
+# Simule un config.env pinné par le dépôt (rc5) + une clé non-version à préserver.
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=3.4.0rc5\nBACKUPS_PATH=/srv/edn/backups\nODOO_ENV=prod\n' > "$tmp_cfg"
+override_config_version "$tmp_cfg" "3.4.0rc6"
+grep -q "^ELECTRICORE_VERSION=3.4.0rc6$" "$tmp_cfg" && ok "override_config_version: ELECTRICORE_VERSION overridé (rc5 → rc6)" || ko "override_config_version n'écrit pas la version"
+grep -q "^INSTANCE_SLUG=edn$" "$tmp_cfg" && ok "override_config_version: INSTANCE_SLUG préservé (baseline GitOps intacte)" || ko "override_config_version a touché INSTANCE_SLUG"
+grep -q "^BACKUPS_PATH=/srv/edn/backups$" "$tmp_cfg" && ok "override_config_version: BACKUPS_PATH préservé" || ko "override_config_version a touché BACKUPS_PATH"
+grep -q "^ODOO_ENV=prod$" "$tmp_cfg" && ok "override_config_version: autres clés préservées (ODOO_ENV)" || ko "override_config_version a touché ODOO_ENV"
+# Une seule ligne ELECTRICORE_VERSION (pas de duplication)
+vcount=$(grep -c "^ELECTRICORE_VERSION=" "$tmp_cfg" || true)
+assert_eq "$vcount" "1" "override_config_version: une seule ligne ELECTRICORE_VERSION après override"
+rm -f "$tmp_cfg"
 
 echo
 echo "→ env_validate.sh / read_env_var"

--- a/docs/adr/0044-secrets-as-code-sops-age.md
+++ b/docs/adr/0044-secrets-as-code-sops-age.md
@@ -50,6 +50,14 @@ chemins de volume) **côté hôte, avant tout conteneur** — il ne peut pas lir
   trousseau `AES__TROUSSEAU__*`, `API_KEY` / `API_KEYS`, `TELEGRAM_BOT_TOKEN`, bloc de connexion `ODOO_*`.
   SOPS chiffre les **valeurs** et laisse les **noms de champs** en clair → diffs Git lisibles.
 
+> **`ELECTRICORE_VERSION` est un *paramètre de déploiement*, pas un secret ni un état GitOps strict**
+> ([#460](https://github.com/Energie-De-Nantes/electricore/issues/460)). La valeur pinée dans le `config.env`
+> du dépôt est une **baseline optionnelle** : `install.sh --version <tag>` l'**override localement** sur la box
+> (réécrit `ELECTRICORE_VERSION` dans le `config.env` tiré, après le pull, sans toucher au dépôt). Motivation :
+> en dev intense, bumper l'image ne doit pas exiger une PR sur le dépôt secrets pour quelque chose qui n'est
+> pas un secret. Sans `--version`, la box redéploie la version pinée du dépôt (comportement GitOps par défaut).
+> Le tag effectivement lancé est surfacé dans le récap d'install (`Image: ghcr.io/.../electricore:<tag>`).
+
 ### 2. Déchiffrement en image, à l'entrypoint (`sops exec-env`)
 
 L'image electricore embarque `sops` + `age` (binaires statiques, ~15 Mo). Un entrypoint déchiffre

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -257,9 +257,12 @@ sudo bash install.sh \
 Options notables :
 - `--deploy-repo <url>` — **obligatoire**. Dépôt de déploiement privé d'où la box pull
   `providers/<slug>/{config.env,secrets.env}` via sa deploy key SSH RO.
-- `--version <tag>` — pin le tag GHCR à déployer (recommandé en prod, défaut `latest`).
-  Accepte `1.7.0`, `1.8.0rc1`, etc. (`ELECTRICORE_VERSION` vit dans `config.env` côté
-  dépôt ; `--version` épingle le tag effectivement déployé.)
+- `--version <tag>` — **override LOCAL** du tag GHCR déployé (accepte `1.7.0`, `1.8.0rc1`,
+  `3.4.0rc6`, etc.). `ELECTRICORE_VERSION` vit dans le `config.env` du dépôt (baseline pinée) ;
+  `--version` **réécrit cette valeur localement après le pull**, sur la box, **sans toucher au
+  dépôt secrets** ([#460](https://github.com/Energie-De-Nantes/electricore/issues/460)) — la
+  version est un paramètre de déploiement, pas un secret. Sans `--version`, la box redéploie la
+  version pinée du dépôt. Le tag effectivement lancé est affiché dans le récap (`Image: …`).
 - `--ssh-pubkey "ssh-ed25519 ..."` — clé SSH dédiée pour `<slug>`. Sans cette
   option, le script copie `~root/.ssh/authorized_keys`.
 - `--skip-dns` — saute la vérification DNS (test local).
@@ -786,8 +789,12 @@ sudo -u <slug> docker compose -f deploy/docker/docker-compose.yml --env-file con
 
 ### Mise à jour standard
 
-Via le mode reconfigure du script, avec `--version` (qui épingle le tag GHCR déployé) ou
-en éditant `ELECTRICORE_VERSION` dans `providers/<slug>/config.env` du dépôt de déploiement :
+Deux voies, selon que le bump doit être versionné ou non ([#460](https://github.com/Energie-De-Nantes/electricore/issues/460)) :
+
+- **Override local** (rapide, dev intense) — `--version <tag>` réécrit `ELECTRICORE_VERSION`
+  sur la box après le pull, **sans toucher au dépôt secrets**. Idéal pour itérer.
+- **Baseline GitOps** (durable) — éditer `ELECTRICORE_VERSION` dans `providers/<slug>/config.env`
+  du dépôt, commit + push, puis reconfigure **sans** `--version` (la box redéploie la version pinée).
 
 ```bash
 sudo bash /srv/<slug>/deploy/install.sh \
@@ -801,7 +808,8 @@ Le script :
 2. Re-télécharge `docker-compose.yml`, `Caddyfile`, `crontab` au tag demandé
    (utile si la stack a évolué).
 3. Re-pull `providers/<slug>/{config.env,secrets.env}` du dépôt, valide le split +
-   déchiffre (le tag déployé est épinglé par `--version`).
+   déchiffre. Si `--version` est fourni, **override local** de `ELECTRICORE_VERSION` dans le
+   `config.env` tiré (sinon : version pinée du dépôt). Le tag effectif est affiché au récap.
 4. `docker compose pull` puis `up -d` (recrée les conteneurs avec la nouvelle image).
 5. ingestion test.
 


### PR DESCRIPTION
## Problème (#460)

En secrets-as-code (`--deploy-repo`), `install.sh --version <tag>` **n'avait aucun effet** sur l'image déployée : le tag réellement lancé venait de `ELECTRICORE_VERSION` pinné dans le `config.env` **du dépôt**, et `--version` ne pilotait que le ref des templates compose. Deux sources de vérité divergeaient silencieusement (le step 7 loggait même « tag rc6 » alors qu'on servait rc5).

Conséquence : bumper la version déployée exigeait de toucher **deux repos** (electricore + electricore-secrets) — une corvée en dev intense, pour quelque chose qui **n'est pas un secret**.

## Correction

`--version` devient un **override LOCAL** effectif, appliqué après le pull :

- `parse_args` expose `OPT_VERSION_EXPLICIT` (distingue `--version` passé du défaut `latest`) ;
- `config.sh::override_config_version` réécrit **uniquement** `ELECTRICORE_VERSION` dans le `config.env` tiré, sans toucher au reste (baseline GitOps préservée) ;
- `install.sh` applique l'override après validation du `config.env`, avec un log clair (`⚠ ELECTRICORE_VERSION overridé localement : X (dépôt : Y)`) ;
- le récap surface le tag effectif : `Image: ghcr.io/.../electricore:<tag>`.

**Sans** `--version`, la box redéploie la version pinée du dépôt (comportement GitOps inchangé = baseline). Après le tag de l'image (incompressible), un **seul geste sur la box** suffit pour déployer un nouveau tag.

## Couverture

- `deploy/tests/unit.sh` : `override_config_version` (override + préservation des autres clés, une seule ligne `ELECTRICORE_VERSION`) et `OPT_VERSION_EXPLICIT` dans `parse_args` — **148 passed, 0 failed**.
- Note **ADR-0044** : la version est un *paramètre de déploiement* (baseline pinée optionnelle), pas un secret.
- `docs/deploiement.md` : description `--version` corrigée + section « Mise à jour de version » (override local vs baseline GitOps).

## Hors périmètre

La « variante plus propre » (sortir `ELECTRICORE_VERSION` du `config.env` vers un 2ᵉ `--env-file` local) et la suite « zéro-cérémonie côté electricore » (build par commit / tag flottant `dev`) restent à arbitrer dans des issues dédiées.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)