### PR TITLE
fix(install): restore backups/ ownership to CONTAINER_UID=1000 apres chown_instance_home

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -204,6 +204,7 @@ main() {
     # (config.env) et secrets (secrets.env chiffré) arrivent par le dépôt privé.
     download_config_files "$OPT_VERSION" "$HOME_DIR"
     chown_instance_home "$OPT_SLUG"
+    setup_backup_dir "$OPT_SLUG" "$HOME_DIR"
 
     # ─── Étape 8 : substitutions ────────────────────────────────────────────
     log_step "Patch des templates (domaine + email)"

--- a/deploy/lib/user.sh
+++ b/deploy/lib/user.sh
@@ -59,3 +59,39 @@ chown_instance_home() {
     local slug="$1"
     chown -R "$slug:$slug" "/srv/${slug}"
 }
+
+# CONTAINER_UID
+# UID du user `electricore` dans le conteneur Docker. Le bind-mount host des
+# backups (/srv/<slug>/backups) doit etre writable par cet uid.
+# Cf. deploy/docker/docker-compose.yml:96-99, ADR-0017.
+readonly CONTAINER_UID=1000
+
+# setup_backup_dir <slug> <home_dir>
+# Apres chown_instance_home, retablit l'ownership du dossier backups/ vers
+# CONTAINER_UID pour que le conteneur Docker puisse y ecrire ses snapshots.
+# Ajoute <slug> au groupe CONTAINER_UID pour permettre ls/rclone offsite.
+# Cf. deploy/docker/docker-compose.yml:96-99, ADR-0017.
+setup_backup_dir() {
+    local slug="$1"
+    local home="$2"
+    local backup_dir="${home}/backups"
+
+    if [[ -z "$slug" || -z "$home" ]]; then
+        die "usage: setup_backup_dir <slug> <home_dir>"
+    fi
+
+    # Creer le dossier s'il n'existe pas deja.
+    install -d -m 755 "$backup_dir"
+
+    # Chowner vers CONTAINER_UID (le user electricore du conteneur).
+    chown "${CONTAINER_UID}:${CONTAINER_UID}" "$backup_dir"
+    log_ok "backups/ (${backup_dir}) chowné a uid ${CONTAINER_UID}"
+
+    # Ajouter le slug au groupe du conteneur pour ls/rclone.
+    if ! id -nG "$slug" | tr ' ' '\n' | grep -qx "${CONTAINER_UID}"; then
+        usermod -aG "${CONTAINER_UID}" "$slug"
+        log_ok "user $slug ajoute au groupe ${CONTAINER_UID}"
+    else
+        log_skip "user $slug deja dans le groupe ${CONTAINER_UID}"
+    fi
+}

--- a/deploy/tests/fixtures/fake_bin/chown
+++ b/deploy/tests/fixtures/fake_bin/chown
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Fake chown — no-op success (can't chown without root in CI/local)
+exit 0

--- a/deploy/tests/fixtures/fake_bin/id
+++ b/deploy/tests/fixtures/fake_bin/id
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Fake id — simule un user non-root appartenant au groupe 'docker'
+if [[ "$*" == *-nG* ]]; then
+  # Extract the last argument as username
+  for arg; do :; done
+  echo "docker"
+fi
+exit 0

--- a/deploy/tests/fixtures/fake_bin/usermod
+++ b/deploy/tests/fixtures/fake_bin/usermod
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Fake usermod — no-op success
+exit 0

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -22,6 +22,8 @@ source "${LIB_DIR}/env_validate.sh"
 source "${LIB_DIR}/secrets.sh"
 # shellcheck source=../lib/harden.sh
 source "${LIB_DIR}/harden.sh"
+# shellcheck source=../lib/user.sh
+source "${LIB_DIR}/user.sh"
 
 # `install.sh` est protégé par un guard `main` ; le sourcer expose
 # `fetch_lib_files` sans déclencher l'exécution du script.
@@ -464,6 +466,19 @@ grep -Eq -- '-v [^ ]*/test_age\.key:/run/secrets/age\.key:ro' "$SMOKE_LOG" \
 rm -f "$SMOKE_LOG"
 
 rm -rf "$SMOKE_FIX"
+
+echo
+echo
+echo
+echo "→ user.sh / setup_backup_dir"
+_src_dir="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.." && pwd)/lib"
+slug_test_dir=$(mktemp -d)
+assert_ok "setup_backup_dir: cree le dossier" bash -c 'PATH="'"${FIXTURES_DIR}"'/fake_bin:$PATH" . "'"${_src_dir}"'/log.sh" && . "'"${_src_dir}"'/user.sh" && setup_backup_dir "testuser" "'"${slug_test_dir}"'"'
+[[ -d "${slug_test_dir}/backups" ]] && ok "setup_backup_dir: backups/ present" || ko "setup_backup_dir: backups/ absent"
+assert_fail "setup_backup_dir: slug vide" bash -c 'PATH="'"${FIXTURES_DIR}"'/fake_bin:$PATH" . "'"${_src_dir}"'/log.sh" && . "'"${_src_dir}"'/user.sh" && setup_backup_dir "" "'"${slug_test_dir}"'"'
+assert_fail "setup_backup_dir: home_dir vide" bash -c 'PATH="'"${FIXTURES_DIR}"'/fake_bin:$PATH" . "'"${_src_dir}"'/log.sh" && . "'"${_src_dir}"'/user.sh" && setup_backup_dir "testuser" ""'
+unset _src_dir
+rm -rf "$slug_test_dir"
 
 echo
 if [[ "$FAIL" -eq 0 ]]; then


### PR DESCRIPTION
Closes #459

## Résumé

Le dossier `/srv/<slug>/backups` est bind-mounté dans le conteneur Docker
(user `electricore`, uid 1000). Après chaque `chown_instance_home` (install,
upgrade), un `chown -R <slug>:<slug> /srv/<slug>` remet l'ownership de
`backups/` sur l'uid hôte, rendant le dossier inaccessible au conteneur.
`backup_duckdb.sh` échoue avec « Permission denied » le lendemain de
l'install.

## Changements

- **`deploy/lib/user.sh`** : Nouvelle fonction `setup_backup_dir()` qui
  restaure l'ownership de `backups/` vers `CONTAINER_UID=1000` et ajoute
  `<slug>` au groupe 1000 pour permettre `ls`/`rclone` offsite.
- **`deploy/install.sh`** : Appelle `setup_backup_dir` après
  `chown_instance_home`.
- **`deploy/tests/unit.sh`** : Tests unitaires avec fakes pour
  `chown`/`usermod`/`id`.

## Notes

- `CONTAINER_UID=1000` correspond à l'uid de `electricore` dans l'image
  Docker (cf. `docker-compose.yml:96-99`).
- La fonction crée le dossier s'il n'existe pas (`install -d -m 755`).
- Les tests passent sur cet environnement (141/145, 4 échecs
  préexistants sur Windows/curl/fake age-keygen).
