### PR TITLE
fix(api): flux JSONL facturiste en application/x-ndjson (#455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### 🐛 Corrections
+
+- **Flux JSONL facturiste servi en `application/x-ndjson`** (#455) : le rc6 documentait la 200
+  (itemSchema OpenAPI 3.2.0) mais gardait le `Content-Type: application/jsonl` runtime — d'où,
+  dans le panneau *Execute* de Swagger UI, le « can't parse JSON. Raw result: [object Blob] »
+  inchangé. swagger-js ne lit en **texte** que les types matchant `/(json|xml|yaml|text)\b/` :
+  `application/jsonl` échoue (pas de frontière de mot après « json ») → corps lu en `Blob` →
+  `JSON.parse(blob)` → `[object Blob]`. `/facturation/{chronologie,meta-periodes}` répondent
+  désormais en `application/x-ndjson` : Swagger affiche les **lignes brutes** (avec une note
+  « can't parse JSON » bénigne — du NDJSON n'est pas un JSON unique). Le client `electricore-client`
+  (lecture `iter_lines`) est insensible au `Content-Type`.
+
 ## [3.4.0rc6] - 2026-06-26
 
 Corrections issues du test de rc5 sur l'instance EDN : connexion Odoo, découvrabilité du flux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.4.0rc7] - 2026-06-26
+
+Correction issue du test de rc6 sur l'instance EDN : le flux JSONL facturiste reste affiché
+« [object Blob] » dans Swagger UI malgré la doc rc6.
+
 ### 🐛 Corrections
 
 - **Flux JSONL facturiste servi en `application/x-ndjson`** (#455) : le rc6 documentait la 200

--- a/docs/adr/0043-electricore-client-paquet-separe.md
+++ b/docs/adr/0043-electricore-client-paquet-separe.md
@@ -48,7 +48,7 @@ est en retard (champs attendus absents).
 
 ### 3. Les deux lectures en **JSONL streamé** (pas d'enveloppe, pas de pagination)
 
-`meta-periodes` et `chronologie` répondent en `application/jsonl` (une ligne = un objet),
+`meta-periodes` et `chronologie` répondent en `application/x-ndjson` (une ligne = un objet),
 construit **par modèle** côté serveur (chaque ligne est validée à l'émission). Pas de
 pagination : le serveur streame **toutes** les lignes. Les métadonnées (`contract_version`,
 `mois` résolu / `grain`) remontent dans les **en-têtes** de réponse. Côté client, un

--- a/docs/electricore-client-design.md
+++ b/docs/electricore-client-design.md
@@ -30,7 +30,7 @@ URL de base + `X-API-Key` + timeout `httpx.Client`, **503 → `IngestionEnCours`
 ## 3. Les deux lectures — JSONL streamé
 
 `GET /facturation/meta-periodes` et `GET /facturation/chronologie` répondent en
-`application/jsonl` (une ligne = un objet), **sans enveloppe ni pagination**. Métadonnées
+`application/x-ndjson` (une ligne = un objet), **sans enveloppe ni pagination**. Métadonnées
 (`contract_version`, `mois` / `grain`) dans les **en-têtes** (`X-Contract-Version`,
 `X-Mois`, `X-Grain`). Chaque ligne est **validée par construction d'un modèle** côté serveur.
 

--- a/electricore/api/routers/chronologie.py
+++ b/electricore/api/routers/chronologie.py
@@ -6,7 +6,7 @@ compris hors-comptage* + relevés) tissés avec les verdicts dérivés (qualité
 énergie). Drill-down/explication du **pourquoi**, là où `/meta-periodes` est l'extrait mensuel
 valorisé — **pas de montants tarifaires** ici (différenciateur explicite).
 
-Réponse en **JSONL streamé** (`application/jsonl`, ADR-0043) : une ligne = un
+Réponse en **JSONL streamé** (`application/x-ndjson`, ADR-0043) : une ligne = un
 `LigneChronologie` (union discriminée sur `type_ligne`), validé par construction. Les
 métadonnées (`contract_version`, `grain`) remontent dans les en-têtes. Le modèle d'union est
 **single-sourcé** dans `electricore_client`.
@@ -55,9 +55,10 @@ async def get_chronologie(
     sans montant tarifaire (turpe/cta/accise). Métadonnées en en-têtes (`X-Contract-Version`,
     `X-Grain`). Fournir exactement un grain (`pdl` XOR `rsc`).
 
-    **Réponse JSONL streamé** (`application/jsonl`, NDJSON) : à consommer **ligne par ligne**,
-    ce n'est pas un document JSON unique. Swagger UI affiche « [object Blob] » car il ne
-    prévisualise que `application/json` — pour inspecter à la main : `curl … | jq -c .`.
+    **Réponse JSONL streamé** (`application/x-ndjson`, NDJSON) : à consommer **ligne par ligne**,
+    ce n'est pas un document JSON unique. Swagger UI ne prévisualise pas le NDJSON (il le passe à
+    `JSON.parse` et affiche une note « can't parse JSON » avant les lignes brutes) — pour
+    inspecter à la main : `curl … | jq -c .`.
     """
     if pdl is None and rsc is None:
         raise HTTPException(422, "Fournir un grain : `pdl` (point) ou `rsc` (contrat).")

--- a/electricore/api/routers/meta_periodes.py
+++ b/electricore/api/routers/meta_periodes.py
@@ -3,7 +3,7 @@
 Endpoint **ERP-agnostique** (zéro `integrations/odoo`, ADR-0016) : il expose un modèle
 electricore-natif (la *méta-période mensuelle*), pas un miroir des modèles `souscription.*`.
 
-Réponse en **JSONL streamé** (`application/jsonl`, une ligne = un `PeriodeMeta`) plutôt
+Réponse en **JSONL streamé** (`application/x-ndjson`, une ligne = un `PeriodeMeta`) plutôt
 qu'en enveloppe paginée (ADR-0043) : pas de pagination, le serveur streame toutes les
 lignes, et les métadonnées (`contract_version`, `mois` résolu) remontent dans les en-têtes
 de réponse. Les modèles de ligne (`PeriodeMeta`/`ObjetReleve`) sont **single-sourcés** dans
@@ -55,9 +55,10 @@ async def get_meta_periodes(
     Charge utile non valorisée aux prix fournisseur : quantités physiques + montants réseau.
     Odoo construit/upsert ses `souscription.periode` à partir de ce flux.
 
-    **Réponse JSONL streamé** (`application/jsonl`, NDJSON) : à consommer **ligne par ligne**,
-    ce n'est pas un document JSON unique. Swagger UI affiche « [object Blob] » car il ne
-    prévisualise que `application/json` — pour inspecter à la main : `curl … | jq -c .`.
+    **Réponse JSONL streamé** (`application/x-ndjson`, NDJSON) : à consommer **ligne par ligne**,
+    ce n'est pas un document JSON unique. Swagger UI ne prévisualise pas le NDJSON (il le passe à
+    `JSON.parse` et affiche une note « can't parse JSON » avant les lignes brutes) — pour
+    inspecter à la main : `curl … | jq -c .`.
     """
     mois_resolu, df = meta_periodes(mois=mois, rsc=rsc)
     headers = {

--- a/electricore/api/serializers/jsonl.py
+++ b/electricore/api/serializers/jsonl.py
@@ -1,6 +1,6 @@
 """Sérialiseur JSONL partagé `jsonl_response` (validate-then-stream, ADR-0043, #426).
 
-Possède le format de fil des endpoints JSONL (`application/jsonl`, une ligne = un modèle
+Possède le format de fil des endpoints JSONL (`application/x-ndjson`, une ligne = un modèle
 de contrat sérialisé) **et** la garantie d'atomicité : toutes les lignes sont construites
 et **validées en amont**, donc une ligne hors-contrat lève *avant* que le premier octet ne
 parte. Le consommateur (`electricore-client` → Odoo, ADR-0027) reçoit alors un **500 propre,
@@ -23,7 +23,13 @@ from pydantic import BaseModel, TypeAdapter
 
 logger = logging.getLogger(__name__)
 
-MEDIA_TYPE_JSONL = "application/jsonl"
+# NDJSON. `application/x-ndjson` (et non `application/jsonl`) car c'est le seul que swagger-js
+# télécharge en *texte* (sa regex `/(json|xml|yaml|text)\b/` veut une frontière de mot après
+# « json » : « jsonl » échoue, « x-ndjson » passe). Sous `application/jsonl`, le corps était lu
+# en `Blob` puis Swagger UI tentait `JSON.parse(blob)` → « can't parse JSON. Raw result:
+# [object Blob] » (#455). En `x-ndjson`, Swagger affiche les lignes brutes (la note « can't parse
+# JSON » subsiste — du NDJSON n'est pas un JSON unique — mais la donnée est visible).
+MEDIA_TYPE_JSONL = "application/x-ndjson"
 
 
 def reponses_openapi_jsonl(modele: Any, description: str) -> dict:
@@ -32,8 +38,8 @@ def reponses_openapi_jsonl(modele: Any, description: str) -> dict:
     OpenAPI 3.2.0 décrit les *sequential media types* (NDJSON…) via **`itemSchema`** : le schéma
     de **chaque ligne**, validé indépendamment (https://spec.openapis.org/oas/v3.2.0.html
     #sequential-media-types). On le dérive du modèle de ligne (`LigneChronologie` — union
-    discriminée — ou `PeriodeMeta`) pour que Swagger UI rende la forme d'une ligne, au lieu du
-    « [object Blob] » qu'il affiche quand il prend le NDJSON pour un `application/json` unique (#455).
+    discriminée — ou `PeriodeMeta`) pour que Swagger UI rende la forme d'une ligne dans la doc,
+    et non plus le NDJSON pris pour un `application/json` unique (#455 ; cf. `MEDIA_TYPE_JSONL`).
 
     On **n'utilise pas** la génération native d'`itemSchema` de FastAPI (endpoints générateurs)
     car elle valide/streame ligne par ligne : ça sacrifierait le *validate-then-stream* atomique
@@ -91,7 +97,7 @@ def jsonl_response(
     headers: dict[str, str],
     omettre_les_nuls: bool = False,
 ) -> StreamingResponse:
-    """Construit, valide et streame un DataFrame en JSONL (`application/jsonl`).
+    """Construit, valide et streame un DataFrame en JSONL (`application/x-ndjson`).
 
     Validate-then-stream : toutes les lignes sont matérialisées en `list[bytes]` avant la
     réponse, donc une ligne hors-contrat lève (et l'appel échoue) *avant* tout octet émis.

--- a/packages/electricore-client/tests/test_chronologie.py
+++ b/packages/electricore-client/tests/test_chronologie.py
@@ -71,7 +71,7 @@ def _handler(*, lignes=_LIGNES, version="1", grain="point"):
         return httpx.Response(
             200,
             content=_jsonl(lignes),
-            headers={"Content-Type": "application/jsonl", "X-Contract-Version": version, "X-Grain": grain},
+            headers={"Content-Type": "application/x-ndjson", "X-Contract-Version": version, "X-Grain": grain},
         )
 
     return handler

--- a/packages/electricore-client/tests/test_meta_periodes.py
+++ b/packages/electricore-client/tests/test_meta_periodes.py
@@ -100,7 +100,7 @@ def _handler(*, lignes=_LIGNES, version="3", mois="2026-05-01"):
             200,
             content=_jsonl(lignes),
             headers={
-                "Content-Type": "application/jsonl",
+                "Content-Type": "application/x-ndjson",
                 "X-Contract-Version": version,
                 "X-Mois": mois,
             },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.4.0rc6"
+version = "3.4.0rc7"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/tests/integration/test_chronologie_endpoint.py
+++ b/tests/integration/test_chronologie_endpoint.py
@@ -1,7 +1,7 @@
 """Tests d'intégration de `GET /facturation/chronologie` (vue facturiste, #367/#408).
 
 Endpoint de lecture (ADR-0027/0012) : frise complète d'un point/contrat + verdicts, **sans
-montant tarifaire**. Depuis #408, la réponse est un **flux JSONL** (`application/jsonl`, une
+montant tarifaire**. Depuis #408, la réponse est un **flux JSONL** (`application/x-ndjson`, une
 ligne = un `LigneChronologie` — union discriminée sur `type_ligne`) avec métadonnées en
 en-têtes (`X-Contract-Version`, `X-Grain`). Le seam de test est la fonction
 `chronologie_point_ou_contrat` référencée par le router — on court-circuite la reconstruction
@@ -77,7 +77,7 @@ def test_chronologie_streame_du_jsonl(monkeypatch, frise_synthetique):
         app.dependency_overrides.clear()
 
     assert response.status_code == 200
-    assert response.headers["content-type"].startswith("application/jsonl")
+    assert response.headers["content-type"].startswith("application/x-ndjson")
     assert response.headers["X-Grain"] == "point"
     assert response.headers["X-Contract-Version"] == "1"
 
@@ -169,21 +169,21 @@ def test_chronologie_ligne_hors_contrat_500_atomique(monkeypatch):
 
     assert response.status_code == 500
     # Le flux n'a pas commencé : pas de données de frise dans le corps.
-    assert not response.headers["content-type"].startswith("application/jsonl")
+    assert not response.headers["content-type"].startswith("application/x-ndjson")
     assert "type_ligne" not in response.text
 
 
 def test_chronologie_openapi_itemschema_3_2():
-    """Découvrabilité (#455) : OpenAPI 3.2.0 documente la 200 en `application/jsonl` avec un
+    """Découvrabilité (#455) : OpenAPI 3.2.0 documente la 200 en `application/x-ndjson` avec un
     `itemSchema` (schéma d'**une ligne**) — l'union discriminée `LigneChronologie` — au lieu d'un
-    `application/json` implicite (que Swagger prend pour un JSON unique → « [object Blob] »).
+    `application/json` implicite (que Swagger prend pour un JSON unique).
     """
     openapi_doc = app.openapi()
     assert openapi_doc["openapi"] == "3.2.0"
     reponse_200 = openapi_doc["paths"]["/facturation/chronologie"]["get"]["responses"]["200"]
-    assert list(reponse_200["content"].keys()) == ["application/jsonl"]
+    assert list(reponse_200["content"].keys()) == ["application/x-ndjson"]
     assert "ligne par ligne" in reponse_200["description"]
-    item = reponse_200["content"]["application/jsonl"]["itemSchema"]
+    item = reponse_200["content"]["application/x-ndjson"]["itemSchema"]
     # Une ligne = un membre de l'union discriminée (oneOf + discriminator sur `type_ligne`).
     assert "oneOf" in item and "discriminator" in item
     # Les $defs ont été remontés : chaque $ref de l'itemSchema résout dans components/schemas.

--- a/tests/integration/test_meta_periodes_endpoint.py
+++ b/tests/integration/test_meta_periodes_endpoint.py
@@ -1,7 +1,7 @@
 """Tests d'intégration de `GET /facturation/meta-periodes` (ADR-0027/0043, #227/#407).
 
 Endpoint de lecture des méta-périodes mensuelles : Odoo tire d'electricore. Depuis #407,
-la réponse est un **flux JSONL** (`application/jsonl`, une ligne = un `PeriodeMeta`) — plus
+la réponse est un **flux JSONL** (`application/x-ndjson`, une ligne = un `PeriodeMeta`) — plus
 d'enveloppe paginée. Les métadonnées (`X-Contract-Version`, `X-Mois`) sont en en-têtes, et
 chaque ligne est **validée par construction d'un modèle** côté serveur. Le seam de test est
 la fonction de service `meta_periodes` référencée dans le router — on court-circuite l'I/O
@@ -86,7 +86,7 @@ def _lignes(response) -> list[dict]:
 
 
 def test_meta_periodes_streame_du_jsonl(monkeypatch, meta_periodes_synthetiques):
-    """Tracer bullet : GET sert les méta-périodes en JSONL (`application/jsonl`)."""
+    """Tracer bullet : GET sert les méta-périodes en JSONL (`application/x-ndjson`)."""
     app.dependency_overrides[get_current_api_key] = lambda: "test-key"
     monkeypatch.setattr(
         "electricore.api.routers.meta_periodes.meta_periodes",
@@ -98,7 +98,7 @@ def test_meta_periodes_streame_du_jsonl(monkeypatch, meta_periodes_synthetiques)
         app.dependency_overrides.clear()
 
     assert response.status_code == 200
-    assert response.headers["content-type"].startswith("application/jsonl")
+    assert response.headers["content-type"].startswith("application/x-ndjson")
 
     lignes = _lignes(response)
     assert len(lignes) == 2
@@ -169,21 +169,21 @@ def test_meta_periodes_ligne_hors_contrat_500_atomique(monkeypatch, meta_periode
 
     assert response.status_code == 500
     # Le flux n'a pas commencé : aucune ligne JSONL (pas de données de contrat) n'a fuité.
-    assert not response.headers["content-type"].startswith("application/jsonl")
+    assert not response.headers["content-type"].startswith("application/x-ndjson")
     assert "ref_situation_contractuelle" not in response.text
 
 
 def test_meta_periodes_openapi_itemschema_3_2():
-    """Découvrabilité (#455) : OpenAPI 3.2.0 documente la 200 en `application/jsonl` avec un
+    """Découvrabilité (#455) : OpenAPI 3.2.0 documente la 200 en `application/x-ndjson` avec un
     `itemSchema` (schéma d'**une ligne** `PeriodeMeta`), au lieu d'un `application/json` implicite
-    (que Swagger prend pour un JSON unique → « [object Blob] »).
+    (que Swagger prend pour un JSON unique).
     """
     openapi_doc = app.openapi()
     assert openapi_doc["openapi"] == "3.2.0"
     reponse_200 = openapi_doc["paths"]["/facturation/meta-periodes"]["get"]["responses"]["200"]
-    assert list(reponse_200["content"].keys()) == ["application/jsonl"]
+    assert list(reponse_200["content"].keys()) == ["application/x-ndjson"]
     assert "ligne par ligne" in reponse_200["description"]
-    item = reponse_200["content"]["application/jsonl"]["itemSchema"]
+    item = reponse_200["content"]["application/x-ndjson"]["itemSchema"]
     # Une ligne = un objet PeriodeMeta (schéma d'objet, pas une string opaque).
     assert item["type"] == "object" and "properties" in item
     # Le modèle imbriqué `ObjetReleve` a été remonté en composant et son $ref résout.

--- a/tests/unit/test_jsonl_response.py
+++ b/tests/unit/test_jsonl_response.py
@@ -2,7 +2,7 @@
 
 Construit et **valide toutes les lignes JSONL en amont** : une ligne hors-contrat lève
 *avant* que le premier octet ne parte (500 atomique, zéro ligne appliquée côté consommateur)
-plutôt qu'en cassant un flux déjà committé en 200. Le format de fil (`application/jsonl`,
+plutôt qu'en cassant un flux déjà committé en 200. Le format de fil (`application/x-ndjson`,
 une ligne = un modèle sérialisé) et la stringification des dates sont possédés par le helper ;
 les deux endpoints JSONL (méta-périodes, chronologie) lui passent leur validateur de ligne.
 """

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.4.0rc6"
+version = "3.4.0rc7"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Contexte

Issue #455 : `/facturation/chronologie` (et `/facturation/meta-periodes`) renvoient un corps NDJSON. Dans le panneau **Execute** de Swagger UI, ça affiche `can't parse JSON.  Raw result: [object Blob]`. Le **rc6** a documenté la réponse (itemSchema OpenAPI 3.2.0) mais **n'a pas changé le `Content-Type` runtime** — donc le `[object Blob]` persistait à l'exécution. C'est ce que résout cette PR.

## Cause (vérifiée sur les sources Swagger)

- **swagger-js** (`src/http/serializers/response/index.js`) décide texte-vs-Blob ainsi :
  ```js
  export const shouldDownloadAsText = (contentType = '') => /(json|xml|yaml|text)\b/.test(contentType);
  const useText = loadSpec || shouldDownloadAsText(contentType);
  const getBody = useText ? oriRes.text : oriRes.blob || oriRes.buffer;
  ```
  La `\b` exige une frontière de mot après `json`. `application/jsonl` → le `l` suit → **pas** de frontière → `false` → corps lu en **`.blob()`**. `application/x-ndjson` → `json` en fin de chaîne → frontière → `true` → lu en **`.text()`**.
- **swagger-ui** (`src/core/components/response-body.jsx`) force le parse JSON pour tout type contenant « json » :
  ```js
  } else if (/json/i.test(contentType)) {
    try { body = JSON.stringify(JSON.parse(content), null, "  ") }
    catch (error) { body = "can't parse JSON.  Raw result:\n\n" + content }
  ```
  Sous `application/jsonl`, `content` est un Blob → `"... " + Blob` = **`[object Blob]`**.

## Changement

`MEDIA_TYPE_JSONL` → `application/x-ndjson` (source unique dans `serializers/jsonl.py`, propagé à l'`itemSchema`, la description et le `StreamingResponse`).

| Content-Type | swagger-js lit | Panneau Execute |
|---|---|---|
| `application/jsonl` (avant) | Blob | `can't parse JSON.  Raw result: [object Blob]` |
| `application/x-ndjson` (après) | texte | **les lignes NDJSON brutes** + note bénigne `can't parse JSON` |

⚠️ **Honnêteté** : `x-ndjson` **supprime le `[object Blob]`** et rend la donnée visible, mais **ne supprime pas** la note `can't parse JSON` (Swagger parse tout type contenant « json », or du NDJSON n'est pas un JSON unique). La seule façon de retirer la note serait un type sans « json » (ex. `text/plain`) — rejeté car sémantiquement faux. C'est aussi le type que l'AC de #455 anticipait.

## Sécurité de la bascule

`electricore-client` lit via `iter_lines()` + `json.loads` et **n'inspecte jamais** le `Content-Type` (`streaming.py`) → insensible. Seules des fixtures de mock portaient `application/jsonl`, alignées ici.

## Tests

- `tests/integration/test_{chronologie,meta_periodes}_endpoint.py`, `tests/unit/test_jsonl_response.py` → **21 passed**
- `packages/electricore-client/tests/test_{chronologie,meta_periodes}.py` → **12 passed**
- `ruff format` + `ruff check` clean

Docs alignées : ADR-0043, design client, CHANGELOG (entrée `[Unreleased]`). Le bump de version / tag rc reste l'étape humaine de release.

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)