### PR TITLE
docs(contributing): refuser les PR automatisées non sollicitées + convention ready-for-agent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,18 @@
 
 Merci pour votre intérêt ! ElectriCore est un outil libre (AGPL-3.0) de traitement des flux Enedis pour les fournisseurs alternatifs d'électricité. Les contributions sont les bienvenues — bug reports, suggestions, PRs.
 
+> [!IMPORTANT]
+> **Les PR non sollicitées générées par des agents ou des outils automatisés ne
+> sont pas acceptées** pour l'instant : le projet n'est pas outillé pour les
+> accueillir et ne les recherche pas — elles seront fermées sans être fusionnées,
+> quelle que soit leur qualité.
+>
+> Le label `ready-for-agent` sur une issue n'est **pas** une invitation à
+> contribuer : il est réservé aux agents du mainteneur, qui se l'assignent au
+> triage (cf. [docs/agents/triage-labels.md](docs/agents/triage-labels.md)). Le
+> chemin de déploiement (`deploy/`, exécuté en root, manipulation de secrets) et
+> la chaîne crypto/SOPS sont maintenus en interne.
+
 ## Installation de l'environnement de développement
 
 Le projet utilise [uv](https://docs.astral.sh/uv/) pour la gestion des dépendances.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -13,3 +13,9 @@ Les skills parlent en termes de cinq rôles canoniques. Ce fichier mappe ces rô
 Quand une skill mentionne un rôle (par ex. « apply the AFK-ready triage label »), utiliser la chaîne de la colonne *Label GitHub*.
 
 Modifier la colonne de droite pour refléter tout renommage futur côté GitHub.
+
+## Convention `ready-for-agent`
+
+Le label `ready-for-agent` est **réservé aux agents du mainteneur**. Au moment où il est posé, l'issue est **immédiatement auto-assignée au mainteneur** : ce n'est pas une invitation ouverte à contribuer.
+
+Les PR externes non sollicitées — en particulier celles générées par des agents ou des outils automatisés — qui répondent à ces issues sont fermées sans être fusionnées, indépendamment de leur qualité (cf. [CONTRIBUTING.md](../../CONTRIBUTING.md)).


### PR DESCRIPTION
## Contexte

Le label `ready-for-agent` est un signal public que des fleets d'agents externes
scannent : l'issue #459 a été reprise par un compte automatisé ([PR #462](https://github.com/Energie-De-Nantes/electricore/pull/462), fermée) moins d'une heure
après son ouverture, parce qu'elle était labellisée et non assignée.

Le projet n'est pas prêt à accueillir ce type de contributions (chemin `deploy/`
exécuté en root, chaîne crypto/SOPS) et ne les recherche pas. Cette PR rend la
politique explicite **en amont**, pour éviter que des contributeurs y consacrent
du temps inutilement.

## Changements

- **`CONTRIBUTING.md`** : callout `[!IMPORTANT]` — les PR non sollicitées
  générées par des agents/outils automatisés ne sont pas acceptées ; le label
  `ready-for-agent` n'est pas une invitation à contribuer.
- **`docs/agents/triage-labels.md`** : nouvelle section « Convention
  `ready-for-agent` » — le label est réservé aux agents du mainteneur et l'issue
  est **auto-assignée au triage**.

## Suivi (process, hors PR)

Penser à **auto-assigner** chaque issue au moment où le label `ready-for-agent`
est posé (la doc le formalise, mais c'est une habitude à tenir côté mainteneur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
