### PR TITLE
fix(deploy): backups DuckDB writable par le conteneur (uid 1000) — corrige le backup nocturne en échec (#459)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -197,6 +197,11 @@ main() {
     log_step "Téléchargement config (tag ${OPT_VERSION})"
     download_config_files "$OPT_VERSION" "$HOME_DIR"
     chown_instance_home "$OPT_SLUG"
+    # Exception au chown global (#459) : /srv/<slug>/backups doit rester writable par
+    # le conteneur (uid 1000), pas par <slug>. À (ré)appliquer APRÈS le `chown -R`,
+    # sinon backup_duckdb.sh plante au mkdir du snapshot et la box tourne sans backup.
+    ensure_backups_dir "$OPT_SLUG"
+    ensure_slug_in_container_group "$OPT_SLUG"
 
     # ─── Étape 8 : substitutions ────────────────────────────────────────────
     log_step "Patch des templates (slug + domaine + email)"

--- a/deploy/lib/user.sh
+++ b/deploy/lib/user.sh
@@ -86,6 +86,11 @@ CONTAINER_GID="${CONTAINER_GID:-1000}"
 # (2750) : les snapshots créés par le conteneur héritent du groupe 1000, donc
 # <slug> — ajouté à ce groupe par ensure_slug_in_container_group — peut les lire
 # et les pousser en offsite (rclone). Idempotent (ré-asserte à chaque reconfigure).
+#
+# Le groupe n'a PAS le write (2750 = rwxr-s---), et c'est suffisant : backup_duckdb.sh
+# — écriture du snapshot ET purge de rétention — tourne DANS le conteneur (uid 1000 =
+# owner), pas en <slug> ; <slug> ne fait que LIRE (ls + `rclone copy`). Ne passer à 2770
+# que si un offsite host-side fait un `rclone move --delete` en tant que <slug>.
 ensure_backups_dir() {
     local slug="$1"
     local backups="${SRV_BASE:-/srv}/${slug}/backups"

--- a/deploy/lib/user.sh
+++ b/deploy/lib/user.sh
@@ -1,13 +1,18 @@
 # shellcheck shell=bash
 # Création du user système <slug>, home /srv/<slug>/, groupe docker, SSH key.
 # Cf. ADR-0017.
+#
+# Toutes les fonctions dérivent le home d'instance via ${SRV_BASE:-/srv} : défaut
+# /srv en prod, surchargeable par les tests pour opérer sur un home jetable sans
+# root. chown_instance_home et ensure_backups_dir doivent ainsi viser le MÊME
+# chemin (l'un écrase l'exception backups/ de l'autre, #459).
 
 # create_instance_user <slug>
 # Crée le user s'il n'existe pas, met son home à /srv/<slug>/, l'ajoute à docker.
 # Garde-fou : refuse si le user existe mais avec un home différent (cas tordu).
 create_instance_user() {
     local slug="$1"
-    local home="/srv/${slug}"
+    local home="${SRV_BASE:-/srv}/${slug}"
     if id "$slug" >/dev/null 2>&1; then
         local existing_home
         existing_home=$(getent passwd "$slug" | cut -d: -f6)
@@ -34,7 +39,7 @@ create_instance_user() {
 setup_ssh_authorized_keys() {
     local slug="$1"
     local pubkey="${2:-}"
-    local home="/srv/${slug}"
+    local home="${SRV_BASE:-/srv}/${slug}"
     local ssh_dir="${home}/.ssh"
     local auth_file="${ssh_dir}/authorized_keys"
     install -d -m 700 -o "$slug" -g "$slug" "$ssh_dir"
@@ -60,7 +65,8 @@ setup_ssh_authorized_keys() {
 # safe.directory du deploy-repo).
 chown_instance_home() {
     local slug="$1"
-    chown -R "$slug:$slug" "/srv/${slug}"
+    local home="${SRV_BASE:-/srv}/${slug}"
+    chown -R "$slug:$slug" "$home"
 }
 
 # Identité du user du conteneur (Dockerfile : `USER electricore`, uid:gid 1000:1000).

--- a/deploy/lib/user.sh
+++ b/deploy/lib/user.sh
@@ -55,7 +55,60 @@ setup_ssh_authorized_keys() {
 
 # chown_instance_home <slug>
 # S'assure que tout sous /srv/<slug>/ est owned par le user.
+# NB : ce chown -R aveugle écrase aussi backups/ → l'exception uid 1000 doit être
+# (ré)appliquée APRÈS lui via ensure_backups_dir (cf. #459, même classe que le seam
+# safe.directory du deploy-repo).
 chown_instance_home() {
     local slug="$1"
     chown -R "$slug:$slug" "/srv/${slug}"
+}
+
+# Identité du user du conteneur (Dockerfile : `USER electricore`, uid:gid 1000:1000).
+# Le bind-mount host des backups doit lui appartenir pour être writable. Overridable
+# pour les tests (chown vers soi-même, sans root).
+CONTAINER_UID="${CONTAINER_UID:-1000}"
+CONTAINER_GID="${CONTAINER_GID:-1000}"
+
+# ensure_backups_dir <slug>
+# Crée /srv/<slug>/backups et le donne au user du conteneur (uid:gid 1000), en
+# EXCEPTION du chown global de chown_instance_home (qui le donnerait à <slug>).
+# Sans ça, le conteneur — qui tourne en uid 1000 — ne peut pas y écrire et
+# backup_duckdb.sh plante au mkdir du snapshot (« Permission denied », #459) :
+# aucune sauvegarde n'est produite.
+#
+# Doit être appelé APRÈS chown_instance_home pour écraser son `chown -R`. setgid
+# (2750) : les snapshots créés par le conteneur héritent du groupe 1000, donc
+# <slug> — ajouté à ce groupe par ensure_slug_in_container_group — peut les lire
+# et les pousser en offsite (rclone). Idempotent (ré-asserte à chaque reconfigure).
+ensure_backups_dir() {
+    local slug="$1"
+    local backups="${SRV_BASE:-/srv}/${slug}/backups"
+    install -d -m 2750 -o "$CONTAINER_UID" -g "$CONTAINER_GID" "$backups"
+    log_ok "backups ${backups} → uid:gid ${CONTAINER_UID}:${CONTAINER_GID} (writable conteneur)"
+}
+
+# ensure_slug_in_container_group <slug>
+# Ajoute <slug> au groupe gid CONTAINER_GID (celui du user conteneur) pour qu'il
+# puisse lire les backups écrits en gid 1000 (`ls`, offsite rclone). Crée le groupe
+# s'il n'existe pas encore sur l'hôte (un host sans user uid 1000 n'a pas forcément
+# de groupe gid 1000). Idempotent.
+ensure_slug_in_container_group() {
+    local slug="$1"
+    local gid="$CONTAINER_GID"
+    local grp
+    grp=$(getent group "$gid" | cut -d: -f1)
+    if [[ -z "$grp" ]]; then
+        grp="electricore-data"
+        if ! groupadd -g "$gid" "$grp" 2>/dev/null; then
+            log_warn "création du groupe gid ${gid} échouée — lecture des backups par ${slug} non garantie."
+            return 0
+        fi
+        log_ok "groupe ${grp} (gid ${gid}) créé"
+    fi
+    if id -nG "$slug" 2>/dev/null | tr ' ' '\n' | grep -qx "$grp"; then
+        log_skip "user $slug déjà dans le groupe $grp (gid $gid)"
+    else
+        usermod -aG "$grp" "$slug"
+        log_ok "user $slug ajouté au groupe $grp (gid $gid) — lecture des backups"
+    fi
 }

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -356,6 +356,32 @@ me=$(id -un)
     && ok "ensure_slug_in_container_group: no-op si déjà membre (pas de usermod)" \
     || ko "ensure_slug_in_container_group a échoué sur un membre existant"
 
+# La branche `usermod -aG` EST le correctif (#459) : sans root, on la rend atteignable
+# via des stubs getent/id/usermod sur le PATH. Groupe gid 1000 « existant » (getent
+# stubé) + <slug> pas encore membre (id stubé) → on vérifie que usermod est invoqué
+# avec le bon groupe (résolu depuis le gid) et le bon slug.
+stub_dir=$(mktemp -d); usermod_log="${stub_dir}/usermod.args"
+cat > "${stub_dir}/getent" <<'STUB'
+#!/usr/bin/env bash
+[[ "$1" == group ]] && { printf 'edn-data:x:%s:\n' "$2"; exit 0; }
+exit 2
+STUB
+cat > "${stub_dir}/id" <<'STUB'
+#!/usr/bin/env bash
+[[ "$1" == -nG ]] && { echo users; exit 0; }
+exit 0
+STUB
+cat > "${stub_dir}/usermod" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$USERMOD_ARGS_FILE"
+STUB
+chmod +x "${stub_dir}/getent" "${stub_dir}/id" "${stub_dir}/usermod"
+( PATH="${stub_dir}:$PATH" USERMOD_ARGS_FILE="$usermod_log" \
+    ensure_slug_in_container_group edn >/dev/null 2>&1 )
+assert_eq "$(cat "$usermod_log" 2>/dev/null)" "-aG edn-data edn" \
+    "ensure_slug_in_container_group: usermod -aG <grp> <slug> quand <slug> non-membre"
+rm -rf "$stub_dir"
+
 echo
 if [[ "$FAIL" -eq 0 ]]; then
     printf "\033[32m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -329,6 +329,34 @@ grep -q "^API_KEY=" "$tmp_env" && ok "strip: API_KEY survit" || ko "strip: API_K
 rm -f "$tmp_env"
 
 echo
+echo "→ user.sh / ensure_backups_dir (contrat uid 1000, #459)"
+# Le conteneur tourne en uid 1000 → /srv/<slug>/backups doit lui appartenir, sinon
+# backup_duckdb.sh plante au mkdir (« Permission denied »). On vérifie sur un home
+# jetable, en chownant vers SOI-MÊME (CONTAINER_UID=$(id -u)) pour tourner sans root.
+bk_root=$(mktemp -d)
+( CONTAINER_UID="$(id -u)" CONTAINER_GID="$(id -g)" SRV_BASE="$bk_root" ensure_backups_dir edn >/dev/null 2>&1 )
+[[ -d "${bk_root}/edn/backups" ]] && ok "ensure_backups_dir: crée /srv/<slug>/backups" || ko "backups non créé"
+assert_eq "$(stat -c '%u' "${bk_root}/edn/backups" 2>/dev/null)" "$(id -u)" \
+    "ensure_backups_dir: backups owned par CONTAINER_UID (pas <slug>)"
+assert_eq "$(stat -c '%a' "${bk_root}/edn/backups" 2>/dev/null)" "2750" \
+    "ensure_backups_dir: setgid 2750 (snapshots héritent du groupe → lecture <slug>)"
+# Idempotent + ré-assertion après un chown -R clobber (cas reconfigure : chown_instance_home
+# redonne backups à <slug>, ensure_backups_dir doit le reprendre).
+chmod 0700 "${bk_root}/edn/backups"
+( CONTAINER_UID="$(id -u)" CONTAINER_GID="$(id -g)" SRV_BASE="$bk_root" ensure_backups_dir edn >/dev/null 2>&1 ) \
+    && ok "ensure_backups_dir: idempotent (2e appel ré-asserte sans erreur)" || ko "ensure_backups_dir 2e appel échoue"
+assert_eq "$(stat -c '%a' "${bk_root}/edn/backups" 2>/dev/null)" "2750" \
+    "ensure_backups_dir: ré-asserte le mode après clobber (reconfigure)"
+rm -rf "$bk_root"
+
+# ensure_slug_in_container_group : no-op si <slug> est déjà membre du groupe cible.
+# On joue le user courant + son gid primaire → branche skip atteignable sans root.
+me=$(id -un)
+( CONTAINER_GID="$(id -g)" ensure_slug_in_container_group "$me" >/dev/null 2>&1 ) \
+    && ok "ensure_slug_in_container_group: no-op si déjà membre (pas de usermod)" \
+    || ko "ensure_slug_in_container_group a échoué sur un membre existant"
+
+echo
 if [[ "$FAIL" -eq 0 ]]; then
     printf "\033[32m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
     exit 0


### PR DESCRIPTION
## Problème

Le job `backup_duckdb.sh` (cron 03:30 + étape « ETL test » de l'install) échoue avec
`IO Error: Failed to create directory ".../snapshot_...": Permission denied` →
**aucun snapshot DuckDB produit, la box tourne sans sauvegarde**.

## Cause racine

Le conteneur tourne en **uid:gid 1000** (`Dockerfile: USER electricore`), donc le
bind-mount host `/srv/<slug>/backups` doit lui appartenir pour être writable
(contrat déjà documenté dans `docker-compose.yml`). Or `install.sh` ne le
respectait pas :

- `useradd <slug>` reçoit un uid attribué par le système (souvent ≠ 1000 — l'uid 1000
  est déjà pris par le user par défaut de l'image cloud) ;
- `chown_instance_home` fait un `chown -R <slug>:<slug> /srv/<slug>` aveugle qui
  donne `backups/` au slug ;
- rien n'implémentait l'exception uid 1000 ni l'ajout de `<slug>` au groupe 1000.

→ `backups/` finit non-writable par le conteneur. Même classe que le bug
« dubious ownership » du deploy-repo (un `chown -R` aveugle écrase une exception
d'ownership requise par un autre acteur).

## Correctif

`deploy/lib/user.sh` — deux helpers idempotents :

- **`ensure_backups_dir`** : crée `/srv/<slug>/backups` owned **uid:gid 1000**,
  setgid `2750` (les snapshots écrits par le conteneur héritent du groupe 1000 →
  `<slug>` peut les lire / les offsiter via rclone). Ré-asserte à chaque run.
- **`ensure_slug_in_container_group`** : ajoute `<slug>` au groupe gid 1000
  (`ls` + rclone), crée le groupe s'il n'existe pas encore sur l'hôte.

`deploy/install.sh` — appelle les deux **après** `chown_instance_home` (l'exception
au `chown -R`, comme le seam `safe.directory` du deploy-repo). Vaut aussi en
reconfigure.

`deploy/tests/unit.sh` — couvre le contrat sans root (chown vers soi-même via
`CONTAINER_UID=$(id -u)`, home jetable via `SRV_BASE`) : `backups/` créé, owned par
`CONTAINER_UID` (pas `<slug>`), setgid `2750`, ré-asserté après un clobber de mode
(reconfigure), + branche no-op de `ensure_slug_in_container_group`.

## Tests

`bash deploy/tests/unit.sh` → **120 passed, 0 failed** (6 nouveaux).

## Notes

- Branché sur le chemin commun de l'étape 7, donc s'applique aux deux modes
  d'install (legacy `.env` et secrets-as-code ADR-0044).
- Le diagnostic trompeur secondaire (logs du mauvais conteneur en étape « ETL
  test ») évoqué dans l'issue n'est **pas** traité ici — hors périmètre de ce fix.

Refs : ADR-0017 (backups) · `deploy/docker/backup_duckdb.sh` ·
`deploy/docker/docker-compose.yml` (contrat uid 1000).

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)