### PR TITLE
chore: dé-traquer --context + ignorer .ruff_cache/dist-client/node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 build/
 develop-eggs/
 dist/
+dist-client/
 downloads/
 eggs/
 .eggs/
@@ -151,6 +152,12 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# ruff
+.ruff_cache/
+
+# Node.js (outillage local : node_modules vide créé par certains outils)
+node_modules/
 
 # Pyre type checker
 .pyre/


### PR DESCRIPTION
## Quoi

Hygiène du dépôt — re-auditée contre `origin/main`.

- **`--context`** : fichier 0 octet committé par erreur à la racine (blob vide `e69de29`). Son nom commençant par `--` est interprété comme une option par ripgrep et **casse le parsing de fichiers/globs** (`rg --files`) dans le dépôt — observé pendant l'audit (faux « 0 résultat »). `git rm`.
- **`.gitignore`** : ajout de `dist-client/` (sortie de build du client), `.ruff_cache/` et `node_modules/`. Aucun n'était couvert (`dist/` ne matche pas `dist-client/`) ; ils polluaient `git status`. Vérifiés `git check-ignore` ✓.

`packages/` (membre uv workspace) et `scripts/sonde_format_aes.py` (non traqué, jetable) ne sont pas touchés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)