### PR TITLE
chore(release): 3.4.0rc8 — purge notebooks morts + hygiène dépôt (#466 #467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,24 +9,41 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
-### 🗑️ Suppressions (purge code mort)
+## [3.4.0rc8] - 2026-06-26
 
-- **14 notebooks de démo/validation obsolètes supprimés** (+ `README_validation_turpe.md`) :
+Nettoyage avant sortie stable : suppression des notebooks morts et de la surface loaders
+qu'ils maintenaient, plus hygiène dépôt et correctif déploiement backups.
+
+### 🗑️ Suppressions (Breaking Changes)
+
+- **14 notebooks de démo/validation obsolètes supprimés** (+ `README_validation_turpe.md`) (#466) :
   cassés à l'import depuis les refactors ADR-0013 (`pipeline_*` → `pipelines.*`) et ADR-0019
   (orchestration → `builds.contexte_mensuel`), tous orphelins — aucun n'était testé, empaqueté,
   ni référencé. Seul subsiste le **trio lanceur** opérateur (`accueil.py`, `facturation.py`,
   `injection_rsc.py`, seuls force-inclus et testés). La boucle de vérif des calculs **TURPE ↔ F15**
   que portaient les `validations/*` sera relogée en harnais CI (issue #468 ; cf. #215 pour
   l'oracle énergie R65).
-- **API publique loaders : `execute_custom_query` retiré** (déf + ré-exports + `__all__` dans
-  `core/loaders` et `core/loaders/duckdb`). Son seul usage était les notebooks supprimés ; le
+- **API publique loaders : `execute_custom_query` retiré** (#466) : déf + ré-exports + `__all__` dans
+  `core/loaders` et `core/loaders/duckdb`. Son seul usage était les notebooks supprimés ; le
   chemin canonique reste les query builders (`c15()`, `releves()`…) ou `.collect()`. Garde
   anti-réintroduction ajoutée au test `#181`.
-- **`DuckDBQuery.exec()` retiré** : méthode dépréciée qui ne faisait que déléguer à `.collect()`,
+- **`DuckDBQuery.exec()` retiré** (#466) : méthode dépréciée qui ne faisait que déléguer à `.collect()`,
   zéro appelant.
-- **Modèle Pandera `RequêteRelevé` retiré** : jamais référencé. `RelevéIndex` (contrat vivant)
+- **Modèle Pandera `RequêteRelevé` retiré** (#466) : jamais référencé. `RelevéIndex` (contrat vivant)
   est inchangé.
-- **Doc** : `docs/qualite-donnees-r151.md` ne pointe plus vers les notebooks de validation supprimés.
+
+### 🐛 Corrections
+
+- **Backups inaccessibles sous Docker** (#459) : `chown_instance_home` écrasait silencieusement le
+  propriétaire du répertoire `backups/` (uid 1000 au lieu du slug) → `Permission denied` à l'écriture.
+  `ensure_backups_dir` (setgid 2750) + `ensure_slug_in_container_group` créent la structure avant le
+  `chown` général ; `install.sh` ré-asserte l'ownership après.
+
+### 🔧 Hygiène dépôt
+
+- Fichier `--context` (0 octet, nom parsé comme option par ripgrep) retiré du suivi (#467).
+- `.gitignore` étendu : `dist-client/`, `.ruff_cache/`, `node_modules/` (#467).
+- **Doc** : `docs/qualite-donnees-r151.md` ne pointe plus vers les notebooks de validation supprimés (#466).
 
 ## [3.4.0rc7] - 2026-06-26
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.4.0rc7"
+version = "3.4.0rc8"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.4.0rc7"
+version = "3.4.0rc8"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Résumé

Bump version `3.4.0rc7` → `3.4.0rc8` — dernier RC avant la sortie stable `3.4.0`.

À merger **après** #466 et #467.

### Contenu de rc8

- **Purge 14 notebooks morts** (#466) : cassés à l'import depuis les refactors ADR-0013/ADR-0019, orphelins (non testés, non emballés, non référencés). Suite verte 970/25 skipped.
- **Suppressions de surface** (#466) : `execute_custom_query`, `DuckDBQuery.exec()`, modèle Pandera `RequêteRelevé` — zéro appelant hors notebooks.
- **Hygiène dépôt** (#467) : retrait du fichier `--context` (cassait rg), `.gitignore` étendu (`dist-client/`, `.ruff_cache/`, `node_modules/`).

## Checklist merge

- [x] #466 mergée
- [x] #467 mergée
- [ ] Tagger `v3.4.0rc8` après merge (CI publie l'image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)