### PR TITLE
fix(deploy): test ingestion lit API_KEY depuis le conteneur + renomme ETL→ingestion

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -15,7 +15,7 @@
 #   9. Édition .env + validation (loop)
 #  10. DNS check bloquant
 #  11. docker compose up + wait_for_health
-#  12. ETL test (mode test, ~3s)
+#  12. Test ingestion (mode test, ~3s)
 #  13. Récap final
 #
 # Mode reconfigure : si /srv/<slug>/.env existe déjà, on backup le .env,
@@ -319,14 +319,14 @@ main() {
         "API non healthy après 60s." \
         "Voir les logs : sudo -u $OPT_SLUG docker compose -f $DOCKER_DIR/docker-compose.yml logs"
 
-    # ─── Étape 12 : ETL test ────────────────────────────────────────────────
-    log_step "ETL test (mode test, ~3s)"
+    # ─── Étape 12 : test ingestion ──────────────────────────────────────────
+    log_step "Test ingestion (mode test, ~3s)"
     if run_ingestion_test "$OPT_SLUG"; then
         log_warn "Échantillon non daté → ne garantit PAS la couverture du trousseau AES ; lancer un resync pour valider la clé courante."
     else
-        log_err "ETL test échoué — la stack tourne mais la chaîne ETL ne valide pas."
+        log_err "Test ingestion échoué — la stack tourne mais la chaîne ingestion ne valide pas."
         show_ingestion_failure_hints "$OPT_SLUG"
-        log_warn "Stack laissée en place. Corrige .env et réessaye (commande ci-dessus)."
+        log_warn "Stack laissée en place. Corrige secrets.env et réessaye (commande ci-dessus)."
     fi
 
     # ─── Étape 13 : récap ───────────────────────────────────────────────────
@@ -349,7 +349,7 @@ ${ssh_recap}
   Logs             sudo -u ${OPT_SLUG} docker compose -f ${DOCKER_DIR}/docker-compose.yml logs -f
   Stop/Start       sudo -u ${OPT_SLUG} docker compose -f ${DOCKER_DIR}/docker-compose.yml {down,up -d}
   Backups          ${HOME_DIR}/backups/ (rotation 14 snapshots, cron 03:30 Europe/Paris)
-  ETL nocturne     02:00 Europe/Paris (cf. ${DOCKER_DIR}/crontab)
+  Ingestion nocturne  02:00 Europe/Paris (cf. ${DOCKER_DIR}/crontab)
 
   Étapes suivantes recommandées :
     - Configurer un offsite des backups (rclone vers un cloud — cf. docs/deploiement.md)

--- a/deploy/lib/ingestion.sh
+++ b/deploy/lib/ingestion.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-# Lancement d'un ETL test (mode test = échantillon de 2 fichiers/flux) pour vérifier
+# Lancement d'un test ingestion (mode test = échantillon de 2 fichiers/flux) pour vérifier
 # que la chaîne SFTP/file → déchiffrement AES → DuckDB répond. ATTENTION : l'échantillon
 # n'est pas trié par date → il ne valide PAS la couverture du trousseau AES (une clé
 # courante manquante peut passer inaperçue). Validation réelle = resync (cf. install.sh).
@@ -61,19 +61,23 @@ poll_ingestion_job() {
         (( i < max )) && sleep "$delay"
         i=$((i+1))
     done
-    log_warn "ETL test : job ${job_id} toujours en cours après ${max} tentatives — timeout."
+    log_warn "Test ingestion : job ${job_id} toujours en cours après ${max} tentatives — timeout."
     return 1
 }
 
 # run_ingestion_test <slug>
-# Lance le test ETL (POST /ingestion/run mode=test), attend la complétion par poll,
+# Lance le test ingestion (POST /ingestion/run mode=test), attend la complétion par poll,
 # et logue le résultat. Retourne 0 si le job est completed, 1 sinon.
 run_ingestion_test() {
     local slug="$1"
     local home="/srv/${slug}"
     local api_key
-    api_key=$(read_env_var "${home}/.env" API_KEY)
-    [[ -n "$api_key" ]] || { log_err "API_KEY introuvable dans ${home}/.env"; return 1; }
+    # Depuis ADR-0044, les secrets vivent dans secrets.env chiffré (plus de .env en clair).
+    # API_KEY est injecté dans le conteneur api par l'entrypoint SOPS — on le lit depuis là.
+    api_key=$(sudo -u "$slug" -- bash -c \
+        "cd '${home}/deploy/docker' && \
+         docker compose exec -T api printenv API_KEY" 2>/dev/null)
+    [[ -n "$api_key" ]] || { log_err "API_KEY introuvable dans le conteneur api (stack démarrée ? secrets déchiffrés ?)"; return 1; }
 
     local resp job_id
     resp=$(_ingestion_call_post "$slug" "$api_key") || {
@@ -86,9 +90,9 @@ run_ingestion_test() {
         return 1
     }
 
-    log_info "Job ETL démarré : ${job_id} — attente de la complétion…"
+    log_info "Job ingestion démarré : ${job_id} — attente de la complétion…"
     if poll_ingestion_job "$slug" "$api_key" "$job_id"; then
-        log_ok "ETL test réussi — chaîne SFTP→déchiffrement→DuckDB OK sur un échantillon (2 fichiers)."
+        log_ok "Test ingestion réussi — chaîne SFTP→déchiffrement→DuckDB OK sur un échantillon (2 fichiers)."
         return 0
     else
         return 1
@@ -111,8 +115,10 @@ show_ingestion_failure_hints() {
         2>&1 | sed 's/^/     | /'
     log_info ""
     log_info "Pour réessayer après correction :"
+    log_info "  # La clé API est dans le conteneur (secrets SOPS) :"
+    log_info "  API_KEY=\$(sudo -u $slug -- bash -c 'cd ${home}/deploy/docker && docker compose exec -T api printenv API_KEY')"
     log_info "  sudo -u $slug docker compose -f ${home}/deploy/docker/docker-compose.yml \\"
-    log_info "      exec ingestion-scheduler curl -X POST -H \"X-API-Key:\$API_KEY\" \\"
+    log_info "      exec -T ingestion-scheduler curl -X POST -H \"X-API-Key:\$API_KEY\" \\"
     log_info "      -H 'Content-Type: application/json' -d '{\"mode\":\"test\"}' \\"
     log_info "      http://api:8001/ingestion/run"
 }


### PR DESCRIPTION
## Summary

- **Fix API_KEY** : `run_ingestion_test()` lisait `API_KEY` dans `${home}/.env` qui n'existe plus depuis ADR-0044 (secrets SOPS). Lit maintenant via `docker compose exec -T api printenv API_KEY` — le conteneur `api` a déjà décrypté ses secrets à l'entrypoint.
- **Renommage** : "ETL test" → "test ingestion" dans `install.sh` et `ingestion.sh` (commentaires, logs, labels d'étape).
- **Hints mis à jour** : la commande de réessai montre comment récupérer l'API_KEY depuis le conteneur.

## Test plan

- [ ] `bash deploy/tests/unit.sh` → verts
- [ ] Sur une box secrets-as-code : step "Test ingestion" de `install.sh` → passe sans `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)