### PR TITLE
fix(deploy): test ingestion — parser le job id sous la clé "id" (pas "job_id")

### DIFF
--- a/deploy/lib/ingestion.sh
+++ b/deploy/lib/ingestion.sh
@@ -5,9 +5,12 @@
 # courante manquante peut passer inaperçue). Validation réelle = resync (cf. install.sh).
 
 # _ingestion_parse_job_id <json>
-# Extrait le job_id d'une réponse JSON /ingestion/run.
+# Extrait l'identifiant de job de la réponse POST /ingestion/run. L'API le sérialise sous
+# la clé "id" (IngestionJobResponse.id) — PAS "job_id", qui n'est qu'un nom de paramètre de
+# route et de prose. Au POST (202), "output" est null → aucune autre occurrence de "id" ne
+# parasite l'extraction.
 _ingestion_parse_job_id() {
-    printf '%s\n' "$1" | sed -n 's/.*"job_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1
+    printf '%s\n' "$1" | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1
 }
 
 # _ingestion_parse_status <json>

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -545,11 +545,14 @@ assert_eq "$(cat "$usermod_log" 2>/dev/null)" "-aG edn-data edn" \
 rm -rf "$stub_dir"
 
 echo
-echo "→ ingestion.sh / _ingestion_parse_job_id"
-assert_eq "$(_ingestion_parse_job_id '{"job_id":"abc-123","status":"running"}')" \
-    "abc-123" "_ingestion_parse_job_id: extrait le job_id"
-assert_eq "$(_ingestion_parse_job_id '{"job_id": "spaced-id","status":"running"}')" \
+echo "→ ingestion.sh / _ingestion_parse_job_id (clé réelle de l'API = id, pas job_id)"
+# Forme RÉELLE de la réponse POST /ingestion/run (202, IngestionJobResponse, output=null).
+assert_eq "$(_ingestion_parse_job_id '{"id":"abc-123","mode":"test","status":"running","started_at":"2026-06-26T16:56:16","finished_at":null,"error":null,"output":null}')" \
+    "abc-123" "_ingestion_parse_job_id: extrait id sur la réponse POST réelle"
+assert_eq "$(_ingestion_parse_job_id '{"id": "spaced-id","status":"running"}')" \
     "spaced-id" "_ingestion_parse_job_id: tolère l'espace après :"
+assert_eq "$(_ingestion_parse_job_id '{"job_id":"old-shape"}')" \
+    "" "_ingestion_parse_job_id: ignore l'ancienne clé fictive job_id (régression)"
 assert_eq "$(_ingestion_parse_job_id '{}')" \
     "" "_ingestion_parse_job_id: champ absent → vide"
 


### PR DESCRIPTION
## Contexte

Suite de #473 (mergée). Une fois la clé scheduler débloquée, l'étape « Test ingestion »
(`install.sh`, 14/15) bute sur l'erreur suivante en prod :

```
✗ Pas de job_id dans la réponse POST /ingestion/run.
```

## Root cause

La réponse `202` de `POST /ingestion/run` (`IngestionJobResponse`) sérialise l'identifiant
de job sous la clé **`id`** ([models.py](electricore/api/models.py) `id: str`, renvoyé par
`IngestionJobResponse(id=job.id, …)`). `"job_id"` n'est qu'un **nom de paramètre de route**
(`/ingestion/jobs/{job_id}`) et de prose — jamais une clé de la réponse JSON.

`_ingestion_parse_job_id` cherchait `"job_id"` → ne matchait jamais → « Pas de job_id ».

**Bug latent** : les tests unitaires nourrissaient une forme *fabriquée* `{"job_id":…}` au
lieu de la réponse réelle de l'API, donc verts à tort. Il n'a fait surface que parce que le
POST atteint enfin l'API (clé scheduler corrigée dans #473).

## Changements

- `_ingestion_parse_job_id` parse désormais la clé `"id"` (au POST, `output` est `null` → pas
  d'autre occurrence de `"id"` qui parasite l'extraction).
- Tests rebâtis sur la forme **RÉELLE** du `202` (`{"id":…,"mode":…,"status":…,"output":null}`)
  + garde de régression : l'ancienne clé fictive `{"job_id":…}` ne matche plus.
- `deploy/tests/unit.sh` : `170 passed, 0 failed`.

## Test plan

- [x] `bash deploy/tests/unit.sh` vert
- [ ] Re-déployer + relancer l'étape 14/15 → le POST renvoie un `id`, le poll suit le job

🤖 Generated with [Claude Code](https://claude.com/claude-code)