### PR TITLE
chore(cleanup): prune dead code (symboles jamais référencés)

### DIFF
--- a/electricore/api/models.py
+++ b/electricore/api/models.py
@@ -4,80 +4,8 @@ Définit les structures de données Pydantic pour les réponses API.
 """
 
 from datetime import date, datetime
-from typing import Any
 
 from pydantic import BaseModel, Field
-
-
-class APIResponse(BaseModel):
-    """Modèle de base pour toutes les réponses API."""
-
-    message: str = Field(..., description="Message descriptif de la réponse")
-    timestamp: datetime = Field(default_factory=datetime.now, description="Horodatage de la réponse")
-
-
-class FluxData(BaseModel):
-    """Modèle pour les données de flux Enedis."""
-
-    table: str = Field(..., description="Nom de la table flux")
-    filters: dict[str, Any] | None = Field(None, description="Filtres appliqués")
-    pagination: dict[str, int] = Field(..., description="Informations de pagination")
-    data: list[dict[str, Any]] = Field(..., description="Données du flux")
-
-
-class TableInfo(BaseModel):
-    """Modèle pour les informations sur une table."""
-
-    table: str = Field(..., description="Nom complet de la table")
-    db_schema: str = Field(..., description="Schéma de la table")
-    count: int = Field(..., description="Nombre total de lignes")
-    columns: list[dict[str, str]] = Field(..., description="Liste des colonnes avec leurs types")
-
-
-class APIKeyConfiguration(BaseModel):
-    """Modèle pour la configuration des clés API."""
-
-    total_keys: int = Field(..., description="Nombre total de clés configurées")
-    methods_enabled: dict[str, bool] = Field(..., description="Méthodes d'authentification activées")
-    public_endpoints: list[str] = Field(..., description="Liste des endpoints publics")
-
-
-class APIKeyInfo(BaseModel):
-    """Modèle pour les informations sur une clé API utilisée."""
-
-    preview: str = Field(..., description="Aperçu de la clé API (masquée)")
-    source: str = Field(..., description="Source de la clé (header/query)")
-    is_valid: bool = Field(..., description="Validité de la clé")
-
-
-class HealthStatus(BaseModel):
-    """Modèle pour le statut de santé de l'API."""
-
-    status: str = Field(..., description="Statut global de l'API")
-    api_version: str = Field(..., description="Version de l'API")
-    database: str = Field(..., description="Statut de la base de données")
-    tables_count: int = Field(..., description="Nombre de tables disponibles")
-    authentication: dict[str, Any] = Field(..., description="Configuration de l'authentification")
-
-
-class APIError(BaseModel):
-    """Modèle pour les erreurs API."""
-
-    error: str = Field(..., description="Type d'erreur")
-    message: str = Field(..., description="Message d'erreur détaillé")
-    details: dict[str, Any] | None = Field(None, description="Détails supplémentaires sur l'erreur")
-
-
-class WelcomeMessage(BaseModel):
-    """Modèle pour le message d'accueil de l'API."""
-
-    message: str = Field(..., description="Message de bienvenue")
-    version: str = Field(..., description="Version de l'API")
-    authentication: dict[str, Any] = Field(..., description="Informations d'authentification")
-    available_tables: list[str] = Field(..., description="Tables disponibles")
-    examples: dict[str, str] = Field(..., description="Exemples d'utilisation")
-    docs: str = Field(..., description="URL de la documentation")
-
 
 # Modèles ingestion
 
@@ -121,35 +49,3 @@ class PeremptionResponse(BaseModel):
     dernier_start: date = Field(..., description="Dernière entrée en vigueur connue")
     consigne: str = Field(..., description="Quoi vérifier (délibération CRE, loi de finances)")
     message: str = Field(..., description="Message prêt à afficher")
-
-
-# Modèles pour les requêtes (si nécessaire pour des POST/PUT futurs)
-
-
-class FluxQuery(BaseModel):
-    """Modèle pour les requêtes de flux avancées."""
-
-    table_name: str = Field(..., description="Nom de la table à interroger")
-    filters: dict[str, Any] | None = Field(None, description="Filtres à appliquer")
-    columns: list[str] | None = Field(None, description="Colonnes à sélectionner")
-    limit: int = Field(100, ge=1, le=1000, description="Nombre maximum de résultats")
-    offset: int = Field(0, ge=0, description="Décalage pour la pagination")
-    order_by: str | None = Field(None, description="Colonne pour le tri")
-
-
-class APIKeyRequest(BaseModel):
-    """Modèle pour les requêtes de gestion des clés API (futur)."""
-
-    name: str | None = Field(None, description="Nom descriptif de la clé API")
-    permissions: list[str] = Field(default=["read"], description="Permissions accordées")
-    expires_at: datetime | None = Field(None, description="Date d'expiration optionnelle")
-
-
-class APIKeyResponse(BaseModel):
-    """Modèle pour les réponses de création de clés API (futur)."""
-
-    api_key: str = Field(..., description="Clé API générée")
-    name: str | None = Field(None, description="Nom descriptif")
-    permissions: list[str] = Field(..., description="Permissions accordées")
-    created_at: datetime = Field(default_factory=datetime.now, description="Date de création")
-    expires_at: datetime | None = Field(None, description="Date d'expiration")

--- a/electricore/api/security.py
+++ b/electricore/api/security.py
@@ -49,19 +49,6 @@ def get_api_key(api_key: str | None = Security(api_key_header)) -> str:
 get_current_api_key = get_api_key
 
 
-def is_public_endpoint(path: str) -> bool:
-    """
-    Vérifie si un endpoint est public (sans authentification requise).
-
-    Args:
-        path: Chemin de l'endpoint
-
-    Returns:
-        bool: True si l'endpoint est public
-    """
-    return path in PUBLIC_ENDPOINTS
-
-
 @dataclass(frozen=True, slots=True)
 class APIKeyInfo:
     """Informations sur une clé API utilisée (pour logging/monitoring)."""

--- a/electricore/bot/client.py
+++ b/electricore/bot/client.py
@@ -125,10 +125,6 @@ class ElectriCoreClient:
         """Avertissements de péremption des taux régulés — #186, ADR-0024."""
         return await self._get_json("/taxes/peremption")
 
-    async def get_facturation_xlsx(self, mois: str | None = None) -> bytes:
-        params = {"mois": mois} if mois else None
-        return await self._get_bytes("/facturation/rapport.xlsx", params=params, timeout=TIMEOUT_LOURD)
-
     async def get_facturation_documents_xlsx(self, mois: str | None = None) -> bytes:
         """Livrable XLSX multi-onglets des documents de campagne facturation (cf. #78)."""
         params = {"mois": mois} if mois else None

--- a/electricore/ingestion/transformers/crypto.py
+++ b/electricore/ingestion/transformers/crypto.py
@@ -120,24 +120,6 @@ def load_aes_key_chain() -> list[tuple[str, bytes, bytes]]:
     return runtime.aes().chaine()
 
 
-def load_aes_credentials() -> tuple[bytes, bytes | None]:
-    """
-    Charge la clé AES principale (compatibilité ascendante).
-
-    Préférer load_aes_key_chain() pour la gestion de la rotation de clés.
-
-    Returns:
-        Tuple (aes_key, aes_iv) de la première clé disponible — `aes_iv` vaut `None`
-        pour une entrée à schéma IV-préfixé (ADR-0040).
-
-    Raises:
-        ValueError: Si les clés ne peuvent pas être chargées
-    """
-    chain = load_aes_key_chain()
-    _, key, iv = chain[0]
-    return key, iv
-
-
 def decrypt_with_key_chain(
     encrypted_data: bytes,
     key_chain: list[tuple[str, bytes, bytes | None]],


### PR DESCRIPTION
## Quoi

Suppression de **code mort vérifié** : symboles définis mais jamais référencés dans tout le dépôt (code, tests, docs), avec chemin de remplacement confirmé. **139 suppressions, 4 fichiers.**

## Méthode

- **ast-grep** : inventaire structurel des 579 def/classes/méthodes top-level + comptage de références repo-wide (electricore/, packages/, tests/, docs/).
- **ruff** `F401/F811/F841` : déjà propre (pre-commit l'impose) — rien à glaner côté imports/vars inutilisés.
- **vulture** comme signal indépendant : ~90 % de faux positifs (routes FastAPI, champs de schémas Pandera, `model_config` pydantic) → filtré, puis **chaque candidat vérifié à la main**.

Piège attrapé : `APIKeyInfo` et `APIError` existent **en double** — une copie pydantic morte dans `api/models.py` et la *vraie* (dataclass / Exception) dans `security.py` / `bot/client.py`. Seules les copies mortes sont retirées.

## Détail

| Fichier | Suppression | Pourquoi mort |
|---|---|---|
| `api/models.py` | 11 classes pydantic (`APIResponse`, `FluxData`, `TableInfo`, `APIKeyConfiguration`, `APIKeyInfo`, `HealthStatus`, `APIError`, `WelcomeMessage`, `FluxQuery`, `APIKeyRequest`, `APIKeyResponse`) | Jamais importées — scaffolding annoté « futur ». Restent les 4 modèles utilisés (ingestion + taxes) ; import `Any` devenu inutile retiré. |
| `api/security.py` | `is_public_endpoint()` | Vestige de l'auth middleware — l'auth se fait par route via `Depends`. La constante `PUBLIC_ENDPOINTS` reste (utilisée par admin). |
| `ingestion/transformers/crypto.py` | `load_aes_credentials()` | Shim mono-clé supersédé par `load_aes_key_chain()` / `decrypt_with_key_chain()` (ADR-0037/0040). |
| `bot/client.py` | `get_facturation_xlsx()` | Le handler utilise `get_facturation_documents_xlsx` ; l'endpoint serveur `/facturation/rapport.xlsx` reste. |

## Volontairement **non** touché (jugement)

- `api/config.py::is_valid_api_key` — inutilisé, mais `APISettings` est une façade de compat délibérée (docstring).
- `api/decorators.py::zip_endpoint` — aucune route ZIP, mais symétrique de `xlsx_endpoint`/`arrow_endpoint`.

## Tests

Suite complète verte : **912 passed, 35 skipped** (skips légitimes : secrets Odoo, marimo, extra dbt). Aucun test ne référençait les symboles retirés. `ruff check` + `ruff format` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)