### PR TITLE
Ingestion: escalade d'échec généralisée du déchiffrement à toute la chaîne (StatsChaine, #445)

### DIFF
--- a/electricore/ingestion/runner.py
+++ b/electricore/ingestion/runner.py
@@ -104,7 +104,7 @@ def interpreter_flux(flux: list[str], max_files: int | None) -> PlanRun:
 def lander_brut(db_path: Path, plan: PlanRun) -> dict[str, StatsChaine]:
     """Étape 1 : SFTP → tables raw_<flux> (colonne JSON) dans flux_raw.
 
-    Retourne les stats de déchiffrement agrégées par flux (escalade per-flux, ADR-0037) :
+    Retourne les stats de chaîne agrégées par flux (escalade per-flux, ADR-0037 étendu) :
     le caller décide ensuite si un flux aveugle doit faire échouer le job.
     """
     config = yaml.safe_load((ICI / "config" / "flux.yaml").read_text())
@@ -304,9 +304,12 @@ def main() -> None:
     _out("🔨 dbt build")
     if not construire_dbt(args.db):
         # Si rien n'a été construit alors que des flux sont aveugles, la vraie cause est
-        # la clé AES manquante, pas dbt — surfacer le bon diagnostic.
+        # en amont (un étage de la chaîne est resté sombre), pas dbt — surfacer le bon diagnostic.
         if aveugles:
-            _out(f"❌ Aucun déchiffrement réussi pour : {', '.join(aveugles)} (clé AES manquante ?)")
+            _out(
+                f"❌ Flux aveugles (0 document produit) : {', '.join(aveugles)} "
+                "— étage(s) sombre(s) au bilan de chaîne ci-dessus"
+            )
         else:
             _out("❌ dbt build a échoué")
         sys.exit(1)
@@ -315,10 +318,14 @@ def main() -> None:
     _out("📊 Bilan")
     bilan(args.db)
 
-    # Escalade per-flux (ADR-0037) : un flux qui a des fichiers mais 0 déchiffrement réussi
-    # fait échouer le job — la surveillance bot alerte alors sur un job `failed`. Placé après
-    # le dbt build pour que les flux sains continuent de couler malgré le flux aveugle.
+    # Escalade per-flux (ADR-0037 étendu) : un flux qui a des fichiers mais 0 document produit
+    # — quel que soit l'étage resté sombre (déchiffrement, extraction ou linéarisation) — fait
+    # échouer le job ; la surveillance bot alerte alors sur un job `failed`. Placé après le dbt
+    # build pour que les flux sains continuent de couler malgré le flux aveugle.
     if aveugles:
-        _out(f"❌ Flux sans aucun déchiffrement réussi (clé AES manquante ?) : {', '.join(aveugles)}")
+        _out(
+            f"❌ Flux aveugles (0 document produit) : {', '.join(aveugles)} "
+            "— étage(s) sombre(s) au bilan de chaîne ci-dessus"
+        )
         sys.exit(1)
     _out("✅ Terminé")


### PR DESCRIPTION
## Résumé

Généralise l'escalade d'échec per-flux (ADR-0037) du seul étage `decrypt` à **toute la chaîne** `decrypt | unzip | parse`. L'invariant « des fichiers en entrée + 0 document en sortie → job `failed` » vit désormais dans **un** objet de comptage (`StatsChaine`) et **un** prédicat (`flux_aveugle`). Closes #445.

## Le spike qui a reformé la prémisse

L'hypothèse naïve « `parse` avale ses échecs en silence » a été **falsifiée**. Les deux étages aval se comportaient de façon **opposée**, et tous deux mal :

| Étage | Sur un fichier fautif | Observable ? | Rayon de souffle |
|-------|-----------------------|--------------|------------------|
| `decrypt` | `except` → compte, continue | ✅ escalade si flux aveugle | isolé |
| `unzip` | `except: log + return`, **aucun compteur** | ❌ **silencieux** | drop les documents du zip |
| `parse` | **lève** `PipelineStepFailed` | ✅ bruyant | ❌ **aborte tout l'`extract`** (aucun flux ne land) |

`unzip` était le vrai trou silencieux ; `parse` était trop bruyant et non isolé — un seul document R64 malformé crashait le landing de **tous** les flux du cycle.

## Ce que fait la PR

- **Discipline uniforme** `attraper → compter → continuer` sur les trois étages — un fichier fautif n'aborte jamais le run.
- **`StatsDechiffrement` → `StatsChaine`** : compteurs par étage (`fichiers`/`dechiffres`/`extraits`/`documents` + `echecs_dechiffrement`/`echecs_extraction`/`echecs_linearisation`), un seul objet partagé par les trois factories de transformer du flux.
- **Prédicat unique généralisé** : `flux_aveugle()` = `documents == 0 ET echecs() > 0`. L'`echecs()` explicite distingue un flux *drop-par-erreur* (escalade) d'un flux *vide par nature* (zip sans fichier interne → `echecs() == 0` ⇒ jamais d'escalade). `flux_sans_dechiffrement` → `flux_aveugles`.
- **Observabilité** : le runner imprime un `_resume_chaine` par flux (mouvement + échecs ventilés) dans le landing → capté dans `job.output` via le seam subprocess de l'API → visible au détail de job du bot, sans nouveau canal d'alerte.

## Tests (TDD, vertical slices)

Harness `file://` étendu (`test_escalade_dechiffrement.py` → `test_escalade_chaine.py`) :
- **Unit par étage** : decrypt / unzip (ZIP corrompu compté sans crash) / parse — dont le **pin du spike** : un document malformé ne lève jamais `PipelineStepFailed`.
- **Truth-table** `flux_aveugle()` : sombre / isolé / propre / vide-par-nature.
- **Bout-en-bout** (un run) : C15 sombre (aveugle), R64 mixte (échec à chaque étage aval mais 1 document landé → NON aveugle), R15 vide-par-nature (NON aveugle). Le run ne plante pas malgré le document R64 malformé.

Suite ingestion complète : 92 passed. (Les échecs `test_rsc_endpoint`/`test_operator_launcher` de la suite globale sont étrangers à cette PR : RSC = WIP concurrent en cours d'édition ; `test_operator_launcher` échoue déjà sur `main`.)

## Record

- ADR-0037 amendé d'une section **Extension** (généralisation, discipline, choix délibéré de ne pas aborter, spike cité).
- Glossaire `electricore/ingestion/CONTEXT.md` : entrée « escalade d'échec de **chaîne** ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)
