### PR TITLE
fix(core): départage déterministe événement/FACTURATION au même instant (#270)

### DIFF
--- a/electricore/core/pipelines/historique.py
+++ b/electricore/core/pipelines/historique.py
@@ -227,9 +227,17 @@ def detecter_points_de_rupture(spine: pl.LazyFrame) -> pl.LazyFrame:
     """
     return (
         spine.sort(
-            ["ref_situation_contractuelle", "date_evenement"],
-            # Départage des ex-aequo de timestamp : événement avant FACTURATION, comme le
-            # forward-fill SQL de la spine (garde-fou #374 : pas de collision de situation).
+            [
+                "ref_situation_contractuelle",
+                "date_evenement",
+                # Départage des ex-aequo de timestamp : événement AVANT facturation (False < True),
+                # exactement comme le forward-fill SQL de la spine (`spine_contrat.sql`). Sans cette
+                # clé, une borne FACTURATION partageant l'instant d'un vrai événement (ex. MCT pile
+                # minuit le 1er) pouvait capter l'état d'avant ou d'après le changement (6 vs 9 kVA)
+                # selon un ordre arbitraire (issue #270). Le garde-fou #374 exclut par ailleurs les
+                # collisions de situation entre deux vrais événements au même instant.
+                (pl.col("type_fait") == "facturation"),
+            ],
             maintain_order=True,
         )
         .set_sorted("ref_situation_contractuelle")  # Indiquer explicitement que ref_situation_contractuelle est trié

--- a/tests/unit/test_pipeline_historique_spine.py
+++ b/tests/unit/test_pipeline_historique_spine.py
@@ -70,3 +70,73 @@ def test_pipeline_historique_force_facturation_a_impacter_abonnement():
     assert impacts["FACTURATION"] is True  # borne de période, même sans changement de situation
     assert impacts["MES"] is True  # événement structurant d'entrée
     assert impacts["MCT"] is True  # changement de puissance 6 → 9
+
+
+def _spine_collision_minuit_1er() -> pl.LazyFrame:
+    """Spine où un **vrai** événement (MCT, 9 kVA) tombe pile au **même instant** qu'une
+    borne FACTURATION (minuit le 1er) — la collision de l'issue #270.
+
+    Les deux jumeaux sont fournis dans l'**ordre adverse** : la borne FACTURATION *avant*
+    l'événement réel. C'est un ordre que la sortie non triée du mart `spine_contrat` peut
+    produire (un mart dbt ne garantit pas l'ordre des lignes). Faithful au forward-fill SQL
+    de la spine (départage événement-avant-facturation, `spine_contrat.sql`), les deux
+    jumeaux portent déjà la situation post-changement (9.0 kVA).
+    """
+    return pl.LazyFrame(
+        {
+            "date_evenement": [
+                datetime(2024, 1, 15, 0, 1, tzinfo=PARIS),  # MES entrée 6 kVA
+                datetime(2024, 2, 1, 0, 0, tzinfo=PARIS),  # FACTURATION 6 kVA
+                datetime(2024, 3, 1, 0, 0, tzinfo=PARIS),  # FACTURATION jumelle 9 kVA — placée AVANT
+                datetime(2024, 3, 1, 0, 0, tzinfo=PARIS),  # MCT 9 kVA — collision pile minuit le 1er
+            ],
+            "pdl": ["PDL00001"] * 4,
+            "ref_situation_contractuelle": ["REF001"] * 4,
+            "source": ["flux_C15", "synthese_mensuelle", "synthese_mensuelle", "flux_C15"],
+            "type_fait": ["evenement", "facturation", "facturation", "evenement"],
+            "evenement_declencheur": ["MES", "FACTURATION", "FACTURATION", "MCT"],
+            "type_evenement": ["contractuel", "artificiel", "artificiel", "contractuel"],
+            "segment_clientele": ["C5"] * 4,
+            "etat_contractuel": ["EN SERVICE"] * 4,
+            "puissance_souscrite_kva": [6.0, 6.0, 9.0, 9.0],
+            "formule_tarifaire_acheminement": ["BTINFCU4"] * 4,
+            "type_compteur": ["LINKY"] * 4,
+            "num_compteur": ["123456"] * 4,
+            "categorie": [None] * 4,
+            "ref_demandeur": [None] * 4,
+            "id_affaire": [None] * 4,
+            "niveau_ouverture_services": ["2"] * 4,
+            "date_changement_niveau_ouverture_services": [None] * 4,
+        },
+        schema_overrides={
+            "date_evenement": pl.Datetime(time_unit="us", time_zone="Europe/Paris"),
+            "categorie": pl.Utf8,
+            "ref_demandeur": pl.Utf8,
+            "id_affaire": pl.Utf8,
+            "date_changement_niveau_ouverture_services": pl.Date,
+        },
+    )
+
+
+def test_collision_minuit_1er_attribue_le_changement_a_l_evenement_reel():
+    """Régression #270 : à un instant partagé par un vrai événement (MCT) et une borne
+    FACTURATION (minuit le 1er), le départage déterministe (événement **avant** facturation,
+    comme le forward-fill SQL de la spine) attribue le changement 6 → 9 au **vrai** événement
+    et laisse la borne FACTURATION « sans changement » — quel que soit l'ordre des lignes en
+    entrée. Sans départage, la photo FACTURATION pouvait capter la valeur d'avant ou d'après
+    le changement (6 vs 9 kVA) selon un ordre arbitraire."""
+    horizon = datetime(2024, 4, 1, tzinfo=PARIS)
+
+    result = pipeline_historique(_spine_collision_minuit_1er(), horizon=horizon).collect()
+
+    collision = result.filter(pl.col("date_evenement") == datetime(2024, 3, 1, 0, 0, tzinfo=PARIS))
+    mct = collision.filter(pl.col("evenement_declencheur") == "MCT").row(0, named=True)
+    facturation = collision.filter(pl.col("evenement_declencheur") == "FACTURATION").row(0, named=True)
+
+    # Le vrai événement porte le changement de puissance (6 → 9)
+    assert mct["avant_puissance_souscrite"] == 6.0
+    assert mct["resume_modification"] == "P: 6.0 → 9.0"
+
+    # La borne FACTURATION jumelle voit déjà l'état post-changement → aucun changement
+    assert facturation["avant_puissance_souscrite"] == 9.0
+    assert facturation["resume_modification"] == ""


### PR DESCRIPTION
## Contexte

Faisant le point sur #270 : le cœur a évolué (ADR-0041 / #378 a descendu l'assemblage de la *Chronologie du contrat* en spine dbt). Le **symptôme facturable** de #270 — la photo FACTURATION qui captait une puissance avant *ou* après un changement (6 vs 9 kVA) selon un ordre arbitraire — est **résolu à la source** : le forward-fill de situation vit désormais en SQL avec un départage déterministe (`spine_contrat.sql`), et le garde-fou #374 fait échouer le build si deux vrais événements C15 collisionnent.

Restait **un résidu côté cœur** : `detecter_points_de_rupture` re-triait la spine par `[RSC, date_evenement]` **sans clé de départage**, alors que son commentaire *prétendait* « événement avant FACTURATION, comme le forward-fill SQL de la spine ». Sur une collision pile minuit le 1er (vrai événement ↔ borne FACTURATION), le `shift(1)` attribuait le changement à la mauvaise ligne. Cosmétique (n'impacte que `resume_modification`/`avant_*`, lus par le cockpit chronologie read-only), mais adossé à un **commentaire mensonger**.

## Changement

Ajoute la 3ᵉ clé de tri `(pl.col("type_fait") == "facturation")` dans le tri de `detecter_points_de_rupture` ([historique.py](../blob/fix/270-departage-collision-spine/electricore/core/pipelines/historique.py)) : l'événement réel passe toujours **avant** la FACTURATION au même instant (`False < True`), exactement comme `order by date_evenement, (case when type_fait='facturation' then 1 else 0 end)` de la spine. Le code rejoint son propre commentaire.

## TDD

- **RED** : `test_collision_minuit_1er_attribue_le_changement_a_l_evenement_reel` — un MCT (6→9 kVA) en collision pile minuit le 1er, **lignes fournies dans l'ordre adverse** (l'ordre non garanti qu'un mart dbt peut émettre). Sans départage, le changement est attribué à la borne FACTURATION (`avant=6.0`) au lieu du vrai événement.
- **GREEN** : après le départage, le MCT porte `P: 6.0 → 9.0` / `avant=6.0`, la borne FACTURATION jumelle reste `avant=9.0` / `resume=""`.

## `abonnements.py` laissé inchangé — délibéré

Les **périodes facturées** sont invariantes à l'ordre des jumeaux : les deux portent la même puissance forward-fillée (spine) et la période inter-jumeaux de durée nulle est filtrée par `nb_jours > 0`. Vérifié empiriquement (200 shuffles → périodes byte-identiques). ⚠️ Cette invariance est **empruntée** à la spine dbt + garde-fou #374, pas locale : si #374 sautait ou si un caller non-spine alimentait des jumeaux à puissances divergentes, `abonnements.py` aurait besoin de son propre départage. Hors scope ici.

## Vérification adversariale

3 sceptiques indépendants (billing-invariance, sweep des consommateurs d'ordre, null-safety/sémantique de la clé) → tous `confirmed_safe`. Aucune instance sœur de l'anti-pattern (l'énergie déduplique `chronologie_releves` au grain unique en dbt). `type_fait` non-null sur 3 couches.

## Tests

738 passent (le seul échec local est `marimo._server` absent, extra viz non installé — sans rapport). Snapshots d'intégration facturation **inchangés** : la sortie facturable ne bouge pas.

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)