### PR TITLE
refactor(ingestion): combinateur etape_chaine — effondre la discipline de chaîne (#479)

### DIFF
--- a/electricore/ingestion/runner.py
+++ b/electricore/ingestion/runner.py
@@ -32,7 +32,7 @@ import yaml
 
 from electricore.config import runtime
 from electricore.ingestion.sources.sftp_enedis_brut import flux_enedis_brut
-from electricore.ingestion.transformers.crypto import StatsChaine
+from electricore.ingestion.transformers.chaine import StatsChaine
 
 # DLT écrit sur stderr — on laisse faire, on ne lit que stdout
 logging.disable(logging.CRITICAL)

--- a/electricore/ingestion/sources/sftp_enedis_brut.py
+++ b/electricore/ingestion/sources/sftp_enedis_brut.py
@@ -22,8 +22,8 @@ from electricore.config import runtime
 from electricore.ingestion.parsing.xml import xml_vers_dict
 from electricore.ingestion.sources.sftp_enedis import create_sftp_resource, mask_password_in_url
 from electricore.ingestion.transformers.archive import create_unzip_transformer
+from electricore.ingestion.transformers.chaine import StatsChaine, etape_chaine
 from electricore.ingestion.transformers.crypto import (
-    StatsChaine,
     create_decrypt_transformer,
     load_aes_key_chain,
 )
@@ -31,26 +31,22 @@ from electricore.ingestion.transformers.crypto import (
 logger = logging.getLogger(__name__)
 
 
-def _vers_document_brut_base(
-    extracted_file: dict, flux_type: str, est_json: bool, stats: StatsChaine
-) -> Iterator[dict]:
-    """Étage parse : fichier extrait → document brut (colonne JSON), avec comptage.
+@etape_chaine(
+    succes="documents",
+    echec="echecs_linearisation",
+    libelle="linéarisation",
+    cle_item="extracted_file_name",
+)
+def _vers_document_brut(extracted_file: dict, flux_type: str, est_json: bool) -> Iterator[dict]:
+    """Étage parse : fichier extrait → document brut (colonne JSON).
 
-    Discipline « attraper → compter → continuer » (ADR-0037 étendu) : un document
-    malformé (JSON/XML illisible) est compté `echecs_linearisation` et sauté — JAMAIS une
-    exception propagée. C'est le pin du spike : une exception non rattrapée d'un transformer
-    fait lever à dlt un `PipelineStepFailed` qui **aborte tout l'`extract`** (tous les flux
-    du run, pas seulement le fichier fautif). Un document linéarisé incrémente `documents`.
+    Ne déclare que **son travail** (linéariser le contenu) : un JSON/XML illisible **lève**.
+    La discipline « attraper → compter → continuer » (capture, comptage `documents`/
+    `echecs_linearisation`, non-propagation — le pin du spike anti-`PipelineStepFailed`)
+    vit dans `etape_chaine`.
     """
     contenu: bytes = extracted_file["extracted_content"]
-    try:
-        document = json.loads(contenu) if est_json else xml_vers_dict(contenu)
-    except Exception as e:  # noqa: BLE001 — tout échec de linéarisation est compté, jamais propagé
-        stats.echecs_linearisation += 1
-        logger.warning("Échec linéarisation %s : %s", extracted_file["extracted_file_name"], e)
-        return
-
-    stats.documents += 1
+    document = json.loads(contenu) if est_json else xml_vers_dict(contenu)  # lève → échec compté
     yield {
         "file_name": extracted_file["extracted_file_name"],
         "modification_date": extracted_file["modification_date"],
@@ -65,7 +61,7 @@ def _create_brut_transformer(flux_type: str, est_json: bool, stats: StatsChaine)
 
     @dlt.transformer
     def vers_document_brut(extracted_file: dict) -> Iterator[dict]:
-        return _vers_document_brut_base(extracted_file, flux_type, est_json, stats)
+        return _vers_document_brut(extracted_file, flux_type, est_json, stats)  # stats : dernier positionnel
 
     return vers_document_brut
 

--- a/electricore/ingestion/transformers/archive.py
+++ b/electricore/ingestion/transformers/archive.py
@@ -10,7 +10,7 @@ from collections.abc import Iterator
 
 import dlt
 
-from electricore.ingestion.transformers.crypto import StatsChaine
+from electricore.ingestion.transformers.chaine import StatsChaine, etape_chaine
 
 logger = logging.getLogger(__name__)
 
@@ -74,22 +74,22 @@ def match_xml_pattern(nom_fichier: str, pattern: str | None) -> bool:
 # =============================================================================
 
 
-def _unzip_transformer_base(
-    decrypted_file: dict, file_extension: str, file_regex: str | None, stats: StatsChaine
-) -> Iterator[dict]:
-    """
-    Fonction de base pour extraire les fichiers d'archives ZIP déchiffrées.
+@etape_chaine(
+    succes="extraits",
+    echec="echecs_extraction",
+    libelle="extraction",
+    cle_item="file_name",
+    niveau_log=logging.ERROR,
+)
+def _unzip(decrypted_file: dict, file_extension: str, file_regex: str | None) -> Iterator[dict]:
+    """Étage unzip : ZIP déchiffré → fichiers internes (un par yield).
 
-    Discipline « attraper → compter → continuer » (ADR-0037 étendu) : un ZIP illisible
-    (corrompu) est compté `echecs_extraction` et sauté — jamais une exception propagée
-    (pas de poison-pill). Chaque fichier interne yieldé incrémente `extraits`. Un ZIP
-    sans fichier interne correspondant (vide par nature) ne compte aucun échec.
-
-    Args:
-        decrypted_file: Fichier déchiffré du transformer crypto
-        file_extension: Extension des fichiers à extraire (ex: '.xml', '.csv')
-        file_regex: Pattern optionnel pour filtrer les noms de fichiers
-        stats: Compteur de chaîne du flux courant, muté en place (étage unzip)
+    Ne déclare que **son travail** (ouvrir le ZIP, filtrer par regex, émettre chaque fichier
+    interne) : un ZIP illisible **lève** → la discipline le compte `echecs_extraction` au niveau
+    ERROR et le saute (pas de poison-pill). Le combinateur compte **chaque yield** (`extraits`) —
+    un N-yields, contrairement aux étages 1-yield. Un fichier filtré par `file_regex` est sauté
+    AVANT le yield → ni succès ni échec. Un ZIP vide par nature (0 fichier interne, sans lever)
+    ne compte aucun échec : seul le `warning` « Aucun fichier… » le signale.
 
     Yields:
         dict: {
@@ -104,20 +104,15 @@ def _unzip_transformer_base(
     zip_modified = decrypted_file["modification_date"]
     decrypted_content = decrypted_file["decrypted_content"]
 
-    try:
-        # Extraire les fichiers de l'extension souhaitée
-        extracted_files = extract_files_from_zip(decrypted_content, file_extension)
-    except Exception as e:
-        stats.echecs_extraction += 1
-        logger.error("Erreur extraction %s: %s", zip_name, e)
-        return
+    # Extraire les fichiers de l'extension souhaitée — un ZIP corrompu lève → échec compté.
+    extracted_files = extract_files_from_zip(decrypted_content, file_extension)
 
     for file_name, file_content in extracted_files:
-        # Filtrer par regex si spécifié
+        # Filtrer par regex si spécifié : un fichier filtré est sauté avant le yield (ni
+        # succès ni échec, invisible aux stats).
         if file_regex and not match_xml_pattern(file_name, file_regex):
             continue
 
-        stats.extraits += 1
         yield {
             "source_zip": zip_name,
             "modification_date": zip_modified,
@@ -151,6 +146,6 @@ def create_unzip_transformer(
 
     @dlt.transformer
     def configured_unzip_transformer(decrypted_file: dict) -> Iterator[dict]:
-        return _unzip_transformer_base(decrypted_file, file_extension, file_regex, stats)
+        return _unzip(decrypted_file, file_extension, file_regex, stats)  # stats : dernier positionnel
 
     return configured_unzip_transformer

--- a/electricore/ingestion/transformers/chaine.py
+++ b/electricore/ingestion/transformers/chaine.py
@@ -1,0 +1,105 @@
+"""Discipline de **chaîne** d'ingestion : « attraper → compter → continuer » (ADR-0037, étendu #445).
+
+Co-localise les deux pièces de l'escalade per-flux, au-dessus des trois étages
+`decrypt | unzip | parse` qu'elles gouvernent :
+
+  - `StatsChaine` — le compteur mutable partagé par les trois étages d'un même flux ;
+  - `etape_chaine` — le combinateur (décorateur) qui enferme en un seul *seam* la
+    discipline répétée mot pour mot dans les trois étages : capture totale de
+    l'itération du travail, comptage au yield, log paramétré, **non-propagation**.
+
+`StatsChaine` est *chain-wide* (relu par le runner) mais vivait historiquement dans
+`crypto.py` ; les étages aval l'importaient depuis crypto (dépendance descendante
+artificielle). Elle est désormais **définie ici**, à côté de la discipline qui la mute.
+"""
+
+import logging
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from functools import wraps
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StatsChaine:
+    """Compteur de la **chaîne** de transformation d'un flux — escalade per-flux (ADR-0037, étendu).
+
+    Un seul objet mutable est partagé par les trois étages de la chaîne
+    (`decrypt | unzip | parse`) d'un même flux (resource). Chaque étage incrémente ses
+    compteurs au fil des fichiers ; le runner agrège ensuite par flux et décide si
+    l'absence totale de documents produits malgré des échecs (`flux_aveugle`) doit faire
+    échouer le job. Discipline uniforme « attraper → compter → continuer » : un fichier
+    fautif est compté, jamais une raison d'interrompre le run.
+    """
+
+    fichiers: int = 0  # zips entrants (entrée de decrypt)
+    dechiffres: int = 0  # déchiffrements réussis (decrypt OK)
+    extraits: int = 0  # fichiers internes extraits par unzip
+    documents: int = 0  # documents produits (parse OK) — entrée du prédicat
+    echecs_dechiffrement: int = 0
+    echecs_extraction: int = 0
+    echecs_linearisation: int = 0
+
+    def echecs(self) -> int:
+        """Total des échecs sur les trois étages de la chaîne."""
+        return self.echecs_dechiffrement + self.echecs_extraction + self.echecs_linearisation
+
+    def flux_aveugle(self) -> bool:
+        """Flux ayant des fichiers mais produisant 0 document malgré ≥ 1 échec → étage sombre.
+
+        Prédicat généralisé (ADR-0037 ext.) : « aveugle » = a produit zéro document de bout
+        en bout *et* a compté au moins un échec — quel qu'en soit l'étage (clé manquante,
+        zip corrompu en masse, documents tous malformés). Un échec **isolé** noyé dans des
+        documents (`documents > 0`) est toléré. Un flux **vide par nature** (aucun document
+        mais aucun échec — un zip sans fichier interne) n'est PAS aveugle : c'est l'`echecs()`
+        explicite qui distingue le drop-par-erreur du vide légitime.
+        """
+        return self.documents == 0 and self.echecs() > 0
+
+
+def etape_chaine(
+    *,
+    succes: str,
+    echec: str,
+    libelle: str,
+    cle_item: str,
+    capture: type[Exception] = Exception,
+    niveau_log: int = logging.WARNING,
+) -> Callable:
+    """Décorateur paramétré : enferme la discipline « attraper → compter → continuer ».
+
+    Chaque étage de la chaîne ne déclare plus que **son travail** — un générateur
+    `(item, *config) -> Iterator[dict]` — plus le nom des **deux compteurs** `StatsChaine`
+    à incrémenter (`succes`/`echec`). La discipline (capture de l'itération, comptage au
+    yield, log paramétré, non-propagation) vit dans cet unique *seam*.
+
+    Convention d'appel de l'enveloppe : `enveloppe(item, *config, stats)` — la factory
+    `@dlt.transformer` injecte `stats` en **dernier positionnel** ; le travail ne le voit pas.
+
+    Args:
+        succes: Nom de l'attribut `StatsChaine` incrémenté à chaque document yieldé.
+        echec: Nom de l'attribut `StatsChaine` incrémenté quand le travail lève.
+        libelle: Mot du log (« déchiffrement », « extraction », « linéarisation »).
+        cle_item: Clé de l'item dont la valeur identifie le fichier fautif dans le log.
+        capture: Classe d'exception attrapée (resserrée par étage : `ValueError` pour
+            decrypt). Une exception **hors** de cette classe propage.
+        niveau_log: Niveau du log d'échec (`WARNING` par défaut, `ERROR` pour unzip).
+    """
+
+    def decorate(travail: Callable[..., Iterator[dict]]) -> Callable[..., Iterator[dict]]:
+        @wraps(travail)
+        def enveloppe(item, *config_et_stats):
+            *config, stats = config_et_stats  # stats = dernier positionnel (injecté par la factory)
+            try:
+                for doc in travail(item, *config):  # le travail NE voit PAS stats
+                    setattr(stats, succes, getattr(stats, succes) + 1)  # +1 AVANT le yield
+                    yield doc
+            except capture as e:  # noqa: BLE001 — compté, JAMAIS propagé (pin du spike : sinon dlt aborte l'extract)
+                setattr(stats, echec, getattr(stats, echec) + 1)
+                logger.log(niveau_log, "Échec %s %s : %s", libelle, item.get(cle_item, "?"), e)
+                return
+
+        return enveloppe
+
+    return decorate

--- a/electricore/ingestion/transformers/crypto.py
+++ b/electricore/ingestion/transformers/crypto.py
@@ -24,7 +24,6 @@ Trousseau de clés N-clés (ADR-0037, registre runtime #141) :
 
 import logging
 from collections.abc import Iterator
-from dataclasses import dataclass
 
 import dlt
 from Crypto.Cipher import AES
@@ -32,48 +31,15 @@ from dlt.common.storages.fsspec_filesystem import FileItemDict
 
 from electricore.config import runtime
 
+# L'étage decrypt applique la discipline de chaîne (`etape_chaine`) et compte dans
+# `StatsChaine` ; les deux vivent dans `transformers/chaine.py`, au-dessus des étages (#479).
+from electricore.ingestion.transformers.chaine import StatsChaine, etape_chaine
+
 logger = logging.getLogger(__name__)
 
 
 # Magic bytes d'un fichier ZIP (PK local file header)
 _ZIP_MAGIC = b"PK\x03\x04"
-
-
-@dataclass
-class StatsChaine:
-    """Compteur de la **chaîne** de transformation d'un flux — escalade per-flux (ADR-0037, étendu).
-
-    Un seul objet mutable est partagé par les trois étages de la chaîne
-    (`decrypt | unzip | parse`) d'un même flux (resource). Chaque étage incrémente ses
-    compteurs au fil des fichiers ; le runner agrège ensuite par flux et décide si
-    l'absence totale de documents produits malgré des échecs (`flux_aveugle`) doit faire
-    échouer le job. Discipline uniforme « attraper → compter → continuer » : un fichier
-    fautif est compté, jamais une raison d'interrompre le run.
-    """
-
-    fichiers: int = 0  # zips entrants (entrée de decrypt)
-    dechiffres: int = 0  # déchiffrements réussis (decrypt OK)
-    extraits: int = 0  # fichiers internes extraits par unzip
-    documents: int = 0  # documents produits (parse OK) — entrée du prédicat
-    echecs_dechiffrement: int = 0
-    echecs_extraction: int = 0
-    echecs_linearisation: int = 0
-
-    def echecs(self) -> int:
-        """Total des échecs sur les trois étages de la chaîne."""
-        return self.echecs_dechiffrement + self.echecs_extraction + self.echecs_linearisation
-
-    def flux_aveugle(self) -> bool:
-        """Flux ayant des fichiers mais produisant 0 document malgré ≥ 1 échec → étage sombre.
-
-        Prédicat généralisé (ADR-0037 ext.) : « aveugle » = a produit zéro document de bout
-        en bout *et* a compté au moins un échec — quel qu'en soit l'étage (clé manquante,
-        zip corrompu en masse, documents tous malformés). Un échec **isolé** noyé dans des
-        documents (`documents > 0`) est toléré. Un flux **vide par nature** (aucun document
-        mais aucun échec — un zip sans fichier interne) n'est PAS aveugle : c'est l'`echecs()`
-        explicite qui distingue le drop-par-erreur du vide légitime.
-        """
-        return self.documents == 0 and self.echecs() > 0
 
 
 # =============================================================================
@@ -191,24 +157,22 @@ def read_sftp_file(encrypted_item: FileItemDict) -> bytes:
 # =============================================================================
 
 
-def _decrypt_aes_transformer_base(
-    encrypted_file: FileItemDict,
-    key_chain: list[tuple[str, bytes, bytes]],
-    stats: StatsChaine,
-) -> Iterator[dict]:
-    """
-    Fonction de base pour déchiffrer les fichiers AES depuis SFTP.
+@etape_chaine(
+    succes="dechiffres",
+    echec="echecs_dechiffrement",
+    libelle="déchiffrement",
+    cle_item="file_name",
+    capture=ValueError,
+)
+def _decrypt(encrypted_file: FileItemDict, key_chain: list[tuple[str, bytes, bytes]]) -> Iterator[dict]:
+    """Étage decrypt (discipline) : fichier chiffré SFTP → document déchiffré.
 
-    Tente chaque clé de key_chain par essai. Fin du fail silencieux (ADR-0037) :
-    un échec de déchiffrement est **compté** dans `stats`, tracé en warn-log, et le
-    fichier est sauté (pas de poison-pill : un fichier corrompu isolé ne fait pas
-    tomber tout le flux). Le runner agrège ensuite `stats` par flux et décide si
-    l'absence totale de succès doit faire échouer le job.
-
-    Args:
-        encrypted_file: Fichier chiffré depuis une resource SFTP
-        key_chain: Chaîne de clés [(label, clé, iv), ...] à essayer
-        stats: Compteur de chaîne du flux courant, muté en place (étage decrypt)
+    Ne déclare que **son travail** (lire, tenter chaque clé par essai, émettre le document) :
+    un échec de toutes les clés **lève** une `ValueError`. La discipline « attraper → compter
+    → continuer » (capture **resserrée** à `ValueError`, comptage `dechiffres`/
+    `echecs_dechiffrement`, non-propagation) vit dans `etape_chaine`. Le pré-compte du zip
+    entrant (`fichiers`) n'est PAS de la discipline (ni succès ni échec) : il vit dans
+    `_decrypt_aes_transformer_base`, hors du combinateur (symétrie à deux compteurs).
 
     Yields:
         dict: {
@@ -220,18 +184,9 @@ def _decrypt_aes_transformer_base(
             'key_used': str,
         }
     """
-    encrypted_data = read_sftp_file(encrypted_file)
-    original_size = len(encrypted_data)
-    stats.fichiers += 1
-
-    try:
-        decrypted_data, key_used = decrypt_with_key_chain(encrypted_data, key_chain)
-    except ValueError as e:
-        stats.echecs_dechiffrement += 1
-        logger.warning("Échec déchiffrement %s : %s", encrypted_file["file_name"], e)
-        return
-
-    stats.dechiffres += 1
+    encrypted_data = read_sftp_file(encrypted_file)  # IO non gardée : une erreur de lecture n'est
+    original_size = len(encrypted_data)  # pas une ValueError → propage (hors discipline ADR-0037).
+    decrypted_data, key_used = decrypt_with_key_chain(encrypted_data, key_chain)  # toutes clés KO → lève
     if len(key_chain) > 1:
         logger.debug("Déchiffré avec clé '%s' : %s", key_used, encrypted_file["file_name"])
 
@@ -243,6 +198,23 @@ def _decrypt_aes_transformer_base(
         "decrypted_size": len(decrypted_data),
         "key_used": key_used,
     }
+
+
+def _decrypt_aes_transformer_base(
+    encrypted_file: FileItemDict,
+    key_chain: list[tuple[str, bytes, bytes]],
+    stats: StatsChaine,
+) -> Iterator[dict]:
+    """Étage decrypt complet : pré-compte le zip entrant (`fichiers`) puis applique la discipline.
+
+    `stats.fichiers` est le compteur d'**entrée** de decrypt — inconditionnel par zip reçu, ni
+    succès ni échec : il vit donc HORS du combinateur (qui reste symétrique à deux compteurs sur
+    les trois étages). Ce pré-compte précède la lecture SFTP de `_decrypt` ; un fichier dont la
+    lecture échouerait est tout de même compté `fichiers` (l'erreur IO propage telle quelle, hors
+    discipline ADR-0037). Seam de test sans dlt : la factory `@dlt.transformer` ci-dessous l'appelle.
+    """
+    stats.fichiers += 1
+    yield from _decrypt(encrypted_file, key_chain, stats)  # stats : dernier positionnel (injecté)
 
 
 def create_decrypt_transformer(

--- a/tests/ingestion/test_chaine.py
+++ b/tests/ingestion/test_chaine.py
@@ -1,0 +1,106 @@
+"""Suite dédiée du combinateur `etape_chaine` (#479).
+
+`etape_chaine` enferme en un seul *seam* la discipline « attraper → compter → continuer »
+(ADR-0037 étendu, #445) jusqu'ici triplée mot pour mot dans `decrypt | unzip | parse` :
+
+  - chaque **document yieldé** par le travail incrémente le compteur de succès (+1 AVANT
+    le yield) — unifie le 1-yield de decrypt/parse et le N-yields d'unzip ;
+  - le travail qui **lève** (dans la classe `capture=`) compte UN échec, log au niveau
+    paramétré, puis se **termine** — JAMAIS de propagation (le pin du spike : une exception
+    non rattrapée d'un transformer dlt aborte tout l'`extract`) ;
+  - une exception **hors** de la classe capturée **propage** (capture resserrée par étage).
+
+Travail-jouet ci-dessous : on n'a besoin d'aucun étage réel pour épingler la discipline.
+La factory `@dlt.transformer` injecte `stats` en **dernier positionnel** ; le travail décoré
+ne voit que `(item, *config)`.
+"""
+
+import logging
+
+import pytest
+
+from electricore.ingestion.transformers.chaine import StatsChaine, etape_chaine
+
+
+def test_compte_un_succes_par_document_yielde():
+    """Tracer bullet : chaque document yieldé par le travail vaut +1 au compteur de succès."""
+    stats = StatsChaine()
+
+    @etape_chaine(succes="documents", echec="echecs_linearisation", libelle="jouet", cle_item="nom")
+    def travail(item, n):
+        for i in range(n):
+            yield {"i": i}
+
+    produits = list(travail({"nom": "x"}, 3, stats))
+
+    assert len(produits) == 3
+    assert stats.documents == 3 and stats.echecs_linearisation == 0
+
+
+def test_zero_document_sans_lever_ne_compte_ni_succes_ni_echec():
+    """Travail qui n'émet rien et ne lève pas → 0 succès, 0 échec (vide par nature).
+
+    Le combinateur ne traite JAMAIS « 0 document yieldé » comme un échec : seul le travail
+    qui **lève** signale un échec."""
+    stats = StatsChaine()
+
+    @etape_chaine(succes="extraits", echec="echecs_extraction", libelle="jouet", cle_item="nom")
+    def travail(item):
+        return
+        yield  # générateur vide
+
+    produits = list(travail({"nom": "x"}, stats))
+
+    assert produits == []
+    assert stats.extraits == 0 and stats.echecs_extraction == 0
+
+
+def test_lever_apres_k_yields_compte_k_succes_un_echec_sans_propager(caplog):
+    """Pin du spike : un travail qui lève après k documents compte k succès + 1 échec,
+    log au niveau paramétré (avec libellé + identité du fichier), et **ne propage JAMAIS**.
+
+    C'est la garantie anti-`PipelineStepFailed` : une exception non rattrapée d'un transformer
+    dlt aborterait tout l'`extract`. Le générateur décoré se termine simplement."""
+    stats = StatsChaine()
+
+    @etape_chaine(
+        succes="extraits",
+        echec="echecs_extraction",
+        libelle="extraction",
+        cle_item="file_name",
+        niveau_log=logging.ERROR,
+    )
+    def travail(item):
+        yield {"i": 0}
+        yield {"i": 1}
+        raise RuntimeError("boom au 3e")
+
+    with caplog.at_level(logging.ERROR):
+        produits = list(travail({"file_name": "z.zip"}, stats))  # ne lève pas
+
+    assert len(produits) == 2  # les k=2 documents d'avant la levée sont bien émis
+    assert stats.extraits == 2 and stats.echecs_extraction == 1
+    assert "extraction" in caplog.text and "z.zip" in caplog.text
+
+
+def test_exception_hors_classe_capturee_propage():
+    """`capture=` est resserré par étage (decrypt n'attrape que `ValueError`). Une exception
+    **hors** de cette classe (ici `TypeError`) n'est PAS avalée : elle propage, et l'échec
+    n'est pas compté — sinon on masquerait des bugs comme une erreur de lecture SFTP."""
+    stats = StatsChaine()
+
+    @etape_chaine(
+        succes="dechiffres",
+        echec="echecs_dechiffrement",
+        libelle="déchiffrement",
+        cle_item="file_name",
+        capture=ValueError,
+    )
+    def travail(item):
+        raise TypeError("pas une ValueError")
+        yield  # générateur
+
+    with pytest.raises(TypeError, match="pas une ValueError"):
+        list(travail({"file_name": "z.zip"}, stats))
+
+    assert stats.echecs_dechiffrement == 0  # non compté : ce n'est pas un échec de la discipline

--- a/tests/ingestion/test_crypto.py
+++ b/tests/ingestion/test_crypto.py
@@ -20,8 +20,8 @@ from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 
 from electricore.config import runtime
+from electricore.ingestion.transformers.chaine import StatsChaine
 from electricore.ingestion.transformers.crypto import (
-    StatsChaine,
     _decrypt_aes_transformer_base,
     decrypt_file_aes,
     decrypt_with_key_chain,

--- a/tests/ingestion/test_escalade_chaine.py
+++ b/tests/ingestion/test_escalade_chaine.py
@@ -34,7 +34,7 @@ from Crypto.Util.Padding import pad
 
 from electricore.config import runtime
 from electricore.ingestion.sources.sftp_enedis_brut import flux_enedis_brut
-from electricore.ingestion.transformers.crypto import StatsChaine
+from electricore.ingestion.transformers.chaine import StatsChaine
 
 _KEY = bytes.fromhex("00112233445566778899aabbccddeeff")  # 16 octets (AES-128)
 _IV = bytes.fromhex("ffeeddccbbaa99887766554433221100")
@@ -172,12 +172,12 @@ def test_escalade_chaine_bout_en_bout(bucket, tmp_path):
 
 def test_unzip_compte_les_fichiers_extraits():
     """Chaque fichier interne yieldé incrémente `extraits` (aucun échec sur un ZIP sain)."""
-    from electricore.ingestion.transformers.archive import _unzip_transformer_base
+    from electricore.ingestion.transformers.archive import _unzip
 
     stats = StatsChaine()
     fichier = _fichier_dechiffre("a.zip", _zip_clair("mesure.xml", b"<data/>"))
 
-    produits = list(_unzip_transformer_base(fichier, ".xml", "*.xml", stats))
+    produits = list(_unzip(fichier, ".xml", "*.xml", stats))  # stats : dernier positionnel
 
     assert len(produits) == 1
     assert stats.extraits == 1 and stats.echecs_extraction == 0
@@ -186,12 +186,12 @@ def test_unzip_compte_les_fichiers_extraits():
 def test_unzip_compte_un_echec_sur_zip_corrompu_sans_crash():
     """Fin du silence d'unzip (ADR-0037 ext.) : un ZIP illisible est compté
     `echecs_extraction`, sans exception propagée (pas de poison-pill)."""
-    from electricore.ingestion.transformers.archive import _unzip_transformer_base
+    from electricore.ingestion.transformers.archive import _unzip
 
     stats = StatsChaine()
     fichier = _fichier_dechiffre("corrompu.zip", b"ceci n'est pas un zip")
 
-    produits = list(_unzip_transformer_base(fichier, ".xml", "*.xml", stats))
+    produits = list(_unzip(fichier, ".xml", "*.xml", stats))  # stats : dernier positionnel
 
     assert produits == []
     assert stats.extraits == 0 and stats.echecs_extraction == 1
@@ -209,12 +209,12 @@ def _fichier_extrait(nom: str, contenu: bytes) -> dict:
 
 def test_parse_compte_un_document_sur_contenu_valide():
     """Un document linéarisable incrémente `documents` et produit la ligne brute."""
-    from electricore.ingestion.sources.sftp_enedis_brut import _vers_document_brut_base
+    from electricore.ingestion.sources.sftp_enedis_brut import _vers_document_brut
 
     stats = StatsChaine()
     extrait = _fichier_extrait("mesure.JSON", _R64_JSON)
 
-    produits = list(_vers_document_brut_base(extrait, "R64", est_json=True, stats=stats))
+    produits = list(_vers_document_brut(extrait, "R64", True, stats))  # stats : dernier positionnel
 
     assert len(produits) == 1
     assert stats.documents == 1 and stats.echecs_linearisation == 0
@@ -224,12 +224,12 @@ def test_parse_compte_un_echec_sur_document_malforme_sans_raise():
     """Pin du spike (ADR-0037 ext.) : dlt aborte tout l'`extract` sur une exception non
     rattrapée d'un transformer. Un document malformé doit donc être compté
     `echecs_linearisation` et sauté — SANS exception propagée."""
-    from electricore.ingestion.sources.sftp_enedis_brut import _vers_document_brut_base
+    from electricore.ingestion.sources.sftp_enedis_brut import _vers_document_brut
 
     stats = StatsChaine()
     extrait = _fichier_extrait("mesure.JSON", b"{ ceci n'est pas du JSON valide")
 
-    produits = list(_vers_document_brut_base(extrait, "R64", est_json=True, stats=stats))
+    produits = list(_vers_document_brut(extrait, "R64", True, stats))  # stats : dernier positionnel
 
     assert produits == []
     assert stats.documents == 0 and stats.echecs_linearisation == 1

--- a/tests/ingestion/test_ingestion.py
+++ b/tests/ingestion/test_ingestion.py
@@ -8,7 +8,7 @@ complet via drop_sources).
 
 from electricore.api.services.ingestion_service import ModeIngestion
 from electricore.ingestion.runner import PlanRun, flux_aveugles, interpreter_flux
-from electricore.ingestion.transformers.crypto import StatsChaine
+from electricore.ingestion.transformers.chaine import StatsChaine
 
 
 def test_flux_aveugles_ne_retient_que_les_flux_sans_document():
@@ -141,7 +141,7 @@ def test_main_echoue_si_un_flux_est_aveugle(monkeypatch):
     import pytest
 
     from electricore.ingestion import runner
-    from electricore.ingestion.transformers.crypto import StatsChaine
+    from electricore.ingestion.transformers.chaine import StatsChaine
 
     monkeypatch.setattr(runner.runtime, "valider", lambda *a, **k: None)
     monkeypatch.setattr(


### PR DESCRIPTION
## Pourquoi

La discipline « attraper → compter → continuer » de la chaîne d'ingestion ([ADR-0037](docs/adr/0037-trousseau-cles-aes-n-cles-selection-par-essai.md), étendu #445) était **triplée mot pour mot** dans les trois étages `decrypt | unzip | parse` : chaque base re-justifiait son `try/except` / `StatsChaine` / règle anti-propagation autant que son *travail* réel. Seam superficiel.

## Quoi

Un **combinateur unique** `etape_chaine` (décorateur paramétré, ~15 lignes de HOF, **aucune dépendance**) enferme la discipline en un seul seam : capture de l'itération du travail, `+1` par document yieldé (avant le yield), log paramétré, et **non-propagation** (le pin du spike anti-`PipelineStepFailed`). Chaque étage ne déclare plus que **son travail** + les deux compteurs `StatsChaine` à incrémenter.

Nouveau module `transformers/chaine.py` co-localise la discipline et le compteur qu'elle mute : **`StatsChaine` y est déplacé** depuis `crypto.py` (il est chain-wide ; les étages aval l'importaient « vers le bas » depuis crypto). Shim de ré-export transitoire retiré dans le même effort ; `runner` + tests recâblés sur `chaine`.

| étage | après |
|-------|-------|
| **parse** | `_vers_document_brut` décoré ; `try/except` disparu |
| **unzip** | `_unzip` décoré ; `extraits += 1` disparaît (le combinateur compte chaque yield → unifie le N-yields), `niveau_log=ERROR`, on garde le `continue` regex + warning zip-vide |
| **decrypt** | `_decrypt` décoré, `capture=ValueError` resserré, dict yieldé **byte-identique** ; pré-compte `fichiers` (ni succès ni échec) sorti du combinateur → thin wrapper non-dlt `_decrypt_aes_transformer_base` (factory + tests decrypt **inchangés**) |

## Garanties

- **Refactor purement interne** : compteurs identiques sur les fixtures existantes (decrypt N=1, parse N=1, unzip N/zip ; `flux_aveugle` inchangé ; zip-vide non-échec ; filtré non-compté). Mêmes documents landés.
- **Anti-`PipelineStepFailed` préservée** et désormais **testée directement** sur le combinateur.
- **Écart acté** (non iso-comportement, hors discipline ADR-0037) : `fichiers` est pré-compté *avant* la lecture SFTP de `_decrypt` ; une erreur IO (non-`ValueError`) propage à l'identique mais compte désormais `fichiers` (chemin non testé).

## Tests

- Nouvelle suite TDD dédiée `tests/ingestion/test_chaine.py` (4 slices) épinglant la discipline : N yields→succès=N ; 0 yield sans lever→0/0 ; lève après k→succès=k/échec=1/**no-raise** ; `capture=ValueError` laisse filer `TypeError`. → le combinateur **porte un comportement**, pas un wrapper cosmétique.
- Les suites existantes (`test_crypto`, `test_escalade_chaine`, `test_ingestion`) passent **sans modification de leurs assertions** (seuls imports/seams de montage ont bougé).
- Suite ingestion complète : **96 verts**. `ruff format`/`check` clean.

Closes #479