### PR TITLE
Audit seams dbt→cœur sans contrat : affaires gardé, F15 audité (#295)

### DIFF
--- a/electricore/core/loaders/duckdb/registry.py
+++ b/electricore/core/loaders/duckdb/registry.py
@@ -8,6 +8,7 @@ schéma SQL (`FLUX_SCHEMAS`) / config appariée (`FLUX_CONFIGS`).
 """
 
 # Imports de validation
+from electricore.core.models.affaire_jalon import AffaireJalon
 from electricore.core.models.releve_index import RelevéIndex
 
 from .descriptor import FluxDescriptor
@@ -115,7 +116,10 @@ DESCRIPTOR_AFFAIRES = FluxDescriptor(
     flux_name="AFFAIRES",
     table="flux_enedis.flux_affaires",
     transform=None,
-    validator=None,  # opérationnel (suivi des affaires SGE), pas de schéma Pandera
+    # Seam `affaires_ouvertes` ← `flux_affaires` gardé par `AffaireJalon` (#295, ADR-0035) :
+    # c'était la dernière lacune de registre de la discovery #147. La parité dbt↔Pandera est
+    # prouvée par `test_dbt_affaires_respecte_le_contrat_pandera`.
+    validator=AffaireJalon,
 )
 
 

--- a/electricore/core/loaders/duckdb/registry.py
+++ b/electricore/core/loaders/duckdb/registry.py
@@ -90,7 +90,14 @@ DESCRIPTOR_F15 = FluxDescriptor(
     flux_name="F15",
     table="flux_enedis.flux_f15_detail",
     transform=None,
-    validator=None,  # Pas encore de modèle Pandera pour les factures
+    # validator=None **par audit** (#295, ADR-0035 §5) : un contrat appartient à un *seam
+    # de consommation* où le cœur dépend de la FORME du flux pour un calcul. F15 n'a pas un
+    # tel seam — son unique consommateur, `contexte_mensuel.documents()`, le **filtre**
+    # (`date_facture`, `unite`) puis le **verse tel quel** dans des onglets XLSX (« F15
+    # complet » / « F15 prestations »), sans calcul typé. Une passe-plat vers tableur ne
+    # justifie pas un miroir Pandera (≠ R151/R15 qui alimentent l'énergie). Le rapprochement
+    # TURPE↔F15 reste une idée future (#468), non implémentée → pas de seam aujourd'hui.
+    validator=None,
 )
 
 

--- a/electricore/core/loaders/duckdb/registry.py
+++ b/electricore/core/loaders/duckdb/registry.py
@@ -73,6 +73,8 @@ DESCRIPTOR_R151 = FluxDescriptor(
 # (rename id_calendrier → id_calendrier_distributeur, placeholders null FTA/calendrier
 # fournisseur, littéraux source/ordre_index/unite/precision) vit dans le modèle dbt
 # `flux_r15`. date_releve est déjà un instant TIMESTAMPTZ (offset). Le loader ne projette plus.
+# Audit registre (#295) : seam **déjà gardé** (`validator=RelevéIndex`) ; la question de
+# l'unité native R15 (source d'un bug Wh latent) a été tranchée par #286 — rien à ajouter ici.
 DESCRIPTOR_R15 = FluxDescriptor(
     flux_name="R15",
     table="flux_enedis.flux_r15",

--- a/electricore/core/models/__init__.py
+++ b/electricore/core/models/__init__.py
@@ -5,9 +5,10 @@ Ces modèles sont adaptés pour fonctionner avec Polars et remplacent
 progressivement les modèles pandas existants.
 """
 
+from .affaire_jalon import AffaireJalon
 from .chronologie_releves import ChronologieReleves
 from .historique import Historique
 from .releve_index import RelevéIndex
 from .spine_contrat import SpineContrat
 
-__all__ = ["RelevéIndex", "Historique", "ChronologieReleves", "SpineContrat"]
+__all__ = ["AffaireJalon", "RelevéIndex", "Historique", "ChronologieReleves", "SpineContrat"]

--- a/electricore/core/models/affaire_jalon.py
+++ b/electricore/core/models/affaire_jalon.py
@@ -1,0 +1,55 @@
+"""Modèle Pandera du seam `affaires_ouvertes` ← `flux_affaires` (#295, ADR-0035).
+
+Garde-fou de la **frontière dbt → pipeline-cœur** où `affaires_ouvertes`
+(`core/pipelines/affaires.py`, suivi opérationnel des affaires SGE, #276) consomme la
+forme de `flux_affaires` (grain = un *jalon* par affaire). Avant #295 ce seam était la
+dernière *lacune de registre* identifiée par la discovery #147 (ADR-0035, Conséquences) :
+le loader `affaires()` portait `validator=None`.
+
+Propriété par fait (ADR-0035) :
+- **Type physique + forme** (1 ligne/jalon, dédup `(affaire_id, jalon_num)`, casts) → dbt
+  (`models/flux/flux_affaires.sql`).
+- **Dtype Polars + nullabilité-règle** → ce contrat, posé au seam.
+- Le **loader** ne connaît aucun type → `SELECT *` ; la parité dbt↔Pandera est *prouvée*
+  (jamais copiée) par `test_dbt_affaires_respecte_le_contrat_pandera` via la table
+  SQL↔Polars de `parite_typage.py`.
+
+Nullabilité (axe par couche, hors test de parité — ADR-0035 §5) : seules les colonnes
+que `flux_affaires` garantit (`not_null` dbt) ET dont le rollup dépend sont non-null —
+`affaire_id` (clé de regroupement), `jalon_num` (clé de tri / max), `jalon_date_heure`
+(ancienneté), `origine`, `affaire_etat`. `statut` est **nullable** (#296 : une affaire
+fraîchement initiée arrive sans statut → `affaires_ouvertes` la traite comme « en attente
+Enedis »). Les libellés / `pdl` / `segment` sont nullable (le rollup `.last()` les tolère).
+"""
+
+import pandera.polars as pa
+import polars as pl
+from pandera.engines.polars_engine import DateTime
+
+
+class AffaireJalon(pa.DataFrameModel):
+    """📌 Un jalon d'affaire SGE consommé par `affaires_ouvertes` (grain = un jalon)."""
+
+    # 🔹 Identité & regroupement (non-null : clés du rollup)
+    affaire_id: pl.Utf8 = pa.Field(nullable=False)
+    origine: pl.Utf8 = pa.Field(nullable=False, isin=["initiee", "recue"])
+    jalon_num: pl.Int32 = pa.Field(nullable=False)
+    jalon_date_heure: DateTime = pa.Field(nullable=False, dtype_kwargs={"time_unit": "us", "time_zone": "Europe/Paris"})
+    affaire_etat: pl.Utf8 = pa.Field(nullable=False)
+
+    # 🔸 Cycle de vie : NULLABLE (#296) — `<statut>` vide pour une affaire fraîchement
+    # initiée qu'Enedis n'a pas encore rangée ; `affaires_ouvertes` la garde (en attente).
+    statut: pl.Utf8 | None = pa.Field(nullable=True)
+
+    # 🏷️ Attributs descriptifs roulés par `.last()` (nullable : le rollup les tolère)
+    prestation: pl.Utf8 | None = pa.Field(nullable=True)
+    prestation_libelle: pl.Utf8 | None = pa.Field(nullable=True)
+    pdl: pl.Utf8 | None = pa.Field(nullable=True)
+    segment: pl.Utf8 | None = pa.Field(nullable=True)
+    affaire_etat_libelle: pl.Utf8 | None = pa.Field(nullable=True)
+
+    class Config:
+        """Tolère les colonnes supplémentaires servies par le loader `SELECT *`
+        (`affaire_jalon_id`, `affaire_date_effet`, `source`)."""
+
+        strict = False

--- a/electricore/core/models/parite_typage.py
+++ b/electricore/core/models/parite_typage.py
@@ -24,6 +24,7 @@ import polars as pl
 # nullabilité, et le fuseau n'est pas porté par le type SQL `timestamptz`.
 SQL_VERS_POLARS: dict[str, pl.DataType] = {
     "BIGINT": pl.Int64,
+    "INTEGER": pl.Int32,
     "VARCHAR": pl.String,
     "BOOLEAN": pl.Boolean,
     "DOUBLE": pl.Float64,

--- a/tests/core/loaders/test_duckdb_flux_factory.py
+++ b/tests/core/loaders/test_duckdb_flux_factory.py
@@ -67,6 +67,18 @@ class TestPorteeFluxFactory:
             flux("releves")
 
 
+class TestValidateursSeams:
+    """Le descripteur d'un flux consommé par un pipeline-cœur porte son contrat
+    Pandera au seam (ADR-0035 §5). #295 ferme la dernière lacune de registre :
+    `affaires` (consommé par `affaires_ouvertes`) gagne `AffaireJalon`."""
+
+    def test_descriptor_affaires_porte_affaire_jalon(self):
+        from electricore.core.loaders.duckdb.registry import DESCRIPTOR_AFFAIRES
+        from electricore.core.models.affaire_jalon import AffaireJalon
+
+        assert DESCRIPTOR_AFFAIRES.validator is AffaireJalon
+
+
 class TestFactoriesNommeesEquivalentesAFlux:
     """#273 : c15()…r64() produisent la même requête que `flux(nom)`.
 

--- a/tests/core/loaders/test_duckdb_flux_factory.py
+++ b/tests/core/loaders/test_duckdb_flux_factory.py
@@ -78,6 +78,17 @@ class TestValidateursSeams:
 
         assert DESCRIPTOR_AFFAIRES.validator is AffaireJalon
 
+    def test_descriptor_f15_sans_validator_par_audit(self):
+        """F15 n'a **pas** de seam de consommation typé (#295, ADR-0035 §5) : son unique
+        consommateur (`contexte_mensuel.documents()`) le filtre puis le verse tel quel dans
+        des onglets XLSX — pas de calcul sur sa forme. Pas de miroir Pandera là où aucun
+        pipeline cœur ne consomme le flux pour un calcul (≠ R151/R15→énergie). Garde-fou : si
+        un futur calcul typé branche F15 (ex. rapprochement TURPE↔F15, #468), ce test rappelle
+        d'ajouter le contrat au lieu de laisser passer une lacune de registre."""
+        from electricore.core.loaders.duckdb.registry import DESCRIPTOR_F15
+
+        assert DESCRIPTOR_F15.validator is None
+
 
 class TestFactoriesNommeesEquivalentesAFlux:
     """#273 : c15()…r64() produisent la même requête que `flux(nom)`.

--- a/tests/ingestion/test_dbt_affaires_dedup.py
+++ b/tests/ingestion/test_dbt_affaires_dedup.py
@@ -18,6 +18,8 @@ pytest.importorskip("dbt.adapters.duckdb", reason="dbt-duckdb absent — uv sync
 import duckdb  # noqa: E402
 from dbt.cli.main import dbtRunner  # noqa: E402
 
+from electricore.core.models.affaire_jalon import AffaireJalon  # noqa: E402
+from electricore.core.models.parite_typage import ecarts_de_typage  # noqa: E402
 from electricore.ingestion.parsing.xml import xml_vers_dict  # noqa: E402
 
 RACINE = Path(__file__).parents[2]
@@ -146,3 +148,57 @@ def test_jalon_reemis_dedupe_derniere_livraison_gagne(tmp_path, monkeypatch):
     assert [r[0] for r in rows] == [1, 2]
     # Le jalon 1 ré-émis porte le statut de la livraison la plus récente (TERMN), pas COURS.
     assert all(r[1] == "TERMN" for r in rows)
+
+
+def test_dbt_affaires_respecte_le_contrat_pandera(tmp_path, monkeypatch):
+    """Parité de typage dbt↔cœur au seam `affaires_ouvertes` ← `flux_affaires` (#295,
+    ADR-0035). Le schéma réellement émis par `flux_affaires` doit être type-compatible
+    avec le contrat Pandera `AffaireJalon`, via la table de correspondance SQL↔Polars. On
+    lit le type **réellement émis par dbt** (`DESCRIBE`), pas la sortie post-cast du loader :
+    sinon un re-cast côté loader blanchirait une dérive du modèle dbt (la pièce à conviction
+    d'ADR-0034). Nullabilité hors périmètre (axe par couche). Calque de
+    `test_releves_dbt_respecte_le_contrat_pandera` — c'est le garde-fou de frontière qui
+    manquait sur ce seam (loader `affaires()` portait `validator=None`)."""
+    import dlt
+
+    from electricore.ingestion.raw_landing import lander_documents_bruts
+
+    db_path = tmp_path / "flux.duckdb"
+    pipeline = dlt.pipeline(
+        pipeline_name="test_affaires_parite",
+        destination=dlt.destinations.duckdb(str(db_path)),
+        dataset_name="flux_raw",
+    )
+    lander_documents_bruts(
+        pipeline,
+        "raw_affaires",
+        [
+            {
+                "file_name": "ENEDIS_X12_parite.xml",
+                "modification_date": "2024-11-22T09:30:00",
+                "content": xml_vers_dict(_affaire("COURS", [(0, "DMTR"), (1, "INPL")])),
+            },
+        ],
+    )
+    monkeypatch.setenv("DBT_DUCKDB_PATH", str(db_path))
+    resultat = dbtRunner().invoke(
+        [
+            "build",
+            "--select",
+            "+flux_affaires",
+            "--project-dir",
+            str(PROJET_DBT),
+            "--profiles-dir",
+            str(PROJET_DBT),
+            "--target-path",
+            str(tmp_path / "target"),
+        ]
+    )
+    assert resultat.success, f"dbt build flux_affaires a échoué : {resultat.exception}"
+
+    con = duckdb.connect(str(db_path))
+    schema_sql = {nom: type_sql for nom, type_sql, *_ in con.execute("describe flux_enedis.flux_affaires").fetchall()}
+    con.close()
+
+    ecarts = ecarts_de_typage(schema_sql, AffaireJalon)
+    assert not ecarts, f"divergences de typage dbt↔AffaireJalon (dbt, pandera) : {ecarts}"

--- a/tests/unit/test_modele_affaire_jalon.py
+++ b/tests/unit/test_modele_affaire_jalon.py
@@ -1,0 +1,76 @@
+"""Contrat Pandera du seam `affaires_ouvertes` ← `flux_affaires` (#295, ADR-0035).
+
+Le modèle `AffaireJalon` garde la **consommation** de `flux_affaires` par
+`affaires_ouvertes` (grain = un jalon par affaire) : il déclare les colonnes que le
+pipeline lit, leurs dtypes Polars et leur nullabilité-règle. Ces tests vérifient qu'une
+frame au format `flux_affaires` passe, que `statut` reste nullable (#296), et qu'un
+dtype faux sur une colonne du contrat est rejeté.
+
+La parité dbt↔Pandera (le type réellement émis par le mart) est prouvée séparément par
+le test de frontière du golden affaires (`test_dbt_affaires_respecte_le_contrat_pandera`).
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+
+from electricore.core.models.affaire_jalon import AffaireJalon
+
+PARIS = ZoneInfo("Europe/Paris")
+
+
+def _frame_affaires(statut: str | None = "COURS") -> pl.DataFrame:
+    """Une ligne au format `flux_affaires` (grain = un jalon), dtypes émis par dbt."""
+    return pl.DataFrame(
+        {
+            "affaire_id": ["AFF1"],
+            "origine": ["initiee"],
+            "prestation": ["CFN"],
+            "prestation_libelle": ["Changement de fournisseur"],
+            "statut": [statut],
+            "pdl": ["99000000000017"],
+            "segment": ["C5"],
+            "jalon_num": [1],
+            "jalon_date_heure": [datetime(2024, 11, 20, 9, tzinfo=PARIS)],
+            "affaire_etat": ["DMTR"],
+            "affaire_etat_libelle": ["Demande transmise"],
+        },
+        schema_overrides={
+            "statut": pl.Utf8,
+            # jalon_num : INTEGER côté dbt → Int32 (cast `as integer`).
+            "jalon_num": pl.Int32,
+            "jalon_date_heure": pl.Datetime(time_unit="us", time_zone="Europe/Paris"),
+        },
+    )
+
+
+def test_accepte_la_forme_de_flux_affaires():
+    """Le contrat valide une frame au format `flux_affaires` consommée par le seam."""
+    AffaireJalon.validate(_frame_affaires(), lazy=True)
+
+
+def test_statut_nullable():
+    """`statut` est nullable (#296) : une affaire fraîchement initiée arrive sans statut
+    (null) — le contrat ne doit pas la rejeter (cf. affaires_ouvertes la traite comme
+    ouverte « en attente Enedis »)."""
+    AffaireJalon.validate(_frame_affaires(statut=None), lazy=True)
+
+
+def test_rejette_jalon_num_non_entier():
+    """Garde-fou de dtype : `jalon_num` est la clé de tri du rollup (max jalon) — un type
+    faux (ici String) doit être rejeté au seam."""
+    frame = _frame_affaires().with_columns(pl.col("jalon_num").cast(pl.Utf8))
+    with pytest.raises(Exception):  # noqa: B017,PT011 — SchemaError(s) Pandera
+        AffaireJalon.validate(frame, lazy=True)
+
+
+def test_colonne_supplementaire_toleree():
+    """Le loader `affaires()` est un `SELECT *` : il sert des colonnes hors seam
+    (`affaire_jalon_id`, `affaire_date_effet`, `source`). Config.strict=False les tolère."""
+    frame = _frame_affaires().with_columns(
+        pl.lit("AFF1#1").alias("affaire_jalon_id"),
+        pl.lit("flux_X12X13").alias("source"),
+    )
+    AffaireJalon.validate(frame, lazy=True)

--- a/tests/unit/test_parite_typage.py
+++ b/tests/unit/test_parite_typage.py
@@ -89,3 +89,15 @@ def test_table_de_correspondance_couvre_les_types_du_contrat_releve():
     types_contrat = {"BIGINT", "VARCHAR", "BOOLEAN", "TIMESTAMP WITH TIME ZONE"}
 
     assert types_contrat <= set(SQL_VERS_POLARS)
+
+
+def test_integer_sql_connu_de_la_table():
+    """Le seam `affaires_ouvertes` ← `flux_affaires` consomme `jalon_num`, émis en
+    INTEGER par dbt (cast `as integer`). La table doit le connaître (→ Int32), sinon le
+    test de frontière des affaires (#295) lèverait `TypeSQLInconnu` au lieu de comparer."""
+    assert SQL_VERS_POLARS["INTEGER"].base_type() == pl.Int32
+
+    class ContratInteger(pa.DataFrameModel):
+        jalon_num: pl.Int32
+
+    assert ecarts_de_typage({"jalon_num": "INTEGER"}, ContratInteger) == {}


### PR DESCRIPTION
Audit des seams dbt→cœur sans contrat : affaires + F15 (ADR-0035).

Comble la dernière lacune de registre de la discovery #147 : le seam
`affaires_ouvertes` ← `flux_affaires` gagne un contrat Pandera `AffaireJalon`
(câblé au `DESCRIPTOR_AFFAIRES`) + un test de parité de frontière qui prouve, via
la table SQL↔Polars du harnais #291, que le schéma réellement émis par dbt
(`DESCRIBE`) épouse le contrat — ajout du mapping `INTEGER → Int32` que ça exige.

Le seam F15 → facturation est audité comme n'ayant **pas** besoin de contrat
(unique consommateur = passe-plat filtre→XLSX dans `documents()`, pas de calcul
typé ; TURPE↔F15 reste futur, #468) : raison enregistrée dans le `DESCRIPTOR_F15`
+ test garde-fou. Le seam R15 est déjà gardé (`RelevéIndex`, #286 résolu).

Closes #295
