### PR TITLE
fix(deploy): rebranche l'override --version perdu en #299

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -246,6 +246,19 @@ main() {
             log_err "config.env invalide :"; printf '%s\n' "$errs" | sed 's/^/     - /'
             die "Corrige providers/${OPT_SLUG}/config.env dans le dépôt, pousse, puis relance reconfigure."
         fi
+
+        # Override LOCAL de la version (#460) : `--version` pilote le tag d'image déployé même
+        # en secrets-as-code, SANS toucher au dépôt secrets (la version n'est pas un secret,
+        # c'est un paramètre de déploiement — ADR-0044). Appliqué APRÈS le pull : le config.env
+        # du dépôt reste la baseline GitOps (reconfigure sans --version = version pinée). Le pull
+        # ré-écrit config.env à chaque reconfigure → l'override est ré-appliqué à chaque fois.
+        # (Régression #299 corrigée : l'appel avait été supprimé → --version devenait inerte.)
+        if [[ "${OPT_VERSION_EXPLICIT:-0}" -eq 1 ]]; then
+            repo_version=$(read_env_var "$config_env" ELECTRICORE_VERSION)
+            override_config_version "$config_env" "$OPT_VERSION"
+            log_warn "ELECTRICORE_VERSION overridé localement : ${OPT_VERSION} (dépôt : ${repo_version}) — non versionné, propre à cette box."
+        fi
+
         if ! box_can_decrypt "$OPT_SLUG"; then
             # La box a sa clé + le ciphertext, mais ne déchiffre pas → sa clé age publique
             # n'est pas (encore) destinataire dans .sops.yaml. 2e temps de l'onboarding.
@@ -339,12 +352,18 @@ main() {
         ssh_recap="  SSH (admin)      ssh ops@${OPT_DOMAIN}   ← root SSH désactivé
   SSH (service)    ssh ${OPT_SLUG}@${OPT_DOMAIN}"
     fi
+    # Image RÉELLEMENT déployée : valeur effective de ELECTRICORE_VERSION dans config.env (qui
+    # a pu être overridée localement par --version, #460), pas l'option brute. Fallback sur
+    # OPT_VERSION pour le chemin legacy .env (pas de config.env).
+    effective_version=$(read_env_var "${HOME_DIR}/config.env" ELECTRICORE_VERSION 2>/dev/null || true)
+    [[ -n "$effective_version" ]] || effective_version="$OPT_VERSION"
     cat <<EOF
 
   ${_C_GREEN}${_C_BOLD}✓ Instance ${OPT_SLUG} opérationnelle.${_C_RESET}
 
   URL              https://${OPT_DOMAIN}
   /health          curl https://${OPT_DOMAIN}/health
+  Image            ghcr.io/energie-de-nantes/electricore:${effective_version}
 ${ssh_recap}
   Logs             sudo -u ${OPT_SLUG} docker compose -f ${DOCKER_DIR}/docker-compose.yml logs -f
   Stop/Start       sudo -u ${OPT_SLUG} docker compose -f ${DOCKER_DIR}/docker-compose.yml {down,up -d}

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -291,6 +291,21 @@ assert_eq "$vcount" "1" "override_config_version: une seule ligne ELECTRICORE_VE
 rm -f "$tmp_cfg"
 
 echo
+echo "→ install.sh / câblage de l'override --version (garde anti-régression #299)"
+# override_config_version a survécu à #299, mais son APPEL dans install.sh avait été
+# supprimé en même temps que le fix ETL → --version devenait inerte (l'image pinée du
+# dépôt déployée quand même). La fonction + son test unitaire passaient vert pendant que
+# le câblage réel disparaissait. On verrouille le câblage par une garde de présence.
+# SCRIPT_DIR a pu être muté par un helper sourcé plus haut → on recalcule depuis BASH_SOURCE.
+install_sh="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/install.sh"
+grep -q "override_config_version" "$install_sh" \
+    && ok "install.sh appelle override_config_version (--version câblé)" \
+    || ko "install.sh n'appelle PAS override_config_version → --version inerte (régression #299)"
+grep -q "OPT_VERSION_EXPLICIT" "$install_sh" \
+    && ok "install.sh garde l'override derrière OPT_VERSION_EXPLICIT" \
+    || ko "install.sh ne garde pas l'override derrière OPT_VERSION_EXPLICIT"
+
+echo
 echo "→ env_validate.sh / read_env_var"
 tmp_rev=$(mktemp)
 printf 'API_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nQUOTED_VALUE="hello world"\nWITH_COMMENT=foo   # trailing comment ignored\n' > "$tmp_rev"


### PR DESCRIPTION
## Symptôme

`sudo bash install.sh --slug edn … --version 3.4.0rc10` déploie quand même **rc5** (swagger affiche rc5). L'option `--version` est silencieusement **inerte** en secrets-as-code : c'est l'image **pinée dans `config.env`** (tirée du dépôt GitOps) qui se déploie, quel que soit `--version`.

## Cause racine

`install.sh` **n'appelle plus** `override_config_version`.

- **#460** (`f73af97`) avait câblé l'appel dans `install.sh` : `--version` réécrit localement `ELECTRICORE_VERSION` dans `config.env` (override de déploiement, pas un secret — ADR-0044).
- **#299** (`284aed1`, *fix poll ETL*) a **clobberé** `install.sh` et supprimé **l'appel** + la ligne `Image` du récapitulatif, sans rapport avec son objet.
- La fonction `override_config_version` **et son test unitaire** ayant survécu (dans `config.sh` / `unit.sh`), la suite restait **verte** pendant que le câblage réel avait disparu → personne ne l'a vu. Classique « on a testé l'unité, pas le câblage ».

## Correctif

- **Rebranche** `override_config_version` dans `install.sh` (gardé par `OPT_VERSION_EXPLICIT`, appliqué **après** le pull + la validation de `config.env`, donc la baseline GitOps reste intacte ; ré-appliqué à chaque `reconfigure`).
- **Restaure** `effective_version` + la ligne `Image ghcr.io/…/electricore:<tag>` du récap (reporte le tag réellement déployé, fallback `--version` pour le chemin legacy `.env`).
- **Garde anti-régression** dans `deploy/tests/unit.sh` : on **assert que `install.sh` APPELLE** `override_config_version` (pas seulement que la fonction existe). → `172 passed, 0 failed`.

## Mise en service

Les helpers (`install.sh` + `lib/`) sont bootstrappés depuis **`main`** (`INSTALL_BASE_URL_DEFAULT = …/electricore/main/deploy`), pas depuis le tag `--version`. **Une fois cette PR mergée dans `main`**, un `reconfigure` sur la box reprend l'`install.sh` corrigé et l'override fonctionne.

> ⚠️ Pré-requis pour que `--version 3.4.0rc10` aboutisse : l'**image `ghcr.io/energie-de-nantes/electricore:3.4.0rc10` doit exister** (build CI du tag `v3.4.0rc10`). À vérifier côté GHCR avant de relancer le déploiement.

_Régression introduite par #299 ; pas d'issue dédiée._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
