### PR TITLE
fix(ingestion): surface r67 dans l'API et le bot d'ingestion

### DIFF
--- a/electricore/api/services/ingestion_service.py
+++ b/electricore/api/services/ingestion_service.py
@@ -44,7 +44,7 @@ class ModeIngestion(StrEnum):
 
 
 # Clés de flux.yaml, en minuscules — le runner accepte aussi une liste de flux (#152).
-FLUX_CONNUS = frozenset({"c15", "f12", "f15", "r15", "r151", "r64"})
+FLUX_CONNUS = frozenset({"c15", "f12", "f15", "r15", "r151", "r64", "r67"})
 
 
 def valider_mode(mode: str) -> str | None:

--- a/electricore/bot/handlers/flux.py
+++ b/electricore/bot/handlers/flux.py
@@ -24,6 +24,7 @@ DESCRIPTIONS = {
     "r15_acc": "Relevés autoconsommation (R15)",
     "r151": "Relevés périodiques",
     "r64": "Relevés courbe (JSON)",
+    "r67": "Mesures facturantes (énergie par période)",
 }
 
 

--- a/electricore/bot/handlers/ingestion.py
+++ b/electricore/bot/handlers/ingestion.py
@@ -20,7 +20,7 @@ POLL_INTERVAL = 5  # secondes entre deux interrogations du job
 POLL_MAX = 360  # ≈ 30 minutes de suivi au maximum
 
 # Clés de flux proposées dans le sous-menu (miroir de FLUX_CONNUS côté API).
-FLUX = ("c15", "f12", "f15", "r15", "r151", "r64")
+FLUX = ("c15", "f12", "f15", "r15", "r151", "r64", "r67")
 
 _STATUS_EMOJI = {
     "running": "⏳",

--- a/tests/integration/test_ingestion_run_modes.py
+++ b/tests/integration/test_ingestion_run_modes.py
@@ -27,7 +27,9 @@ def _pipeline_courtcircuite(monkeypatch):
     app.dependency_overrides.clear()
 
 
-@pytest.mark.parametrize("mode", ["test", "all", "rebuild", "resync", "r151", "c15", "r151 c15", "R151 C15"])
+@pytest.mark.parametrize(
+    "mode", ["test", "all", "rebuild", "resync", "r151", "c15", "r64", "r67", "r151 c15", "r151 r67", "R151 C15"]
+)
 def test_run_accepte_les_modes_reels(mode):
     response = TestClient(app).post("/ingestion/run", json={"mode": mode})
     assert response.status_code == 202, response.text


### PR DESCRIPTION
## Problème

`POST /ingestion/run` avec `mode: "r67"` renvoyait `422` :

> Mode invalide : 'r67'. Acceptés : test, all, rebuild, resync, ou une liste de flux parmi c15, f12, f15, r15, r151, r64.

Le flux **R67** (mesures facturantes, ADR-0047) est pourtant ingéré par le runner depuis #214 — il est dans `flux.yaml` et câblé `raw_r67 → flux_r67` dans le runner. Seules les **allowlists figées** côté API et bot (des miroirs manuels de `flux.yaml`) ne le connaissaient pas.

## Correctif

On aligne les trois miroirs de `flux.yaml` :

| Endroit | Avant | Après |
|---|---|---|
| `ingestion_service.FLUX_CONNUS` (API) | r64 | **+ r67** → `valider_mode` accepte `r67` |
| `handlers/ingestion.FLUX` (bot `/ingestion`) | r64 | **+ r67** → bouton r67 dans le sous-menu ciblé |
| `handlers/flux.DESCRIPTIONS` (bot `/flux`) | r64 | **+ r67** → libellé de la table `flux_r67` auto-listée |

Le runner CLI lui-même n'avait rien à changer (`nargs="+"`, validation contre `flux.yaml` qui a déjà `R67`).

## Test

Régression verrouillée dans `test_ingestion_run_modes` (ajout de `r64`, `r67`, `r151 r67` aux modes acceptés). Le test bot lit `FLUX` dynamiquement → couverture automatique.

```
42 passed (test_ingestion_run_modes + test_bot_handlers_ingestion + test_bot_handlers_flux)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)