### PR TITLE
fix(api): /provision/estimation → 503 actionnable si flux_r67 absent (pas 500)

### DIFF
--- a/electricore/api/routers/provision.py
+++ b/electricore/api/routers/provision.py
@@ -8,11 +8,17 @@ ADR-0016/0027). Réponse JSON enveloppée avec `contract_version`, auth `X-API-K
 conventions que `POST /facturation/rsc`.
 """
 
-from fastapi import APIRouter, Depends, Query, Response
+import logging
+
+import duckdb
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
 from electricore.api.security import get_current_api_key
 from electricore.api.services.provision_service import CONTRAT_VERSION, serialiser_rapport
 from electricore.core.builds.rapport_provision import RapportProvision
+from electricore.core.loaders.duckdb import DuckDBLockError
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["provision"])
 
@@ -45,4 +51,25 @@ async def get_estimation_provision(
     aucune période R67 dans la fenêtre de 12 mois. **Zéro €** (ADR-0016/0027).
     """
     response.headers["X-Contract-Version"] = str(CONTRAT_VERSION)
-    return serialiser_rapport(_estimer(pdl))
+    try:
+        rapport = _estimer(pdl)
+    except (HTTPException, DuckDBLockError):
+        # DuckDBLockError → handler d'app (503 « ingestion en cours », main.py).
+        raise
+    except duckdb.CatalogException as e:
+        # flux_r67 pas (encore) matérialisé : aucune mesure facturante M023 (R67) ingérée.
+        # État opérationnel attendu, pas un bug → 503 actionnable plutôt qu'un 500 brut.
+        logger.warning("provision/estimation: flux_r67 absent — %s", e)
+        raise HTTPException(
+            503,
+            "Données R67 indisponibles : le flux flux_r67 n'est pas matérialisé (aucune "
+            "mesure facturante M023 ingérée). Déclencher une demande M023 sur le portail "
+            "SGE, l'ingérer, puis réessayer.",
+        ) from e
+    except FileNotFoundError as e:
+        logger.warning("provision/estimation: base DuckDB absente — %s", e)
+        raise HTTPException(503, f"Base de données indisponible : {e}") from e
+    except Exception as e:
+        logger.exception("provision/estimation: erreur inattendue")
+        raise HTTPException(503, f"Erreur lors de l'estimation : {e}") from e
+    return serialiser_rapport(rapport)

--- a/tests/integration/test_provision_endpoint.py
+++ b/tests/integration/test_provision_endpoint.py
@@ -9,6 +9,7 @@ câblage transport + enveloppe (`contract_version`, en-tête, sérialisation), p
 
 import datetime as dt
 
+import duckdb
 import polars as pl
 import pytest
 from fastapi.testclient import TestClient
@@ -74,6 +75,33 @@ def test_estimation_renvoie_enveloppe_kwh(client, monkeypatch):
     assert est["couverture_suffisante"] is True
     # Zéro € exposé (convention de colonne € = suffixe `_eur`, ADR-0016/0027).
     assert not any(cle.endswith("_eur") or "_eur_" in cle for cle in est)
+
+
+def test_flux_r67_absent_renvoie_503_actionnable(client, monkeypatch):
+    """Régression : flux_r67 non matérialisé (R67 ponctuel jamais ingéré / aucune M023) → 503
+    ACTIONNABLE, pas un 500 brut. Le chemin loader réel n'était pas couvert (estimateur
+    monkeypatché), d'où la CatalogException non gérée remontée en prod."""
+
+    def _table_absente(pdl):
+        raise duckdb.CatalogException("Catalog Error: Table with name flux_r67 does not exist!")
+
+    monkeypatch.setattr("electricore.api.routers.provision._estimer", _table_absente)
+    response = client.get("/provision/estimation", params={"pdl": "12345678901234"})
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert "flux_r67" in detail and "M023" in detail  # message qui dit quoi faire
+
+
+def test_erreur_inattendue_renvoie_503_pas_500(client, monkeypatch):
+    """Garde : toute erreur inattendue du seam est emballée en 503 — l'endpoint n'émet jamais
+    de 500 brut (convention `binary_endpoint`/decorators.py)."""
+
+    def _boom(pdl):
+        raise RuntimeError("imprévu")
+
+    monkeypatch.setattr("electricore.api.routers.provision._estimer", _boom)
+    response = client.get("/provision/estimation", params={"pdl": "12345678901234"})
+    assert response.status_code == 503
 
 
 def _rapport_4_cadrans(pdl: str) -> RapportProvision:


### PR DESCRIPTION
## Symptôme

`GET /provision/estimation?pdl=…` renvoie un **500 brut** en prod :
```
_duckdb.CatalogException: Catalog Error: Table with name flux_r67 does not exist!
```

## Cause

`flux_r67` n'est matérialisé que si `raw_r67` est présent (runner `construire_dbt` :
`--select` restreint aux modèles dont la table brute existe). R67 est **ponctuel** (prestation
M023, ADR-0047) → tant qu'aucune demande M023 n'a déposé de fichier `*_R67_*.zip` sur le SFTP,
`raw_r67`/`flux_r67` n'existent pas. Le chemin loader réel n'était pas couvert en test
(l'estimateur `_estimer` est monkeypatché dans les tests d'intégration), d'où la
`CatalogException` non gérée → 500.

## Correctif (défensif, indépendant)

Le endpoint ne doit jamais émettre de **500 brut** :
- `CatalogException` (flux_r67 absent) → **503** avec message **actionnable** (« déclencher une
  demande M023 sur le portail SGE, l'ingérer, puis réessayer »).
- `FileNotFoundError` (base DuckDB absente) → 503 ; `DuckDBLockError` propagé au handler d'app
  (503 « ingestion en cours ») ; fallback `Exception` → 503 (`logger.exception`).
- **2 tests garde** : table absente → 503 actionnable ; erreur inattendue → 503.

> N.B. — n'**active pas** la feature : pour obtenir des estimations il faut d'abord ingérer du
> R67 (demande M023 manuelle, #216 wontfix). Ce fix ne fait que rendre l'état « pas encore de
> R67 » lisible plutôt qu'un 500. Complémentaire au fix d'allowlist d'ingestion (branche
> `fix/ingestion-api-r67`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)