### PR TITLE
feat(ingestion): --resync ciblé purge l'état incrémental d'un flux

### DIFF
--- a/electricore/ingestion/runner.py
+++ b/electricore/ingestion/runner.py
@@ -79,16 +79,22 @@ class PlanRun:
     rebuild: bool = False  # True = saute le landing, dbt build seul (zéro réseau)
 
 
-def interpreter_flux(flux: list[str], max_files: int | None) -> PlanRun:
+def interpreter_flux(flux: list[str], max_files: int | None, resync: bool = False) -> PlanRun:
     """Traduit les arguments de flux (modes API compris) en plan d'exécution.
 
     - 'all'     → tous les flux ;
     - 'test'    → tous les flux, 2 fichiers chacun (smoke) ;
     - 'rebuild' → re-matérialise les tables depuis le brut, zéro réseau (~13 s) —
                   le geste standard après un changement de modèle dbt (#140) ;
-    - 'resync'  → état incrémental dlt purgé, tout re-téléchargé (brut perdu/corrompu) ;
+    - 'resync'  → état incrémental dlt purgé sur TOUS les flux, tout re-téléchargé
+                  (`drop_sources`, exceptionnel : brut perdu/corrompu) ;
     - 'reset'   → déprécié, alias de resync ;
     - sinon     → liste de flux (r151 c15 …), upper-casée vers les clés de flux.yaml.
+
+    `resync=True` (drapeau `--resync`) ne vaut que pour la branche liste-de-flux : il
+    purge l'état incrémental des SEULS flux sélectionnés (`drop_resources` scopé au run)
+    pour rejouer un curseur bloqué sans re-télécharger les autres flux. Sans effet sur
+    'all'/'test'/'rebuild'/'resync' (ces modes ont déjà leur propre refresh).
     """
     if flux == ["all"]:
         return PlanRun(selection=None, max_files=max_files, refresh=None)
@@ -98,7 +104,8 @@ def interpreter_flux(flux: list[str], max_files: int | None) -> PlanRun:
         return PlanRun(selection=None, max_files=max_files, refresh=None, rebuild=True)
     if flux in (["resync"], ["reset"]):
         return PlanRun(selection=None, max_files=max_files, refresh="drop_sources")
-    return PlanRun(selection=[f.upper() for f in flux], max_files=max_files, refresh=None)
+    refresh = "drop_resources" if resync else None
+    return PlanRun(selection=[f.upper() for f in flux], max_files=max_files, refresh=refresh)
 
 
 def lander_brut(db_path: Path, plan: PlanRun) -> dict[str, StatsChaine]:
@@ -282,9 +289,15 @@ def main() -> None:
         "--db", type=Path, default=None, help="base DuckDB cible (défaut : $DUCKDB__PATH ou la base de prod locale)"
     )
     parseur.add_argument("--max-files", type=int, default=None, help="limite de fichiers par flux")
+    parseur.add_argument(
+        "--resync",
+        action="store_true",
+        help="purge l'état incrémental des flux sélectionnés (drop_resources scopé au run) "
+        "pour rejouer un curseur bloqué — n'a d'effet qu'avec une liste de flux, ex. « r67 --resync »",
+    )
     args = parseur.parse_args()
 
-    plan = interpreter_flux(args.flux, args.max_files)
+    plan = interpreter_flux(args.flux, args.max_files, resync=args.resync)
 
     # Fail-fast par point d'entrée (ADR-0025) : rebuild ne touche ni SFTP ni AES.
     if plan.rebuild:

--- a/tests/ingestion/test_ingestion.py
+++ b/tests/ingestion/test_ingestion.py
@@ -67,6 +67,27 @@ def test_selection_multi_flux():
     assert plan.selection == ["R151", "C15"]
 
 
+def test_resync_cible_purge_l_etat_du_seul_flux_selectionne():
+    """`--resync` sur une liste de flux → `drop_resources` scopé au run (purge le seul
+    curseur des flux sélectionnés, pour rejouer un curseur bloqué). Cas d'usage : R67
+    ponctuel dont le curseur a avancé au listing sans atterrissage."""
+    plan = interpreter_flux(["r67"], max_files=None, resync=True)
+    assert plan.selection == ["R67"]
+    assert plan.refresh == "drop_resources"
+
+
+def test_sans_resync_une_liste_de_flux_ne_purge_rien():
+    """Le défaut reste l'incrémental : pas de drapeau → aucun refresh."""
+    assert interpreter_flux(["r67"], max_files=None).refresh is None
+
+
+def test_resync_cible_ne_se_confond_pas_avec_le_mode_resync_global():
+    """Deux purges distinctes : le MODE `resync` rejoue TOUS les flux (`drop_sources`) ;
+    le DRAPEAU `--resync` sur une liste rejoue les SEULS flux visés (`drop_resources`)."""
+    assert interpreter_flux(["resync"], max_files=None).refresh == "drop_sources"
+    assert interpreter_flux(["r67"], max_files=None, resync=True).refresh == "drop_resources"
+
+
 def test_la_base_par_defaut_honore_duckdb_path(monkeypatch):
     """En conteneur, DUCKDB__PATH pointe le volume de données (docker-compose) :
     le runner doit l'honorer, comme l'API et les loaders."""


### PR DESCRIPTION
## Pourquoi

Le mode `resync` du runner purge l'état incrémental de **tous** les flux
(`drop_sources` → re-télécharge tout, lourd). Or le besoin réel est souvent de
**rejouer le curseur d'un seul flux** dont le listing a avancé sans que les
fichiers atterrissent — c'est exactement le cas R67 (flux ponctuel M023) :
son curseur a sauté les fichiers du jour, et `raw_r67` reste vide.

## Quoi

- `interpreter_flux(flux, max_files, resync=False)` : nouveau paramètre. Sur une
  **liste de flux**, `resync=True` pose `refresh="drop_resources"` — dlt purge
  l'état **et** les tables des seules resources du run (la sélection est déjà
  filtrée à ces flux). Aucun effet sur `all`/`test`/`rebuild`/`resync` (ces modes
  ont déjà leur propre refresh).
- Drapeau CLI `--resync` câblé dans `main()`.

```bash
python -m electricore.ingestion r67 --resync
```

## Distinction des deux purges

| Geste | Portée | refresh dlt |
|---|---|---|
| mode `resync` / `reset` | **tous** les flux | `drop_sources` |
| drapeau `--resync` sur une liste | **seuls** les flux visés | `drop_resources` |

## Tests

3 tests ajoutés dans `tests/ingestion/test_ingestion.py` (résolution du plan :
`--resync` ciblé → `drop_resources`, défaut sans drapeau → aucun refresh, et
non-confusion avec le mode `resync` global). Suite `test_ingestion.py` verte (14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
