### PR TITLE
fix(ingestion): R67 re-liste tout (incremental: false) — anti curseur bloqué

### DIFF
--- a/electricore/ingestion/config/flux.yaml
+++ b/electricore/ingestion/config/flux.yaml
@@ -39,10 +39,15 @@ R64:
 
 # R67 (« mesures facturantes ») : énergie facturante par période, à la demande (prestation
 # M023, ADR-0047). Même répertoire SFTP que R64, mais JSON minuscules dans les ZIPs R67.
+# incremental: false → re-liste TOUT à chaque run. Flux ponctuel et peu volumineux : un
+# fichier qui n'atterrit pas (decrypt/parse → 0 document) doit pouvoir se rejouer au run
+# suivant ; le merge `file_name` dédoublonne. Évite le « curseur bloqué » qui sautait à
+# jamais les M023 du jour (le listing avançait sans landing).
 R67:
   file_pattern: "**/R63_R64_R65_R66_R67_C68/*_R67_*.zip"
   format: json
   file_regex: "*.json"  # JSON en minuscules dans les ZIPs R67
+  incremental: false
 
 # X12 (affaires initiées par l'instance) + X13 (affaires reçues d'autres acteurs)
 # partagent le même schéma XSD → une seule table brute `raw_affaires` ; l'origine se

--- a/electricore/ingestion/sources/sftp_enedis.py
+++ b/electricore/ingestion/sources/sftp_enedis.py
@@ -51,7 +51,9 @@ def mask_password_in_url(url: str) -> str:
     return re.sub(pattern, r"\1****\2", url)
 
 
-def create_sftp_resource(flux_type: str, table_name: str, file_pattern: str, sftp_url: str, max_files: int = None):
+def create_sftp_resource(
+    flux_type: str, table_name: str, file_pattern: str, sftp_url: str, max_files: int = None, incremental: bool = True
+):
     """
     Crée une resource SFTP réutilisable avec limitation optionnelle.
 
@@ -61,6 +63,12 @@ def create_sftp_resource(flux_type: str, table_name: str, file_pattern: str, sft
         file_pattern: Pattern pour les fichiers (ZIP ou JSON directs)
         sftp_url: URL du serveur SFTP
         max_files: Nombre max de fichiers à traiter
+        incremental: Si True (défaut), le listing n'émet que les fichiers plus récents
+            que le dernier curseur (modification_date). Si False, RE-LISTE tout à chaque
+            run : le curseur ne peut plus « avancer au listing » et sauter à jamais un
+            fichier qui n'a pas atterri en aval (decrypt/parse → 0 document). Le dédoublon
+            est alors assuré en aval par le merge sur `file_name` (write_disposition merge
+            de la source brute). Réservé aux flux ponctuels et peu volumineux (R67/M023).
     """
 
     @dlt.resource(
@@ -93,7 +101,10 @@ def create_sftp_resource(flux_type: str, table_name: str, file_pattern: str, sft
 
         files.add_map(_normalize_date)
 
-        files.apply_hints(incremental=dlt.sources.incremental("modification_date"))
+        # L'incrémental est OPTIONNEL : sans lui, le curseur ne peut pas avancer au listing
+        # et sauter à jamais un fichier non atterri (le merge `file_name` en aval dédoublonne).
+        if incremental:
+            files.apply_hints(incremental=dlt.sources.incremental("modification_date"))
 
         # Limiter le nombre de fichiers si spécifié
         file_count = 0

--- a/electricore/ingestion/sources/sftp_enedis_brut.py
+++ b/electricore/ingestion/sources/sftp_enedis_brut.py
@@ -95,8 +95,11 @@ def flux_enedis_brut(flux_config: dict, max_files: int = None, stats: dict[str, 
         est_json = config_flux.get("format") == "json"
         extension = ".json" if est_json else ".xml"
         file_regex = config_flux.get("file_regex", f"*{extension}")
+        # Incrémental par défaut ; un flux peut l'éteindre (`incremental: false` dans flux.yaml)
+        # pour re-lister tout à chaque run et ne jamais sauter un fichier non atterri (R67/M023).
+        incremental = config_flux.get("incremental", True)
 
-        sftp_resource = create_sftp_resource(flux_type, table, file_pattern, sftp_url, max_files)
+        sftp_resource = create_sftp_resource(flux_type, table, file_pattern, sftp_url, max_files, incremental)
         stats_flux = stats.setdefault(flux_type, StatsChaine())
         decrypt_transformer = create_decrypt_transformer(key_chain=key_chain, stats=stats_flux)
         unzip_transformer = create_unzip_transformer(extension, file_regex, stats=stats_flux)

--- a/tests/ingestion/test_incremental_optionnel.py
+++ b/tests/ingestion/test_incremental_optionnel.py
@@ -1,0 +1,97 @@
+"""Un flux peut éteindre l'incrémental (`incremental: false`) → il re-liste TOUT.
+
+Le bug de classe : l'incrémental dlt vit sur le **listing** (modification_date), pas sur
+le **landing**. Un flux qui liste un fichier mais échoue en aval (decrypt/parse → 0
+document) **avance quand même son curseur** → le fichier est sauté à JAMAIS au run
+suivant. C'est ce qui a vidé `raw_r67` en prod (M023 du jour skippés).
+
+Fix scopé : R67 (flux ponctuel, peu volumineux) éteint l'incrémental dans flux.yaml ; il
+liste tout à chaque run, le merge `file_name` en aval dédoublonne. Les flux quotidiens
+(R64/R151/C15…) gardent leur incrémental.
+
+Ces tests verrouillent : (1) flux.yaml éteint bien l'incrémental pour R67 ; (2) à travers
+`flux_enedis_brut`, un flux `incremental: false` ne pose AUCUN curseur de listing, là où un
+flux incrémental en pose un (même avec 0 document atterri — le cœur du bug).
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+
+import dlt
+import pytest
+import yaml
+
+from electricore.config import runtime
+from electricore.ingestion.sources.sftp_enedis_brut import flux_enedis_brut
+
+_CONFIG = {
+    # R64 : incrémental par défaut (le curseur DOIT avancer au listing — bug de classe).
+    "R64": {"file_pattern": "**/R63_R64_R65_R66_R67_C68/*_R64_*.zip", "format": "json", "file_regex": "*.JSON"},
+    # R67 : incrémental éteint → re-liste tout, aucun curseur posé (le fix).
+    "R67": {
+        "file_pattern": "**/R63_R64_R65_R66_R67_C68/*_R67_*.zip",
+        "format": "json",
+        "file_regex": "*.json",
+        "incremental": False,
+    },
+}
+
+
+def test_flux_yaml_eteint_l_incremental_pour_r67():
+    """La config de prod livrée porte bien la décision : R67 re-liste tout."""
+    chemin = Path(__file__).parents[2] / "electricore" / "ingestion" / "config" / "flux.yaml"
+    flux = yaml.safe_load(chemin.read_text())
+    assert flux["R67"].get("incremental") is False
+
+
+@pytest.fixture
+def bucket_local(tmp_path):
+    """Un bucket file:// avec un leurre R64 et un leurre R67 (datés, contenu bidon)."""
+    b = tmp_path / "bucket"
+    (b / "R63_R64_R65_R66_R67_C68").mkdir(parents=True)
+    for nom in ("R63_R64_R65_R66_R67_C68/a_R64_x.zip", "R63_R64_R65_R66_R67_C68/a_R67_x.zip"):
+        f = b / nom
+        f.write_bytes(b"pas un vrai zip")
+        ts = time.mktime((2026, 1, 1, 12, 0, 0, 0, 0, -1))
+        os.utime(f, (ts, ts))
+    return b
+
+
+def _etat_resource(pipelines_dir, resource: str) -> dict | None:
+    """État dlt d'une resource de listing (sftp), tous namespaces confondus."""
+    state = json.loads((pipelines_dir / "flux_brut_t" / "state.json").read_text())
+    for source_state in state.get("sources", {}).values():
+        resources = source_state.get("resources", {})
+        if resource in resources:
+            return resources[resource]
+    return None
+
+
+def test_incremental_off_ne_pose_aucun_curseur_de_listing(tmp_path, bucket_local, monkeypatch):
+    """Cœur du fix : à travers `flux_enedis_brut`, le flux incrémental (R64) pose un curseur
+    `modification_date` — même avec 0 document atterri (contenu bidon → decrypt échoue) :
+    c'est exactement le piège qui sautait les fichiers non atterris. Le flux `incremental:
+    false` (R67), lui, n'en pose AUCUN → il re-listera le fichier au run suivant."""
+    monkeypatch.setenv("SFTP__URL", f"file://{bucket_local}/")
+    monkeypatch.setenv("AES__TROUSSEAU__test__KEY", "00112233445566778899aabbccddeeff")
+    monkeypatch.setenv("AES__TROUSSEAU__test__IV", "ffeeddccbbaa99887766554433221100")
+    runtime.vider_cache()
+
+    pipelines_dir = tmp_path / "pipelines"
+    pipeline = dlt.pipeline(
+        pipeline_name="flux_brut_t",
+        destination=dlt.destinations.duckdb(str(tmp_path / "t.duckdb")),
+        dataset_name="flux_raw",
+        pipelines_dir=str(pipelines_dir),
+    )
+    pipeline.run(flux_enedis_brut(_CONFIG, max_files=None))
+
+    etat_r64 = _etat_resource(pipelines_dir, "filesystem_raw_r64")
+    etat_r67 = _etat_resource(pipelines_dir, "filesystem_raw_r67")
+
+    # R64 incrémental : un curseur de listing existe (le bug de classe, ici inoffensif).
+    assert etat_r64 is not None and "incremental" in etat_r64
+    # R67 incrémental éteint : aucun curseur → le fichier non atterri se rejouera.
+    assert etat_r67 is None or "incremental" not in etat_r67


### PR DESCRIPTION
## Le bug de classe

L'incrémental dlt vit sur le **listing** (`modification_date`), pas sur le
**landing**. Un flux qui liste un fichier mais échoue en aval
(decrypt/parse → 0 document) **avance quand même son curseur** → le fichier est
**sauté à jamais** au run suivant (filtre incrémental strict).

C'est exactement ce qui a vidé `raw_r67` en prod : le curseur R67 a avancé au
listing au-delà des M023 du jour sans qu'ils atterrissent → `R67 : 0 fichiers`
→ `flux_r67` jamais bâti → `GET /provision/estimation` en erreur.

## Le fix (scopé R67)

R67 est un flux **ponctuel** (prestation M023) et peu volumineux → on **éteint
l'incrémental** pour lui : il **re-liste tout** à chaque run, et le `merge` sur
`file_name` (déjà la `write_disposition` de la source brute) dédoublonne. Un
fichier non atterri **se rejoue** au run suivant.

- `flux.yaml` : `R67:` porte `incremental: false`.
- `flux_enedis_brut` lit `incremental = config_flux.get("incremental", True)` et
  le passe à `create_sftp_resource(...)`.
- `create_sftp_resource(..., incremental=True)` : n'applique
  `apply_hints(incremental=…)` **que si** `incremental`. Le pin du namespace
  d'état (`source_name = ESPACE_ETAT_INCREMENTAL`, #346) et la normalisation ISO
  de `modification_date` restent inchangés.

Les flux quotidiens (R64/R151/C15…) gardent leur incrémental — **inchangés**.

> La variante générale « le curseur n'avance qu'au landing réussi » toucherait
> **tout** l'incrémental : trop risquée pour ce besoin. Le scope R67 suffit.

## Tests

`tests/ingestion/test_incremental_optionnel.py` (2) :
1. `flux.yaml` éteint bien l'incrémental pour R67 (verrou de la décision prod).
2. À travers `flux_enedis_brut` (contenu bidon → 0 document atterri), le flux
   incrémental R64 **pose** un curseur de listing — le piège même —, tandis que
   R67 (`incremental: false`) n'en pose **aucun**.

Tests des sources/runner adjacents (escalade chaîne, namespace d'état, reset,
runner, crypto) restés verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
