### PR TITLE
chore(release): 3.4.0rc11 — robustesse ingestion R67 (curseur incrémental)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.4.0rc11] - 2026-06-28
+
+### 🛠️ Robustesse ingestion (curseur incrémental R67)
+
+- **R67 re-liste tout à chaque run (`incremental: false`)** (#495) : l'incrémental dlt vit
+  sur le **listing** (`modification_date`), pas sur le **landing** — un flux qui liste un
+  fichier mais échoue en aval (decrypt/parse → 0 document) avançait quand même son curseur
+  et **sautait le fichier à jamais**. C'est ce qui a vidé `raw_r67` en prod (M023 du jour
+  skippés → `flux_r67` absent → `/provision/estimation` en erreur). R67 étant un flux
+  ponctuel et peu volumineux, il éteint l'incrémental : il liste tout, le `merge` sur
+  `file_name` dédoublonne, un fichier non atterri se rejoue. Les flux quotidiens
+  (R64/R151/C15…) gardent leur incrémental.
+- **`--resync` ciblé sur le CLI** (#494) : `python -m electricore.ingestion <flux> --resync`
+  purge l'état incrémental des **seuls** flux sélectionnés (`drop_resources` scopé au run),
+  pour rejouer un curseur bloqué sans re-télécharger tous les flux (le mode `resync` global
+  reste `drop_sources`).
+
+### 🐛 Corrections
+
+- **R67 surfacé dans l'API et le bot d'ingestion** (#492) : `mode: "r67"` accepté par
+  `POST /ingestion/run` et bouton dédié dans le bot.
+- **Déploiement : override `--version` rebranché** (#491) : l'option `--version` de
+  `install.sh`, rendue inerte par #299, réécrit de nouveau `ELECTRICORE_VERSION` dans
+  `config.env` ; garde anti-régression ajoutée.
+
 ## [3.4.0rc10] - 2026-06-27
 
 ### ✨ Nouveautés (estimation de provision des lissés — cold-start R67)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.4.0rc10"
+version = "3.4.0rc11"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.4.0rc10"
+version = "3.4.0rc11"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Bump `3.4.0rc10` → `3.4.0rc11` (pyproject + uv.lock + CHANGELOG) **avant** de tagger
`v3.4.0rc11`. Le workflow Release est déclenché par le tag, pas par cette PR.

## Contenu de rc11 (depuis rc10)

**Robustesse ingestion — curseur incrémental R67**
- **#495** — R67 `incremental: false` : re-liste tout à chaque run. L'incrémental dlt vit
  sur le *listing*, pas sur le *landing* → un flux qui liste mais échoue en aval avançait
  son curseur et sautait le fichier à jamais (a vidé `raw_r67` en prod). _(à merger)_
- **#494** — `--resync` ciblé CLI : purge l'état du seul flux visé (`drop_resources`). _(à merger)_

**Corrections déjà sur main**
- **#492** — r67 surfacé dans l'API et le bot d'ingestion.
- **#491** — déploiement : override `--version` rebranché (régression #299).

## ⚠️ Avant de tagger

Cette PR ne fait que le bump. **#494 et #495 doivent être mergées avant le tag**
`v3.4.0rc11` pour que rc11 porte réellement les fixes annoncés au CHANGELOG. Le tag
reste un geste manuel publiant (build PyPI OIDC + image ghcr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
