### PR TITLE
fix(config): dé-quote du bloc ODOO__* (parité sops exec-env) — rc12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.4.0rc12] - 2026-06-28
+
+### 🐛 Corrections
+
+- **Config Odoo : dé-quote `ODOO__DB` / `ODOO__USERNAME` / `ODOO__PASSWORD`** (suite #454) :
+  en prod `sops exec-env` exporte les valeurs dotenv **verbatim** (guillemets compris) là
+  où le `.env` dev passe par python-dotenv qui les retire. Un secret écrit
+  `ODOO__DB="<base>"` atteignait `authenticate()` quotes incluses → Postgres répondait
+  `database ""<base>"" does not exist` (échec d'auth XML-RPC cryptique). Le nettoyage
+  `_dequote` (jusque-là réservé à `ODOO__URL`, #454) couvre désormais tout le bloc
+  `ODOO__*`, refermant l'écart dev↔prod.
+
 ## [3.4.0rc11] - 2026-06-28
 
 ### 🛠️ Robustesse ingestion (curseur incrémental R67)

--- a/electricore/config/runtime.py
+++ b/electricore/config/runtime.py
@@ -121,19 +121,29 @@ class Aes(BaseSettings):
         return [(label, *paire.octets(label)) for label, paire in self.trousseau.items()]
 
 
-def _normaliser_url(valeur: str, *, var: str) -> str:
-    """Trim + dé-quote + exige un schéma http(s) (#454).
+def _dequote(valeur: str) -> str:
+    """Trim + retire une paire de guillemets appariés (parité python-dotenv).
 
     En prod, `sops exec-env` exporte les valeurs dotenv **verbatim**, guillemets
-    compris — là où le `.env` lu en dev passe par python-dotenv qui les retire. Un
-    `ODOO__URL="https://…"` (guillemets dans le secret) atteint alors `ServerProxy`
-    tel quel : `urlsplit` lit le schéma `"https` ≠ `http`/`https` et lève
-    « unsupported XML-RPC protocol » (503 cryptique). On retire l'espace et les
-    guillemets appariés, et on rejette tôt un schéma absent avec un message clair.
+    compris — là où le `.env` lu en dev passe par python-dotenv qui les retire. Sans
+    rattrapage, un `ODOO__DB="edn"` (guillemets dans le secret) atteint `authenticate()`
+    tel quel et Postgres répond `database ""edn"" does not exist`. On réplique donc la
+    sémantique dotenv pour tout le bloc `ODOO__*` (#454 ne l'avait fait que pour l'URL).
     """
-    url = valeur.strip()
-    if len(url) >= 2 and url[0] == url[-1] and url[0] in "\"'":
-        url = url[1:-1].strip()
+    nettoyee = valeur.strip()
+    if len(nettoyee) >= 2 and nettoyee[0] == nettoyee[-1] and nettoyee[0] in "\"'":
+        nettoyee = nettoyee[1:-1].strip()
+    return nettoyee
+
+
+def _normaliser_url(valeur: str, *, var: str) -> str:
+    """Dé-quote (cf. `_dequote`) + exige un schéma http(s) (#454).
+
+    Un `ODOO__URL="https://…"` non nettoyée atteint `ServerProxy` tel quel : `urlsplit`
+    lit le schéma `"https` ≠ `http`/`https` et lève « unsupported XML-RPC protocol »
+    (503 cryptique). On rejette en plus tôt un schéma absent avec un message clair.
+    """
+    url = _dequote(valeur)
     if not url.startswith(("http://", "https://")):
         raise ValueError(f"{var} doit commencer par http:// ou https:// (reçu : {valeur!r})")
     return url
@@ -157,6 +167,11 @@ class Odoo(BaseSettings):
     @classmethod
     def _url_normalisee(cls, valeur: str) -> str:
         return _normaliser_url(valeur, var="ODOO__URL")
+
+    @field_validator("db", "username", "password")
+    @classmethod
+    def _identifiants_dequote(cls, valeur: str) -> str:
+        return _dequote(valeur)
 
 
 def _version_package() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.4.0rc11"
+version = "3.4.0rc12"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -140,6 +140,31 @@ class TestDomaineOdoo:
         monkeypatch.setenv("ODOO__URL", brut)
         assert runtime.odoo().url == "https://odoo.example"
 
+    def test_db_entre_guillemets_dequote(self, monkeypatch):
+        """`ODOO__DB` entre guillemets doubles (sops exec-env verbatim) est dé-quotée.
+
+        Sans ça, le nom de base littéral `"edn"` atteint `authenticate()` et Postgres
+        répond `database ""edn"" does not exist` (même classe que #454 pour l'URL).
+        """
+        monkeypatch.setenv("ODOO__DB", '"mainteniste-edn-odoo-edn-main-25347145"')
+        assert runtime.odoo().db == "mainteniste-edn-odoo-edn-main-25347145"
+
+    def test_username_entre_guillemets_dequote(self, monkeypatch):
+        """`ODOO__USERNAME` quotée échoue à l'auth (login littéral `"bot"` introuvable)."""
+        monkeypatch.setenv("ODOO__USERNAME", '"bot"')
+        assert runtime.odoo().username == "bot"
+
+    def test_password_entre_guillemets_dequote(self, monkeypatch):
+        """`ODOO__PASSWORD` dé-quotée pour parité dev↔prod.
+
+        En dev le `.env` passe par python-dotenv qui retire les guillemets appariés ;
+        sans le même traitement en prod (`sops exec-env` verbatim), un secret écrit
+        `ODOO__PASSWORD="secret"` authentifierait avec deux mots de passe différents
+        selon l'environnement.
+        """
+        monkeypatch.setenv("ODOO__PASSWORD", '"secret"')
+        assert runtime.odoo().password == "secret"
+
     def test_url_sans_schema_signalee_clairement(self, monkeypatch):
         """Un schéma absent ne tombe plus en 503 cryptique : message explicite nommant ODOO__URL."""
         monkeypatch.setenv("ODOO__URL", "odoo.example")

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.4.0rc11"
+version = "3.4.0rc12"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Symptôme (prod)

L'auth XML-RPC Odoo tombait sur une `OperationalError` Postgres au nom de base **doublement quoté** :

```
psycopg2.OperationalError: ... database ""mainteniste-edn-odoo-edn-main-25347145"" does not exist
```

La paire de guillemets *interne* est littéralement dans la valeur : le nom de base configuré était `"<base>"` (guillemets compris), pas `<base>`.

## Cause

Même classe que **#454** (qui n'avait nettoyé que `ODOO__URL`). En prod, `sops exec-env` exporte les valeurs dotenv **verbatim**, guillemets compris — là où le `.env` lu en dev passe par python-dotenv qui les retire. Un secret écrit `ODOO__DB="<base>"` atteignait donc `authenticate()` quotes incluses. `db`, `username`, `password` n'avaient aucun validateur de nettoyage ; seul `url` était couvert.

## Correctif

- Extrait `_dequote` (sémantique python-dotenv : trim + paire de guillemets appariés) hors du `_normaliser_url` existant.
- L'applique à tout le bloc `ODOO__*` via un seul `@field_validator("db", "username", "password")`.
- `url` délègue désormais au même helper — zéro duplication.

Refermé l'écart dev↔prod pour de bon : `password` est dé-quoté aussi, sinon dev (python-dotenv) et prod (`sops exec-env`) authentifieraient avec deux mots de passe différents pour le même secret.

## Tests (TDD red→green)

3 nouveaux tests dans `tests/unit/test_runtime.py`, un par champ (db / username / password), chacun documentant son *pourquoi* (erreur Postgres / login introuvable / parité dev-prod). `test_runtime.py` : **43 passed**, régressions #454 intactes.

## Note de déploiement

Ce correctif ne prend effet qu'une fois mergé + déployé. Le hotfix immédiat côté box reste : `sops` le `secrets.env`, retirer les guillemets autour de `ODOO__DB`, puis `reconfigure`.

Bump **3.4.0rc12** (pyproject + uv.lock + CHANGELOG) inclus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)