### PR TITLE
refactor(deploy): retire la validation bash redondante + le chemin legacy .env (ADR-0049, #501)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -329,7 +329,6 @@ ${ssh_recap}
   Étapes suivantes recommandées :
     - Configurer un offsite des backups (rclone vers un cloud — cf. docs/deploiement.md)
     - Ajouter https://${OPT_DOMAIN}/health à votre monitoring distant
-    - Sauvegarder ${ENV_FILE} dans un gestionnaire de secrets
 
   Pour reconfigurer plus tard (rotation clés AES, bump version, etc.) :
     sudo bash $0 --slug ${OPT_SLUG} --domain ${OPT_DOMAIN}

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -12,16 +12,15 @@
 #   6. Durcissement VPS (admin ops + sshd root-off + fail2ban + maj auto, ADR-0031 ; --no-harden)
 #   7. Téléchargement config tag-pinné
 #   8. Substitutions (slug, domaine, email)
-#   9. Édition .env + validation (loop)
+#   9. Identité box + pull dépôt secrets + validation config.env + box_can_decrypt (ADR-0044)
 #  10. DNS check bloquant
 #  11. docker compose up + wait_for_health
-#  12. Test ingestion (mode test, ~3s)
+#  12. Test ingestion (mode test, ~3s) — valide le CONTENU des secrets via le vrai conteneur
 #  13. Récap final
 #
-# Mode reconfigure : si /srv/<slug>/.env existe déjà, on backup le .env,
-# on saute la création user/Docker/UFW (idempotents de toute façon), on
-# ne télécharge pas le .env (mais on rafraîchit compose/Caddy/crontab pour
-# bump de version), et on ne touche jamais à la DB DuckDB.
+# Mode reconfigure : si /srv/<slug>/ porte déjà une clé age (ou un legacy .env),
+# on saute la création user/Docker/UFW (idempotents de toute façon), on rafraîchit
+# compose/Caddy/crontab pour le bump de version, et on ne touche jamais à la DB DuckDB.
 #
 # Sourçage : le script est protégé par un guard `main` (en fin de fichier).
 # Sourcer install.sh expose `fetch_lib_files` sans déclencher l'installation.
@@ -216,100 +215,57 @@ main() {
                  "Éditer à la main avant de mettre en prod."
     fi
 
-    # ─── Étape 9 : secrets-as-code (ADR-0044) OU legacy .env ────────────────
-    if [[ -n "$OPT_DEPLOY_REPO" ]]; then
-        # ── Secrets-as-code : identité de la box + auto-pull + déchiffrement ──
-        log_step "Identité de la box (age + SSH deploy key)"
-        if pubs=$(generate_box_identities "$OPT_SLUG"); then
-            age_pub=$(printf '%s\n' "$pubs" | sed -n 's/^AGE_PUBLIC_KEY=//p')
-            ssh_pub=$(printf '%s\n' "$pubs" | sed -n 's/^SSH_DEPLOY_PUBKEY=//p')
-        else
-            die "Génération des identités de la box échouée (image ${SECRETS_IMAGE} indisponible ?)."
-        fi
-
-        log_step "Pull du dépôt de déploiement privé"
-        if ! pull_deploy_repo "$OPT_DEPLOY_REPO" "$OPT_SLUG"; then
-            # Onboarding EN DEUX TEMPS (ADR-0044 §4) : la deploy key SSH doit être
-            # enregistrée comme deploy key RO avant que le pull réussisse.
-            print_onboarding_pending "$OPT_SLUG" "$OPT_DOMAIN" "$age_pub" "$ssh_pub"
-            _CLEAN_EXIT=1
-            return 0
-        fi
-
-        log_step "Validation du split config/secret + déchiffrement"
-        config_env="${HOME_DIR}/config.env"
-        secrets_env="${HOME_DIR}/providers/${OPT_SLUG}/secrets.env"
-        age_key="${HOME_DIR}/age.key"
-        if errs=$(validate_config_env "$config_env" "$OPT_SLUG"); then
-            log_ok "config.env valide"
-        else
-            log_err "config.env invalide :"; printf '%s\n' "$errs" | sed 's/^/     - /'
-            die "Corrige providers/${OPT_SLUG}/config.env dans le dépôt, pousse, puis relance reconfigure."
-        fi
-
-        # Override LOCAL de la version (#460) : `--version` pilote le tag d'image déployé même
-        # en secrets-as-code, SANS toucher au dépôt secrets (la version n'est pas un secret,
-        # c'est un paramètre de déploiement — ADR-0044). Appliqué APRÈS le pull : le config.env
-        # du dépôt reste la baseline GitOps (reconfigure sans --version = version pinée). Le pull
-        # ré-écrit config.env à chaque reconfigure → l'override est ré-appliqué à chaque fois.
-        # (Régression #299 corrigée : l'appel avait été supprimé → --version devenait inerte.)
-        if [[ "${OPT_VERSION_EXPLICIT:-0}" -eq 1 ]]; then
-            repo_version=$(read_env_var "$config_env" ELECTRICORE_VERSION)
-            override_config_version "$config_env" "$OPT_VERSION"
-            log_warn "ELECTRICORE_VERSION overridé localement : ${OPT_VERSION} (dépôt : ${repo_version}) — non versionné, propre à cette box."
-        fi
-
-        if ! box_can_decrypt "$OPT_SLUG"; then
-            # La box a sa clé + le ciphertext, mais ne déchiffre pas → sa clé age publique
-            # n'est pas (encore) destinataire dans .sops.yaml. 2e temps de l'onboarding.
-            print_onboarding_pending "$OPT_SLUG" "$OPT_DOMAIN" "$age_pub" "$ssh_pub"
-            die "La box ne déchiffre pas encore : enregistre sa clé age comme destinataire (.sops.yaml + sops updatekeys), pousse, puis relance reconfigure."
-        fi
-        if errs=$(validate_secrets_env "$secrets_env" "$age_key"); then
-            log_ok "secrets.env déchiffré et valide"
-        else
-            log_err "secrets.env invalide (après déchiffrement) :"; printf '%s\n' "$errs" | sed 's/^/     - /'
-            die "Corrige les secrets dans le dépôt (sops providers/${OPT_SLUG}/secrets.env), pousse, puis relance reconfigure."
-        fi
+    # ─── Étape 9 : secrets-as-code (ADR-0044) ──────────────────────────────
+    # --deploy-repo est obligatoire depuis le cutover (cli.sh) : on génère l'identité
+    # de la box, on tire le dépôt, on valide la POLITIQUE de split (config.env : présence
+    # des substitutions compose + anti-leak) et on teste que la box DÉCHIFFRE (box_can_decrypt).
+    # On ne valide PLUS le contenu de secrets.env par un preflight bash : le vrai conteneur le
+    # fait verbatim via `sops exec-env` aux étapes 11-12 (cf. ADR-0049, classe de bug rc12).
+    log_step "Identité de la box (age + SSH deploy key)"
+    if pubs=$(generate_box_identities "$OPT_SLUG"); then
+        age_pub=$(printf '%s\n' "$pubs" | sed -n 's/^AGE_PUBLIC_KEY=//p')
+        ssh_pub=$(printf '%s\n' "$pubs" | sed -n 's/^SSH_DEPLOY_PUBKEY=//p')
     else
-        # ── Legacy .env (migration / tests) : édition + validation monolithique ──
-        substitute_env "$ENV_FILE" "$OPT_SLUG" "$OPT_VERSION"
-        log_step "Configuration .env (édition + validation)"
-        if [[ "$MODE_RECONFIGURE" -eq 1 ]]; then
-            backup="${ENV_FILE}.bak.$(date +%Y%m%dT%H%M%SZ)"
-            cp -p "$ENV_FILE" "$backup"
-            chown "$OPT_SLUG:$OPT_SLUG" "$backup"
-            log_info "backup du .env existant → ${backup}"
-        fi
-        if [[ -n "$OPT_ENV_FROM" ]]; then
-            [[ -r "$OPT_ENV_FROM" ]] || die "--env-from : fichier illisible : $OPT_ENV_FROM"
-            cp "$OPT_ENV_FROM" "$ENV_FILE"
-            chown "$OPT_SLUG:$OPT_SLUG" "$ENV_FILE"
-            chmod 600 "$ENV_FILE"
-            log_info "chargement depuis $OPT_ENV_FROM"
-        else
-            log_info "ouverture de $ENV_FILE dans \${EDITOR:-nano}…"
-        fi
-        while true; do
-            if [[ -z "$OPT_ENV_FROM" ]]; then
-                sudo -u "$OPT_SLUG" "${EDITOR:-nano}" "$ENV_FILE"
-            fi
-            if errs=$(validate_env_file "$ENV_FILE" "$OPT_SLUG"); then
-                log_ok ".env valide"
-                strip_validation_error_block "$ENV_FILE"
-                chmod 600 "$ENV_FILE"
-                break
-            fi
-            log_err ".env invalide :"
-            printf '%s\n' "$errs" | sed 's/^/     - /'
-            if [[ -n "$OPT_ENV_FROM" ]]; then
-                die ".env fourni invalide, abandon."
-            fi
-            prepend_errors_to_env "$ENV_FILE" "$errs"
-            log_warn "ré-ouverture de l'éditeur dans 2s…"
-            sleep 2
-        done
+        die "Génération des identités de la box échouée (image ${SECRETS_IMAGE} indisponible ?)."
     fi
+
+    log_step "Pull du dépôt de déploiement privé"
+    if ! pull_deploy_repo "$OPT_DEPLOY_REPO" "$OPT_SLUG"; then
+        # Onboarding EN DEUX TEMPS (ADR-0044 §4) : la deploy key SSH doit être
+        # enregistrée comme deploy key RO avant que le pull réussisse.
+        print_onboarding_pending "$OPT_SLUG" "$OPT_DOMAIN" "$age_pub" "$ssh_pub"
+        _CLEAN_EXIT=1
+        return 0
+    fi
+
+    log_step "Validation du split config + test de déchiffrement"
+    config_env="${HOME_DIR}/config.env"
+    if errs=$(validate_config_env "$config_env" "$OPT_SLUG"); then
+        log_ok "config.env valide"
+    else
+        log_err "config.env invalide :"; printf '%s\n' "$errs" | sed 's/^/     - /'
+        die "Corrige providers/${OPT_SLUG}/config.env dans le dépôt, pousse, puis relance reconfigure."
+    fi
+
+    # Override LOCAL de la version (#460) : `--version` pilote le tag d'image déployé même
+    # en secrets-as-code, SANS toucher au dépôt secrets (la version n'est pas un secret,
+    # c'est un paramètre de déploiement — ADR-0044). Appliqué APRÈS le pull : le config.env
+    # du dépôt reste la baseline GitOps (reconfigure sans --version = version pinée). Le pull
+    # ré-écrit config.env à chaque reconfigure → l'override est ré-appliqué à chaque fois.
+    # (Régression #299 corrigée : l'appel avait été supprimé → --version devenait inerte.)
+    if [[ "${OPT_VERSION_EXPLICIT:-0}" -eq 1 ]]; then
+        repo_version=$(read_env_var "$config_env" ELECTRICORE_VERSION)
+        override_config_version "$config_env" "$OPT_VERSION"
+        log_warn "ELECTRICORE_VERSION overridé localement : ${OPT_VERSION} (dépôt : ${repo_version}) — non versionné, propre à cette box."
+    fi
+
+    if ! box_can_decrypt "$OPT_SLUG"; then
+        # La box a sa clé + le ciphertext, mais ne déchiffre pas → sa clé age publique
+        # n'est pas (encore) destinataire dans .sops.yaml. 2e temps de l'onboarding.
+        print_onboarding_pending "$OPT_SLUG" "$OPT_DOMAIN" "$age_pub" "$ssh_pub"
+        die "La box ne déchiffre pas encore : enregistre sa clé age comme destinataire (.sops.yaml + sops updatekeys), pousse, puis relance reconfigure."
+    fi
+    log_ok "secrets.env déchiffrable (contenu validé par le conteneur, étapes 11-12)"
 
     # ─── Étape 10 : DNS ─────────────────────────────────────────────────────
     log_step "Vérification DNS"

--- a/deploy/lib/env_validate.sh
+++ b/deploy/lib/env_validate.sh
@@ -1,10 +1,11 @@
 # shellcheck shell=bash
-# Validation du split config/secret d'une instance (secrets-as-code, ADR-0044) : la moitié
-# CLAIRE (config.env, versionnée) et la moitié SECRÈTE (secrets.env, chiffrée SOPS+age).
-# Chaque validateur lit le fichier, vérifie ses variables obligatoires, renvoie 0 si OK,
-# 1 si erreurs (et liste les erreurs sur stdout).
+# Validation de la POLITIQUE de split d'une instance (secrets-as-code, ADR-0044) : la moitié
+# CLAIRE (config.env, versionnée) porte les substitutions compose et AUCUN secret en clair.
+# Renvoie 0 si OK, 1 si erreurs (listées sur stdout).
 #
-# Dépend de validate.sh (validate_slug, validate_aes_key, validate_api_key, validate_url).
+# Le CONTENU de secrets.env (format des clés AES/API, URL SFTP) n'est PAS validé ici : la SSOT
+# du schéma est le registre pydantic (electricore/config/runtime.py), vérifié par le vrai
+# conteneur via `sops exec-env` aux étapes 11-12 d'install.sh (ADR-0049).
 
 # read_env_var <env_file> <key>
 # Extrait la valeur de <key> dans le .env (gère KEY=value avec/sans guillemets,
@@ -65,92 +66,4 @@ validate_config_env() {
         return 1
     fi
     return 0
-}
-
-# validate_secrets_plaintext <plaintext_file>
-# Valide la moitié SECRÈTE déjà DÉCHIFFRÉE (dotenv en clair, jamais sur disque en prod) :
-# trousseau API (ADR-0046 §4), SFTP__URL, trousseau AES (ADR-0037/0040, __IV optionnel)
-# présents et valides. Imprime les erreurs sur stdout ; 0 si OK, 1 sinon.
-validate_secrets_plaintext() {
-    local file="$1"
-    local errors=()
-
-    [[ -r "$file" ]] || { echo "secrets (clair) introuvable : $file"; return 1; }
-
-    local sftp
-    sftp=$(read_env_var "$file" SFTP__URL)
-
-    # Trousseau API (ADR-0046 §4) : ≥ 1 clé API__TROUSSEAU__<consommateur>__KEY (≥ 32 chars).
-    local api_labels api_label api_cle
-    mapfile -t api_labels < <(
-        grep -oE '^[[:space:]]*API__TROUSSEAU__.+__KEY[[:space:]]*=' "$file" 2>/dev/null \
-            | sed -E 's/^[[:space:]]*API__TROUSSEAU__(.+)__KEY[[:space:]]*=.*/\1/' | sort -u
-    )
-    if [[ ${#api_labels[@]} -eq 0 ]]; then
-        errors+=("trousseau API vide : ajoutez au moins une clé API__TROUSSEAU__<consommateur>__KEY (≥ 32 caractères)")
-    else
-        for api_label in "${api_labels[@]}"; do
-            api_cle=$(read_env_var "$file" "API__TROUSSEAU__${api_label}__KEY")
-            validate_api_key "$api_cle" || \
-                errors+=("API__TROUSSEAU__${api_label}__KEY absent ou trop court (≥ 32 caractères)")
-        done
-    fi
-
-    validate_url "$sftp" || \
-        errors+=("SFTP__URL invalide (attendu sftp://… ou file://…) : '${sftp}'")
-
-    local labels label key iv
-    mapfile -t labels < <(
-        grep -oE '^[[:space:]]*AES__TROUSSEAU__.+__KEY[[:space:]]*=' "$file" 2>/dev/null \
-            | sed -E 's/^[[:space:]]*AES__TROUSSEAU__(.+)__KEY[[:space:]]*=.*/\1/' | sort -u
-    )
-    if [[ ${#labels[@]} -eq 0 ]]; then
-        errors+=("trousseau AES vide : ajoutez au moins une clé AES__TROUSSEAU__<label>__KEY (hex 32 ou 64)")
-    else
-        for label in "${labels[@]}"; do
-            key=$(read_env_var "$file" "AES__TROUSSEAU__${label}__KEY")
-            iv=$(read_env_var "$file" "AES__TROUSSEAU__${label}__IV")
-            if ! validate_aes_key "$key"; then
-                errors+=("AES__TROUSSEAU__${label}__KEY absent ou pas en hex 32/64 chars")
-            elif [[ -n "$iv" ]] && ! validate_aes_iv "$iv"; then
-                errors+=("AES__TROUSSEAU__${label}__IV présent mais pas en hex 32/64 (retire-le pour le schéma IV-préfixé AES-256)")
-            fi
-        done
-    fi
-
-    if [[ ${#errors[@]} -gt 0 ]]; then
-        printf '%s\n' "${errors[@]}"
-        return 1
-    fi
-    return 0
-}
-
-# validate_secrets_env <secrets_file> <age_keyfile>
-# Déchiffre <secrets_file> (SOPS+age) avec <age_keyfile> et valide le clair via
-# `validate_secrets_plaintext`. 0 si OK, 1 sinon (erreurs stdout). NB : chemin de
-# validation côté MACHINE ADMIN à la (re)config — PAS le runtime (l'entrypoint
-# `sops exec-env` n'écrit, lui, jamais de clair). Ici le clair transite par un tmp 0600
-# shreddé immédiatement (cf. plus bas pourquoi un fichier et pas un pipe).
-validate_secrets_env() {
-    local file="$1"
-    local keyfile="$2"
-    [[ -r "$file" ]]    || { echo "secrets.env introuvable : $file"; return 1; }
-    [[ -r "$keyfile" ]] || { echo "clé age introuvable : $keyfile"; return 1; }
-    local plaintext
-    if ! plaintext=$(SOPS_AGE_KEY_FILE="$keyfile" sops decrypt --input-type dotenv --output-type dotenv "$file" 2>/dev/null); then
-        echo "déchiffrement SOPS échoué (clé age non destinataire ? fichier corrompu ?)"
-        return 1
-    fi
-    # validate_secrets_plaintext relit son argument plusieurs fois (un read_env_var/grep
-    # par variable) → une substitution de process (pipe à lecture unique) ne convient pas.
-    # Le clair touche donc un tmp 0600 (mktemp), shreddé immédiatement après validation.
-    # (Pas de trap de nettoyage ici : install.sh possède déjà un `trap … INT TERM` au
-    #  niveau process qu'on ne doit pas écraser depuis une fonction de lib.)
-    local tmp; tmp=$(mktemp)
-    printf '%s\n' "$plaintext" > "$tmp"
-    local rc=0 out
-    out=$(validate_secrets_plaintext "$tmp") || rc=1
-    shred -u "$tmp" 2>/dev/null || rm -f "$tmp"
-    [[ -n "$out" ]] && printf '%s\n' "$out"
-    return "$rc"
 }

--- a/deploy/lib/ingestion.sh
+++ b/deploy/lib/ingestion.sh
@@ -115,10 +115,26 @@ run_ingestion_test() {
 }
 
 # show_ingestion_failure_hints <slug>
-# Affiche les 50 dernières lignes des logs ingestion-scheduler + les causes typiques.
+# Remonte un `ConfigurationManquante` éventuel (secret malformé, ADR-0049), puis les 50
+# dernières lignes des logs ingestion-scheduler + les causes typiques.
 show_ingestion_failure_hints() {
     local slug="$1"
     local home="/srv/${slug}"
+
+    # Motif le plus probant en premier : si l'entrypoint a fail-fast sur un secret mal formé
+    # (clé AES non-hex, URL SFTP sans schéma…), le conteneur a loggé `ConfigurationManquante`
+    # (runtime.py, valider(...)) — on l'extrait des logs pour ne pas le noyer dans le dump brut.
+    # C'est ici que surface désormais un secret invalide, le preflight bash ayant disparu (ADR-0049).
+    local conf_err
+    conf_err=$(sudo -u "$slug" -- bash -c \
+        "cd '${home}/deploy/docker' && docker compose logs --tail=200 ingestion-scheduler" 2>/dev/null \
+        | grep -iE 'configuration manquante|ConfigurationManquante' | tail -3)
+    if [[ -n "$conf_err" ]]; then
+        log_err "Secret malformé détecté par le conteneur (corrige secrets.env dans le dépôt) :"
+        printf '%s\n' "$conf_err" | sed 's/^/     ! /'
+        log_info ""
+    fi
+
     log_warn "Causes typiques :"
     log_info "  - Clé manquante au trousseau AES__TROUSSEAU__<label>__{KEY,IV} (flux non déchiffré → job failed)"
     log_info "  - SFTP__URL inaccessible (credentials ou réseau)"

--- a/deploy/lib/validate.sh
+++ b/deploy/lib/validate.sh
@@ -1,30 +1,14 @@
 # shellcheck shell=bash
-# Validateurs purs sourcés par install.sh. Renvoient 0 si valide, 1 sinon.
-# Aucun side-effect, aucune sortie : utiliser via `if validate_X "$v"; then`.
+# Validation des ARGUMENTS CLI de install.sh (slug, domaine). Pures : 0 si valide,
+# 1 sinon, aucun side-effect — utiliser via `if validate_X "$v"; then`.
+#
+# Le FORMAT des secrets (clés AES/API hex, URL SFTP) n'est plus validé ici : c'est
+# désormais la SSOT du registre pydantic (electricore/config/runtime.py, field_validators),
+# vérifié par le vrai conteneur aux étapes 11-12 d'install.sh (ADR-0049).
 
 validate_slug() {
     local v="${1:-}"
     [[ "$v" =~ ^[a-z0-9-]+$ ]] && (( ${#v} >= 2 )) && (( ${#v} <= 32 ))
-}
-
-validate_aes_key() {
-    local v="${1:-}"
-    [[ "$v" =~ ^[0-9a-fA-F]{32}$ ]] || [[ "$v" =~ ^[0-9a-fA-F]{64}$ ]]
-}
-
-validate_aes_iv() { validate_aes_key "$@"; }
-
-validate_api_key() {
-    local v="${1:-}"
-    [[ -n "$v" ]] && (( ${#v} >= 32 ))
-}
-
-validate_url() {
-    [[ "${1:-}" =~ ^(https?|sftp|file):// ]]
-}
-
-validate_email() {
-    [[ "${1:-}" =~ ^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]+$ ]]
 }
 
 validate_domain() {

--- a/deploy/tests/README.md
+++ b/deploy/tests/README.md
@@ -8,7 +8,7 @@ Deux niveaux : unit pour les helpers purs (`deploy/lib/`), e2e pour le script co
 ./deploy/tests/unit.sh
 ```
 
-Lance ~30 assertions sur les validateurs (`validate_slug`, `validate_aes_key`, etc.) et la détection OS (avec fixtures `/etc/os-release` mockées). Sortie type :
+Lance les assertions sur les validateurs d'args CLI (`validate_slug`, `validate_domain`), la politique de split (`validate_config_env`) et la détection OS (avec fixtures `/etc/os-release` mockées). Sortie type :
 
 ```
 → validate.sh

--- a/deploy/tests/fixtures/fake_bin/sops
+++ b/deploy/tests/fixtures/fake_bin/sops
@@ -16,7 +16,7 @@ case "$sub" in
             echo "fake sops: échec déchiffrement (clé non destinataire)" >&2
             exit 1
         fi
-        # Émet un clair factice cohérent (utilisé par validate_secrets_env +
+        # Émet un clair factice cohérent (utilisé par box_can_decrypt +
         # _ingestion_read_scheduler_key, qui extrait le label "scheduler").
         cat <<'EOF'
 API__TROUSSEAU__librewatt__KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -59,32 +59,13 @@ assert_ok()   { local desc="$1"; shift; if "$@" >/dev/null 2>&1; then ok "$desc"
 assert_fail() { local desc="$1"; shift; if "$@" >/dev/null 2>&1; then ko "$desc (devait échouer)"; else ok "$desc"; fi; }
 assert_eq()   { if [[ "$1" == "$2" ]]; then ok "$3"; else ko "$3 — got '$1', want '$2'"; fi; }
 
-echo "→ validate.sh"
+echo "→ validate.sh (args CLI seulement — le format des secrets vit en pydantic, ADR-0049)"
 assert_ok   "slug 'edn'"                       validate_slug edn
 assert_ok   "slug 'enargia-test'"              validate_slug enargia-test
 assert_fail "slug 'EDN' (majuscules)"          validate_slug EDN
 assert_fail "slug 'edn_test' (underscore)"     validate_slug edn_test
 assert_fail "slug 'e' (trop court)"            validate_slug e
 assert_fail "slug vide"                        validate_slug ""
-
-assert_ok   "aes_key 32 hex"                   validate_aes_key "$(printf 'a%.0s' {1..32})"
-assert_ok   "aes_key 64 hex MAJ+min"           validate_aes_key "abCDef0123456789abCDef0123456789abCDef0123456789abCDef0123456789"
-assert_fail "aes_key 31 hex (trop court)"      validate_aes_key "$(printf 'a%.0s' {1..31})"
-assert_fail "aes_key 64 non-hex"               validate_aes_key "$(printf 'z%.0s' {1..64})"
-assert_fail "aes_key vide"                     validate_aes_key ""
-
-assert_ok   "api_key 32 chars"                 validate_api_key "$(printf 'a%.0s' {1..32})"
-assert_fail "api_key 31 chars"                 validate_api_key "$(printf 'a%.0s' {1..31})"
-assert_fail "api_key vide"                     validate_api_key ""
-
-assert_ok   "url sftp avec creds"              validate_url "sftp://u:p@h.fr:22/p"
-assert_ok   "url file"                         validate_url "file:///var/enedis/"
-assert_ok   "url https"                        validate_url "https://example.com"
-assert_fail "url plain"                        validate_url "not-a-url"
-assert_fail "url ftp (non supporté)"           validate_url "ftp://h.fr/"
-
-assert_ok   "email basique"                    validate_email "user@example.com"
-assert_fail "email sans @"                     validate_email "user.example.com"
 
 assert_ok   "domain electricore.fr"            validate_domain "electricore.fr"
 assert_ok   "domain edn.electricore.fr"        validate_domain "edn.electricore.fr"
@@ -352,20 +333,8 @@ rm -f "$tmp_cfg"
 tmp_cfg=$(mktemp); printf 'INSTANCE_SLUG=edn\nBACKUPS_PATH=/srv/edn/backups\n' > "$tmp_cfg"
 assert_fail "validate_config_env exige ELECTRICORE_VERSION" validate_config_env "$tmp_cfg" "edn"
 rm -f "$tmp_cfg"
-
-# Secrets (clair) : trousseau API + SFTP + trousseau AES (ADR-0046 §4)
-tmp_sec=$(mktemp)
-printf 'API__TROUSSEAU__librewatt__KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nSFTP__URL=sftp://u:p@h.fr:22/x\nAES__TROUSSEAU__demo__KEY=00112233445566778899aabbccddeeff\n' > "$tmp_sec"
-assert_ok   "validate_secrets_plaintext (secrets clairs valides)" validate_secrets_plaintext "$tmp_sec"
-rm -f "$tmp_sec"
-# Trousseau AES vide → échec
-tmp_sec=$(mktemp); printf 'API__TROUSSEAU__librewatt__KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nSFTP__URL=sftp://u:p@h.fr:22/x\n' > "$tmp_sec"
-assert_fail "validate_secrets_plaintext refuse trousseau AES vide" validate_secrets_plaintext "$tmp_sec"
-rm -f "$tmp_sec"
-# Trousseau API vide → échec (ADR-0046 §4 : ≥ 1 consommateur requis)
-tmp_sec=$(mktemp); printf 'SFTP__URL=sftp://u:p@h.fr:22/x\nAES__TROUSSEAU__demo__KEY=00112233445566778899aabbccddeeff\n' > "$tmp_sec"
-assert_fail "validate_secrets_plaintext refuse trousseau API vide" validate_secrets_plaintext "$tmp_sec"
-rm -f "$tmp_sec"
+# Le CONTENU de secrets.env (format clés AES/API, URL SFTP) n'est plus validé en bash :
+# SSOT pydantic (tests/unit/test_runtime.py), vérifié par le conteneur étapes 11-12 (ADR-0049).
 
 echo
 echo "→ secrets.sh (fake-binaries age-keygen/ssh-keygen/sops/git)"
@@ -407,13 +376,6 @@ PATH="${FAKE_BIN}:$PATH" FAKE_SOPS_FAIL=0 box_can_decrypt edn \
 PATH="${FAKE_BIN}:$PATH" FAKE_SOPS_FAIL=1 box_can_decrypt edn \
     && ko "box_can_decrypt: devait échouer si sops échoue (clé non destinataire)" \
     || ok "box_can_decrypt: faux quand sops échoue (deux temps — pas encore destinataire)"
-
-# validate_secrets_env : déchiffre via (fake) sops puis valide le clair.
-PATH="${FAKE_BIN}:$PATH" validate_secrets_env "${secrets_root}/edn/providers/edn/secrets.env" "${secrets_root}/edn/age.key" >/dev/null 2>&1 \
-    && ok "validate_secrets_env: déchiffre + valide le clair (fake sops)" || ko "validate_secrets_env a échoué"
-PATH="${FAKE_BIN}:$PATH" FAKE_SOPS_FAIL=1 validate_secrets_env "${secrets_root}/edn/providers/edn/secrets.env" "${secrets_root}/edn/age.key" >/dev/null 2>&1 \
-    && ko "validate_secrets_env: devait échouer si déchiffrement KO" \
-    || ok "validate_secrets_env: échec propre si le déchiffrement KO"
 
 unset SRV_BASE
 rm -rf "$secrets_root"

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -152,10 +152,15 @@ La colonne **Bloc** ci-dessous indique dans quel fichier chaque variable vit.
 
 `install.sh` **valide le split** automatiquement (pas d'éditeur) : `validate_config_env`
 sur la moitié claire (slug qui matche, `ELECTRICORE_VERSION`/`BACKUPS_PATH` présents,
-**garde-fou anti-fuite** rejetant tout secret en clair), et `validate_secrets_plaintext`
-sur la moitié **déchiffrée** (trousseau API ≥ 1 clé ≥ 32 chars, `SFTP__URL` parseable,
-trousseau AES ≥ 1 clé hex 32/64, `__IV` optionnel cohérent). En cas d'erreur, l'install
-**échoue** en listant les manques : tu corriges les fichiers **dans le dépôt de
+**garde-fou anti-fuite** rejetant tout secret en clair), et un **test de déchiffrement**
+(`box_can_decrypt`) sur la moitié chiffrée. Le **format** des secrets (trousseau API ≥ 1
+clé ≥ 32 chars, `SFTP__URL` parseable, trousseau AES ≥ 1 clé hex 32/64, `__IV` optionnel
+cohérent) n'est plus revérifié en bash : c'est la SSOT du registre pydantic
+(`electricore/config/runtime.py`), appliquée par le **vrai conteneur** au test ingestion
+(étape 12, `valider(sftp, aes, duckdb)` via `sops exec-env`) — voir
+[ADR-0049](adr/0049-schema-secrets-ssot-pydantic-deploy-valide-le-split.md). En cas
+d'erreur, l'install **échoue** en listant les manques (un secret malformé remonte le
+`ConfigurationManquante` du conteneur) : tu corriges les fichiers **dans le dépôt de
 déploiement**, push, et relances le `reconfigure`.
 
 ## Provisionner une nouvelle instance


### PR DESCRIPTION
Closes #501.

Fait suite à #500/#502 (field_validators de format dans le registre pydantic) : le **schéma des secrets vit désormais en SSOT pydantic** (`electricore/config/runtime.py`), donc le bash de deploy ne valide plus que la **politique de split**, pas le format.

## Ce qui change

- **`deploy/lib/validate.sh`** — supprime `validate_aes_key` / `validate_aes_iv` / `validate_api_key` / `validate_url` / `validate_email` (format = pydantic). **Garde** `validate_slug` / `validate_domain` (validation des args CLI).
- **`deploy/lib/env_validate.sh`** — supprime `validate_secrets_plaintext` + `validate_secrets_env` (preflight qui divergerait de la sémantique verbatim de `sops exec-env` — classe rc12 ODOO dequote). **Garde** `read_env_var` + `validate_config_env` (présence des substitutions compose + anti-leak).
- **`deploy/install.sh`** — effondre l'étape 9 sur le seul chemin secrets-as-code (`--deploy-repo` obligatoire depuis le cutover ADR-0044). Supprime la **branche legacy `.env` morte** (le `else`, inatteignable) + ses helpers orphelins jamais définis (`substitute_env`, l'editor-loop, `validate_env_file`, `strip_validation_error_block`, `prepend_errors_to_env`, `--env-from`). `box_can_decrypt` reste le gate ; le **contenu** de `secrets.env` est validé par le vrai conteneur (étapes 11-12, `valider(sftp, aes, duckdb)`).
- **`deploy/lib/ingestion.sh`** — le hint d'échec de l'étape 12 remonte le `ConfigurationManquante` du conteneur (c'est là que surface désormais un secret malformé).
- **`deploy/tests/unit.sh`** — élague les ~15 assertions des fonctions supprimées.
- **`docs/deploiement.md`** + README/fixture — refléter le nouveau partage (format en pydantic, vérifié par le conteneur).

## Vérifs

- `deploy/tests/unit.sh` : **152 passed, 0 failed**.
- `bash -n` OK sur tous les fichiers touchés ; `install.sh` se source sans fonction indéfinie (unit.sh le source).
- Aucune référence vivante restante aux fonctions supprimées.
- Net **−164 lignes**.

Cf. [ADR-0049](docs/adr/0049-schema-secrets-ssot-pydantic-deploy-valide-le-split.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)