### PR TITLE
test(deploy): anti-régression onboarding box secrets-as-code (chemin réel, pas les fakes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,29 @@ jobs:
       - name: Run deploy unit tests
         run: bash deploy/tests/unit.sh
 
+      # sops + age : mêmes versions pinnées que le job `test` (déchiffrement image) et
+      # que deploy/lib/secrets.sh (SOPS_VERSION/AGE_VERSION) pour l'aller-retour crypto
+      # réel de l'onboarding (secrets_roundtrip.sh, anti-régression #453).
+      - name: Installer sops + age (aller-retour crypto onboarding, #453)
+        run: |
+          set -euo pipefail
+          SOPS_VERSION=3.9.4
+          SOPS_SHA256=5488e32bc471de7982ad895dd054bbab3ab91c417a118426134551e9626e4e85
+          AGE_VERSION=1.2.1
+          AGE_SHA256=7df45a6cc87d4da11cc03a539a7470c15b1041ab2b396af088fe9990f7c79d50
+          curl -fsSL -o /tmp/sops "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          echo "${SOPS_SHA256}  /tmp/sops" | sha256sum -c -
+          sudo install -m 0755 /tmp/sops /usr/local/bin/sops
+          curl -fsSL -o /tmp/age.tgz "https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz"
+          echo "${AGE_SHA256}  /tmp/age.tgz" | sha256sum -c -
+          tar -xzf /tmp/age.tgz -C /tmp
+          sudo install -m 0755 /tmp/age/age /usr/local/bin/age
+          sudo install -m 0755 /tmp/age/age-keygen /usr/local/bin/age-keygen
+          sops --version
+          age --version
+      - name: Run secrets onboarding round-trip (#453)
+        run: bash deploy/tests/secrets_roundtrip.sh
+
   # Build + scan + smoke de l'image Docker sur CHAQUE PR (#435) — via le workflow
   # réutilisable partagé avec release.yml. `push` reste à false : seul release.yml pousse.
   docker-image:

--- a/deploy/tests/README.md
+++ b/deploy/tests/README.md
@@ -45,12 +45,41 @@ Bash uniquement, pas de framework. Pour ajouter un test : éditer `unit.sh` (voi
 
 Le harnais monte le repo sur `/repo` dans la VM, injecte une clé SSH root bidon, et lance `install.sh` en `sudo`. Snapshot/restore permettent d'itérer sans relancer un `up` complet.
 
+## Aller-retour crypto onboarding (vrais binaires, anti-régression #453)
+
+```bash
+./deploy/tests/secrets_roundtrip.sh
+```
+
+Exerce le chemin **HOST-CRYPTO bout-en-bout** avec de vrais `sops` + `age-keygen` (pas les fakes) :
+`generate_box_identities` → `sops encrypt` → `box_can_decrypt` / `_ingestion_read_scheduler_key` + assert négatif (mauvaise clé → échec).
+
+**En CI** (job `deploy-tests`) : les outils sont installés (mêmes versions pinnées que le job `test`) → le test tourne pour de VRAI et une régression crypto casse CI.
+
+**En local sans sops/age** : skip propre (`skipped: sops/age absent`, exit 0) — pas de régression locale.
+
+### Ce que la vérification couvre
+
+| Vérification | Fichier | Vecteur de régression gardé |
+|---|---|---|
+| Aller-retour crypto réel (generate → encrypt → decrypt) | `secrets_roundtrip.sh` | Outil hôte absent, `box_can_decrypt` cassé, clé scheduler non extraite |
+| Assert négatif (autre clé → échec) | `secrets_roundtrip.sh` | `box_can_decrypt` serait un rubber-stamp |
+| Fake docker modèle le fail-fast de l'entrypoint | `fixtures/fake_bin/docker` + `unit.sh` | Crypto reroutée via l'image sans bypass |
+| Bypass `ELECTRICORE_DECRYPT=off` toujours fonctionnel | `unit.sh` (section fake docker #453) | Smoke d'importabilité cassé |
+
+### Ce que la vérification ne couvre PAS délibérément
+
+- **Vrai Docker / runtime de l'image** : couvert par `tests/integration/test_entrypoint_dechiffrement.py` (job `test` de CI). Pas de vrai `docker` ni `docker compose` dans le job `deploy-tests`.
+- **Pull du dépôt de déploiement réel** : couvert par les tests e2e (VM Multipass ou VPS). `pull_deploy_repo` utilise le fake `git` en tests unitaires.
+- **Validation du contenu de secrets.env** (format des clés) : SSOT pydantic (`electricore/config/runtime.py`), vérifié par le conteneur au runtime (ADR-0049).
+
 ## Cycle de dev recommandé
 
 1. Modifier `deploy/lib/<fichier>.sh` ou `deploy/install.sh`.
 2. Si on a touché à une fonction pure : `./deploy/tests/unit.sh` (en boucle, ~instantané).
-3. Si on a touché à l'orchestration : `./deploy/tests/e2e/multipass.sh run` (puis `restore` pour réessayer).
-4. Avant push : `unit.sh` doit être vert ; e2e idéalement aussi.
+3. Si on a touché au crypto onboarding : `./deploy/tests/secrets_roundtrip.sh` (nécessite sops + age).
+4. Si on a touché à l'orchestration : `./deploy/tests/e2e/multipass.sh run` (puis `restore` pour réessayer).
+5. Avant push : `unit.sh` + `secrets_roundtrip.sh` doivent être verts ; e2e idéalement aussi.
 
 ## Ajouter une fonction + son test
 

--- a/deploy/tests/fixtures/fake_bin/docker
+++ b/deploy/tests/fixtures/fake_bin/docker
@@ -1,43 +1,49 @@
 #!/usr/bin/env bash
-# Fake `docker` pour les tests de secrets.sh (ADR-0044) — simule `docker run … <tool>`.
-# On n'a PAS de vrai Docker en CI deploy-shell : on imite juste les sous-commandes
-# qu'appelle secrets.sh (age-keygen, age-keygen -y, ssh-keygen). Trace les appels
-# dans $FAKE_DOCKER_LOG si défini.
+# Fake `docker` pour les tests deploy-shell (ADR-0044, #453).
+# Modélise le VRAI comportement de l'entrypoint electricore-entrypoint :
+#   - sans contournement ET sans secrets montés → fail-fast (exit 1)
+#   - avec -e ELECTRICORE_DECRYPT=off → bypass, exécute la commande
+#   - avec les deux secrets montés (/run/secrets/{secrets.env,age.key}) → OK
+# Trace les appels dans $FAKE_DOCKER_LOG si défini.
 [[ -n "${FAKE_DOCKER_LOG:-}" ]] && printf '%s\n' "$*" >> "$FAKE_DOCKER_LOG"
 
-# Sauter les flags `run --rm [-v src:dst[:ro]]* <image>` pour atteindre la commande.
+# ─── Parse les flags `docker run` ────────────────────────────────────────────
 args=("$@")
 i=0
-# avance jusqu'après l'image (1er token qui ne commence pas par '-' après 'run',
-# en sautant les valeurs de -v). Simplification : on cherche le 1er token connu.
 tool=""
+decrypt_off=0
+secrets_env_mounted=0
+age_key_mounted=0
 mount_src=""
+
 while [[ $i -lt ${#args[@]} ]]; do
     case "${args[$i]}" in
-        -v) mount_src="${args[$((i+1))]%%:*}"; i=$((i+2)); continue ;;
+        -v)
+            val="${args[$((i+1))]}"
+            dst="${val#*:}"; dst="${dst%%:*}"
+            [[ "$dst" == "/run/secrets/secrets.env" ]] && secrets_env_mounted=1
+            [[ "$dst" == "/run/secrets/age.key" ]]     && age_key_mounted=1
+            mount_src="${val%%:*}"
+            i=$((i+2)); continue ;;
+        -e)
+            [[ "${args[$((i+1))]}" == "ELECTRICORE_DECRYPT=off" ]] && decrypt_off=1
+            i=$((i+2)); continue ;;
         age-keygen|ssh-keygen|python|python3|sh) tool="${args[$i]}"; break ;;
     esac
     i=$((i+1))
 done
 
+# ─── Modèle entrypoint : fail-fast si pas de bypass ET secrets incomplets ──────
+# Miroir de deploy/docker/entrypoint.sh (ADR-0044 §3) :
+#   - ELECTRICORE_DECRYPT=off → bypass total (importabilité smoke, #434)
+#   - LES DEUX secrets montés → OK (déchiffrement smoke, montent secrets.env + age.key)
+#   - Sinon → fail-fast (empêche crypto via l'image sans bypass, régression #453)
+if [[ "$decrypt_off" -eq 0 && ( "$secrets_env_mounted" -eq 0 || "$age_key_mounted" -eq 0 ) ]]; then
+    echo "fake docker: entrypoint fail-fast (ni ELECTRICORE_DECRYPT=off, ni les deux secrets montés)" >&2
+    exit 1
+fi
+
 case "$tool" in
-    age-keygen)
-        # `age-keygen -y /age.key` → imprime une pub factice déterministe ;
-        # `age-keygen` seul → imprime une clé privée factice (format age) sur stdout.
-        if [[ "${args[$((i+1))]:-}" == "-y" ]]; then
-            echo "age1faketestpublickeyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxq9"
-        else
-            echo "# created: fake"
-            echo "# public key: age1faketestpublickeyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxq9"
-            echo "AGE-SECRET-KEY-1FAKETESTPRIVATEKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-        fi
-        ;;
-    ssh-keygen)
-        # `ssh-keygen … -f /out/ssh_deploy_key` → écrit privée + .pub dans le mount.
-        out="${mount_src}/ssh_deploy_key"
-        echo "FAKE-OPENSSH-PRIVATE-KEY" > "$out"
-        echo "ssh-ed25519 AAAAFAKEDEPLOYKEY deploy-key" > "${out}.pub"
-        ;;
     python|python3)
         # smoke d'importabilité (smoke.sh) : l'image importe les modules de tête.
         # FAKE_SMOKE_IMPORT_FAIL=1 simule une image cassée (import KO).

--- a/deploy/tests/secrets_roundtrip.sh
+++ b/deploy/tests/secrets_roundtrip.sh
@@ -70,8 +70,7 @@ AES__TROUSSEAU__aes256_2026__KEY=00112233445566778899aabbccddeeff001122334455667
 EOF
 
 secrets_path="${srv_root}/${TEST_SLUG}/providers/${TEST_SLUG}/secrets.env"
-SOPS_AGE_RECIPIENTS="$BOX_AGE_PUBKEY" \
-    sops encrypt --input-type dotenv --output-type dotenv "$plaintext" \
+sops encrypt --age "$BOX_AGE_PUBKEY" --input-type dotenv --output-type dotenv "$plaintext" \
     > "$secrets_path" 2>/dev/null \
     && ok "sops encrypt: secrets.env chiffré pour la box" \
     || ko "sops encrypt: échec du chiffrement"

--- a/deploy/tests/secrets_roundtrip.sh
+++ b/deploy/tests/secrets_roundtrip.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Test d'aller-retour onboarding crypto (ADR-0044) avec de VRAIS binaires sops + age.
+#
+# Exercice le chemin HOST-CRYPTO bout-en-bout :
+#   generate_box_identities → sops encrypt → box_can_decrypt / _ingestion_read_scheduler_key
+# Avec un provider + un home d'instance JETABLES.
+#
+# Skip propre (exit 0) si sops ou age-keygen sont absents — pas de régression locale
+# sans outils. En CI (deploy-tests), les outils sont installés ⇒ le test tourne pour de VRAI.
+#
+# Réutilise le motif ok/ko/PASS/FAIL de unit.sh (cohérence de sortie).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/../lib"
+
+# shellcheck source=../lib/log.sh
+source "${LIB_DIR}/log.sh"
+# shellcheck source=../lib/secrets.sh
+source "${LIB_DIR}/secrets.sh"
+# shellcheck source=../lib/ingestion.sh
+source "${LIB_DIR}/ingestion.sh"
+
+PASS=0; FAIL=0
+ok() { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+ko() { printf '  \033[31m✗\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+# ─── Skip propre si les vrais outils sont absents ────────────────────────────
+if ! command -v sops >/dev/null 2>&1 || ! command -v age-keygen >/dev/null 2>&1; then
+    echo "  skipped: sops/age absent — test non lancé (installe sops + age pour l'exécuter)"
+    exit 0
+fi
+
+echo "→ secrets_roundtrip.sh (vrais sops + age, provider jetable)"
+
+# ─── Setup : home + provider jetables ────────────────────────────────────────
+TEST_SLUG="roundtrip-$$"
+srv_root=$(mktemp -d)
+export SRV_BASE="$srv_root"
+install -d "${srv_root}/${TEST_SLUG}"
+install -d "${srv_root}/${TEST_SLUG}/providers/${TEST_SLUG}"
+
+# ─── 1. generate_box_identities avec les vrais age-keygen + ssh-keygen ───────
+out=$(generate_box_identities "$TEST_SLUG" 2>/dev/null)
+grep -q "^AGE_PUBLIC_KEY=age1" <<<"$out" \
+    && ok "generate_box_identities: AGE_PUBLIC_KEY réelle (préfixe age1)" \
+    || ko "generate_box_identities: pas d'AGE_PUBLIC_KEY valide"
+grep -q "^SSH_DEPLOY_PUBKEY=ssh-ed25519" <<<"$out" \
+    && ok "generate_box_identities: SSH_DEPLOY_PUBKEY réelle (ed25519)" \
+    || ko "generate_box_identities: pas de SSH_DEPLOY_PUBKEY valide"
+[[ -f "${srv_root}/${TEST_SLUG}/age.key" ]] \
+    && ok "generate_box_identities: age.key créée" \
+    || ko "generate_box_identities: age.key absente"
+perm=$(stat -c '%a' "${srv_root}/${TEST_SLUG}/age.key" 2>/dev/null)
+[[ "$perm" == "600" ]] \
+    && ok "generate_box_identities: age.key en 600" \
+    || ko "generate_box_identities: age.key permissions incorrectes (got ${perm})"
+
+# Récupère la vraie clé publique age pour le chiffrement
+BOX_AGE_PUBKEY=$(grep "^AGE_PUBLIC_KEY=" <<<"$out" | cut -d= -f2-)
+
+# ─── 2. Chiffrer un secrets.env valide pour la box ───────────────────────────
+plaintext="${srv_root}/secrets_plain.env"
+cat > "$plaintext" <<EOF
+API__TROUSSEAU__librewatt__KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+API__TROUSSEAU__scheduler__KEY=ssssssssssssssssssssssssssssssss
+SFTP__URL=sftp://user:pass@sftp.example.fr:22/exports
+AES__TROUSSEAU__aes256_2026__KEY=00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff
+EOF
+
+secrets_path="${srv_root}/${TEST_SLUG}/providers/${TEST_SLUG}/secrets.env"
+SOPS_AGE_RECIPIENTS="$BOX_AGE_PUBKEY" \
+    sops encrypt --input-type dotenv --output-type dotenv "$plaintext" \
+    > "$secrets_path" 2>/dev/null \
+    && ok "sops encrypt: secrets.env chiffré pour la box" \
+    || ko "sops encrypt: échec du chiffrement"
+
+# ─── 3. Asserts POSITIFS : déchiffrement réel ────────────────────────────────
+box_can_decrypt "$TEST_SLUG" \
+    && ok "box_can_decrypt: réussit avec la vraie clé (la box est destinataire)" \
+    || ko "box_can_decrypt: devait réussir avec la vraie clé"
+
+sched_key=$(SRV_BASE="$srv_root" _ingestion_read_scheduler_key "$TEST_SLUG" 2>/dev/null)
+[[ "$sched_key" == "ssssssssssssssssssssssssssssssss" ]] \
+    && ok "_ingestion_read_scheduler_key: extrait la clé scheduler réelle" \
+    || ko "_ingestion_read_scheduler_key: valeur inattendue (got '${sched_key}')"
+
+# ─── 4. Assert NÉGATIF : mauvaise clé → déchiffrement impossible ─────────────
+other_root=$(mktemp -d)
+install -d "${other_root}/${TEST_SLUG}/providers/${TEST_SLUG}"
+# Génère une AUTRE paire age (non destinataire du secrets.env ci-dessus)
+SAVED_SRV="$SRV_BASE"
+export SRV_BASE="$other_root"
+generate_age_identity "${other_root}/${TEST_SLUG}" >/dev/null 2>&1
+# Copie le même ciphertext (chiffré pour la BONNE box, pas pour celle-ci)
+cp "$secrets_path" "${other_root}/${TEST_SLUG}/providers/${TEST_SLUG}/secrets.env"
+box_can_decrypt "$TEST_SLUG" \
+    && ko "box_can_decrypt: devait ÉCHOUER avec une clé non-destinataire (déchiffrement factice ?)" \
+    || ok "box_can_decrypt: échoue avec une clé non-destinataire (déchiffrement réel prouvé)"
+export SRV_BASE="$SAVED_SRV"
+
+# ─── Cleanup ─────────────────────────────────────────────────────────────────
+rm -rf "$srv_root" "$other_root" 2>/dev/null || true
+unset SRV_BASE
+
+echo
+if [[ "$FAIL" -eq 0 ]]; then
+    printf "\033[32m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
+    exit 0
+else
+    printf "\033[31m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
+    exit 1
+fi

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -465,6 +465,30 @@ grep -Eq -- '-v [^ ]*/test_age\.key:/run/secrets/age\.key:ro' "$SMOKE_LOG" \
     || ko "smoke_image: clé age non montée au bon chemin"
 rm -f "$SMOKE_LOG"
 
+# ── Fake docker modèle le fail-fast de l'entrypoint (#453) ───────────────────
+# Un `docker run <image> <cmd>` sans bypass (ELECTRICORE_DECRYPT=off) NI secrets
+# montés doit fail-fast. Cela verrouille la règle : la crypto ne passe JAMAIS par
+# l'image (son entrypoint SOPS bloquerait sans secrets → bug #1 de la bascule EDN).
+echo
+echo "→ fake docker / entrypoint fail-fast (#453)"
+out=$(PATH="${FAKE_BIN}:$PATH" docker run --rm electricore:test age-keygen 2>&1); rc=$?
+[[ "$rc" -ne 0 ]] \
+    && ok "fake docker: age-keygen sans bypass → fail-fast (crypto ne passe jamais par l'image)" \
+    || ko "fake docker: age-keygen sans bypass devait fail-fast"
+grep -qi "fail-fast\|entrypoint" <<<"$out" \
+    && ok "fake docker: fail-fast mentionne l'entrypoint" \
+    || ko "fake docker: fail-fast manque le motif entrypoint"
+
+# Avec bypass ELECTRICORE_DECRYPT=off → l'appel doit RÉUSSIR (bypass explicite documenté).
+# Ici age-keygen n'est plus une commande simulée mais la règle est :
+# le fail-fast est levé par le bypass, puis la commande non-simulée retourne exit 1 —
+# ce qui est distinct du fail-fast d'entrypoint (l'entrypoint n'a pas bloqué).
+# On teste le cas le plus simple : python (toujours simulé) avec bypass → succès.
+out=$(PATH="${FAKE_BIN}:$PATH" docker run --rm -e ELECTRICORE_DECRYPT=off electricore:test python -c "pass" 2>&1); rc=$?
+[[ "$rc" -eq 0 ]] \
+    && ok "fake docker: python avec ELECTRICORE_DECRYPT=off → bypass (entrypoint non bloquant)" \
+    || ko "fake docker: python avec bypass devait réussir (got rc=$rc)"
+
 rm -rf "$SMOKE_FIX"
 
 echo


### PR DESCRIPTION
## Summary

- Ajoute `deploy/tests/secrets_roundtrip.sh` : aller-retour HOST-CRYPTO réel (vrais sops + age) — generate_box_identities → sops encrypt → box_can_decrypt / _ingestion_read_scheduler_key + assert négatif (mauvaise clé → échec, déchiffrement réel prouvé)
- Wire dans CI (job `deploy-tests`) : installe sops 3.9.4 + age 1.2.1 (mêmes versions pinnées que l'image) puis lance le roundtrip — une régression crypto / outil-hôte-absent casse désormais la CI
- Fake `docker` modèle l'entrypoint fail-fast (ADR-0044 §3) : `docker run <image> age-keygen` sans bypass → exit 1, verrouillé par 3 nouvelles assertions dans `unit.sh` → garde le vecteur *image-sans-bypass*
- Doc `deploy/tests/README.md` : tableau vecteurs couverts / délibérément non couverts (Docker réel + entrypoint runtime → `tests/integration/test_entrypoint_dechiffrement.py`)

Réutilise le motif d'assertion-trace (#452/#434).

## Test plan

- [x] `bash deploy/tests/unit.sh` → 155 passed, 0 failed (+3 vs 152)
- [x] `bash deploy/tests/secrets_roundtrip.sh` → 8 passed, 0 failed (sops/age présents) ; sinon `skipped` + exit 0
- [ ] CI job `deploy-tests` tourne les deux étapes sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #453