### PR TITLE
fix: dé-masquer le 503 « ingestion en cours » — verrous, IO non-verrou, préconditions RSC (#424)

### DIFF
--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -127,9 +127,17 @@ async def verrou_duckdb_en_503(request, exc: DuckDBLockError) -> JSONResponse:
 
     Conversion centrale : tout endpoint de lecture qui laisse remonter
     `DuckDBLockError` en bénéficie, sans logique par route.
+
+    L'en-tête `X-Error-Kind: ingestion-lock` distingue ce 503 des 503 génériques :
+    le client peut ainsi mapper uniquement le vrai verrou en `IngestionEnCours`,
+    sans faux positifs (ADR, #424).
     """
     logger.warning("Lecture refusée, base verrouillée par un writer (%s %s) : %s", request.method, request.url, exc)
-    return JSONResponse(status_code=503, content={"detail": DETAIL_INGESTION_EN_COURS})
+    return JSONResponse(
+        status_code=503,
+        content={"detail": DETAIL_INGESTION_EN_COURS},
+        headers={"X-Error-Kind": "ingestion-lock"},
+    )
 
 
 # Routers per-domaine (issue #82). Chaque router porte son tag OpenAPI et ses endpoints.

--- a/electricore/api/services/facturation_service.py
+++ b/electricore/api/services/facturation_service.py
@@ -14,6 +14,7 @@ Les 3 fonctions de service correspondent aux 4 endpoints :
 """
 
 import polars as pl
+from fastapi import HTTPException
 
 from electricore.core.builds.contexte_mensuel import (
     _MAPPING_CATEGORIE_COLONNE,
@@ -45,6 +46,22 @@ def _contexte_et_lignes(odoo: OdooReader, mois: str | None) -> tuple[ContexteMen
         .filter(pl.col("categorie_produit").is_in(categories_facturables))
         .collect()
     )
+    # Précondition RSC (#424) : des lignes sans ref_situation_contractuelle signalent
+    # un mois non réconcilié. On lève ici un 422 actionnable (X-Error-Kind: precondition)
+    # plutôt que de laisser rapprocher() échouer en SERIES_CONTAINS_NULLS → 503 opaque.
+    # collect() → DataFrame dans le chemin réel ; le mock de test peut rendre LazyFrame.
+    lignes_collected = lignes_df.collect() if isinstance(lignes_df, pl.LazyFrame) else lignes_df
+    n_sans_rsc = lignes_collected["ref_situation_contractuelle"].is_null().sum()
+    if n_sans_rsc > 0:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Réconciliation RSC requise pour {contexte.mois} : "
+                f"{n_sans_rsc} ligne(s) de facture sans ref_situation_contractuelle. "
+                "Réconcilie les RSC dans Odoo avant de facturer ce mois."
+            ),
+            headers={"X-Error-Kind": "precondition"},
+        )
     return contexte, lignes_df
 
 

--- a/electricore/core/loaders/duckdb/config.py
+++ b/electricore/core/loaders/duckdb/config.py
@@ -54,14 +54,20 @@ class DuckDBLockError(duckdb.IOException):
 
 
 def _is_lock_error(exc: duckdb.IOException) -> bool:
-    """Discrimine un verrou (récupérable) d'une erreur non récupérable.
+    """Discrimine un verrou writer (récupérable) d'une erreur IO non récupérable.
 
-    DuckDB n'expose qu'`IOException` ; on inspecte le message.
+    DuckDB n'expose qu'`IOException` ; on inspecte le message pour ne reconnaître
+    que les formulations de verrou réel (#424). Toute autre IOException (version
+    mismatch, corruption, WAL illisible, fichier manquant) est renvoyée brute —
+    elle ne se résoudra jamais seule et ne doit pas s'afficher « ingestion en cours ».
+
+    Phrasings connus du verrou DuckDB :
+    - « Could not set lock on file »
+    - « Conflicting lock is held »
     """
     msg = str(exc).lower()
-    if "does not exist" in msg or "no such file" in msg:
-        return False
-    return True
+    # ponytail: deux marqueurs suffisent — les phrasing DuckDB sont stables
+    return "could not set lock" in msg or "conflicting lock" in msg
 
 
 @contextmanager

--- a/packages/electricore-client/src/electricore_client/exceptions.py
+++ b/packages/electricore-client/src/electricore_client/exceptions.py
@@ -1,9 +1,14 @@
 """Exceptions du client electricore.
 
 Toutes dérivent d'`ElectricoreClientError` pour qu'un appelant puisse attraper
-*toute* erreur du client en une seule clause. `IngestionEnCours` est le cas
-métier distingué : la base DuckDB est verrouillée par un cycle d'ingestion
-(l'API répond **503**), et l'appelant peut simplement réessayer plus tard.
+*toute* erreur du client en une seule clause.
+
+Contrat X-Error-Kind (#424) — les erreurs sont discriminées par l'en-tête de
+réponse `X-Error-Kind`, pas par le code HTTP seul :
+- `ingestion-lock` (503) → `IngestionEnCours` : verrou writer, réessayable.
+- `precondition`  (422) → `PreconditionNonRemplie` : précondition métier non
+  remplie, l'appelant doit agir (pas retryable).
+- header absent → `httpx.HTTPStatusError` : erreur inattendue.
 """
 
 from __future__ import annotations
@@ -14,10 +19,21 @@ class ElectricoreClientError(Exception):
 
 
 class IngestionEnCours(ElectricoreClientError):
-    """L'API a répondu 503 : la base est verrouillée par un cycle d'ingestion.
+    """L'API a répondu 503 + X-Error-Kind: ingestion-lock : la base est verrouillée
+    par un cycle d'ingestion (#424).
 
     Transitoire — l'API se rétablit d'elle-même après le checkpoint. L'appelant
     peut réessayer après un délai court (cf. `main.verrou_duckdb_en_503`, #171).
+    """
+
+
+class PreconditionNonRemplie(ElectricoreClientError):
+    """L'API a répondu 422 + X-Error-Kind: precondition : une précondition métier
+    n'est pas remplie (#424).
+
+    Non retryable — l'appelant doit corriger la situation côté Odoo/données avant
+    de réessayer (ex. : réconcilier les RSC avant de facturer le mois).
+    Le message contient le détail actionnable fourni par le serveur.
     """
 
 

--- a/packages/electricore-client/src/electricore_client/transport.py
+++ b/packages/electricore-client/src/electricore_client/transport.py
@@ -2,7 +2,14 @@
 
 `_BaseClient` factorise tout ce qui est commun aux endpoints : URL de base,
 en-tête `X-API-Key`, construction du `httpx.Client` (timeout), conversion
-d'erreur HTTP (503 → `IngestionEnCours`) et la garde de version de contrat.
+d'erreur HTTP et la garde de version de contrat.
+
+Contrat X-Error-Kind (#424) — `_raise_for_status` discrimine les erreurs via
+l'en-tête `X-Error-Kind` de la réponse, pas le code HTTP seul :
+- `ingestion-lock` (503) → `IngestionEnCours` : verrou writer DuckDB, réessayable.
+- `precondition`  (422) → `PreconditionNonRemplie` : précondition métier, actionnable.
+- header absent → `httpx.HTTPStatusError` (raise_for_status standard).
+
 Les méthodes d'endpoint (méta-périodes, chronologie, turpe variable, Arrow)
 sont montées par-dessus dans `client.py`.
 """
@@ -13,13 +20,10 @@ import warnings
 
 import httpx
 
-from .exceptions import ContractVersionError, IngestionEnCours
+from .exceptions import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
 
 # Timeout généreux en lecture : les flux JSONL peuvent durer (gros parc).
 DEFAULT_TIMEOUT = httpx.Timeout(30.0, read=300.0)
-
-# Code HTTP « ingestion en cours » (base DuckDB verrouillée par un writer, #171).
-STATUS_INGESTION_EN_COURS = 503
 
 
 class _BaseClient:
@@ -56,16 +60,25 @@ class _BaseClient:
         return {"X-API-Key": self.api_key}
 
     def _raise_for_status(self, response: httpx.Response) -> None:
-        """Convertit les erreurs HTTP en exceptions du client.
+        """Convertit les erreurs HTTP en exceptions du client via X-Error-Kind (#424).
 
-        503 (base verrouillée par l'ingestion) → `IngestionEnCours` ; tout autre
-        statut d'erreur → `httpx.HTTPStatusError` via `raise_for_status`.
+        Priorité à l'en-tête `X-Error-Kind` pour discriminer les cas :
+        - `ingestion-lock` → `IngestionEnCours` (503 verrou writer, réessayable).
+        - `precondition`   → `PreconditionNonRemplie` (422, action requise côté Odoo).
+        - absent           → `httpx.HTTPStatusError` (raise_for_status standard).
         """
-        if response.status_code == STATUS_INGESTION_EN_COURS:
+        kind = response.headers.get("X-Error-Kind")
+        if kind == "ingestion-lock":
             raise IngestionEnCours(
                 "L'API electricore est momentanément indisponible : un cycle d'ingestion "
                 "verrouille la base. Réessayer après le checkpoint."
             )
+        if kind == "precondition":
+            try:
+                detail = response.json().get("detail", "Précondition métier non remplie.")
+            except Exception:
+                detail = "Précondition métier non remplie."
+            raise PreconditionNonRemplie(detail)
         response.raise_for_status()
 
     @staticmethod

--- a/packages/electricore-client/tests/test_transport.py
+++ b/packages/electricore-client/tests/test_transport.py
@@ -1,16 +1,22 @@
 """Tests du substrat de transport (`_BaseClient`).
 
 Couvre les invariants partagés par tous les endpoints : en-tête `X-API-Key`,
-conversion 503 → `IngestionEnCours`, propagation des autres erreurs HTTP, et la
+discrimination via X-Error-Kind (#424), propagation des autres erreurs HTTP, et la
 garde de version de contrat asymétrique (warn si serveur en avance, raise si en
 retard). Tout est testé via `httpx.MockTransport` (aucun serveur réel).
+
+Contrat X-Error-Kind (3 familles, #424) :
+1. 503 + X-Error-Kind: ingestion-lock → IngestionEnCours (verrou, réessayable).
+2. 503 sans header               → httpx.HTTPStatusError (erreur générique).
+3. 422 + X-Error-Kind: precondition → PreconditionNonRemplie (actionnable).
 """
 
+import json
 import warnings
 
 import httpx
 import pytest
-from electricore_client.exceptions import ContractVersionError, IngestionEnCours
+from electricore_client.exceptions import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
 from electricore_client.headers import EnTetesMeta
 from electricore_client.transport import _BaseClient
 
@@ -20,15 +26,54 @@ def _client(handler) -> _BaseClient:
     return _BaseClient(url="http://testserver", api_key="secret-key", http_client=http)
 
 
-def test_raise_for_status_mappe_503_sur_ingestion_en_cours():
-    """Un 503 (base verrouillée par l'ingestion) → `IngestionEnCours`, pas une HTTPStatusError."""
+# -- Famille 1 : 503 + X-Error-Kind: ingestion-lock → IngestionEnCours ----------
+
+
+def test_raise_for_status_mappe_503_ingestion_lock_sur_ingestion_en_cours():
+    """503 + X-Error-Kind: ingestion-lock → IngestionEnCours (#424)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, headers={"X-Error-Kind": "ingestion-lock"})
+
+    client = _client(handler)
+    response = client._http.get("http://testserver/x")
+    with pytest.raises(IngestionEnCours):
+        client._raise_for_status(response)
+
+
+# -- Famille 2 : 503 sans header → HTTPStatusError (générique, pas IngestionEnCours) --
+
+
+def test_raise_for_status_503_sans_header_nest_pas_ingestion_en_cours():
+    """503 sans X-Error-Kind → HTTPStatusError, pas IngestionEnCours (#424).
+    Un 503 générique (ex. proxy timeout) ne doit pas être maquillé en verrou."""
 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(503)
 
     client = _client(handler)
     response = client._http.get("http://testserver/x")
-    with pytest.raises(IngestionEnCours):
+    with pytest.raises(httpx.HTTPStatusError):
+        client._raise_for_status(response)
+
+
+# -- Famille 3 : 422 + X-Error-Kind: precondition → PreconditionNonRemplie ------
+
+
+def test_raise_for_status_mappe_422_precondition_sur_precondition_non_remplie():
+    """422 + X-Error-Kind: precondition → PreconditionNonRemplie avec le détail serveur (#424)."""
+    detail_serveur = "Réconciliation RSC requise pour 2025-03-01 : 1 ligne(s) sans RSC."
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            422,
+            headers={"X-Error-Kind": "precondition", "Content-Type": "application/json"},
+            content=json.dumps({"detail": detail_serveur}).encode(),
+        )
+
+    client = _client(handler)
+    response = client._http.get("http://testserver/x")
+    with pytest.raises(PreconditionNonRemplie, match="RSC"):
         client._raise_for_status(response)
 
 

--- a/tests/core/loaders/test_duckdb_retry.py
+++ b/tests/core/loaders/test_duckdb_retry.py
@@ -88,3 +88,29 @@ class TestDuckdbReadonlyConn:
                     pass  # pragma: no cover
 
         assert not isinstance(excinfo.value, DuckDBLockError)
+
+    def test_non_lock_ioexception_propagates_immediately_without_retry(self):
+        """IOException non-verrou (corruption, version mismatch…) → propagée
+        sans retry, jamais wrappée en DuckDBLockError (#424)."""
+        exc = duckdb.IOException("IO Error: Could not read from file: corrupt")
+
+        with patch("duckdb.connect", side_effect=exc) as mock_connect:
+            with patch("time.sleep") as mock_sleep:
+                with pytest.raises(duckdb.IOException, match="corrupt"):
+                    with duckdb_readonly_conn("/corrupt.duckdb"):
+                        pass  # pragma: no cover
+
+        assert mock_connect.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_non_lock_ioexception_is_not_wrapped_as_lock_error(self):
+        """Une IOException non-verrou ne doit PAS devenir DuckDBLockError (#424).
+        Sinon l'API afficherait « ingestion en cours » pour une corruption."""
+        exc = duckdb.IOException("IO Error: Unsupported DuckDB file format version")
+
+        with patch("duckdb.connect", side_effect=exc):
+            with pytest.raises(duckdb.IOException) as excinfo:
+                with duckdb_readonly_conn("/version-mismatch.duckdb"):
+                    pass  # pragma: no cover
+
+        assert not isinstance(excinfo.value, DuckDBLockError)

--- a/tests/integration/test_verrou_duckdb_503.py
+++ b/tests/integration/test_verrou_duckdb_503.py
@@ -42,6 +42,15 @@ class TestVerrouPendantIngestion:
         assert response.status_code == 503
         assert "ingestion en cours" in response.json()["detail"].lower()
 
+    def test_verrou_503_porte_header_x_error_kind_ingestion_lock(self, client, base_verrouillee):
+        """Le 503 verrou porte `X-Error-Kind: ingestion-lock` (#424) : signal
+        distinctif qui permet au client de mapper ce seul cas en IngestionEnCours,
+        sans confondre avec un 503 générique."""
+        response = client.get("/flux/r151.xlsx")
+
+        assert response.status_code == 503
+        assert response.headers.get("x-error-kind") == "ingestion-lock"
+
     def test_flux_json_repond_503_avec_detail_ingestion(self, client, base_verrouillee):
         response = client.get("/flux/r151")
 

--- a/tests/unit/test_facturation_service.py
+++ b/tests/unit/test_facturation_service.py
@@ -201,3 +201,102 @@ def test_categories_hors_scope_ecartees_avant_rapprochement(monkeypatch):
     assert "All" not in categories
     assert result.height == 1
     assert result["quantite_enedis"].to_list() == [123.45]
+
+
+def test_contexte_et_lignes_leve_422_si_rsc_nulle(monkeypatch):
+    """Précondition RSC (#424) : des lignes Odoo sans ref_situation_contractuelle
+    signalent un mois non réconcilié → HTTPException 422 avec X-Error-Kind: precondition
+    et le mois dans le message — avant que rapprocher() voie les nulls."""
+    from datetime import datetime
+
+    import polars as pl
+    import pytest
+    from fastapi import HTTPException
+
+    from electricore.api.services import facturation_service
+    from electricore.core.builds.contexte_mensuel import ContexteMensuel
+
+    df_fact_mensuelle = pl.DataFrame(
+        {
+            "ref_situation_contractuelle": ["RSC001"],
+            "pdl": ["12345678901234"],
+            "debut": [datetime(2025, 3, 1)],
+            "fin": [datetime(2025, 4, 1)],
+            "energie_hp_kwh": [100.0],
+            "energie_hc_kwh": [0.0],
+            "energie_base_kwh": [0.0],
+            "nb_jours": [31],
+            "turpe_fixe_eur": [10.0],
+            "turpe_variable_eur": [50.0],
+            "qualite": ["réelle"],
+            "statut_communication": ["communicante"],
+            "memo_puissance": [""],
+        }
+    ).with_columns(
+        pl.col("debut").dt.replace_time_zone("Europe/Paris"),
+        pl.col("fin").dt.replace_time_zone("Europe/Paris"),
+    )
+
+    contexte_prefab = ContexteMensuel(
+        mois="2025-03-01",
+        historique_enrichi=pl.LazyFrame(
+            {"ref_situation_contractuelle": ["RSC001"], "num_compteur": ["12345678"], "type_compteur": ["LINKY"]}
+        ),
+        abonnements=pl.LazyFrame(),
+        energie=pl.LazyFrame(),
+        releves_utilises=pl.LazyFrame(),
+        facturation_mensuelle=df_fact_mensuelle,
+    )
+    monkeypatch.setattr(facturation_service, "contexte_du_mois", lambda mois=None: contexte_prefab)
+
+    # Ligne Odoo avec RSC null : mois non réconcilié
+    df_lignes_avec_rsc_nulle = pl.DataFrame(
+        {
+            "ref_situation_contractuelle": [None],
+            "categorie_produit": ["HP"],
+            "quantite": [100.0],
+            "est_brouillon": [True],
+            "invoice_line_ids": [201],
+            "x_pdl": ["12345678901234"],
+            "x_lisse": [False],
+            "name_account_move": ["INV/2025/0003"],
+            "name_product_product": ["Énergie HP"],
+        },
+        schema={
+            "ref_situation_contractuelle": pl.Utf8,
+            "categorie_produit": pl.Utf8,
+            "quantite": pl.Float64,
+            "est_brouillon": pl.Boolean,
+            "invoice_line_ids": pl.Int64,
+            "x_pdl": pl.Utf8,
+            "x_lisse": pl.Boolean,
+            "name_account_move": pl.Utf8,
+            "name_product_product": pl.Utf8,
+        },
+    )
+
+    class _QueryMock:
+        def __init__(self, df):
+            self._df = df
+
+        def lazy(self):
+            return self._df.lazy()
+
+        def collect(self):
+            return self._df
+
+        def filter(self, *a, **k):
+            return _QueryMock(self._df.lazy().filter(*a, **k).collect())
+
+    monkeypatch.setattr(
+        facturation_service, "lignes_factures_du_mois", lambda odoo, mois: _QueryMock(df_lignes_avec_rsc_nulle)
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        facturation_service._contexte_et_lignes(odoo=None, mois="2025-03-01")
+
+    exc = exc_info.value
+    assert exc.status_code == 422
+    assert exc.headers.get("X-Error-Kind") == "precondition"
+    assert "2025-03-01" in exc.detail
+    assert "1" in exc.detail  # n=1 ligne sans RSC


### PR DESCRIPTION
## Résumé

- `_is_lock_error` reconnaît désormais **uniquement** les vrais verrous DuckDB (`"could not set lock"`, `"conflicting lock"`) — une corruption ou version mismatch remonte comme erreur réelle, jamais comme « ingestion en cours ».
- Le 503 verrou porte l'en-tête **`X-Error-Kind: ingestion-lock`** ; le client mappe ce seul cas en `IngestionEnCours`, les 503 sans header restent des `httpx.HTTPStatusError`.
- Facturation d'un mois aux RSC non réconciliées → **422 actionnable** (`X-Error-Kind: precondition`) avec le mois et le nombre de lignes concernées, avant que `rapprocher()` explose en `SERIES_CONTAINS_NULLS`.
- Nouveau `PreconditionNonRemplie(ElectricoreClientError)` dans le client pour le cas 422-precondition.

## Contrat (X-Error-Kind)

| Valeur | HTTP | Exception client | Sémantique |
|---|---|---|---|
| `ingestion-lock` | 503 | `IngestionEnCours` | Verrou writer DuckDB — réessayable |
| `precondition` | 422 | `PreconditionNonRemplie` | Précondition métier — actionnable, non retryable |
| *(absent)* | any | `httpx.HTTPStatusError` | Erreur inattendue |

## Test plan

- `tests/core/loaders/test_duckdb_retry.py` — 2 nouveaux cas non-verrou (corruption, version mismatch)
- `tests/integration/test_verrou_duckdb_503.py` — assert `X-Error-Kind: ingestion-lock` sur le 503 verrou
- `tests/unit/test_facturation_service.py` — HTTPException 422 + header precondition + mois dans le détail
- `packages/electricore-client/tests/test_transport.py` — 3 familles X-Error-Kind

## Note (hors scope)

Le fallback générique du décorateur `binary_endpoint` reste `error_status=503` (decorators.py:88) : une `IOException` non-verrou non interceptée produit un 503-sans-header — que le client traite correctement en `httpx.HTTPStatusError` (pas `IngestionEnCours`). Basculer ce fallback en 500 serait un changement de scope séparé.

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
