### PR TITLE
chore(release): 3.4.1 (promotion rc1 → stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
-## [3.4.1rc1] - 2026-06-29
+## [3.4.1] - 2026-06-29
 
-Première RC de la ligne **3.4.1** — durcissement et élagage post-stable, **sans changement
-de comportement fonctionnel** (suite verte, symboles disparus).
+Patch stable **3.4.1** (promotion de la rc1) — durcissement et élagage post-stable, **sans
+changement de comportement fonctionnel** (suite verte, symboles disparus).
 
 ### 🧹 Élagage de la dette de sur-ingénierie (épic #505)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.4.1rc1"
+version = "3.4.1"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.4.1rc1"
+version = "3.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Promotion pure de `3.4.1rc1` → `3.4.1` (même arbre, pas de changement fonctionnel), même schéma que la PR #498 pour le stable 3.4.0.

- `pyproject.toml` : `3.4.1rc1` → `3.4.1`
- `uv.lock` (paquet `electricore`) : idem
- `CHANGELOG.md` : section `[3.4.1rc1]` promue en `[3.4.1]`

⚠️ **Ordre inversé à corriger après merge.** Le tag `v3.4.1` a été posé **avant** ce bump : il pointe sur `43d3a8f` dont le `pyproject` dit encore `3.4.1rc1`. Une fois cette PR mergée, re-pointer `v3.4.1` sur le commit de merge (delete + re-tag + push, force si déjà publié) pour que l'image publiée reporte bien `3.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)