### PR TITLE
feat(ingestion): ingérer le flux C12 (contractuel C2-C4, >36 kVA)

### DIFF
--- a/docs/adr/0051-flux-c12-spine-c4.md
+++ b/docs/adr/0051-flux-c12-spine-c4.md
@@ -1,5 +1,9 @@
 # ADR-0051 — Ingestion flux C12 : spine contractuelle C4
 
+## Statut
+
+Accepté (#344).
+
 ## Contexte
 
 Le flux **C12** (SGE GUI 0129, XSD 0130 v1.12.1) porte la *description contractuelle des PRM
@@ -39,8 +43,10 @@ Le mapping HPE→hpb / HCE→hcb suit la convention de nommage des cadrans (ADR-
 
 **Classes HTA non mappées** (Pointe, HPDemiSaison, HCDemiSaison, JA, PM) : présentes dans le
 XSD pour les tarifs HTA5/HTA8 ; produisent NULL dans le pivot. Gardées en blanc pour l'instant
-(aucun cas de production observé dans le périmètre C2-C4 BT courant). Un `accepted_values`
-dbt sur `Libelle` attrape toute valeur hors de l'enum XSD complet.
+(aucun cas de production observé dans le périmètre C2-C4 BT courant). Un test singulier dbt
+(`assert_flux_c12_libelle_classe_dans_enum_xsd`) attrape toute valeur hors de l'enum XSD
+complet (dérive de schéma Enedis) ; il ne fait **pas** échouer les classes HTA connues mais
+non mappées.
 
 **Pas de colonne `segment_clientele`** : absent du XSD C12. Le segment est inféré en aval
 depuis le domaine de tension et l'option tarifaire.

--- a/docs/adr/0051-flux-c12-spine-c4.md
+++ b/docs/adr/0051-flux-c12-spine-c4.md
@@ -1,0 +1,60 @@
+# ADR-0051 — Ingestion flux C12 : spine contractuelle C4
+
+## Contexte
+
+Le flux **C12** (SGE GUI 0129, XSD 0130 v1.12.1) porte la *description contractuelle des PRM
+du segment C2-C4* (>36 kVA) : options tarifaires TURPE, puissances souscrites par classe
+temporelle, utilisateur réseau (personne morale, code APE), informations d'alimentation et de
+comptage. Prérequis tracé en #344 comme condition du calcul d'accise (#226) : le **Code_APE**
+et le domaine de tension sont nécessaires pour déterminer la catégorie d'accise d'un PRM
+C2-C4.
+
+Structure XSD notable : les puissances souscrites ne sont **pas** un champ scalaire mais une
+liste de `Classe_Temporelle_TURPE_Souscrite` (Libelle + Puissance_Souscrite). Il n'y a **pas**
+de `Segment_Clientele` natif (absent du XSD C12 — le segment est inféré à l'usage).
+
+## Décision
+
+C12 est ingéré comme une **spine contractuelle C4** minimale, suivant exactement la même
+plomberie que C15 (xml_vers_dict → landing JSON → dbt stg_c12 + flux_c12).
+
+**Grain** : une ligne par `Type_Evenement[0].Situation_Contractuelle[0]` (un événement
+contractuel par fichier C12 ; grain identique à C15).
+
+**Pivot des puissances** : les `Classe_Temporelle_TURPE_Souscrite` sont pivotés en colonnes
+par agrégation conditionnelle sur le vocabulaire TURPE :
+
+| Libelle XSD | colonne produite               |
+|-------------|-------------------------------|
+| Base        | puissance_souscrite_kva        |
+| HP          | puissance_souscrite_hp_kva     |
+| HC          | puissance_souscrite_hc_kva     |
+| HPH         | puissance_souscrite_hph_kva    |
+| HCH         | puissance_souscrite_hch_kva    |
+| HPE         | puissance_souscrite_hpb_kva    |
+| HCE         | puissance_souscrite_hcb_kva    |
+
+Le mapping HPE→hpb / HCE→hcb suit la convention de nommage des cadrans (ADR-0035, §1) :
+« hpb » = Heures Pleines Basse saison, « hcb » = Heures Creuses Basse saison.
+
+**Classes HTA non mappées** (Pointe, HPDemiSaison, HCDemiSaison, JA, PM) : présentes dans le
+XSD pour les tarifs HTA5/HTA8 ; produisent NULL dans le pivot. Gardées en blanc pour l'instant
+(aucun cas de production observé dans le périmètre C2-C4 BT courant). Un `accepted_values`
+dbt sur `Libelle` attrape toute valeur hors de l'enum XSD complet.
+
+**Pas de colonne `segment_clientele`** : absent du XSD C12. Le segment est inféré en aval
+depuis le domaine de tension et l'option tarifaire.
+
+**Golden sur données réelles différé** : nécessite le trousseau AES de prod. La fixture XSD
+maximale (`c12_xsd.xml`) et son golden servent de filet de régression en attendant.
+
+## Raison
+
+- Même plomberie que C15 : réutilise le générateur `generer_fixtures_xsd.py`, le harness
+  `test_dbt_flux_golden.py`, le loader SELECT * (ADR-0042), la factory `c12()` calquée sur
+  `c15()`.
+- Scope minimal : uniquement les champs nécessaires à l'accise (#226) et à la spine
+  contractuelle. Les classes HTA et la structure d'alimentation détaillée sont délibérément
+  hors périmètre pour l'instant.
+- `c12()` ne porte pas de validateur Pandera : pas de seam de calcul consommateur établi
+  à ce stade (ADR-0035 §5 — même raisonnement que F15/R64).

--- a/electricore/core/loaders/__init__.py
+++ b/electricore/core/loaders/__init__.py
@@ -9,6 +9,7 @@ from .duckdb import (
     DuckDBQuery,
     # API fluide
     affaires,
+    c12,
     c15,
     chronologie_releves,
     f15,
@@ -22,6 +23,7 @@ from .duckdb import (
 
 __all__ = [
     # API fluide DuckDB (recommandée)
+    "c12",
     "c15",
     "r151",
     "r15",

--- a/electricore/core/loaders/duckdb/__init__.py
+++ b/electricore/core/loaders/duckdb/__init__.py
@@ -23,6 +23,7 @@ from .config import DuckDBConfig, DuckDBLockError, duckdb_readonly_conn
 from .helpers import (
     # API fluide
     affaires,
+    c12,
     c15,
     chronologie_releves,
     f15,
@@ -50,6 +51,7 @@ __all__ = [
     "DuckDBQuery",
     # API fluide (recommandée)
     "flux",
+    "c12",
     "c15",
     "r151",
     "r15",

--- a/electricore/core/loaders/duckdb/helpers.py
+++ b/electricore/core/loaders/duckdb/helpers.py
@@ -67,6 +67,28 @@ def c15(database_path: str | Path | None = None) -> DuckDBQuery:
     return flux("c15", database_path)
 
 
+def c12(database_path: str | Path | None = None) -> DuckDBQuery:
+    """
+    Crée un DuckDBQuery pour les données flux C12 (description contractuelle C2-C4).
+
+    C12 porte la spine contractuelle des PRM >36 kVA : option tarifaire TURPE,
+    puissances souscrites pivotées par cadran (HPH/HCH/hpb/hcb/HP/HC/Base),
+    utilisateur réseau (Raison_Sociale, Code_APE — proxy accise #226), profil,
+    domaine de tension. Pas de Segment_Clientele natif (ADR-0051).
+
+    Args:
+        database_path: Chemin vers la base DuckDB (optionnel)
+
+    Returns:
+        DuckDBQuery configuré pour flux_c12
+
+    Example:
+        >>> # PDLs C4 par option tarifaire
+        >>> df = c12().filter({"option_tarifaire_turpe": "BTSUPLU4"}).collect()
+    """
+    return flux("c12", database_path)
+
+
 def r151(database_path: str | Path | None = None) -> DuckDBQuery:
     """
     Crée un DuckDBQuery pour les données flux R151 (relevés périodiques).

--- a/electricore/core/loaders/duckdb/registry.py
+++ b/electricore/core/loaders/duckdb/registry.py
@@ -54,6 +54,19 @@ DESCRIPTOR_C15 = FluxDescriptor(
 )
 
 
+# Flux C12 - Description contractuelle C2-C4 (>36 kVA, ADR-0051). SELECT * (ADR-0042) :
+# la forme résiduelle (littéral source) vit dans le modèle dbt `flux_c12`. Les puissances
+# sont en BIGINT (kVA entiers). Pas de validateur Pandera : pas de seam de calcul établi
+# à ce stade (ADR-0035 §5 — même raisonnement que F15/R64 ; le premier consommateur
+# établira le contrat).
+DESCRIPTOR_C12 = FluxDescriptor(
+    flux_name="C12",
+    table="flux_enedis.flux_c12",
+    transform=None,
+    validator=None,
+)
+
+
 # Flux R151 - Relevés périodiques. SELECT * (ADR-0042, #395) : la forme résiduelle
 # (source, ordre_index, placeholders null RSC/FTA, precision) et l'instant J+1 vivent
 # désormais dans le modèle dbt `flux_r151`. date_releve sert l'INSTANT harmonisé (révise
@@ -151,6 +164,7 @@ DESCRIPTOR_AFFAIRES = FluxDescriptor(
 
 FLUX_DESCRIPTORS: dict[str, FluxDescriptor] = {
     "c15": DESCRIPTOR_C15,
+    "c12": DESCRIPTOR_C12,
     "r151": DESCRIPTOR_R151,
     "r15": DESCRIPTOR_R15,
     "f15": DESCRIPTOR_F15,

--- a/electricore/ingestion/CONTEXT.md
+++ b/electricore/ingestion/CONTEXT.md
@@ -32,6 +32,13 @@ Flux quotidiens de suivi des *affaires* SGE (cycle de vie des demandes de presta
 **Énergies de consommation** *retenues pour la facturation*, par **période** et par cadran (`etapeMetier = FACT`), portées en **deux grilles parallèles** qui réconcilient (à l'arrondi cadran près) — *distributeur* (les 4 cadrans saisonniers HPH/HPB/HCH/HCB, pour le TURPE) et *fournisseur* (le tarif de facturation : Base ou HP/HC). Contrairement à un **relevé d'index** (cumul à un instant), R67 porte de l'**énergie déjà différenciée sur une période** → **asset parallèle, hors de l'union `releves`** (modèle figé en [ADR-0047](../../docs/adr/0047-flux-r67-energie-par-periode-distributeur-hors-releves.md)). Le flux **R67** les publie **à la demande** (prestation **M023**, ponctuelle, JSON). Réservé au **fournisseur titulaire actif** ; profondeur restituée = `max(aujourd'hui − 36 mois, dernière mise en service)` — **deux bornes RGPD distinctes** : le *mur occupant* (jamais la donnée d'un occupant précédent — coupée à la dernière MES) et l'*horizon de rétention glissant* (36 mois). Conséquence : sur un **CFNE** (même foyer, MES ancienne) il remonte *avant* l'entrée chez le fournisseur → sert l'amorçage (*cold-start*) de la *provision d'énergie* d'un mensualisé ; sur un **MES/PMES** (nouvel occupant) il est coupé à l'entrée → sans valeur. Les **régularisations** (révision physique d'une consommation estimée) peuvent être **négatives**. Ingestion figée en ADR-0047 ([#214](https://github.com/Energie-De-Nantes/electricore/issues/214), brique de l'épique [#191](https://github.com/Energie-De-Nantes/electricore/issues/191)).
 _Éviter_ : confondre avec les *mesures fines* (courbe de charge R63/R66, soumises au consentement CDC) ; « 60 mois » (la profondeur effective constatée est 36 mois).
 
+**C12** :
+Flux de description contractuelle des PRM du segment C2-C4 (>36 kVA, SGE GUI 0129) ; même
+plomberie que C15 mais sans `Segment_Clientele` natif (segment inféré) ni attribut fiscal ;
+puissance par classe temporelle TURPE → pivot vers les 4 cadrans C4 + scalaire mono ;
+classes HTA non mappées (gardées) ; `Personne_Morale` (`Raison_Sociale`, `Code_APE`) = proxy
+nature économique pour l'accise (#226). Voir [ADR-0051](../../docs/adr/0051-flux-c12-spine-c4.md).
+
 **CAR (Consommation Annuelle de Référence)** :
 Consommation annuelle de référence qu'Enedis recalcule à chaque relève (profilage des points non télérelevés). Alternative *théorique* à R67 pour estimer une provision — un seul nombre annuel, auto-tenu par Enedis — mais **absente de tout flux ingéré** : l'obtenir exigerait l'API SGE web-service (candidat non bâti, [#207](https://github.com/Energie-De-Nantes/electricore/issues/207)). Porte la même borne *mur occupant* que les *mesures facturantes*.
 

--- a/electricore/ingestion/config/flux.yaml
+++ b/electricore/ingestion/config/flux.yaml
@@ -49,6 +49,12 @@ R67:
   file_regex: "*.json"  # JSON en minuscules dans les ZIPs R67
   incremental: false
 
+
+C12:
+  file_pattern: "**/*_C12_*.zip"
+  format: xml
+  file_regex: "*_C12_*.xml"
+
 # X12 (affaires initiées par l'instance) + X13 (affaires reçues d'autres acteurs)
 # partagent le même schéma XSD → une seule table brute `raw_affaires` ; l'origine se
 # dérive du nom de fichier dans le modèle dbt. Le glob `[23]` capture X12 et X13 sans

--- a/electricore/ingestion/dbt/models/flux/flux_c12.sql
+++ b/electricore/ingestion/dbt/models/flux/flux_c12.sql
@@ -1,0 +1,80 @@
+-- Linéarisation C12 : une ligne par PRM, spine contractuelle C4 avec puissances
+-- TURPE pivotées en colonnes (ADR-0051, issue #344).
+--
+-- Grain : une ligne par PRM (prm_id = fichier + position). Un fichier C12 porte en
+-- général plusieurs PRM ; on prend Type_Evenement[0].Situation_Contractuelle[0] pour
+-- chaque PRM (grain « dernière situation contractuelle du dernier événement »).
+--
+-- Pas de Segment_Clientele natif dans le XSD C12 : le segment (C2/C3/C4) est inféré
+-- en aval depuis domaine_de_tension et option_tarifaire_turpe.
+--
+-- Pivot puissances (à confirmer sur golden réel prod, #344) :
+--   HPE→hpb (Heures Pleines Été = Basse saison), HCE→hcb (Heures Creuses Été = Basse saison)
+--   Classes HTA (Pointe, HPDemiSaison, HCDemiSaison, JA, PM) → NULL (non mappées, gardées)
+
+with flat as (
+    select
+        prm_id,
+        prm ->> '$.Identifiant'                                                                       as pdl,
+        cast(prm ->> '$.Type_Evenement[0].Date_Evenement' as date)                                   as date_evenement,
+        cast(prm ->> '$.Type_Evenement[0].Situation_Contractuelle[0].Date_Debut' as date)             as date_debut,
+        cast(prm ->> '$.Type_Evenement[0].Situation_Contractuelle[0].Date_Fin' as date)               as date_fin,
+        cast(
+            prm ->> '$.Type_Evenement[0].Situation_Contractuelle[0].Synthese_Contractuelle[0].Date_De_Premiere_Mise_En_Service'
+            as date
+        )                                                                                              as date_premiere_mise_en_service,
+        -- Événement : nature (liste) → première valeur (pattern C15-compatible)
+        prm ->> '$.Type_Evenement[0].Situation_Contractuelle[0].Evenement[0].Nature_Evenement[0]'    as nature_evenement,
+        prm ->> '$.Type_Evenement[0].Situation_Contractuelle[0].Evenement[0].Numero_Affaire'         as numero_affaire,
+        -- Option tarifaire TURPE
+        prm ->> '$.Type_Evenement[0].Situation_Contractuelle[0].Option_Tarifaire_TURPE_Souscrite[0].Option_Tarifaire_TURPE[0].Libelle'
+                                                                                                      as option_tarifaire_turpe,
+        -- Profil
+        prm ->> '$.Type_Evenement[0].Situation_Contractuelle[0].Profil'                              as profil,
+        -- Domaine de tension (depuis Alimentation_Principale, optionnel)
+        prm ->> '$.Type_Evenement[0].Alimentation[0].Alimentation_Principale[0].Domaine_De_Tension'  as domaine_de_tension,
+        -- Utilisateur réseau (Personne_Morale — proxy nature économique pour l'accise #226)
+        prm ->> '$.Type_Evenement[0].Situation_Contractuelle[0].Utilisateur_Reseau[0].Personne_Morale[0].Raison_Sociale'
+                                                                                                      as raison_sociale,
+        prm ->> '$.Type_Evenement[0].Situation_Contractuelle[0].Utilisateur_Reseau[0].Personne_Morale[0].Code_APE'
+                                                                                                      as code_ape,
+        -- Classes temporelles TURPE souscrites (liste pour le pivot aval)
+        cast(
+            prm -> '$.Type_Evenement[0].Situation_Contractuelle[0].Option_Tarifaire_TURPE_Souscrite[0].Classe_Temporelle_TURPE_Souscrite'
+            as json[]
+        )                                                                                              as classes
+    from {{ ref('stg_c12') }}
+),
+
+-- Unnest des classes temporelles : une ligne par (prm_id, classe) pour le pivot.
+-- CTE isolé avant le WHERE (discipline anti-pushdown-sous-unnest, comme flux_c15).
+classes as (
+    select
+        prm_id,
+        t.classe ->> '$.Libelle'             as libelle,
+        cast(t.classe ->> '$.Puissance_Souscrite' as bigint) as puissance_kva
+    from flat,
+        unnest(classes) as t(classe)
+),
+
+-- Pivot des puissances par libelle TURPE → colonnes standard cadrans.
+-- HPE→hpb / HCE→hcb : convention Basse saison (ADR-0035 §1).
+-- Classes HTA (Pointe, HPDemiSaison, HCDemiSaison, JA, PM) : NULL délibéré, gardées.
+puissances as (
+    select
+        prm_id,
+        max(case when libelle = 'Base' then puissance_kva end) as puissance_souscrite_kva,
+        max(case when libelle = 'HP'   then puissance_kva end) as puissance_souscrite_hp_kva,
+        max(case when libelle = 'HC'   then puissance_kva end) as puissance_souscrite_hc_kva,
+        max(case when libelle = 'HPH'  then puissance_kva end) as puissance_souscrite_hph_kva,
+        max(case when libelle = 'HCH'  then puissance_kva end) as puissance_souscrite_hch_kva,
+        max(case when libelle = 'HPE'  then puissance_kva end) as puissance_souscrite_hpb_kva,
+        max(case when libelle = 'HCE'  then puissance_kva end) as puissance_souscrite_hcb_kva
+    from classes
+    group by prm_id
+)
+
+select
+    * exclude (prm_id),
+    'flux_C12' as source
+from flat left join puissances using (prm_id)

--- a/electricore/ingestion/dbt/models/flux/flux_c12.sql
+++ b/electricore/ingestion/dbt/models/flux/flux_c12.sql
@@ -75,6 +75,6 @@ puissances as (
 )
 
 select
-    * exclude (prm_id),
+    * exclude (prm_id, classes),
     'flux_C12' as source
 from flat left join puissances using (prm_id)

--- a/electricore/ingestion/dbt/models/flux/schema.yml
+++ b/electricore/ingestion/dbt/models/flux/schema.yml
@@ -197,16 +197,3 @@ models:
           HTA5, HTA8, HTASansDiff, BTINFCUST, BTINFMUDT, BTINFLU, BTINFMUST, HTALU5,
           HTACU5, HTALUPM5, HTACUPM5, BTSUPLU4, BTSUPCU4, BTSUPCUACC, BTSUPLUACC, HTAST5.
 
-  - name: stg_c12
-    description: >
-      Staging C12 : une ligne par PRM, prm complète en colonne json (avant extraction).
-      Sert exclusivement flux_c12 via ref().
-    columns:
-      - name: pdl
-        description: Point de livraison extrait de l'Identifiant (14 chiffres).
-      - name: libelle_classe_temporelle
-        description: >
-          Libelle de la Classe_Temporelle_TURPE_Souscrite. Enum XSD complet :
-          Pointe, HPH, HPDemiSaison, HCH, HCDemiSaison, HPE, HCE, JA, Base, HP, HC, PM.
-          Un accepted_values sur ce champ attrape toute valeur inconnue d'Enedis.
-

--- a/electricore/ingestion/dbt/models/flux/schema.yml
+++ b/electricore/ingestion/dbt/models/flux/schema.yml
@@ -176,3 +176,37 @@ models:
       - name: affaire_etat
         description: État fin de l'affaire au jalon (DMTR, DMREC, CPRE, CPNR…).
         data_tests: [not_null]
+
+  - name: flux_c12
+    description: >
+      Description contractuelle C12 : une ligne par PRM, segment C2-C4 (>36 kVA).
+      Puissances souscrites par cadran TURPE pivotées en colonnes (HPE→hpb, HCE→hcb) ;
+      classes HTA (Pointe, HPDemiSaison, HCDemiSaison, JA, PM) ignorées → NULL.
+      Pas de Segment_Clientele natif : inféré en aval (ADR-0051, #344).
+      Parité golden vérifiée (tests/ingestion/test_dbt_flux_golden.py).
+    columns:
+      - name: pdl
+        description: Point de livraison (14 chiffres).
+        data_tests: [not_null]
+      - name: date_debut
+        description: Date de début de la situation contractuelle (DATE).
+        data_tests: [not_null]
+      - name: option_tarifaire_turpe
+        description: >
+          Option tarifaire TURPE souscrite (Libelle XSD). Valeurs XSD : BTSUPLU, BTSUPMU,
+          HTA5, HTA8, HTASansDiff, BTINFCUST, BTINFMUDT, BTINFLU, BTINFMUST, HTALU5,
+          HTACU5, HTALUPM5, HTACUPM5, BTSUPLU4, BTSUPCU4, BTSUPCUACC, BTSUPLUACC, HTAST5.
+
+  - name: stg_c12
+    description: >
+      Staging C12 : une ligne par PRM, prm complète en colonne json (avant extraction).
+      Sert exclusivement flux_c12 via ref().
+    columns:
+      - name: pdl
+        description: Point de livraison extrait de l'Identifiant (14 chiffres).
+      - name: libelle_classe_temporelle
+        description: >
+          Libelle de la Classe_Temporelle_TURPE_Souscrite. Enum XSD complet :
+          Pointe, HPH, HPDemiSaison, HCH, HCDemiSaison, HPE, HCE, JA, Base, HP, HC, PM.
+          Un accepted_values sur ce champ attrape toute valeur inconnue d'Enedis.
+

--- a/electricore/ingestion/dbt/models/sources.yml
+++ b/electricore/ingestion/dbt/models/sources.yml
@@ -81,6 +81,19 @@ sources:
             description: Nom du fichier source (traçabilité).
           - name: modification_date
             description: Date de modification SFTP (clé d'incrémental dlt).
+      - name: raw_c12
+        description: >
+          Flux C12 (description contractuelle des PRM C2-C4, >36 kVA), un document par ligne.
+          Le XML est converti en dict par `etl/parsing/xml.xml_vers_dict` avant landing.
+          Contient les puissances souscrites par classe temporelle TURPE, l'option tarifaire,
+          l'utilisateur réseau (Personne_Morale avec Raison_Sociale et Code_APE).
+        columns:
+          - name: content
+            description: Document JSON intégral (En_Tete_Flux + Contrat + PRM[]).
+          - name: file_name
+            description: Nom du fichier source (traçabilité).
+          - name: modification_date
+            description: Date de modification SFTP (clé d'incrémental dlt).
       - name: raw_affaires
         description: >
           Flux X12 + X13 (suivi des affaires SGE), un document XML→dict par ligne.

--- a/electricore/ingestion/dbt/models/staging/stg_c12.sql
+++ b/electricore/ingestion/dbt/models/staging/stg_c12.sql
@@ -1,0 +1,20 @@
+-- Éclatement du document C12 : une ligne par PRM.
+--
+-- C12 (SGE GUI 0129, XSD 0130) : description contractuelle C2-C4 (>36 kVA).
+-- Même politique que stg_c15 (accès JSON tolérant ->>/->, pas de cast struct géant).
+-- `xml_vers_dict` applique « conteneur = liste » → PRM est sous Contrat[0], toujours
+-- tableau même unique → unnest direct avec generate_subscripts.
+--
+-- Différence clé vs C15 : PRM est dans content -> '$.Contrat[0].PRM' (pas à la racine).
+
+-- prm_id : clé d'occurrence stable (fichier + position du PRM), portée à l'aval pour
+-- l'unnest des classes temporelles. generate_subscripts s'aligne sur unnest.
+select
+    file_name,
+    modification_date,
+    file_name || '#' || generate_subscripts(prms, 1) as prm_id,
+    unnest(prms)                                      as prm
+from (
+    select file_name, modification_date, cast(content -> '$.Contrat[0].PRM' as json[]) as prms
+    from {{ source('flux_raw', 'raw_c12') }}
+)

--- a/electricore/ingestion/dbt/tests/assert_flux_c12_libelle_classe_dans_enum_xsd.sql
+++ b/electricore/ingestion/dbt/tests/assert_flux_c12_libelle_classe_dans_enum_xsd.sql
@@ -1,0 +1,27 @@
+-- Garde-fou ADR-0051 (#344) : tout Libelle de Classe_Temporelle_TURPE_Souscrite dans
+-- flux_c12 doit appartenir à l'enum XSD complet.
+--
+-- Les classes HTA (Pointe, HPDemiSaison, HCDemiSaison, JA, PM) sont dans l'enum et
+-- passent ici (leur pivot produit NULL, mais elles ne sont pas « inconnues »).
+-- Un Libelle hors enum = Enedis a étendu le schéma → il faut mettre à jour le pivot.
+-- Le test échoue s'il renvoie des lignes.
+
+with classes as (
+    select
+        prm_id,
+        t.classe ->> '$.Libelle' as libelle
+    from {{ ref('stg_c12') }},
+        unnest(
+            cast(
+                prm -> '$.Type_Evenement[0].Situation_Contractuelle[0].Option_Tarifaire_TURPE_Souscrite[0].Classe_Temporelle_TURPE_Souscrite'
+                as json[]
+            )
+        ) as t(classe)
+)
+
+select libelle
+from classes
+where libelle not in (
+    'Pointe', 'HPH', 'HPDemiSaison', 'HCH', 'HCDemiSaison',
+    'HPE', 'HCE', 'JA', 'Base', 'HP', 'HC', 'PM'
+)

--- a/electricore/ingestion/runner.py
+++ b/electricore/ingestion/runner.py
@@ -178,6 +178,7 @@ def _msg_flux_aveugles(aveugles: list[str]) -> str:
 # Modèles dbt servis par chaque table brute (raw_r15 sert deux linéarisations).
 MODELES_PAR_RAW = {
     "raw_c15": ["flux_c15"],
+    "raw_c12": ["flux_c12"],
     "raw_r15": ["flux_r15", "flux_r15_acc"],
     "raw_r151": ["flux_r151"],
     "raw_f12": ["flux_f12_detail"],

--- a/tests/fixtures/flux/anonymiser.py
+++ b/tests/fixtures/flux/anonymiser.py
@@ -106,6 +106,7 @@ PLACEHOLDERS = {
     "Code_Commune": "00000",
     "Code_Departement": "00",
     "Raison_Sociale": "FOURNISSEUR EXEMPLE",
+    "Code_APE": "3514Z",  # code APE fictif (production électricité)
 }
 
 

--- a/tests/fixtures/flux/c12_xsd.xml
+++ b/tests/fixtures/flux/c12_xsd.xml
@@ -1,0 +1,143 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Fixture XSD C12 — construite à la main (le générateur generer_fixtures_xsd.py ne
+  gère pas encore les attributs XML requis, ex. Commune[@Code_INSEE], SI_Contractuel
+  [@Identifiant_Historique]). Marqué hand-authored.
+
+  Deux PRM pour couvrir les deux cas de pivot :
+    PRM #1 : tarif BTSUPLU4 — 4 classes (HPH/HCH/HPE/HCE) → colonnes C4 hph/hch/hpb/hcb
+    PRM #2 : tarif BTSUPLU  — 2 classes (HP/HC)             → colonnes HP/HC seulement
+
+  Les valeurs de Puissance_Souscrite sont distinctes pour détecter les transpositions.
+-->
+<C12>
+  <En_Tete_Flux>
+    <Identifiant_Flux>C12</Identifiant_Flux>
+    <Libelle_Flux>Description contractuelle des PRM du segment C2-C4</Libelle_Flux>
+    <Version_XSD>1.12.1</Version_XSD>
+    <Identifiant_Emetteur>Enedis</Identifiant_Emetteur>
+    <Identifiant_Destinataire>17XFICTIF000001X</Identifiant_Destinataire>
+    <Date_Creation>2024-06-15T00:01:00+02:00</Date_Creation>
+    <Mode_Generation>COMPLET</Mode_Generation>
+  </En_Tete_Flux>
+  <Contrat>
+    <Identifiant>CTR0000001</Identifiant>
+    <Date_Debut>2024-01-01</Date_Debut>
+    <Responsable_Equilibre>
+      <Date_Debut>2024-01-01</Date_Debut>
+      <Code_EIC>17XFICTIF000002X</Code_EIC>
+      <Raison_Sociale>FOURNISSEUR EXEMPLE</Raison_Sociale>
+    </Responsable_Equilibre>
+    <Client_Contractant>
+      <Code_EIC>17XFICTIF000003X</Code_EIC>
+      <Raison_Sociale>FOURNISSEUR EXEMPLE</Raison_Sociale>
+    </Client_Contractant>
+    <!-- PRM #1 : 4 classes TURPE (HPH/HCH/HPE/HCE) — cas C4 standard -->
+    <PRM>
+      <Identifiant>99100000000001</Identifiant>
+      <Type_Evenement>
+        <Contractuel>false</Contractuel>
+        <Comptage>false</Comptage>
+        <Reseau>false</Reseau>
+        <Administratif>false</Administratif>
+        <Date_Evenement>2024-06-15</Date_Evenement>
+        <Adresse_Postale>
+          <Code_Postal>44000</Code_Postal>
+          <Commune Code_INSEE="44109"/>
+        </Adresse_Postale>
+        <CAD>
+          <Num_Depan_24>0000000000</Num_Depan_24>
+        </CAD>
+        <Situation_Contractuelle>
+          <Synthese_Contractuelle>
+            <Date_De_Premiere_Mise_En_Service>2020-01-01</Date_De_Premiere_Mise_En_Service>
+          </Synthese_Contractuelle>
+          <Date_Debut>2024-01-01</Date_Debut>
+          <Evenement>
+            <Nature_Evenement>MES</Nature_Evenement>
+            <Numero_Affaire>AFF000001</Numero_Affaire>
+          </Evenement>
+          <Utilisateur_Reseau>
+            <Personne_Morale>
+              <Raison_Sociale>FOURNISSEUR EXEMPLE</Raison_Sociale>
+              <Code_APE>3514Z</Code_APE>
+            </Personne_Morale>
+          </Utilisateur_Reseau>
+          <Option_Tarifaire_TURPE_Souscrite>
+            <Option_Tarifaire_TURPE>
+              <Libelle>BTSUPLU4</Libelle>
+            </Option_Tarifaire_TURPE>
+            <Classe_Temporelle_TURPE_Souscrite>
+              <Libelle>HPH</Libelle>
+              <Puissance_Souscrite>250</Puissance_Souscrite>
+            </Classe_Temporelle_TURPE_Souscrite>
+            <Classe_Temporelle_TURPE_Souscrite>
+              <Libelle>HCH</Libelle>
+              <Puissance_Souscrite>200</Puissance_Souscrite>
+            </Classe_Temporelle_TURPE_Souscrite>
+            <Classe_Temporelle_TURPE_Souscrite>
+              <Libelle>HPE</Libelle>
+              <Puissance_Souscrite>180</Puissance_Souscrite>
+            </Classe_Temporelle_TURPE_Souscrite>
+            <Classe_Temporelle_TURPE_Souscrite>
+              <Libelle>HCE</Libelle>
+              <Puissance_Souscrite>150</Puissance_Souscrite>
+            </Classe_Temporelle_TURPE_Souscrite>
+          </Option_Tarifaire_TURPE_Souscrite>
+          <Profil>ENT4</Profil>
+        </Situation_Contractuelle>
+        <Alimentation>
+          <Alimentation_Principale>
+            <Tension_De_Livraison>230_400V</Tension_De_Livraison>
+            <Domaine_De_Tension>BTSUP</Domaine_De_Tension>
+          </Alimentation_Principale>
+        </Alimentation>
+      </Type_Evenement>
+    </PRM>
+    <!-- PRM #2 : 2 classes TURPE (HP/HC) — cas mono/HPHC -->
+    <PRM>
+      <Identifiant>99100000000002</Identifiant>
+      <Type_Evenement>
+        <Contractuel>false</Contractuel>
+        <Comptage>false</Comptage>
+        <Reseau>false</Reseau>
+        <Administratif>false</Administratif>
+        <Date_Evenement>2024-06-15</Date_Evenement>
+        <Adresse_Postale>
+          <Code_Postal>75001</Code_Postal>
+          <Commune Code_INSEE="75056"/>
+        </Adresse_Postale>
+        <CAD>
+          <Num_Depan_24>0000000000</Num_Depan_24>
+        </CAD>
+        <Situation_Contractuelle>
+          <Synthese_Contractuelle>
+            <Date_De_Premiere_Mise_En_Service>2019-06-01</Date_De_Premiere_Mise_En_Service>
+          </Synthese_Contractuelle>
+          <Date_Debut>2024-03-01</Date_Debut>
+          <Date_Fin>2024-12-31</Date_Fin>
+          <Utilisateur_Reseau>
+            <Personne_Morale>
+              <Raison_Sociale>FOURNISSEUR EXEMPLE</Raison_Sociale>
+              <Code_APE>4321A</Code_APE>
+            </Personne_Morale>
+          </Utilisateur_Reseau>
+          <Option_Tarifaire_TURPE_Souscrite>
+            <Option_Tarifaire_TURPE>
+              <Libelle>BTSUPMU</Libelle>
+            </Option_Tarifaire_TURPE>
+            <Classe_Temporelle_TURPE_Souscrite>
+              <Libelle>HP</Libelle>
+              <Puissance_Souscrite>100</Puissance_Souscrite>
+            </Classe_Temporelle_TURPE_Souscrite>
+            <Classe_Temporelle_TURPE_Souscrite>
+              <Libelle>HC</Libelle>
+              <Puissance_Souscrite>80</Puissance_Souscrite>
+            </Classe_Temporelle_TURPE_Souscrite>
+          </Option_Tarifaire_TURPE_Souscrite>
+          <Profil>ENT2</Profil>
+        </Situation_Contractuelle>
+      </Type_Evenement>
+    </PRM>
+  </Contrat>
+</C12>

--- a/tests/fixtures/flux/generer_fixtures_xsd.py
+++ b/tests/fixtures/flux/generer_fixtures_xsd.py
@@ -76,6 +76,8 @@ SURCHARGES_NOM = {
     "Id_Classe_Temporelle": lambda occ: ("BASE", "HP", "HC", "HPH")[occ % 4],
     "Valeur": lambda occ: str(next(_COMPTEUR_VALEUR)),
     "Valeur_Precedent": lambda occ: str(next(_COMPTEUR_VALEUR)),
+    # C12 : Code_APE (APE fictif plausible pour la production électricité)
+    "Code_APE": lambda occ: ("3514Z", "4321A")[occ % 2],
 }
 
 VALEURS_BASE = {

--- a/tests/fixtures/flux/generer_golden.py
+++ b/tests/fixtures/flux/generer_golden.py
@@ -50,6 +50,9 @@ CAS_GOLDEN: list[tuple[str, str, str, str | None]] = [
     # R67 (mesures facturantes, ADR-0047) : fixture = LISTE de documents JSON (un par PDL),
     # landés en plusieurs lignes (un document par fichier) — cf. lignes_via_dbt.
     ("r67.json", "raw_r67", "flux_r67", None),
+    # C12 (description contractuelle C2-C4) : fixture hand-crafted (attributs XML requis
+    # empêchent le générateur XSD, voir c12_xsd.xml pour le détail).
+    ("c12_xsd.xml", "raw_c12", "flux_c12", "flux_c12_xsd"),
     # X12/X13 (affaires SGE) : même source raw_affaires, origine dérivée du file_name.
     ("affaires_X12.xml", "raw_affaires", "flux_affaires", None),
     ("affaires_X13.xml", "raw_affaires", "flux_affaires", "flux_affaires_x13"),

--- a/tests/fixtures/flux/golden/flux_c12_xsd.json
+++ b/tests/fixtures/flux/golden/flux_c12_xsd.json
@@ -1,0 +1,33 @@
+[
+  {
+    "pdl": "99100000000001",
+    "date_evenement": "2024-06-15",
+    "date_debut": "2024-01-01",
+    "date_premiere_mise_en_service": "2020-01-01",
+    "numero_affaire": "AFF000001",
+    "option_tarifaire_turpe": "BTSUPLU4",
+    "profil": "ENT4",
+    "domaine_de_tension": "BTSUP",
+    "raison_sociale": "FOURNISSEUR EXEMPLE",
+    "code_ape": "3514Z",
+    "puissance_souscrite_hph_kva": 250,
+    "puissance_souscrite_hch_kva": 200,
+    "puissance_souscrite_hpb_kva": 180,
+    "puissance_souscrite_hcb_kva": 150,
+    "source": "flux_C12"
+  },
+  {
+    "pdl": "99100000000002",
+    "date_evenement": "2024-06-15",
+    "date_debut": "2024-03-01",
+    "date_fin": "2024-12-31",
+    "date_premiere_mise_en_service": "2019-06-01",
+    "option_tarifaire_turpe": "BTSUPMU",
+    "profil": "ENT2",
+    "raison_sociale": "FOURNISSEUR EXEMPLE",
+    "code_ape": "4321A",
+    "puissance_souscrite_hp_kva": 100,
+    "puissance_souscrite_hc_kva": 80,
+    "source": "flux_C12"
+  }
+]

--- a/tests/ingestion/test_dbt_flux_golden.py
+++ b/tests/ingestion/test_dbt_flux_golden.py
@@ -186,6 +186,25 @@ SPECS = [
         cas="flux_f15_detail_xsd",
         numeric_cols=frozenset({"prix_unitaire", "quantite", "montant_ht"}),
     ),
+    FluxSpec(
+        "flux_c12",
+        "c12_xsd.xml",
+        "raw_c12",
+        cas="flux_c12_xsd",
+        type_contract={
+            "date_evenement": DATE,
+            "date_debut": DATE,
+            "date_fin": DATE,
+            "date_premiere_mise_en_service": DATE,
+            "puissance_souscrite_kva": "BIGINT",
+            "puissance_souscrite_hp_kva": "BIGINT",
+            "puissance_souscrite_hc_kva": "BIGINT",
+            "puissance_souscrite_hph_kva": "BIGINT",
+            "puissance_souscrite_hch_kva": "BIGINT",
+            "puissance_souscrite_hpb_kva": "BIGINT",
+            "puissance_souscrite_hcb_kva": "BIGINT",
+        },
+    ),
     # X12/X13 (affaires SGE) : id d'affaire + codes statut/objet/état portés en
     # *attributs* XML (premier flux à en exposer) ; origine dérivée du file_name.
     FluxSpec(


### PR DESCRIPTION
## Summary

Ingère le **flux C12** (description contractuelle des PRM du segment **C2-C4, >36 kVA** — Enedis SGE GUI 0129) via le même pipeline ELT que C15 : landing → `stg_c12` → `flux_c12` (dbt), loader `c12()`. Prépare l'ouverture au segment C4 et débloque #226 (catégorie accise). Scope = **ingestion seule** (pas d'intégration périmètre/abonnement/facturation).

- **`flux_c12`** : spine contractuel C4 minimal (pdl, dates de situation, événement/affaire, `option_tarifaire_turpe`, `domaine_de_tension`, `profil`, `raison_sociale`/`code_ape`). Le reste du XSD (comptage, pertes, qualité de fourniture, coupures, CDC) reste dans le brut, ajoutable à la demande.
- **Puissances** : pivot des `Classe_Temporelle_TURPE_Souscrite[]` → 4 cadrans C4 `puissance_souscrite_{hph,hch,hpb,hcb}_kva` (`HPE→hpb`, `HCE→hcb`) + scalaire mono / HP-HC. Classes HTA (Pointe, HPDemiSaison, HCDemiSaison, JA, PM) → NULL délibéré (cible = C4, pas HTA).
- **Segment inféré** : C12 n'a pas de `Segment_Clientele` natif → C2/C3/C4 + seuils 36/250 kVA se dérivent en aval de `domaine_de_tension` + `option_tarifaire_turpe` + puissance.
- **Garde anti-drift** (`assert_flux_c12_libelle_classe_dans_enum_xsd`) : échoue si un `Libelle` de classe temporelle sort de l'enum XSD complet (= Enedis a étendu le schéma → mettre à jour le pivot).
- Loader `c12()` enregistré + exporté ; `anonymiser.py` couvre `Code_APE` ; ADR-0051 + glossaire `CONTEXT.md`.

## Test plan

- [x] `uv run --group test pytest -q` — **1064 passed** (vérifié 2× : agent build + orchestrateur)
- [x] `tests/ingestion/test_dbt_flux_golden.py` — nouveau cas `flux_c12_xsd` PASS (fixture XSD-valide : 1 PRM 4-cadrans C4 + 1 PRM HP/HC)
- [x] Garde dbt anti-drift PASS sur la fixture
- [x] Gate de pureté/architecture PASS

## Follow-up avant merge

- **Golden réel prod** (nécessite le trousseau AES — indisponible en sandbox) : dès qu'une archive C12 réelle est déchiffrable (`sops exec-env` / env équipé), lancer `generer_golden.py` pour capturer `flux_c12.json` et **confirmer le mapping puissances** (`HPE→hpb` / `HCE→hcb`) contre la donnée réelle. 67 échantillons chiffrés dispo (`~/data/c12_samples`). Le golden XSD sert de filet de régression en attendant.
- **Garde HTA** : la garde actuelle ne fire que sur un label *hors enum XSD*. Un site HTA (hors scope C4) verrait sa classe `Pointe` tomber en NULL sans alerte. À durcir si des PRM HTA entrent au périmètre (décision : différé, ADR-0051).

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)
