### PR TITLE
fix(docs): page d'accueil du site (corrige le 404 à la racine)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# Documentation ElectriCore
+
+**ElectriCore** transforme les flux bruts d'Enedis en données de facturation
+structurées, traçables et vérifiables.
+
+## Par où commencer
+
+- **[Guide facturiste](facturiste/changelog-facturiste.md)** — la lecture côté métier :
+  le cycle de facturation, l'anatomie d'un mois facturable, les verdicts de qualité,
+  et ce qui se prépare.
+
+---
+
+Code source et détails techniques : [dépôt GitHub](https://github.com/Energie-De-Nantes/electricore).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,4 +16,5 @@ validation:
 exclude_docs: "*.excalidraw"
 
 nav:
+  - Accueil: index.md
   - Guide facturiste: facturiste/changelog-facturiste.md


### PR DESCRIPTION
Suivi de #526. Le site MkDocs n'avait pas de `docs/index.md`, donc la racine `https://energie-de-nantes.github.io/electricore/` renvoyait **404** (seul `/facturiste/changelog-facturiste/` était servi).

- Ajoute une page d'accueil minimale `docs/index.md` (intro + lien vers le guide facturiste).
- L'expose en première entrée de nav (`Accueil`), avant le guide.

Vérifié en local : `uv run --group docs mkdocs build` produit `site/index.html` (lien vers le guide OK) et la page du guide reste construite.

Au merge, le workflow `docs` redéploie automatiquement → la racine servira l'accueil.