### PR TITLE
docs(facturiste): préciser qu'aucune fausse facture n'a été émise

### DIFF
--- a/docs/facturiste/changelog-facturiste.md
+++ b/docs/facturiste/changelog-facturiste.md
@@ -73,6 +73,13 @@ facturable, et avec quelle assurance.
 Avant juin, plusieurs chiffres étaient **silencieusement faux** — pas en erreur, juste
 faux. Le gros du travail de juin a été de les rendre **exacts et démontrables**.
 
+> **Aucune fausse facture émise.** Ces versions (v2.0, v3.0) **n'ont jamais été le chemin
+> de facturation en production** : pendant toute cette période, la facturation réelle
+> passait par l'**ancien système**. Les chiffres « silencieusement faux » vivaient dans
+> electricore **en construction**, jamais sur les factures de vos clients. Ce qui suit
+> décrit les défauts qu'on a corrigés *avant* de faire d'electricore une source de
+> facturation fiable.
+
 - **Les index étaient ~1000× trop grands** *(v3.0)*. Les relevés périodiques (R151/R64)
   arrivent d'Enedis en **wattheures** ; ils étaient mélangés aux index C15 déjà en kWh.
   Résultat : énergie, TURPE variable, accise **et** facturation corrompus. Désormais tout


### PR DESCRIPTION
## Contexte

Le [changelog facturiste](docs/facturiste/changelog-facturiste.md) présente les corrections de calcul de juin (index Wh→kWh, fin des chimères…) sous le titre « plusieurs chiffres étaient silencieusement faux ». Lu seul, un facturiste pouvait croire que de **fausses factures** avaient été émises.

## Changement

Un encart juste sous l'intro de la section « calculs justes » : ces versions (v2.0/v3.0) **n'ont jamais été le chemin de facturation en production** — la facturation réelle passait par l'**ancien système**. Les chiffres faux vivaient dans electricore *en construction*, jamais sur les factures clients.

Docs uniquement, aucun code touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)