### PR TITLE
fix(bot): tronquer le cockpit /perimetre affaires sous la limite Telegram (rc3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.5.0rc3] - 2026-06-30
+
+Troisième release candidate de la **minor 3.5**.
+
+### 🐛 Corrigé — cockpit `/perimetre affaires` muet (bot)
+
+La vue « Affaires en cours » du bot construisait un message dépassant la limite dure
+de **4096 caractères** de l'API Telegram dès qu'assez d'affaires étaient en cours
+(≈ 46 suffisaient), faisant échouer `edit_message_text` hors `try/except` : le spinner
+« ⏳ Affaires en cours… » restait bloqué, le bot paraissait muet. `_formater_affaires`
+tronque désormais la liste aux frontières de lignes sous la limite, en gardant les
+affaires les plus anciennes (les plus actionnables) et en signalant le reste — même
+garde-fou que le récap de facturation.
+
 ## [3.5.0rc2] - 2026-06-30
 
 Deuxième release candidate de la **minor 3.5** — discrimination des erreurs côté

--- a/electricore/bot/handlers/perimetre.py
+++ b/electricore/bot/handlers/perimetre.py
@@ -21,6 +21,8 @@ _EXPORTS = {
     "sorties": ("sorties_c15.xlsx", "Sorties C15 (RES, CFNS)"),
 }
 
+_TELEGRAM_MSG_MAX = 4096  # limite dure de l'API Telegram par message
+
 
 def clavier_principal() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
@@ -38,14 +40,26 @@ def _formater_affaires(affaires: list[dict]) -> str:
     """Rend la vue cockpit des affaires non soldées (texte HTML Telegram)."""
     if not affaires:
         return "✅ Aucune affaire en cours."
-    lignes = [f"<b>Affaires en cours</b> ({len(affaires)}) :"]
+    entete = f"<b>Affaires en cours</b> ({len(affaires)}) :"
+    lignes = [entete]
+    # La liste arrive triée par ancienneté décroissante : on garde les plus anciennes
+    # (= les plus actionnables) et on tronque la queue si on dépasse la limite Telegram —
+    # sinon edit_message_text échoue (>4096 car.) et le bot reste muet (cf. facturation.py).
+    budget = _TELEGRAM_MSG_MAX - 100
+    affichees = 0
     for a in affaires:
         prestation = a.get("prestation_libelle") or a.get("prestation") or "?"
         etat = a.get("dernier_etat_libelle") or a.get("dernier_etat") or "?"
-        lignes.append(
+        ligne = (
             f"• <code>{escape(a.get('pdl'))}</code> — {escape(prestation)} · "
             f"{escape(etat)} · {a.get('anciennete_jours')} j"
         )
+        if sum(len(li) + 1 for li in lignes) + len(ligne) > budget:
+            break
+        lignes.append(ligne)
+        affichees += 1
+    if affichees < len(affaires):
+        lignes.append(f"\n<i>… et {len(affaires) - affichees} autres (les plus anciennes affichées)</i>")
     return "\n".join(lignes)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.5.0rc2"
+version = "3.5.0rc3"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/tests/unit/test_bot_handlers_perimetre.py
+++ b/tests/unit/test_bot_handlers_perimetre.py
@@ -139,6 +139,25 @@ def test_formater_affaires_vide():
     assert "aucune" in txt.lower()
 
 
+def test_formater_affaires_tronque_sous_la_limite_telegram():
+    """Une liste qui dépasserait 4096 car. est raccourcie aux frontières de lignes —
+    sinon edit_message_text échoue et le bot reste muet."""
+    affaires = [
+        {
+            "pdl": f"{i:014d}",
+            "prestation": "CST",
+            "prestation_libelle": "Changement de structure tarifaire",
+            "dernier_etat_libelle": "Demande recevable",
+            "anciennete_jours": 500 - i,
+        }
+        for i in range(80)
+    ]
+    txt = handlers_perimetre._formater_affaires(affaires)
+    assert len(txt) <= 4096
+    assert "autres" in txt  # mention de troncature
+    assert "(80)" in txt  # l'en-tête garde le compte total
+
+
 def test_menu_propose_les_affaires(client):
     update = update_commande()
 

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.5.0rc2"
+version = "3.5.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Problème

La vue **« Affaires en cours »** de `/perimetre` (bot) construit un message qui
dépasse la limite dure de **4096 caractères** de l'API Telegram dès qu'assez
d'affaires sont en cours (≈ 46 suffisent — déjà le cas en prod). Le
`edit_message_text` final de `_envoyer_affaires` n'est **pas** dans le `try/except`
(qui n'entoure que l'appel API) → `BadRequest: message too long` non gérée → le
spinner « ⏳ Affaires en cours… » reste bloqué et le bot paraît muet.

Reproduit sur données réelles : 46 affaires → message de **4137 car.** > 4096.

## Fix

`_formater_affaires` tronque maintenant la liste aux frontières de lignes sous la
limite, en gardant les affaires les **plus anciennes** (déjà triées en tête = les
plus actionnables) et en signalant le reste (« … et N autres »). C'est exactement
le garde-fou déjà en place dans `facturation.py` pour le récap.

Sur les mêmes données : 4137 → 4017 car., sous la limite.

## Hors scope

Pagination / bouton « voir plus » / export XLSX des affaires — à ajouter si on veut
consulter au-delà du top affiché.

## Release

Bump **3.5.0rc3** (pyproject + uv.lock + CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)