### PR TITLE
docs(spikes): axe 2 #545 — couverture NC + R67 landé (M023), verdict V2 définitif

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,6 +190,7 @@ electricore/ingestion/.dlt/secrets.toml
 *.duckdb
 perimetre_manquants/
 surveillance_perimetre_manquants.csv
+sorties-locales/
 .serena/
 
 # Artefacts de déploiement Docker générés à partir des fichiers .example

--- a/docs/spikes/nc/axe2-couverture.md
+++ b/docs/spikes/nc/axe2-couverture.md
@@ -1,0 +1,120 @@
+# Axe 2 — couverture data par NC → source de vérité moisniversaire
+
+Spike #545 (sous-issue du PRD #542, Observabilité des non-communicants). **Scope partiel**
+de ce rapport : R15 / F15 / C15 uniquement. Le **R67 n'est pas encore en base** (campagne
+M023 [#543](https://github.com/Energie-De-Nantes/electricore/issues/543) pas atterrie) —
+la section 4 le constate, le verdict de la section 6 est **explicitement provisoire** et
+sera révisé une fois le R67 intégré (V2).
+
+Script rejouable : [`axe2_couverture.py`](axe2_couverture.py) (`uv run python
+docs/spikes/nc/axe2_couverture.py`), lecture seule DuckDB, invariants inline. Base locale
+au 2026-07-03 : données jusqu'au 2026-06-17. Détail par PDL en sortie locale non
+committée (`sorties-locales/axe2_couverture_nc.csv`) — RGPD : ce rapport ne contient que
+des agrégats.
+
+## Cohorte
+
+25 PDL non-communicants (présents au périmètre selon [ADR-0052](../../adr/0052-presence-perimetre-spans-rsc-fermeture-code-sortie.md),
+`niveau_ouverture_services = '0'` sur le dernier fait connu de leur RSC).
+
+## 1. R15 cyclique
+
+- Couverture : 25/25 PDL ont au moins un relevé R15 cyclique (`Motif_Releve = 'CYCL'`).
+- Fréquence : écart médian de **61 jours** entre deux relevés cycliques (min 5, max 123,
+  105 intervalles observés) — **88 % des intervalles dépassent 40 jours** : chez les NC,
+  le rythme de relève dominant est bimestriel/trimestriel, pas mensuel.
+- Nature d'index : **100 % des relevés cycliques NC sont marqués `estimé`** (0 `réel`
+  parmi les relevés `CYCL` — la relève réelle existe mais est portée par d'autres motifs,
+  cf. section 5).
+- Régularité du moisniversaire : sur les 19/25 PDL avec ≥3 relevés cycliques, l'écart-type
+  du jour du mois de relevé est **médian 0,3 jour** (max 6,3 j) — le jour de relève
+  cyclique est très stable une fois établi.
+- **Écart d'ingestion découvert** : la colonne d'index canonique de `flux_r15` (dbt) est
+  **NULLE à 100 %** pour les 25 PDL NC (0 valeur sur l'ensemble de leurs relevés, tous
+  motifs confondus). Cause : le modèle dbt n'extrait que le bloc JSON
+  `Classe_Temporelle_Distributeur`, absent des relevés de ces PDL (compteurs
+  électromécaniques / non-Linky). L'index existe pourtant, sous un bloc frère
+  `Classe_Temporelle` (singulier), universellement présent dans le flux — l'écart est une
+  lacune d'ingestion, pas une absence Enedis. Hors scope de correction pour ce spike ;
+  signalé comme piste de suivi.
+
+## 2. F15
+
+- Couverture : 24/25 PDL ont au moins une ligne F15.
+- 200 fenêtres de facturation cyclique valorisées en kWh (`type_facturation = 'CYCL'`,
+  `nature_ev = '01'`) sur 24 PDL.
+- **Invariant — absence de recouvrement** : 0 chevauchement détecté sur les 177 paires de
+  fenêtres consécutives (139 strictement adjacentes, 38 avec un trou entre deux fenêtres).
+- **Invariant — réconciliation somme-des-fenêtres vs total** : pour les 23 PDL avec ≥2
+  fenêtres, la somme des durées de fenêtres ne dépasse jamais l'amplitude totale observée
+  (23/23 conformes) — la partition temporelle est saine.
+- Durée des fenêtres : médiane **50 jours** (min 1, max 89), cohérente avec la cadence
+  bimestrielle observée côté R15.
+
+## 3. C15 — index aux événements
+
+- 33 événements C15 sur les 25/25 PDL NC : `CFNE` (21), `MDPRM` bascule de niveau (6),
+  `MES` (4), `MDACT` (1), `AUTRE` (1).
+- **0/25 PDL avec un index avant/après porté par un de ces événements.** Sur ce corpus,
+  les types d'événements observés chez les NC (entrée en portefeuille, bascule de niveau
+  d'ouverture) ne matérialisent structurellement pas de relevé d'index — contrairement à
+  un `MES`/`MCT` classique côté communicant. Le C15 n'est donc **pas** une source d'index
+  exploitable pour les NC sur cette base.
+
+## 4. R67 — en attente de la campagne M023 (#543)
+
+Table `flux_r67` absente de la base à ce jour. Le script tolère son arrivée (vérification
+`information_schema`, bascule automatique dès que la table existe). **Ce volet et le
+verdict final (V2) attendent l'atterrissage de la campagne #543.**
+
+## 5. Fréquence des relevés Réels (relève physique) chez les NC
+
+Seuls **7/25 PDL** portent au moins un relevé de nature `réel` sur toute la fenêtre
+d'observation (18/25 n'en ont aucun) — et aucun PDL n'en a plus d'un. Fenêtre
+d'observation médiane par PDL : ~405 jours. Autrement dit, **une relève physique
+"propre" est un événement rare chez les NC** (à peine plus d'un tiers des PDL en ont vu
+une seule en plus d'un an) : un solde basé sur des bornes réelles n'est praticable qu'à
+une cadence largement supra-annuelle, jamais mensuelle. Donnée directement consommée par
+la praticabilité « bornes réelles » de l'axe 4.
+
+## 6. Cohérence R15 vs F15
+
+En s'appuyant sur l'extraction de secours (`Classe_Temporelle`, cf. section 1 — lecture
+brute hors dbt, propre à ce spike, aucune modification de production), 53 fenêtres ont
+des bornes strictement identiques entre R15 (diff d'index entre deux relevés cycliques)
+et F15 (période facturée). Sur ces fenêtres communes :
+
+| Cadran | Fenêtres comparées | Écart moyen | Écart max | Exactes (±1 kWh) |
+|---|---|---|---|---|
+| base | 43 | 0,00 kWh | 0 kWh | 43/43 |
+| hp | 2 | 0,00 kWh | 0 kWh | 2/2 |
+| hc | 2 | 0,00 kWh | 0 kWh | 2/2 |
+
+**Concordance parfaite** sur les 47 fenêtres comparables : une fois l'index R15 extrait
+correctement (bloc `Classe_Temporelle`), il redonne exactement l'énergie facturée en F15.
+R15 et F15 ne sont donc pas deux vérités concurrentes mais **la même énergie**, vue depuis
+deux flux différents — F15 l'agrège déjà par fenêtre facturée, R15 exige un diff
+d'index entre deux relevés.
+
+## 7. V2 (provisoire) — désignation de la source de vérité moisniversaire
+
+> **Provisoire — verdict final V2 après intégration R67** (#543).
+
+Sur le périmètre R15/F15/C15 :
+
+- **C15 est écarté** : 0 % de couverture en index chez les NC sur ce corpus.
+- **R15 seul (tel qu'ingéré aujourd'hui) est écarté comme source d'énergie** : son index
+  canonique est nul à 100 % pour les NC (lacune d'ingestion identifiée en section 1) ;
+  seules ses *dates* de relevé sont exploitables en l'état.
+- **F15 est la source d'énergie la plus directement exploitable** : fenêtres propres
+  (aucun recouvrement, réconciliation vérifiée), énergies déjà agrégées par cadran,
+  24/25 PDL couverts, et confirmée **identique** à l'énergie R15 réellement mesurée
+  (section 6) quand cette dernière est correctement extraite.
+
+**Candidat provisoire : F15** comme source de vérité des fenêtres moisniversaire et des
+énergies associées, complété par les dates de relevé R15 pour les PDL sans facture F15
+récente. Ce verdict reste **partiel** : le R67 (énergie par période déjà différenciée par
+le distributeur, cf. [ADR-0047](../../adr/0047-flux-r67-energie-par-periode-distributeur-hors-releves.md))
+n'a pas encore été confronté aux deux autres sources et pourrait s'avérer préférable une
+fois disponible (troisième candidat, jamais dans l'union des relevés par construction). Le
+verdict définitif est déféré à V2, après atterrissage de la campagne M023 #543.

--- a/docs/spikes/nc/axe2-couverture.md
+++ b/docs/spikes/nc/axe2-couverture.md
@@ -75,8 +75,10 @@ Un lot M023 a été landé (via [`lander_r67_m023.py`](lander_r67_m023.py) → `
   cohérent avec le parc pré-Linky de l'axe 1.
 - Motifs : `CYCL` 246, `AUTRE` 132, `CFNS` 25.
 - **Fenêtres** : taille médiane **56 j** (moisniversaire, bimestriel). Le pavage est propre
-  à un recouvrement résiduel près (1 recouvrement inter-motifs — CFNS/CYCL — toléré par
-  l'ADR-0047, contrairement à F15 dont l'unicité de motif garantit le non-recouvrement).
+  à un recouvrement résiduel près : l'ADR-0047 avait vérifié **zéro** recouvrement inter-motifs
+  sur 4 fichiers pilotes ; ce lot NC plus large en montre **1** (CFNS/CYCL). On l'**observe**
+  plutôt qu'on l'assert (contrairement à F15, dont l'unicité de motif garantit le
+  non-recouvrement). La cohérence ci-dessous filtre CYCL des deux côtés → aucun double-compte.
 - **Profondeur** : R67 remonte à **2023-06-27** contre **2024-04-09** pour le F15 en base —
   ~9 mois de mesures moisniversaire de plus.
 - **Invariant — cohérence R67↔F15** : sur les **84 fenêtres à bornes strictement identiques**

--- a/docs/spikes/nc/axe2-couverture.md
+++ b/docs/spikes/nc/axe2-couverture.md
@@ -1,16 +1,17 @@
 # Axe 2 — couverture data par NC → source de vérité moisniversaire
 
-Spike #545 (sous-issue du PRD #542, Observabilité des non-communicants). **Scope partiel**
-de ce rapport : R15 / F15 / C15 uniquement. Le **R67 n'est pas encore en base** (campagne
-M023 [#543](https://github.com/Energie-De-Nantes/electricore/issues/543) pas atterrie) —
-la section 4 le constate, le verdict de la section 6 est **explicitement provisoire** et
-sera révisé une fois le R67 intégré (V2).
+Spike #545 (sous-issue du PRD #542, Observabilité des non-communicants). Couvre **R15 /
+F15 / C15 / R67** : un premier lot de la campagne M023
+[#543](https://github.com/Energie-De-Nantes/electricore/issues/543) a été landé (22/25 NC),
+ce qui permet le **verdict V2 définitif** (section 7).
 
 Script rejouable : [`axe2_couverture.py`](axe2_couverture.py) (`uv run python
-docs/spikes/nc/axe2_couverture.py`), lecture seule DuckDB, invariants inline. Base locale
-au 2026-07-03 : données jusqu'au 2026-06-17. Détail par PDL en sortie locale non
-committée (`sorties-locales/axe2_couverture_nc.csv`) — RGPD : ce rapport ne contient que
-des agrégats.
+docs/spikes/nc/axe2_couverture.py`), lecture seule DuckDB, invariants inline. Il s'adapte à
+la présence du R67 : verdict définitif si `flux_r67` est landé, provisoire sinon. Le landing
+d'un ZIP M023 se fait via [`lander_r67_m023.py`](lander_r67_m023.py) puis `uv run python -m
+electricore.ingestion rebuild`. Base locale au 2026-07-03 : données jusqu'au 2026-06-17.
+Détail par PDL en sortie locale non committée (`sorties-locales/axe2_couverture_nc.csv`) —
+RGPD : ce rapport ne contient que des agrégats.
 
 ## Cohorte
 
@@ -61,11 +62,27 @@ des agrégats.
   un `MES`/`MCT` classique côté communicant. Le C15 n'est donc **pas** une source d'index
   exploitable pour les NC sur cette base.
 
-## 4. R67 — en attente de la campagne M023 (#543)
+## 4. R67 — mesures facturantes (campagne M023 #543 landée)
 
-Table `flux_r67` absente de la base à ce jour. Le script tolère son arrivée (vérification
-`information_schema`, bascule automatique dès que la table existe). **Ce volet et le
-verdict final (V2) attendent l'atterrissage de la campagne #543.**
+Un lot M023 a été landé (via [`lander_r67_m023.py`](lander_r67_m023.py) → `flux_r67`,
+[ADR-0047](../../adr/0047-flux-r67-energie-par-periode-distributeur-hors-releves.md)).
+
+- **Couverture : 22/25 PDL NC**, 403 fenêtres (une mesure d'énergie par période, déjà
+  différenciée par cadran et par période par Enedis). Les 3 NC manquants ne sont pas dans
+  ce lot (vraisemblablement définitivement absents côté SGE).
+- **Nature : 65 % `estimé`, 27 % `régularisé`, 8 % `réel`.** R67 apporte surtout de
+  l'*estimation Enedis* — il ne résout **pas** la rareté du relevé réel (cf. section 5),
+  cohérent avec le parc pré-Linky de l'axe 1.
+- Motifs : `CYCL` 246, `AUTRE` 132, `CFNS` 25.
+- **Fenêtres** : taille médiane **56 j** (moisniversaire, bimestriel). Le pavage est propre
+  à un recouvrement résiduel près (1 recouvrement inter-motifs — CFNS/CYCL — toléré par
+  l'ADR-0047, contrairement à F15 dont l'unicité de motif garantit le non-recouvrement).
+- **Profondeur** : R67 remonte à **2023-06-27** contre **2024-04-09** pour le F15 en base —
+  ~9 mois de mesures moisniversaire de plus.
+- **Invariant — cohérence R67↔F15** : sur les **84 fenêtres à bornes strictement identiques**
+  (CYCL des deux côtés), R67 et F15 donnent **exactement** la même énergie (84/84 à ±1 kWh,
+  écart moyen 0,00 kWh). R67 ne contredit jamais le facturé : il l'**étend** (246 fenêtres
+  CYCL vs 200 pour F15, et plus profond).
 
 ## 5. Fréquence des relevés Réels (relève physique) chez les NC
 
@@ -96,25 +113,27 @@ R15 et F15 ne sont donc pas deux vérités concurrentes mais **la même énergie
 deux flux différents — F15 l'agrège déjà par fenêtre facturée, R15 exige un diff
 d'index entre deux relevés.
 
-## 7. V2 (provisoire) — désignation de la source de vérité moisniversaire
+## 7. V2 (définitif) — désignation de la source de vérité moisniversaire
 
-> **Provisoire — verdict final V2 après intégration R67** (#543).
+> **Verdict V2 définitif** — un lot R67 de la campagne M023 #543 est landé.
 
-Sur le périmètre R15/F15/C15 :
+Confrontation des quatre sources chez les NC :
 
-- **C15 est écarté** : 0 % de couverture en index chez les NC sur ce corpus.
-- **R15 seul (tel qu'ingéré aujourd'hui) est écarté comme source d'énergie** : son index
-  canonique est nul à 100 % pour les NC (lacune d'ingestion identifiée en section 1) ;
-  seules ses *dates* de relevé sont exploitables en l'état.
-- **F15 est la source d'énergie la plus directement exploitable** : fenêtres propres
-  (aucun recouvrement, réconciliation vérifiée), énergies déjà agrégées par cadran,
-  24/25 PDL couverts, et confirmée **identique** à l'énergie R15 réellement mesurée
-  (section 6) quand cette dernière est correctement extraite.
+- **C15 écarté** : 0 % de couverture en index chez les NC sur ce corpus.
+- **R15 seul écarté comme source d'énergie** : son index canonique est nul à 100 % pour les
+  NC (lacune d'ingestion, section 1) ; seules ses *dates* de relevé sont exploitables.
+- **F15** : source facturée fiable (fenêtres propres, 24/25), mais moins profonde que R67 et
+  strictement corroborante (identique à R67 sur bornes communes).
+- **R67** : énergie moisniversaire déjà différenciée par cadran ET par période, 22/25 NC,
+  profondeur ~3 ans (9 mois de plus que F15), nature étiquetée, **identique à F15 là où les
+  bornes coïncident**.
 
-**Candidat provisoire : F15** comme source de vérité des fenêtres moisniversaire et des
-énergies associées, complété par les dates de relevé R15 pour les PDL sans facture F15
-récente. Ce verdict reste **partiel** : le R67 (énergie par période déjà différenciée par
-le distributeur, cf. [ADR-0047](../../adr/0047-flux-r67-energie-par-periode-distributeur-hors-releves.md))
-n'a pas encore été confronté aux deux autres sources et pourrait s'avérer préférable une
-fois disponible (troisième candidat, jamais dans l'union des relevés par construction). Le
-verdict définitif est déféré à V2, après atterrissage de la campagne M023 #543.
+**Source de vérité désignée : R67**, avec F15 en corroboration et garde-fou. R67 est le
+seul flux qui donne, pour les NC, une énergie déjà ventilée par période moisniversaire sur
+une profondeur exploitable, sans jamais contredire le facturé.
+
+**Réserve assumée** : R67 est **majoritairement `estimé`** (8 % de lignes réelles) — c'est
+la meilleure estimation Enedis disponible, pas du relevé physique. Le solde « propre » sur
+relevé réel reste hors de portée à cadence utile (section 5). Une régularisation NC
+s'appuie donc sur R67 en assumant son caractère estimé. Ce verdict alimente l'ADR final
+[#548](https://github.com/Energie-De-Nantes/electricore/issues/548).

--- a/docs/spikes/nc/axe2_couverture.py
+++ b/docs/spikes/nc/axe2_couverture.py
@@ -237,9 +237,11 @@ else:
     motifs = qdf(NC_PDL_CTE + "select id_motif_releve m, count(*) n from flux_r67 r join nc_pdl using (pdl) group by 1")
     print("  motifs :", {r["m"]: r["n"] for r in motifs.iter_rows(named=True)})
 
-    # Fenêtres : taille + pavage. ADR-0047 dit que les motifs partitionnent le temps ; en
-    # pratique un recouvrement résiduel entre motifs (CFNS/CYCL) reste possible → on OBSERVE
-    # (pas d'assertion à zéro comme F15, dont l'unicité de motif garantit le non-recouvrement).
+    # Fenêtres : taille + pavage. L'ADR-0047 a vérifié ZÉRO recouvrement inter-motifs sur 4
+    # fichiers pilotes ; ce lot NC plus large en montre 1 (CFNS/CYCL) → on OBSERVE plutôt qu'on
+    # assert (contrairement à F15, dont l'unicité de motif garantit le non-recouvrement). La
+    # jointure de cohérence ci-dessous filtre CYCL des deux côtés, donc ce recouvrement résiduel
+    # ne peut pas double-compter.
     r67_fen = qdf(NC_PDL_CTE + "select r.pdl, r.debut, r.fin from flux_r67 r join nc_pdl using (pdl)").sort(
         ["pdl", "debut"]
     )
@@ -262,7 +264,9 @@ else:
     # côtés pour éviter le double-compte du recouvrement inter-motifs résiduel.
     r67_cyc = qdf(
         NC_PDL_CTE + "select r.pdl, r.debut date_debut, r.fin date_fin, "
-        "coalesce(energie_base_kwh,0)+coalesce(energie_hp_kwh,0)+coalesce(energie_hc_kwh,0) r67_kwh "
+        "coalesce(energie_base_kwh,0)+coalesce(energie_hp_kwh,0)+coalesce(energie_hc_kwh,0)"
+        "+coalesce(energie_hph_kwh,0)+coalesce(energie_hpb_kwh,0)+coalesce(energie_hch_kwh,0)"
+        "+coalesce(energie_hcb_kwh,0) r67_kwh "
         "from flux_r67 r join nc_pdl using (pdl) where id_motif_releve='CYCL'"
     )
     f15_cyc = qdf(
@@ -280,7 +284,14 @@ else:
             f"  cohérence R67↔F15 (bornes identiques CYCL) : {coh.height} fenêtres communes, "
             f"{exact}/{coh.height} à ±1 kWh (écart moyen {coh['ecart'].mean():.2f} kWh)"
         )
-        assert exact == coh.height, "INVARIANT : R67 et F15 divergent sur des bornes identiques"
+        # Tripwire souple (pas une égalité dure) : sur ce lot 84/84 sont à 0,00 kWh, mais
+        # l'ADR-0047 documente un arrondi par cadran (~1 kWh sur la moitié des intervalles à
+        # 4 cadrans) qui pourrait, sur un futur lot >36 kVA, faire diverger un rare intervalle
+        # au-delà de ±1 kWh sans que R67 « mente ». On exige donc une concordance massive, pas
+        # parfaite — un vrai désaccord de fond ferait chuter le ratio bien en-deçà.
+        assert exact >= coh.height * 0.95, (
+            f"INVARIANT : R67 et F15 divergent sur {coh.height - exact}/{coh.height} bornes identiques (>5%)"
+        )
 
 # === 5. Fréquence des relevés Réels (relève physique) =================================
 print("\n=== 5. Fréquence des relevés Réels chez les NC ===")
@@ -470,7 +481,7 @@ Constats de ce spike (volet R15/F15/C15) :
 """
     )
 
-# === 9. Garde RGPD — scan du rapport committé =========================================
+# === 8. Garde RGPD — scan du rapport committé =========================================
 print("=== 8. Garde RGPD — scan du rapport committé ===")
 motif_pdl = re.compile(r"\b\d{14}\b")
 if RAPPORT.exists():

--- a/docs/spikes/nc/axe2_couverture.py
+++ b/docs/spikes/nc/axe2_couverture.py
@@ -1,12 +1,15 @@
 """Spike #545 (PRD #542, axe 2) — couverture data par NC → source de vérité moisniversaire.
 
-SCOPE PARTIEL (volet R15/F15/C15) : le R67 n'est pas encore en base (campagne M023 #543
-pas atterrie) — la section 4 le constate proprement et tolère l'arrivée future de la
-table. Le verdict V2 (section 7) est donc explicitement PROVISOIRE : il sera révisé une
-fois le R67 intégré.
+Le script s'adapte à la présence du R67 (campagne M023 #543) :
+  - flux_r67 landé  → section 4 = analyse R67 complète (couverture, nature, pavage,
+    profondeur vs F15, cohérence R67↔F15) ; verdict V2 (section 7) DÉFINITIF : R67.
+  - flux_r67 absent → section 4 constate l'absence ; verdict V2 PROVISOIRE (F15).
+Pour lander l'échantillon : docs/spikes/nc/lander_r67_m023.py puis
+`uv run python -m electricore.ingestion rebuild`.
 
 Repro : uv run python docs/spikes/nc/axe2_couverture.py
-(lecture seule ; nécessite la base d'ingestion locale peuplée en C15/R15/F15.)
+(lecture seule ; nécessite la base d'ingestion locale peuplée en C15/R15/F15, +R67 landé
+pour le verdict définitif.)
 
 RGPD : ce script n'imprime QUE des agrégats. Le détail par PDL part en sortie locale
 (sorties-locales/axe2_couverture_nc.csv, non committée). Une assertion finale scanne le
@@ -200,8 +203,8 @@ if c15_idx[0] == 0:
     print("→ 0 index C15 chez les NC : les événements observés (entrée CFNE/MES, bascule niveau MDPRM/MDACT)")
     print("  ne portent structurellement pas d'index avant/après sur ce corpus.")
 
-# === 4. R67 — en attente campagne M023 #543 ===========================================
-print("\n=== 4. R67 — en attente campagne M023 (#543) ===")
+# === 4. R67 — mesures facturantes (campagne M023 #543) ================================
+print("\n=== 4. R67 — mesures facturantes (ADR-0047, campagne M023 #543) ===")
 r67_existe = (
     q(
         """
@@ -211,12 +214,73 @@ r67_existe = (
     )[0][0]
     > 0
 )
+# Résultats R67 partagés avec le verdict V2 (section 7) ; None si le flux n'est pas landé.
+r67_cov = r67_reel_pct = r67_prof = coh_r67_f15 = None
 if not r67_existe:
-    print("Table flux_r67 absente de la base — campagne M023 #543 pas encore atterrie.")
-    print("Volet R67 DIFFÉRÉ (voir #545, blocked-by #543) : ce script tolère l'arrivée future de la table.")
+    print("Table flux_r67 absente de la base — campagne M023 #543 pas encore landée.")
+    print("Volet R67 DIFFÉRÉ : lander un ZIP M023 via docs/spikes/nc/lander_r67_m023.py puis")
+    print("`uv run python -m electricore.ingestion rebuild`, et rejouer ce script pour le verdict final.")
 else:
-    r67_cov = q(NC_PDL_CTE + "select count(distinct r.pdl) from flux_r67 r join nc_pdl using (pdl)")[0][0]
-    print(f"Table flux_r67 présente : couverture NC {r67_cov}/{nb_nc}")
+    cov = q(NC_PDL_CTE + "select count(distinct r.pdl), count(*) from flux_r67 r join nc_pdl using (pdl)")[0]
+    r67_cov = cov[0]
+    print(f"Couverture NC : {cov[0]}/{nb_nc} PDL, {cov[1]} fenêtres (une mesure d'énergie par période).")
+
+    # Nature (ADR-0047 : réel / estimé / régularisé). La campagne apporte surtout de l'estimé
+    # → R67 ne résout PAS la rareté du relevé réel (cf. section 5), il fournit l'estimation Enedis.
+    nat = qdf(
+        NC_PDL_CTE + "select nature, count(*) n from flux_r67 r join nc_pdl using (pdl) group by 1 order by 2 desc"
+    )
+    n_tot = int(nat["n"].sum())
+    r67_reel_pct = int(nat.filter(pl.col("nature") == "réel")["n"].sum()) / n_tot * 100
+    print("  nature :", {r["nature"]: f"{r['n']} ({r['n'] / n_tot:.0%})" for r in nat.iter_rows(named=True)})
+
+    motifs = qdf(NC_PDL_CTE + "select id_motif_releve m, count(*) n from flux_r67 r join nc_pdl using (pdl) group by 1")
+    print("  motifs :", {r["m"]: r["n"] for r in motifs.iter_rows(named=True)})
+
+    # Fenêtres : taille + pavage. ADR-0047 dit que les motifs partitionnent le temps ; en
+    # pratique un recouvrement résiduel entre motifs (CFNS/CYCL) reste possible → on OBSERVE
+    # (pas d'assertion à zéro comme F15, dont l'unicité de motif garantit le non-recouvrement).
+    r67_fen = qdf(NC_PDL_CTE + "select r.pdl, r.debut, r.fin from flux_r67 r join nc_pdl using (pdl)").sort(
+        ["pdl", "debut"]
+    )
+    r67_fen = r67_fen.with_columns(pl.col("fin").shift(1).over("pdl").alias("fin_prec"))
+    r67_dur = (r67_fen["fin"] - r67_fen["debut"]).dt.total_days()
+    chev = r67_fen.filter(pl.col("debut") < pl.col("fin_prec")).height
+    print(f"  fenêtres : taille médiane {r67_dur.median():.0f} j ; {chev} recouvrement(s) résiduel(s) inter-motifs")
+
+    # Profondeur vs F15 : la campagne M023 remonte plus loin que le F15 déjà en base.
+    r67_span = q(NC_PDL_CTE + "select min(debut), max(fin) from flux_r67 r join nc_pdl using (pdl)")[0]
+    f15_span = q(
+        NC_PDL_CTE + "select min(date_debut), max(date_fin) from flux_f15_detail f join nc_pdl using (pdl) "
+        "where type_facturation='CYCL' and unite='kWh' and nature_ev='01'"
+    )[0]
+    r67_prof = (r67_span, f15_span)
+    print(f"  profondeur R67 {r67_span[0]} → {r67_span[1]}  vs  F15 {f15_span[0]} → {f15_span[1]}")
+
+    # Cohérence R67↔F15 sur bornes IDENTIQUES (CYCL vs CYCL) : deux flux Enedis indépendants
+    # doivent raconter la même énergie là où leurs fenêtres coïncident. CYCL seul des deux
+    # côtés pour éviter le double-compte du recouvrement inter-motifs résiduel.
+    r67_cyc = qdf(
+        NC_PDL_CTE + "select r.pdl, r.debut date_debut, r.fin date_fin, "
+        "coalesce(energie_base_kwh,0)+coalesce(energie_hp_kwh,0)+coalesce(energie_hc_kwh,0) r67_kwh "
+        "from flux_r67 r join nc_pdl using (pdl) where id_motif_releve='CYCL'"
+    )
+    f15_cyc = qdf(
+        NC_PDL_CTE + "select f.pdl, f.date_debut, f.date_fin, sum(f.quantite) f15_kwh "
+        "from flux_f15_detail f join nc_pdl using (pdl) "
+        "where nature_ev='01' and unite='kWh' and type_facturation='CYCL' group by 1,2,3"
+    )
+    coh = r67_cyc.join(f15_cyc, on=["pdl", "date_debut", "date_fin"], how="inner").with_columns(
+        (pl.col("r67_kwh") - pl.col("f15_kwh")).abs().alias("ecart")
+    )
+    if coh.height:
+        exact = int((coh["ecart"] <= 1).sum())
+        coh_r67_f15 = (coh.height, exact)
+        print(
+            f"  cohérence R67↔F15 (bornes identiques CYCL) : {coh.height} fenêtres communes, "
+            f"{exact}/{coh.height} à ±1 kWh (écart moyen {coh['ecart'].mean():.2f} kWh)"
+        )
+        assert exact == coh.height, "INVARIANT : R67 et F15 divergent sur des bornes identiques"
 
 # === 5. Fréquence des relevés Réels (relève physique) =================================
 print("\n=== 5. Fréquence des relevés Réels chez les NC ===")
@@ -359,31 +423,52 @@ detail = (
 detail.write_csv(DETAIL_CSV)
 print(f"\nDétail par PDL écrit dans {DETAIL_CSV} (non committé, RGPD).")
 
-# === 8. V2 (provisoire) — source de vérité moisniversaire =============================
-print("\n=== 7. V2 (PROVISOIRE) — source de vérité moisniversaire ===")
-print(
-    """
-Verdict PROVISOIRE — le R67 n'est pas encore en base (campagne M023 #543) ; à réviser
-une fois intégré.
+# === 7. V2 — source de vérité moisniversaire =========================================
+if r67_existe:
+    print("\n=== 7. V2 (DÉFINITIF) — source de vérité moisniversaire ===")
+    print(
+        f"""
+Verdict V2 — le R67 est en base (campagne M023 #543 landée) : la source de vérité
+moisniversaire pour les NC est **R67**, corroborée par F15.
 
 Constats de ce spike :
+  - R67 (mesures facturantes, ADR-0047) couvre {r67_cov}/{nb_nc} NC sur ~3 ans, énergie déjà
+    différenciée par cadran ET par période par Enedis. Il remonte ~9 mois plus loin que le
+    F15 en base ({r67_prof[0][0]} vs {r67_prof[1][0]}).
+  - Là où R67 et F15 partagent des bornes identiques ({coh_r67_f15[1]}/{coh_r67_f15[0]} fenêtres à ±1 kWh),
+    ils donnent EXACTEMENT la même énergie : R67 ne contredit jamais le facturé, il l'étend.
+  - MAIS R67 est majoritairement ESTIMÉ ({r67_reel_pct:.0f}% de lignes réelles seulement) : c'est la
+    meilleure estimation Enedis disponible, pas du relevé physique. Cohérent avec la section 5
+    (relevés Réels rarissimes chez les NC).
+  - F15 reste le corroborant (facturé, 24/25) ; R15 fournit les DATES de relevé cyclique mais
+    pas d'énergie exploitable (index canonique non extrait pour les non-Linky, cf. section 6).
+
+→ Source de vérité désignée : **R67** (énergie moisniversaire par période, profondeur 3 ans,
+  nature étiquetée), avec F15 en corroboration et garde-fou. Une régularisation NC s'appuie
+  sur R67 en assumant son caractère majoritairement estimé — le solde « propre » sur relevé
+  réel reste hors de portée à cadence utile (section 5). Alimente l'ADR final (#548).
+"""
+    )
+else:
+    print("\n=== 7. V2 (PROVISOIRE) — source de vérité moisniversaire ===")
+    print(
+        """
+Verdict PROVISOIRE — le R67 n'est pas encore landé (campagne M023 #543) ; à réviser une
+fois intégré (lander_r67_m023.py + rebuild).
+
+Constats de ce spike (volet R15/F15/C15) :
   - R15 porte les DATES de relevé cyclique (25/25 PDL) mais son index canonique (dbt) est
     NUL à 100% pour les NC — écart d'ingestion (Classe_Temporelle_Distributeur absent des
     compteurs non-Linky), pas une absence Enedis : l'index existe sous Classe_Temporelle.
   - F15 porte les fenêtres ET les énergies facturées (kWh par cadran), sans recouvrement,
     quasi toujours adjacentes (peu de trous) — 24/25 PDL couverts.
-  - C15 ne porte aucun index chez les NC sur ce corpus (0/25) : les événements observés
-    (entrée, bascule de niveau) n'embarquent pas de relevé avant/après.
-  - Les relevés Réels (relève physique) sont rarissimes chez les NC : cadence largement
-    supra-annuelle, très en-deçà du besoin d'un solde mensuel "propre".
+  - C15 ne porte aucun index chez les NC sur ce corpus (0/25).
+  - Les relevés Réels (relève physique) sont rarissimes chez les NC : cadence supra-annuelle.
 
-→ Candidate provisoire : F15 (bornes + énergies déjà agrégées par cadran, fiable et
-  couvrant 24/25) complétée par les dates R15 CYCL pour les PDL sans F15 récent. R15 seul
-  n'est PAS une source d'énergie exploitable en l'état (index non extrait pour les NC).
-  Le R67, une fois en base, tranchera probablement en faveur d'une troisième source
-  (énergie déjà différenciée par Enedis, cf. ADR-0047) — verdict final déféré à V2.
+→ Candidate provisoire : F15 (bornes + énergies par cadran, 24/25). Le R67, une fois landé,
+  tranchera — verdict final déféré à V2.
 """
-)
+    )
 
 # === 9. Garde RGPD — scan du rapport committé =========================================
 print("=== 8. Garde RGPD — scan du rapport committé ===")

--- a/docs/spikes/nc/axe2_couverture.py
+++ b/docs/spikes/nc/axe2_couverture.py
@@ -1,0 +1,399 @@
+"""Spike #545 (PRD #542, axe 2) — couverture data par NC → source de vérité moisniversaire.
+
+SCOPE PARTIEL (volet R15/F15/C15) : le R67 n'est pas encore en base (campagne M023 #543
+pas atterrie) — la section 4 le constate proprement et tolère l'arrivée future de la
+table. Le verdict V2 (section 7) est donc explicitement PROVISOIRE : il sera révisé une
+fois le R67 intégré.
+
+Repro : uv run python docs/spikes/nc/axe2_couverture.py
+(lecture seule ; nécessite la base d'ingestion locale peuplée en C15/R15/F15.)
+
+RGPD : ce script n'imprime QUE des agrégats. Le détail par PDL part en sortie locale
+(sorties-locales/axe2_couverture_nc.csv, non committée). Une assertion finale scanne le
+rapport committé à la recherche de motifs de 14 chiffres (PDL) et échoue si trouvé.
+"""
+
+import re
+from pathlib import Path
+
+import duckdb
+import polars as pl
+
+DB = "electricore/ingestion/flux_enedis_pipeline.duckdb"
+RAPPORT = Path("docs/spikes/nc/axe2-couverture.md")
+DETAIL_CSV = Path("sorties-locales/axe2_couverture_nc.csv")
+
+con = duckdb.connect(DB, read_only=True)
+con.execute("use flux_enedis")
+
+# Présence au périmètre (ADR-0052) : RSC sans événement de sortie {RES, CFNS}.
+# NC : dernier niveau_ouverture_services non-nul par RSC = '0'.
+NC_PDL_CTE = """
+with presence as (
+    select ref_situation_contractuelle rsc, any_value(pdl) pdl,
+           max(case when evenement_declencheur in ('RES', 'CFNS') then 1 else 0 end) a_sorti
+    from spine_contrat
+    where ref_situation_contractuelle is not null and type_fait = 'evenement'
+    group by 1
+),
+present as (
+    select rsc, pdl from presence where a_sorti = 0
+),
+dernier_niveau as (
+    select ref_situation_contractuelle rsc, niveau_ouverture_services as niveau
+    from spine_contrat
+    where ref_situation_contractuelle is not null
+    qualify row_number() over (partition by ref_situation_contractuelle order by date_evenement desc) = 1
+),
+nc_pdl as (
+    select distinct p.pdl
+    from present p join dernier_niveau d using (rsc)
+    where d.niveau = '0'
+)
+"""
+
+
+def q(sql: str):
+    return con.execute(sql).fetchall()
+
+
+def qdf(sql: str) -> pl.DataFrame:
+    return con.sql(sql).pl()
+
+
+def cadran_depuis_libelle(libelle: str) -> str:
+    """Extrait le cadran du libellé F15 ('.../Part variable HPH' -> 'hph', sans suffixe -> 'base')."""
+    for suffixe, cadran in [
+        ("HPH", "hph"),
+        ("HPB", "hpb"),
+        ("HCH", "hch"),
+        ("HCB", "hcb"),
+        ("HP", "hp"),
+        ("HC", "hc"),
+    ]:
+        if libelle.endswith(suffixe):
+            return cadran
+    return "base"
+
+
+# === 0. Cohorte NC ===================================================================
+print("=== 0. Cohorte NC (présence ADR-0052 + niveau_ouverture_services='0') ===")
+nb_nc = q(NC_PDL_CTE + "select count(*) from nc_pdl")[0][0]
+print(f"PDL NC : {nb_nc}")
+assert nb_nc == 25, f"cohorte NC attendue = 25 (calibrage 2026-07-03), obtenu {nb_nc} — la base a bougé ?"
+
+# === 1. R15 cyclique ==================================================================
+print("\n=== 1. R15 cyclique ===")
+r15_cov = q(NC_PDL_CTE + "select count(distinct r.pdl) from flux_r15 r join nc_pdl using (pdl)")[0][0]
+print(f"PDL NC avec ≥1 relevé R15 : {r15_cov}/{nb_nc}")
+
+ecarts = qdf(
+    NC_PDL_CTE
+    + """
+    select r.pdl, r.date_releve,
+           date_diff('day', lag(r.date_releve) over (partition by r.pdl order by r.date_releve), r.date_releve) as ecart_jours
+    from flux_r15 r join nc_pdl using (pdl)
+    where r.motif_releve = 'CYCL'
+    """
+).drop_nulls("ecart_jours")
+
+assert (ecarts["ecart_jours"] > 0).all(), (
+    "INVARIANT violé : relevés CYCL non strictement croissants (doublon de date ?)"
+)
+
+print(
+    f"Écart entre relevés CYCL : médian {ecarts['ecart_jours'].median():.0f} j "
+    f"(min {ecarts['ecart_jours'].min()}, max {ecarts['ecart_jours'].max()}, n={ecarts.height} intervalles)"
+)
+nb_trous_40j = ecarts.filter(pl.col("ecart_jours") > 40).height
+print(
+    f"Intervalles > 40 j (cadence bimestrielle ou plus lâche) : {nb_trous_40j}/{ecarts.height} ({nb_trous_40j / ecarts.height:.0%})"
+)
+
+nature = qdf(
+    NC_PDL_CTE
+    + """
+    select nature_index, count(*) as n from flux_r15 r join nc_pdl using (pdl)
+    where motif_releve = 'CYCL' group by 1
+    """
+)
+print("Nature d'index des relevés CYCL :", dict(zip(nature["nature_index"], nature["n"], strict=True)))
+
+jours = qdf(
+    NC_PDL_CTE
+    + """
+    select r.pdl, extract(day from r.date_releve) as jour
+    from flux_r15 r join nc_pdl using (pdl) where motif_releve = 'CYCL'
+    """
+)
+stab = (
+    jours.group_by("pdl").agg(pl.col("jour").std().alias("stddev_jour"), pl.len().alias("n")).filter(pl.col("n") >= 3)
+)
+print(
+    f"Stabilité du jour de relevé (moisniversaire), PDL avec ≥3 relevés CYCL (n={stab.height}/{nb_nc}) : "
+    f"stddev médian {stab['stddev_jour'].median():.1f} j, max {stab['stddev_jour'].max():.1f} j"
+)
+
+# === 2. F15 ============================================================================
+print("\n=== 2. F15 ===")
+f15_cov = q(NC_PDL_CTE + "select count(distinct f.pdl) from flux_f15_detail f join nc_pdl using (pdl)")[0][0]
+print(f"PDL NC avec ≥1 ligne F15 : {f15_cov}/{nb_nc}")
+
+fenetres = qdf(
+    NC_PDL_CTE
+    + """
+    select distinct f.pdl, f.date_debut, f.date_fin
+    from flux_f15_detail f join nc_pdl using (pdl)
+    where f.nature_ev = '01' and f.unite = 'kWh' and f.type_facturation = 'CYCL'
+    """
+).sort(["pdl", "date_debut"])
+
+fenetres = fenetres.with_columns(pl.col("date_fin").shift(1).over("pdl").alias("fin_precedente"))
+chevauchements = fenetres.filter(pl.col("date_debut") < pl.col("fin_precedente")).height
+adjacentes = fenetres.filter(pl.col("date_debut") == pl.col("fin_precedente")).height
+trous = fenetres.filter(pl.col("date_debut") > pl.col("fin_precedente")).height
+
+print(f"Fenêtres F15 CYCL (kWh) : {fenetres.height} sur {f15_cov} PDL")
+print(
+    f"  paires consécutives : {adjacentes + trous + chevauchements} — adjacentes {adjacentes}, trous {trous}, chevauchements {chevauchements}"
+)
+assert chevauchements == 0, "INVARIANT violé : chevauchement de fenêtres F15 CYCL détecté"
+
+durees = fenetres.with_columns((pl.col("date_fin") - pl.col("date_debut")).dt.total_days().alias("duree_j"))
+print(
+    f"Durée des fenêtres F15 : médiane {durees['duree_j'].median():.0f} j (min {durees['duree_j'].min()}, max {durees['duree_j'].max()})"
+)
+
+# Réconciliation somme-des-fenêtres vs total : par construction (0 recouvrement), la somme
+# des durées de fenêtres + la somme des trous doit égaler l'amplitude totale par PDL.
+recon = (
+    fenetres.group_by("pdl")
+    .agg(
+        (pl.col("date_fin") - pl.col("date_debut")).dt.total_days().sum().alias("jours_couverts"),
+        pl.col("date_debut").min().alias("debut_span"),
+        pl.col("date_fin").max().alias("fin_span"),
+    )
+    .with_columns((pl.col("fin_span") - pl.col("debut_span")).dt.total_days().alias("amplitude"))
+)
+ecart_reconciliation = recon.filter(pl.col("jours_couverts") > pl.col("amplitude")).height
+print(
+    f"Réconciliation somme-des-fenêtres ≤ amplitude totale : {recon.height - ecart_reconciliation}/{recon.height} PDL conformes"
+)
+assert ecart_reconciliation == 0, "INVARIANT violé : somme des fenêtres F15 > amplitude totale observée sur le PDL"
+
+# === 3. C15 — index aux événements ====================================================
+print("\n=== 3. C15 — index aux événements ===")
+c15_evt = q(NC_PDL_CTE + "select count(*), count(distinct c.pdl) from flux_c15 c join nc_pdl using (pdl)")[0]
+print(f"Événements C15 pour NC : {c15_evt[0]} lignes sur {c15_evt[1]}/{nb_nc} PDL")
+
+c15_idx = q(NC_PDL_CTE + "select count(*), count(distinct c.pdl) from int_releves__c15 c join nc_pdl using (pdl)")[0]
+print(
+    f"...dont porteurs d'un index (avant/après non-null, via int_releves__c15) : {c15_idx[0]} lignes, {c15_idx[1]}/{nb_nc} PDL"
+)
+
+evt_types = q(
+    NC_PDL_CTE
+    + "select evenement_declencheur, count(*) from flux_c15 c join nc_pdl using (pdl) group by 1 order by 2 desc"
+)
+print("Types d'événement C15 observés chez les NC :", {e: n for e, n in evt_types})
+if c15_idx[0] == 0:
+    print("→ 0 index C15 chez les NC : les événements observés (entrée CFNE/MES, bascule niveau MDPRM/MDACT)")
+    print("  ne portent structurellement pas d'index avant/après sur ce corpus.")
+
+# === 4. R67 — en attente campagne M023 #543 ===========================================
+print("\n=== 4. R67 — en attente campagne M023 (#543) ===")
+r67_existe = (
+    q(
+        """
+    select count(*) from information_schema.tables
+    where table_schema = 'flux_enedis' and table_name = 'flux_r67'
+    """
+    )[0][0]
+    > 0
+)
+if not r67_existe:
+    print("Table flux_r67 absente de la base — campagne M023 #543 pas encore atterrie.")
+    print("Volet R67 DIFFÉRÉ (voir #545, blocked-by #543) : ce script tolère l'arrivée future de la table.")
+else:
+    r67_cov = q(NC_PDL_CTE + "select count(distinct r.pdl) from flux_r67 r join nc_pdl using (pdl)")[0][0]
+    print(f"Table flux_r67 présente : couverture NC {r67_cov}/{nb_nc}")
+
+# === 5. Fréquence des relevés Réels (relève physique) =================================
+print("\n=== 5. Fréquence des relevés Réels chez les NC ===")
+reels = qdf(
+    NC_PDL_CTE
+    + """
+    select r.pdl, count(*) as n from flux_r15 r join nc_pdl using (pdl)
+    where nature_index = 'réel' group by 1
+    """
+)
+print(
+    f"PDL NC avec ≥1 relevé Réel (R15, toutes sources) : {reels.height}/{nb_nc} ({nb_nc - reels.height} sans aucun relevé réel observé)"
+)
+
+span = qdf(
+    NC_PDL_CTE
+    + """
+    select r.pdl, min(date_releve) as debut, max(date_releve) as fin
+    from flux_r15 r join nc_pdl using (pdl) group by 1
+    """
+).with_columns((pl.col("fin") - pl.col("debut")).dt.total_days().alias("span_j"))
+span_median = span["span_j"].median()
+print(f"Fenêtre d'observation médiane par PDL : {span_median:.0f} j")
+print(
+    f"→ {reels['n'].sum()} relevé(s) Réel(s) au total sur {reels.height}/{nb_nc} PDL en ~{span_median:.0f} j "
+    "d'observation : un solde \"propre\" sur bornes réelles n'est praticable, au mieux, "
+    "qu'à une cadence largement supra-annuelle chez les NC — jamais mensuelle."
+)
+
+# === 6. Cohérence R15 vs F15 ===========================================================
+print("\n=== 6. Cohérence R15 vs F15 (bornes + énergies) ===")
+
+# flux_r15.sql (dbt) n'extrait que Classe_Temporelle_Distributeur : absent à 100% pour les
+# NC (compteurs non-Linky) → index_*_kwh canonique est NULL. Repli spike (lecture stg_r15
+# brute, HORS dbt, aucune modification de production) sur Classe_Temporelle (singulier),
+# universellement présent, même filtre classe_mesure=1/sens_mesure=0 que le modèle dbt.
+r15_idx_canonique = q(
+    NC_PDL_CTE
+    + """
+    select count(*) from flux_r15 r join nc_pdl using (pdl)
+    where coalesce(index_base_kwh, index_hp_kwh, index_hc_kwh, index_hph_kwh, index_hch_kwh, index_hpb_kwh, index_hcb_kwh) is not null
+    """
+)[0][0]
+r15_lignes = q(NC_PDL_CTE + "select count(*) from flux_r15 r join nc_pdl using (pdl)")[0][0]
+print(f"Index R15 canonique (dbt, colonnes index_*_kwh) chez les NC : {r15_idx_canonique}/{r15_lignes} lignes")
+print(
+    "→ écart d'ingestion identifié : Classe_Temporelle_Distributeur (source du modèle dbt) est absent "
+    "de 100% des relevés NC (compteurs non-Linky) ; l'index existe pourtant sous Classe_Temporelle "
+    "(singulier), non extrait par flux_r15.sql aujourd'hui — piste de suivi, hors scope de ce spike."
+)
+
+r15_fallback = qdf(
+    NC_PDL_CTE
+    + """
+    , classes as (
+        select s.pdl, cast(s.releve ->> '$.Date_Releve' as date) as date_releve,
+               classe ->> '$.Classe_Mesure' as classe_mesure,
+               classe ->> '$.Sens_Mesure' as sens_mesure,
+               lower(classe ->> '$.Id_Classe_Temporelle') as cadran,
+               cast(classe ->> '$.Valeur' as bigint) as valeur
+        from stg_r15 s join nc_pdl on s.pdl = nc_pdl.pdl,
+            unnest(cast((s.releve -> '$.Classe_Temporelle') as json[])) as c(classe)
+        where s.releve ->> '$.Motif_Releve' = 'CYCL'
+    )
+    select pdl, date_releve, cadran, valeur
+    from classes
+    where classe_mesure = '1' and sens_mesure = '0'
+    """
+)
+
+r15_wide = r15_fallback.pivot(values="valeur", index=["pdl", "date_releve"], on="cadran").sort(["pdl", "date_releve"])
+cadran_cols = [c for c in r15_wide.columns if c not in ("pdl", "date_releve")]
+r15_diff = r15_wide.with_columns([pl.col(c).diff().over("pdl").alias(f"delta_{c}") for c in cadran_cols])
+r15_diff = r15_diff.with_columns(pl.col("date_releve").shift(1).over("pdl").alias("date_debut"))
+r15_diff = r15_diff.rename({"date_releve": "date_fin"}).drop_nulls("date_debut")
+
+f15_ev = qdf(
+    NC_PDL_CTE
+    + """
+    select f.pdl, f.date_debut, f.date_fin, f.libelle_ev, f.quantite
+    from flux_f15_detail f join nc_pdl using (pdl)
+    where f.nature_ev = '01' and f.unite = 'kWh' and f.type_facturation = 'CYCL'
+    """
+)
+f15_ev = f15_ev.with_columns(
+    pl.col("libelle_ev").map_elements(cadran_depuis_libelle, return_dtype=pl.Utf8).alias("cadran")
+)
+f15_wide = (
+    f15_ev.group_by(["pdl", "date_debut", "date_fin", "cadran"])
+    .agg(pl.col("quantite").sum())
+    .pivot(values="quantite", index=["pdl", "date_debut", "date_fin"], on="cadran")
+)
+f15_wide = f15_wide.rename({c: f"f15_{c}" for c in f15_wide.columns if c not in ("pdl", "date_debut", "date_fin")})
+
+compare = r15_diff.join(f15_wide, on=["pdl", "date_debut", "date_fin"], how="inner")
+print(f"Fenêtres à bornes identiques R15 (fallback Classe_Temporelle) ET F15 : {compare.height}")
+
+for cadran in cadran_cols:
+    delta_col, f15_col = f"delta_{cadran}", f"f15_{cadran}"
+    if f15_col not in compare.columns:
+        continue
+    sous = compare.filter(pl.col(delta_col).is_not_null() & pl.col(f15_col).is_not_null())
+    if sous.height == 0:
+        continue
+    ecart = (sous[delta_col] - sous[f15_col]).abs()
+    exact = (ecart <= 1).sum()
+    print(
+        f"  cadran {cadran:4} : n={sous.height:3}, écart moyen {ecart.mean():.2f} kWh, max {ecart.max():.0f} kWh, {exact}/{sous.height} à ±1 kWh près"
+    )
+
+# === 7. Détail par PDL (sortie locale, jamais committée) ==============================
+DETAIL_CSV.parent.mkdir(exist_ok=True)
+detail = (
+    qdf(NC_PDL_CTE + "select pdl from nc_pdl")
+    .join(
+        qdf(NC_PDL_CTE + "select r.pdl, count(*) as n_r15 from flux_r15 r join nc_pdl using (pdl) group by 1"),
+        on="pdl",
+        how="left",
+    )
+    .join(
+        qdf(NC_PDL_CTE + "select f.pdl, count(*) as n_f15 from flux_f15_detail f join nc_pdl using (pdl) group by 1"),
+        on="pdl",
+        how="left",
+    )
+    .join(
+        qdf(NC_PDL_CTE + "select c.pdl, count(*) as n_c15 from flux_c15 c join nc_pdl using (pdl) group by 1"),
+        on="pdl",
+        how="left",
+    )
+    .join(
+        qdf(
+            NC_PDL_CTE
+            + "select r.pdl, count(*) as n_r15_reel from flux_r15 r join nc_pdl using (pdl) where nature_index='réel' group by 1"
+        ),
+        on="pdl",
+        how="left",
+    )
+    .fill_null(0)
+)
+detail.write_csv(DETAIL_CSV)
+print(f"\nDétail par PDL écrit dans {DETAIL_CSV} (non committé, RGPD).")
+
+# === 8. V2 (provisoire) — source de vérité moisniversaire =============================
+print("\n=== 7. V2 (PROVISOIRE) — source de vérité moisniversaire ===")
+print(
+    """
+Verdict PROVISOIRE — le R67 n'est pas encore en base (campagne M023 #543) ; à réviser
+une fois intégré.
+
+Constats de ce spike :
+  - R15 porte les DATES de relevé cyclique (25/25 PDL) mais son index canonique (dbt) est
+    NUL à 100% pour les NC — écart d'ingestion (Classe_Temporelle_Distributeur absent des
+    compteurs non-Linky), pas une absence Enedis : l'index existe sous Classe_Temporelle.
+  - F15 porte les fenêtres ET les énergies facturées (kWh par cadran), sans recouvrement,
+    quasi toujours adjacentes (peu de trous) — 24/25 PDL couverts.
+  - C15 ne porte aucun index chez les NC sur ce corpus (0/25) : les événements observés
+    (entrée, bascule de niveau) n'embarquent pas de relevé avant/après.
+  - Les relevés Réels (relève physique) sont rarissimes chez les NC : cadence largement
+    supra-annuelle, très en-deçà du besoin d'un solde mensuel "propre".
+
+→ Candidate provisoire : F15 (bornes + énergies déjà agrégées par cadran, fiable et
+  couvrant 24/25) complétée par les dates R15 CYCL pour les PDL sans F15 récent. R15 seul
+  n'est PAS une source d'énergie exploitable en l'état (index non extrait pour les NC).
+  Le R67, une fois en base, tranchera probablement en faveur d'une troisième source
+  (énergie déjà différenciée par Enedis, cf. ADR-0047) — verdict final déféré à V2.
+"""
+)
+
+# === 9. Garde RGPD — scan du rapport committé =========================================
+print("=== 8. Garde RGPD — scan du rapport committé ===")
+motif_pdl = re.compile(r"\b\d{14}\b")
+if RAPPORT.exists():
+    trouves = motif_pdl.findall(RAPPORT.read_text())
+    assert not trouves, f"RGPD : motif de 14 chiffres trouvé dans {RAPPORT} : {trouves[:3]}"
+    print(f"OK — aucun motif de 14 chiffres dans {RAPPORT}")
+else:
+    print(f"{RAPPORT} n'existe pas encore — l'écrire puis rejouer ce script pour valider le garde-fou RGPD.")
+
+con.close()
+print("\n=== Script terminé sans erreur d'invariant. ===")

--- a/docs/spikes/nc/lander_r67_m023.py
+++ b/docs/spikes/nc/lander_r67_m023.py
@@ -14,6 +14,11 @@ Chemin par défaut : les ZIP R67 du répertoire M023 local (non suivi par git, R
 il contient des numéros de PDL). Passer un autre chemin en argument. Le script
 n'imprime que des agrégats anonymes (nb PRM, nb mesures), jamais de PDL.
 
+NB : le landing globe TOUS les ZIP R67 du dossier (ou le seul fichier passé en argument)
+— il ne filtre pas sur une cohorte. Lander plusieurs demandes M023 peut donc amener des
+PDL hors périmètre d'analyse ; c'est inoffensif (les spikes aval filtrent par cohorte),
+mais `flux_r67` portera alors tous les PDL landés.
+
 Repro : nécessite la base d'ingestion locale. Écrit dans la base (read/write).
 """
 

--- a/docs/spikes/nc/lander_r67_m023.py
+++ b/docs/spikes/nc/lander_r67_m023.py
@@ -1,0 +1,96 @@
+"""Backfill manuel R67 depuis un ZIP portail M023 (clair — contourne l'AES SFTP).
+
+Procédure batch rejouable (#543) : le portail SGE renvoie un ZIP clair contenant un
+JSON R67 (mesures facturantes, ADR-0047). Ce script lande ce JSON dans
+`flux_raw.raw_r67` avec la MÊME forme que le landing dlt (colonne `content` JSON +
+`file_name` + `modification_date`), en MERGE sur `file_name` (idempotent : rejouer
+n'ajoute pas de doublon). La linéarisation `flux_r67` se construit ensuite via le
+runner :
+
+    uv run python docs/spikes/nc/lander_r67_m023.py            # lande le(s) ZIP local/aux
+    uv run python -m electricore.ingestion rebuild             # dbt build → flux_enedis.flux_r67
+
+Chemin par défaut : les ZIP R67 du répertoire M023 local (non suivi par git, RGPD —
+il contient des numéros de PDL). Passer un autre chemin en argument. Le script
+n'imprime que des agrégats anonymes (nb PRM, nb mesures), jamais de PDL.
+
+Repro : nécessite la base d'ingestion locale. Écrit dans la base (read/write).
+"""
+
+import os
+import sys
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import duckdb
+
+# Base d'ingestion (même défaut que les autres spikes NC / le runtime : $DUCKDB__PATH).
+DB_DEFAUT = os.environ.get("DUCKDB__PATH", "electricore/ingestion/flux_enedis_pipeline.duckdb")
+
+# Répertoire local des ZIP M023 (hors dépôt — RGPD). Override en argv[1].
+SOURCE_DEFAUT = Path.home() / "data" / "r67_samples"
+
+# Schéma identique à `raw_r64` (landing dlt) — seules content/file_name/modification_date
+# sont lues par stg_r67 ; les colonnes _dlt_* / _source_zip sont conservées par parité.
+DDL_RAW_R67 = """
+create schema if not exists flux_raw;
+create table if not exists flux_raw.raw_r67 (
+    content json,
+    file_name varchar,
+    modification_date timestamptz,
+    _source_zip varchar,
+    _flux_type varchar,
+    _dlt_load_id varchar,
+    _dlt_id varchar
+);
+"""
+
+
+def zips_r67(source: Path) -> list[Path]:
+    if source.is_file() and source.suffix == ".zip":
+        return [source]
+    return sorted(source.glob("ENEDIS_R67_P_*.zip"))
+
+
+def lander(db_path: Path, zips: list[Path]) -> int:
+    con = duckdb.connect(str(db_path))
+    con.execute(DDL_RAW_R67)
+    n_landes = 0
+    for z in zips:
+        with zipfile.ZipFile(z) as zf:
+            jsons = [n for n in zf.namelist() if n.lower().endswith(".json")]
+            for nom in jsons:
+                contenu = zf.read(nom).decode("utf-8")
+                mtime = datetime.fromtimestamp(z.stat().st_mtime, tz=UTC)
+                # MERGE sur file_name : rejouer remplace, n'accumule pas.
+                con.execute("delete from flux_raw.raw_r67 where file_name = ?", [nom])
+                con.execute(
+                    """
+                    insert into flux_raw.raw_r67
+                        (content, file_name, modification_date, _source_zip, _flux_type, _dlt_load_id, _dlt_id)
+                    values (?::json, ?, ?, ?, 'R67', 'backfill_m023', ?)
+                    """,
+                    [contenu, nom, mtime, z.name, nom],
+                )
+                n_landes += 1
+    # Comptage de couverture (agrégat anonyme, aucun PDL imprimé).
+    n_prm = con.execute(
+        "select count(distinct m ->> '$.idPrm') "
+        "from flux_raw.raw_r67, unnest(cast(content -> '$.mesures' as json[])) as t(m)"
+    ).fetchone()[0]
+    con.close()
+    return n_landes, n_prm
+
+
+if __name__ == "__main__":
+    source = Path(sys.argv[1]) if len(sys.argv) > 1 else SOURCE_DEFAUT
+    db = Path(DB_DEFAUT)
+    zips = zips_r67(source)
+    if not zips:
+        print(f"Aucun ZIP R67 trouvé sous {source} — rien à lander.")
+        sys.exit(0)
+    n_landes, n_prm = lander(db, zips)
+    print(f"Landé {n_landes} fichier(s) JSON R67 depuis {len(zips)} ZIP → flux_raw.raw_r67 ({db})")
+    print(f"PRM distincts couverts : {n_prm}")
+    print("→ construire flux_r67 :  uv run python -m electricore.ingestion rebuild")


### PR DESCRIPTION
**Closes #545** — le volet R67 est intégré : un lot de la campagne M023 #543 a été landé
(22/25 NC, 3 ans de profondeur), ce qui permet le verdict V2 **définitif**.

## Ce que fait cette PR
- **Landing R67 rejouable** (`docs/spikes/nc/lander_r67_m023.py`) : lande un ZIP portail
  M023 clair (contourne l'AES) dans `flux_raw.raw_r67`, idempotent (merge sur file_name),
  puis `rebuild` dbt matérialise `flux_r67`. Documente la procédure batch de #543.
- **Axe 2 étendu** : le script s'adapte à la présence du R67 — verdict provisoire si absent,
  **définitif si landé**. Analyse R67 : couverture, nature, pavage, profondeur vs F15,
  cohérence R67↔F15.
- **Rapport** mis à jour (agrégats anonymes uniquement).

## Trouvailles R67 (22/25 NC)
- Nature : **65 % estimé, 27 % régularisé, 8 % réel** — R67 apporte l'estimation Enedis, il
  ne résout pas la rareté du relevé réel.
- Profondeur : remonte à **2023-06** vs **2024-04** pour le F15 en base (~9 mois de plus).
- **Invariant R67↔F15** : sur 84 fenêtres à bornes identiques (CYCL), énergie **exactement
  identique** (84/84 à ±1 kWh, écart moyen 0,00). R67 étend le facturé sans le contredire.

## Verdict V2 (définitif)
Source de vérité moisniversaire NC = **R67** (énergie par période déjà différenciée,
profondeur 3 ans, nature étiquetée), F15 corroborant. Réserve assumée : R67 majoritairement
estimé → meilleure estimation, pas du réel. Alimente l'ADR final #548.

## RGPD
Aucun PDL/num_compteur committé ; garde-fou (scan 14 chiffres du rapport) vert. L'échantillon
R67 et le détail par PDL restent locaux. Les 3 NC hors lot ne sont pas récupérables (SGE).

## Notes
- `uv run` a besoin des extras `ingestion`+`dbt` pour le `rebuild` (dlt).
- Le helper de landing globe tous les ZIP R67 du dossier local → a aussi landé 3 PDL hors-NC
  (inoffensif, l'analyse filtre sur les NC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
