### PR TITLE
fix(odoo): sélection des factures du mois par date-ancre (#561)

### DIFF
--- a/docs/adr/0054-convention-date-ancre-campagne-facturation.md
+++ b/docs/adr/0054-convention-date-ancre-campagne-facturation.md
@@ -1,0 +1,72 @@
+# ADR-0054 — Convention date-ancre pour la sélection des factures d'une campagne
+
+## Statut
+
+Accepté (#561, PR #562).
+
+## Contexte
+
+Le rapprochement facturation (`lignes_factures_du_mois`, `electricore/integrations/odoo/sources.py`)
+croise les quantités Enedis du mois M avec les lignes de facture Odoo du mois M. La
+sélection initiale filtrait par fenêtre : `invoice_date ∈ [M, M+1)`.
+
+Deux faits Odoo rendent cette fenêtre bogée :
+
+- Les brouillons de campagne (`account.move.state = draft`) naissent **sans**
+  `invoice_date` — cette date ne se pose qu'à la validation de la facture. Une
+  fenêtre par date ne peut donc jamais les voir : la campagne en cours de saisie
+  était invisible du rapprochement tant qu'elle n'était pas validée.
+- Une fois la campagne validée, `invoice_date` est en réalité posée à **une seule
+  et même date** pour toutes les factures de la campagne — pas répartie dans le
+  mois. La fenêtre était donc une approximation inutilement large d'une valeur en
+  fait unique.
+
+## Décision
+
+**Sélection par égalité stricte sur une date-ancre**, pas par fenêtre :
+
+- Odoo pose `invoice_date = 05/(M+1)` sur **tous** les brouillons de la campagne
+  du mois M, au moment de « lancer la facturation du mois » (conso de juin →
+  factures datées 05/07). Rollover décembre : conso de décembre N → `05/01/(N+1)`.
+- `date_ancre(mois)` (`electricore/integrations/odoo/sources.py`) calcule cette
+  date. `lignes_factures_du_mois` sélectionne par `invoice_date == date_ancre(mois)` —
+  une clé, plus de fenêtre.
+- **Une seule campagne par mois** : pas de distinction cycle automatique / campagne
+  manuelle, une seule date-ancre à surveiller.
+
+C'est une **convention inter-systèmes**, pas un détail d'implémentation local :
+Odoo la pose à la génération, electricore la lit. Si l'un des deux bascule l'ancre
+sans que l'autre suive, la sélection casse **silencieusement** (une requête sur la
+mauvaise date ne renvoie simplement rien, ou renvoie l'ancienne campagne). D'où le
+check pré-campagne côté vérifications Odoo (#564, `electricore/integrations/odoo/verification.py`)
+qui détecte, avant chaque lancement de campagne, tout brouillon de commande énergie
+daté hors de l'ancre courante ou sans date — la violation de convention devient
+visible dans `/check odoo` au lieu d'être absorbée en silence par la sélection.
+
+### Alternatives écartées
+
+- **Fenêtre `[M, M+1)`** (comportement initial) : n'a jamais vu les brouillons de
+  campagne (ceux-ci naissent sans date) — c'est le bug d'origine (#561).
+- **« Fenêtre OU brouillon » (palliatif)** : rendait la campagne courante visible
+  en avalant tout `state = draft`, y compris un brouillon d'une campagne
+  antérieure resté traînant, ou un brouillon hors énergie — pas de garde-fou sur
+  la convention de date, juste un filtre plus permissif.
+- **Antidatage** (poser `invoice_date` au 30/06 au lieu du 05/07) : déplace le
+  problème sans le résoudre — reste une date arbitraire à synchroniser entre les
+  deux systèmes.
+- **Poser la date à l'injection** (côté electricore plutôt qu'Odoo) : Odoo est le
+  système qui génère la campagne ; il est le seul à savoir quand elle a réellement
+  eu lieu.
+- **Heuristique « dernière facture »** : fragile dès que deux campagnes
+  coexistent (rattrapage, re-génération) — pas de garantie d'ordre stable.
+
+## Conséquences
+
+- Un seul calcul d'ancre (`date_ancre`), réutilisé par la sélection (#561) et par
+  le check pré-campagne (#564) — pas de risque de dérive entre les deux.
+- La convention doit être documentée côté Odoo (génération de la campagne) autant
+  que côté electricore : un changement de l'un sans l'autre casse silencieusement,
+  d'où le check pré-campagne en garde-fou plutôt qu'une simple note de documentation.
+- Un brouillon sans date, ou daté ailleurs qu'à l'ancre courante, n'est plus
+  ramassé du tout par `lignes_factures_du_mois` — il doit être corrigé à la
+  source (Odoo) avant de pouvoir être rapproché.

--- a/electricore/integrations/odoo/CONTEXT.md
+++ b/electricore/integrations/odoo/CONTEXT.md
@@ -55,3 +55,10 @@ _Éviter_ : réconciliation (anglicisme), jointure facturation, `updates_rsc` (a
 
 **`lignes_facture_rapprochees`** :
 DataFrame résultat du *Rapprochement facturation mensuelle*. Une ligne par ligne de facture Odoo du mois cible (tous états confondus), enrichie de la quantité calculée à partir des flux Enedis (`quantite_enedis`) et de deux flags : `a_facturer` (ligne en attente d'injection de quantité) et `a_supprimer` (ligne brouillon à quantité nulle, candidate à `unlink`). Sert de proposition de mise à jour : la décision d'écriture dans Odoo est prise par l'opérateur depuis un notebook (cf. [ADR-0012](../../../docs/adr/0012-api-read-only-odoo.md)).
+
+**Campagne de facturation** :
+Ensemble des factures (et brouillons de facture) générés par Odoo en une fois pour un mois donné, lors de l'action « lancer la facturation du mois ». Une seule campagne par mois (pas de distinction cycle automatique / campagne manuelle). C'est la campagne du mois M que sélectionne `lignes_factures_du_mois` pour le *Rapprochement facturation mensuelle*. Voir [ADR-0054](../../../docs/adr/0054-convention-date-ancre-campagne-facturation.md).
+
+**Date-ancre** :
+Convention inter-systèmes (Odoo ↔ electricore, [ADR-0054](../../../docs/adr/0054-convention-date-ancre-campagne-facturation.md)) : Odoo pose `invoice_date = 05/(M+1)` sur toutes les factures et brouillons de la *campagne de facturation* du mois M (conso de juin → factures datées 05/07 ; rollover décembre → 05/01/(N+1)). `date_ancre(mois)` (`sources.py`) calcule cette date ; `lignes_factures_du_mois` sélectionne par égalité stricte dessus (plus de fenêtre). Réutilisée par le check pré-campagne (`verification.py`, #564) sous la forme d'une *ancre courante* (le 05 du mois courant) qui détecte tout brouillon de commande énergie daté hors de cette ancre ou sans date — une violation de la convention, si l'un des deux systèmes bascule l'ancre sans l'autre, devient visible dans `/check odoo` au lieu de casser silencieusement la sélection.
+_Éviter_ : fenêtre de dates, antidatage.

--- a/electricore/integrations/odoo/sources.py
+++ b/electricore/integrations/odoo/sources.py
@@ -65,13 +65,36 @@ def _expr_est_brouillon() -> pl.Expr:
     return ((pl.col("x_invoicing_state") == "draft") & (pl.col("state_account_move") == "draft")).alias("est_brouillon")
 
 
-def lignes_factures_du_mois(odoo: OdooReader, mois: str, domain: list | None = None) -> pl.LazyFrame:
-    """Lignes de factures Odoo du mois cible : datées du mois **ou brouillon** (#561).
+def date_ancre(mois: str) -> str:
+    """Date-ancre de la campagne de facturation du mois cible (#561, ADR-0054).
 
-    Les brouillons de campagne naissent sans `invoice_date` (elle se pose à la
-    validation) : une fenêtre par date seule ne peut jamais les voir. La sélection
-    est donc « `invoice_date` ∈ [mois, mois+1) OU `state = draft` » — la campagne
-    courante est toujours visible, l'historique validé reste fenêtré pour l'audit.
+    Odoo pose `invoice_date = 05/(M+1)` sur tous les brouillons de la campagne
+    du mois `mois` au moment de « lancer la facturation du mois » (conso de
+    juin → factures datées 05/07). Convention inter-systèmes : Odoo la pose,
+    electricore la lit par égalité stricte — si l'un des deux bascule l'ancre,
+    l'autre casse silencieusement (d'où le check pré-campagne, #564, qui
+    réutilise ce calcul pour l'« ancre courante »).
+
+    Args:
+        mois: Premier jour du mois cible au format "YYYY-MM-DD".
+
+    Returns:
+        Date-ancre au format "YYYY-MM-DD" (05 du mois suivant ; rollover
+        décembre géré : conso de décembre N → 05/01/(N+1)).
+    """
+    d = date.fromisoformat(mois)
+    annee, mois_suivant = (d.year + 1, 1) if d.month == 12 else (d.year, d.month + 1)
+    return date(annee, mois_suivant, 5).isoformat()
+
+
+def lignes_factures_du_mois(odoo: OdooReader, mois: str, domain: list | None = None) -> pl.LazyFrame:
+    """Lignes de factures Odoo du mois cible, sélectionnées par date-ancre (#561, ADR-0054).
+
+    La campagne du mois cible est entièrement datée à l'ancre `date_ancre(mois)`
+    (posée par Odoo à la génération) : la sélection est une égalité stricte sur
+    `invoice_date`, pas une fenêtre. Un brouillon sans date ou daté ailleurs est
+    une violation de la convention — elle n'est pas absorbée ici silencieusement,
+    elle est détectée en amont par le check pré-campagne (#564).
 
     Source du chemin facturation (déménagée de `helpers.py`, #144 — symétrie
     avec les sources taxes ci-dessus). Aucun filtre sur `x_invoicing_state` ni
@@ -88,10 +111,9 @@ def lignes_factures_du_mois(odoo: OdooReader, mois: str, domain: list | None = N
 
     Returns:
         LazyFrame Polars `LignesFacture`-compatible : une ligne par
-        `account.move.line` du mois cible ou en brouillon.
+        `account.move.line` de la campagne du mois cible.
     """
-    d = date.fromisoformat(mois)
-    mois_suivant = (date(d.year + 1, 1, 1) if d.month == 12 else date(d.year, d.month + 1, 1)).isoformat()
+    ancre = date_ancre(mois)
     base_domain = [("state", "=", "sale")] + (domain or [])
 
     return (
@@ -111,14 +133,8 @@ def lignes_factures_du_mois(odoo: OdooReader, mois: str, domain: list | None = N
         )
         .follow(
             "invoice_ids",
-            # Notation préfixe Odoo : fenêtre du mois OU brouillon (#561).
-            domain=[
-                "|",
-                "&",
-                ("invoice_date", ">=", mois),
-                ("invoice_date", "<", mois_suivant),
-                ("state", "=", "draft"),
-            ],
+            # Égalité stricte sur la date-ancre de la campagne (#561, ADR-0054).
+            domain=[("invoice_date", "=", ancre)],
             fields=["name", "invoice_date", "state", "invoice_line_ids"],
         )
         .follow("invoice_line_ids", fields=["name", "product_id", "quantity"])

--- a/electricore/integrations/odoo/sources.py
+++ b/electricore/integrations/odoo/sources.py
@@ -66,7 +66,12 @@ def _expr_est_brouillon() -> pl.Expr:
 
 
 def lignes_factures_du_mois(odoo: OdooReader, mois: str, domain: list | None = None) -> pl.LazyFrame:
-    """Toutes les lignes de factures Odoo dont `invoice_date` tombe dans le mois cible.
+    """Lignes de factures Odoo du mois cible : datées du mois **ou brouillon** (#561).
+
+    Les brouillons de campagne naissent sans `invoice_date` (elle se pose à la
+    validation) : une fenêtre par date seule ne peut jamais les voir. La sélection
+    est donc « `invoice_date` ∈ [mois, mois+1) OU `state = draft` » — la campagne
+    courante est toujours visible, l'historique validé reste fenêtré pour l'audit.
 
     Source du chemin facturation (déménagée de `helpers.py`, #144 — symétrie
     avec les sources taxes ci-dessus). Aucun filtre sur `x_invoicing_state` ni
@@ -83,7 +88,7 @@ def lignes_factures_du_mois(odoo: OdooReader, mois: str, domain: list | None = N
 
     Returns:
         LazyFrame Polars `LignesFacture`-compatible : une ligne par
-        `account.move.line` du mois cible.
+        `account.move.line` du mois cible ou en brouillon.
     """
     d = date.fromisoformat(mois)
     mois_suivant = (date(d.year + 1, 1, 1) if d.month == 12 else date(d.year, d.month + 1, 1)).isoformat()
@@ -106,7 +111,14 @@ def lignes_factures_du_mois(odoo: OdooReader, mois: str, domain: list | None = N
         )
         .follow(
             "invoice_ids",
-            domain=[("invoice_date", ">=", mois), ("invoice_date", "<", mois_suivant)],
+            # Notation préfixe Odoo : fenêtre du mois OU brouillon (#561).
+            domain=[
+                "|",
+                "&",
+                ("invoice_date", ">=", mois),
+                ("invoice_date", "<", mois_suivant),
+                ("state", "=", "draft"),
+            ],
             fields=["name", "invoice_date", "state", "invoice_line_ids"],
         )
         .follow("invoice_line_ids", fields=["name", "product_id", "quantity"])

--- a/tests/unit/test_sources_odoo.py
+++ b/tests/unit/test_sources_odoo.py
@@ -1,0 +1,56 @@
+"""Tests du domaine de sélection de `lignes_factures_du_mois` (#561).
+
+Les tests du service facturation mockent la fonction entière : le domaine Odoo
+n'était exercé nulle part — c'est ainsi que « fenêtre par date seule » a pu rendre
+les brouillons de campagne invisibles pendant toute une campagne. Ici on capture
+le domaine réellement passé au `follow('invoice_ids')`.
+"""
+
+import polars as pl
+
+from electricore.integrations.odoo import sources
+
+
+class _QueryStub:
+    """Enregistre les appels follow/enrich, rend un LazyFrame au schéma minimal."""
+
+    def __init__(self, calls: list) -> None:
+        self.calls = calls
+
+    def follow(self, field, domain=None, fields=None, **kwargs):
+        self.calls.append((field, domain))
+        return self
+
+    def enrich(self, field, domain=None, fields=None, **kwargs):
+        self.calls.append((field, domain))
+        return self
+
+    def lazy(self) -> pl.LazyFrame:
+        # Colonnes minimales pour que `_expr_est_brouillon()` et le rename passent.
+        return pl.DataFrame(
+            schema={
+                "x_invoicing_state": pl.Utf8,
+                "state_account_move": pl.Utf8,
+                "x_ref_situation_contractuelle": pl.Utf8,
+                "name_product_category": pl.Utf8,
+                "quantity": pl.Float64,
+            }
+        ).lazy()
+
+
+def test_lignes_factures_du_mois_inclut_les_brouillons_hors_fenetre(monkeypatch):
+    """#561 : les brouillons de campagne naissent sans `invoice_date` — la sélection
+    doit être « fenêtre du mois OU brouillon », sinon la campagne est invisible."""
+    calls: list = []
+    monkeypatch.setattr(sources, "query", lambda odoo, model, domain=None, fields=None: _QueryStub(calls))
+
+    sources.lignes_factures_du_mois(object(), "2026-06-01").collect()
+
+    domaine_factures = next(domain for field, domain in calls if field == "invoice_ids")
+    assert domaine_factures == [
+        "|",
+        "&",
+        ("invoice_date", ">=", "2026-06-01"),
+        ("invoice_date", "<", "2026-07-01"),
+        ("state", "=", "draft"),
+    ]

--- a/tests/unit/test_sources_odoo.py
+++ b/tests/unit/test_sources_odoo.py
@@ -1,9 +1,14 @@
-"""Tests du domaine de sélection de `lignes_factures_du_mois` (#561).
+"""Tests du domaine de sélection de `lignes_factures_du_mois` (#561, ADR-0054).
 
 Les tests du service facturation mockent la fonction entière : le domaine Odoo
 n'était exercé nulle part — c'est ainsi que « fenêtre par date seule » a pu rendre
 les brouillons de campagne invisibles pendant toute une campagne. Ici on capture
 le domaine réellement passé au `follow('invoice_ids')`.
+
+Convention date-ancre (ADR-0054) : Odoo pose `invoice_date = 05/(M+1)` sur tous
+les brouillons de la campagne du mois M. La sélection lit cette même ancre par
+égalité stricte — plus de fenêtre, plus d'avalement silencieux des brouillons
+sans date (une violation de la convention doit être visible, pas absorbée).
 """
 
 import polars as pl
@@ -38,19 +43,32 @@ class _QueryStub:
         ).lazy()
 
 
-def test_lignes_factures_du_mois_inclut_les_brouillons_hors_fenetre(monkeypatch):
-    """#561 : les brouillons de campagne naissent sans `invoice_date` — la sélection
-    doit être « fenêtre du mois OU brouillon », sinon la campagne est invisible."""
+def test_date_ancre_05_du_mois_suivant():
+    """Conso de juin → ancre 05/07 (#561, ADR-0054)."""
+    assert sources.date_ancre("2026-06-01") == "2026-07-05"
+
+
+def test_date_ancre_rollover_decembre():
+    """Conso de décembre N → ancre 05/01/(N+1)."""
+    assert sources.date_ancre("2026-12-01") == "2027-01-05"
+
+
+def test_lignes_factures_du_mois_selectionne_par_egalite_stricte_sur_l_ancre(monkeypatch):
+    """#561/ADR-0054 : sélection par égalité stricte sur `invoice_date`, plus de fenêtre."""
     calls: list = []
     monkeypatch.setattr(sources, "query", lambda odoo, model, domain=None, fields=None: _QueryStub(calls))
 
     sources.lignes_factures_du_mois(object(), "2026-06-01").collect()
 
     domaine_factures = next(domain for field, domain in calls if field == "invoice_ids")
-    assert domaine_factures == [
-        "|",
-        "&",
-        ("invoice_date", ">=", "2026-06-01"),
-        ("invoice_date", "<", "2026-07-01"),
-        ("state", "=", "draft"),
-    ]
+    assert domaine_factures == [("invoice_date", "=", "2026-07-05")]
+
+
+def test_lignes_factures_du_mois_rollover_decembre(monkeypatch):
+    calls: list = []
+    monkeypatch.setattr(sources, "query", lambda odoo, model, domain=None, fields=None: _QueryStub(calls))
+
+    sources.lignes_factures_du_mois(object(), "2026-12-01").collect()
+
+    domaine_factures = next(domain for field, domain in calls if field == "invoice_ids")
+    assert domaine_factures == [("invoice_date", "=", "2027-01-05")]


### PR DESCRIPTION
## Résumé

Remplace le palliatif « fenêtre OU brouillon » par une sélection par
date-ancre : Odoo pose `invoice_date = 05/(M+1)` sur toute la campagne de
facturation du mois M (rollover décembre → 05/01/(N+1)), et
`lignes_factures_du_mois` sélectionne désormais par égalité stricte sur
cette date-ancre — une clé, plus de fenêtre, plus d'avalement silencieux
d'un `state=draft` errant. Convention documentée en
[ADR-0054](docs/adr/0054-convention-date-ancre-campagne-facturation.md) et
glossaire `integrations/odoo/CONTEXT.md`. `date_ancre()` est la petite
fonction réutilisable reprise par le check pré-campagne de la PR de
l'issue #564 (stackée sur celle-ci).

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)
