### PR TITLE
docs : charpente du chemin par rôles — ADR escalier, nav 5 sections, accueil 5 portes, charte, README panneau

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/Energie-De-Nantes/electricore/actions/workflows/ci.yml/badge.svg)](https://github.com/Energie-De-Nantes/electricore/actions/workflows/ci.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](pyproject.toml)
-[![Polars](https://img.shields.io/badge/data-Polars%20%2B%20DuckDB-9C27B0.svg)](docs/adr/0002-polars-uniquement.md)
+[![Polars](https://img.shields.io/badge/data-Polars%20%2B%20DuckDB-9C27B0.svg)](https://energie-de-nantes.github.io/electricore/adr/0002-polars-uniquement/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Docs](https://img.shields.io/badge/docs-site-blue)](https://energie-de-nantes.github.io/electricore/)
 
@@ -16,425 +16,41 @@ taxes — exposées via une **API REST** pour Odoo, des notebooks et tout outil 
 > ce qu'il facture, à partir de la donnée brute Enedis, sans dépendre des agrégats
 > « moisniversaire » du distributeur — inexploitables pour une facturation au mois calendaire.
 
-**Stack** : Polars + DuckDB (zéro pandas, [ADR-0002](docs/adr/0002-polars-uniquement.md)),
-ingestion ELT dlt + dbt, FastAPI, Pandera pour la validation.
-**Langue** : tout le code et la doc sont en français — le domaine (Enedis, CRE, TURPE, accise)
-l'est intrinsèquement ([ADR-0004](docs/adr/0004-langue-francaise.md)).
+**Stack** : Polars + DuckDB (zéro pandas), ingestion ELT dlt + dbt, FastAPI, Pandera. Tout le code
+et la doc sont en français — le domaine (Enedis, CRE, TURPE, accise) l'est intrinsèquement.
 
 ---
 
-## 🏗️ Architecture
+## 📖 Documentation — 5 portes, une par rôle
 
-```mermaid
-graph TB
-    SFTP[/SFTP Enedis<br/>flux chiffrés AES\]
-    ODOO[(Odoo ERP)]
+Le [site de documentation](https://energie-de-nantes.github.io/electricore/) est rangé par rôle
+de lecture, en escalier (quoi → comment s'en servir → comment c'est fait → comment le faire
+évoluer) :
 
-    SFTP -->|dlt : déchiffre · dézippe · parse| RAW[(DuckDB · flux_raw<br/>brut JSON, 1 ligne/fichier)]
-    RAW -->|dbt : linéarisation SQL| FLUX[(DuckDB · flux_enedis<br/>flux_* + marts spine/releves)]
-
-    FLUX -->|loaders SELECT *| CORE[Pipelines core<br/>Polars LazyFrame]
-    ODOO -->|OdooReader · lecture| CORE
-    CORE -->|builds| API
-    FLUX --> API[API REST<br/>FastAPI]
-
-    API -->|JSONL · Arrow · XLSX| CLIENT[electricore-client<br/>notebooks · souscriptions_odoo]
-    API <-->|in-process| BOT[Bot Telegram]
-    NB[Notebooks opérateur] -->|écriture validée à la main| ODOO
-
-    style API fill:#4CAF50,stroke:#2E7D32,color:#fff
-    style FLUX fill:#1976D2,stroke:#0D47A1,color:#fff
-    style RAW fill:#1976D2,stroke:#0D47A1,color:#fff
-    style ODOO fill:#FF9800,stroke:#E65100,color:#fff
-    style CORE fill:#9C27B0,stroke:#4A148C,color:#fff
-```
-
-Deux principes structurants :
-
-- **L'API est le hub.** Bot, notebooks, intégrations et clients externes passent tous par l'API
-  REST ; DuckDB, les pipelines `core/` et les adaptateurs ERP sont des composants internes
-  ([ADR-0009](docs/adr/0009-architecture-api-centrique.md)). L'API est en **lecture seule** vis-à-vis
-  d'Odoo : toute écriture est appliquée à la main par un opérateur, depuis un notebook
-  ([ADR-0012](docs/adr/0012-api-read-only-odoo.md)).
-- **`core/` est strictement ERP-agnostique.** Il ne dépend que de Polars/DuckDB/Pandera/stdlib —
-  garanti par un test de pureté CI. Tout adaptateur ERP vit dans `integrations/`
-  ([ADR-0016](docs/adr/0016-core-erp-agnostique.md)).
-
-### Les modules en un coup d'œil
-
-| Module | Rôle | Doc |
-|--------|------|-----|
-| 📥 **`ingestion/`** | ELT dlt + dbt : SFTP Enedis → DuckDB (déchiffrement AES, landing brut, linéarisation SQL) | [README](electricore/ingestion/README.md) · [docs/ingestion.md](docs/ingestion.md) |
-| 🧮 **`core/`** | Calculs énergétiques en Polars pur (`loaders` · `pipelines` · `builds` · `models`), ERP-agnostique | [CONTEXT.md](electricore/core/CONTEXT.md) |
-| 🔌 **`integrations/odoo/`** | Adaptateur Odoo : `OdooReader` / `OdooQuery` / `OdooWriter` | [Query Builder Odoo](docs/odoo-query-builder.md) |
-| 🌐 **`api/`** | API REST FastAPI : flux, relevés, taxes, facturation, chronologie, ingestion | [README](electricore/api/README.md) |
-| 🤖 **`bot/`** | Bot Telegram : UI opérationnelle, client de l'API (zéro logique métier) | [README](electricore/bot/README.md) |
-| ⚙️ **`config/`** | Registre runtime pydantic-settings + règles tarifaires CSV (TURPE, accise, CTA) | [ADR-0024](docs/adr/0024-trois-registres-de-savoir.md)/[0025](docs/adr/0025-registre-runtime-pydantic-settings.md) |
-| 📦 **`packages/electricore-client/`** | **Client léger distribué séparément** (PyPI) : httpx + pydantic, flux JSONL typé | [README](packages/electricore-client/README.md) · [ADR-0043](docs/adr/0043-electricore-client-paquet-separe.md) |
-
-> `electricore/operator_launcher.py` (commande `electricore-notebooks`) est un **pont
-> transitoire** vers les notebooks opérateur (voir la section Notebooks plus bas).
-> Le dossier `electricore/client/` est un résidu vide : le vrai client est
-> `packages/electricore-client/`.
-
----
+- **[Comprendre](https://energie-de-nantes.github.io/electricore/comprendre/)** — ce qu'ElectriCore
+  calcule et pourquoi, pour un public non technique.
+- **[Facturer](https://energie-de-nantes.github.io/electricore/facturiste/changelog-facturiste/)** —
+  le cycle de facturation au quotidien, bot Telegram et notebooks.
+- **[Déployer](https://energie-de-nantes.github.io/electricore/deployer/)** — installer et
+  administrer une instance (VPS, Docker Compose, secrets).
+- **[Contribuer](https://energie-de-nantes.github.io/electricore/contribuer/)** — architecture,
+  exemples de code, patterns, installation dev et tests.
+- **[Maintenir](https://energie-de-nantes.github.io/electricore/maintenir/)** — décisions
+  d'architecture, releases, suivi réglementaire.
 
 ## 🚀 Démarrage rapide
-
-### Prérequis
-
-- Python 3.12+ et [uv](https://docs.astral.sh/uv/getting-started/installation/)
 
 ```bash
 git clone https://github.com/Energie-De-Nantes/electricore.git
 cd electricore
+uv sync   # runtime : core + API + bot (voir la section Contribuer pour les extras)
 
-uv sync                                   # runtime : core + API + bot
-uv sync --extra ingestion --extra dbt     # + ingestion SFTP (dlt + dbt)
-uv sync --extra viz                        # + libs notebooks (marimo, altair, plotly)
-uv sync --extra ingestion --extra dbt --extra viz   # dev local complet
-```
-
-### 1. Ingérer les flux Enedis → DuckDB
-
-```bash
-uv run --extra ingestion --extra dbt python -m electricore.ingestion test   # smoke : 2 fichiers/flux
-uv run --extra ingestion --extra dbt python -m electricore.ingestion r151    # un flux
-uv run --extra ingestion --extra dbt python -m electricore.ingestion all     # production : tous les flux
-uv run --extra ingestion --extra dbt python -m electricore.ingestion rebuild # dbt seul (zéro réseau, ~13 s)
-```
-
-Résultat : la base `electricore/ingestion/flux_enedis_pipeline.duckdb` (schéma `flux_raw` pour le
-brut, `flux_enedis` pour les tables linéarisées et les marts). Voir [docs/ingestion.md](docs/ingestion.md).
-
-### 2. Calculer une facturation mensuelle (core)
-
-```python
-from electricore.core.builds.contexte_mensuel import contexte_du_mois
-
-# Compose : spine/chronologie (dbt) → historique → abonnements + énergie → facturation
-ctx = contexte_du_mois("2026-05-01")   # None → dernier mois disponible
-
-ctx.facturation_mensuelle   # méta-périodes mensuelles agrégées (validé Pandera)
-ctx.abonnements             # périodes d'abonnement + TURPE fixe
-ctx.energie                 # périodes d'énergie par cadran + TURPE variable
-ctx.releves_utilises        # relevés tracés = relevés utilisés (traçabilité d'index, ADR-0038)
-ctx.historique_enrichi      # substrat d'événements filtré sur l'horizon
-```
-
-Les loaders DuckDB sont des **query builders fluides immuables** ([ADR-0007](docs/adr/0007-query-builders.md))
-qui poussent les filtres dans le `WHERE` :
-
-```python
-from electricore.core.loaders import c15, r151, releves, spine, chronologie
-
-historique = c15().filter({"Date_Evenement": ">= '2024-01-01'"}).limit(100).collect()
-tous_releves = releves().filter({"prm": ["PDL123"]}).collect()   # mart canonique (ADR-0029)
-```
-
-> Fonctions disponibles : `c15()`, `r151()`, `r15()`, `f15()`, `r64()` (flux Enedis bruts) et
-> `releves()`, `spine()`, `chronologie()`, `affaires()` (marts transverses).
-
-### 3. Consommer l'API
-
-```bash
 uv run uvicorn electricore.api.main:app --reload
 curl http://localhost:8000/health
-curl -H "X-API-Key: votre_cle" "http://localhost:8000/releves?prm=12345678901234&limit=10"
-open http://localhost:8000/docs   # Swagger interactif
 ```
 
-Depuis un consommateur externe, le **client léger** typé (paquet PyPI distinct) évite de tirer
-polars/duckdb/fastapi :
-
-```bash
-pip install electricore-client            # base : httpx + pydantic
-pip install "electricore-client[arrow]"   # + client Arrow (DataFrames polars)
-```
-
-```python
-from electricore_client import ElectricoreClient
-
-client = ElectricoreClient(url="https://electricore.example", api_key="…")
-
-# Méta-périodes : flux JSONL typé, sans enveloppe ni pagination
-with client.meta_periodes(mois="2026-05-01", rsc=["RSC1"]) as flux:
-    for periode in flux:        # PeriodeMeta (releves_utilises imbriqués, source_hash)
-        ...
-
-# Chronologie facturiste : faits + verdicts, sans montant
-with client.chronologie(pdl="12345678901234") as flux:
-    lignes = flux.collect()
-```
-
-### 4. Piloter via le bot Telegram
-
-L'exploitation quotidienne (ingestion, exports, taxes, contrôles pré-facturation) passe par un
-bot Telegram ([ADR-0010](docs/adr/0010-bot-telegram-ui-operationnelle.md)) démarré dans le process
-de l'API quand `BOT__TOKEN` est défini. Cinq domaines : `/ingestion`, `/flux`,
-`/perimetre`, `/taxes`, `/facturation` (sans argument = clavier découvrable ; avec argument =
-action directe). Voir le [README du bot](electricore/bot/README.md).
-
----
-
-## 🗃️ Modèle de données — la spine assemblée en dbt
-
-Le changement structurant récent ([ADR-0041](docs/adr/0041-chronologie-contrat-spine-relationnelle-dbt.md),
-[ADR-0045](docs/adr/0045-relations-spine-reference-cle-normalisation-chronologie-releves.md)) tient
-en une phrase : **le cœur consomme, dbt assemble**. La *Chronologie du contrat* — la séquence
-ordonnée des faits d'une situation contractuelle — n'est plus reconstruite dans des DataFrames
-Polars ; c'est une **spine relationnelle assemblée entièrement en dbt**, que le cœur se contente
-de **filtrer et découper**.
-
-Trois marts dbt forment le substrat (schéma `flux_enedis`, exposés hors du namespace `/flux`,
-[ADR-0032](docs/adr/0032-modeles-marts-hors-flux-namespace.md)) :
-
-- **`releves`** — la ligne de temps **canonique** des relevés : union arbitrée des sources
-  (priorité `C15 > R64 > R151`), dédupliquée par **identité métier** du relevé, harmonisation
-  R151 J→J+1 portée ici, `releve_id` = clé courte stable. Source de vérité unique des valeurs
-  d'index ([ADR-0028](docs/adr/0028-identite-releve-cle-metier-priorite-sources.md)/[0029](docs/adr/0029-modele-releves-canonique-dbt-assemble-coeur-arbitre.md)).
-- **`spine_contrat`** — l'épine `(pdl, ref_situation_contractuelle, date, source, type_fait)` :
-  événements C15 ∪ grille FACTURATION calendaire (1ᵉʳ de chaque mois), avec les **attributs de
-  situation forward-fillés en SQL** (FTA, puissance, niveau d'ouverture…).
-- **`chronologie_releves`** — la projection énergie de la spine : bornes FACTURATION appariées
-  aux relevés périodiques au **grain jour** (equi-join, l'ancien `join_asof` ±4 h a disparu du cœur).
-
-Les marts sont **indépendants de l'horizon** ; l'horizon n'est qu'un **filtre** posé au boundary du
-cœur, ce qui préserve la pureté (deux runs à horizon fixe découpent identiquement). Une seule
-spine, **N frises** : le substrat est partagé, mais les découpages **abonnement** et **énergie**
-restent séparés ([ADR-0023](docs/adr/0023-periodisations-separees-abonnement-energie.md)) — ils se
-croisent, ils ne s'imbriquent pas.
-
-### Vocabulaire essentiel
-
-- **PDL** : point de livraison physique (14 chiffres, un Linky). **RSC** : situation contractuelle
-  d'un PDL — c'est le **grain de facturation** (un PDL qui change de RSC en cours de mois porte deux
-  méta-périodes). **FTA** : formule tarifaire d'acheminement (sélectionne la grille TURPE et le
-  nombre de cadrans).
-- **Chronologie du contrat (RSC)** vs **Chronologie du point (PDL)** vs **Chronologie des relevés**
-  (projection énergie). Chaque périodisation est `filtre(spine) ⨝ relation`.
-- **Cadrans** (convention `grandeur_cadran_unité`) : `base` ; `hp`/`hc` ; `hph`/`hch`/`hpb`/`hcb`
-  (4 quadrants saison × heures). Index en kWh **entiers** (floor au boundary dbt,
-  [ADR-0034](docs/adr/0034-index-kwh-entiers-floor-au-boundary-dbt.md)).
-- **TURPE fixe** (part puissance) vs **variable** (part énergie). **Accise** (TICFE) et **CTA**
-  (taxe sur le TURPE fixe). Règle d'intégration : electricore livre le **montant €** quand il
-  possède l'assiette, le **taux** sinon ([ADR-0027](docs/adr/0027-endpoint-lecture-meta-periodes-odoo-tire.md)).
-- **Qualité de période** (`réelle`/`estimée`/`incalculable`, [ADR-0033](docs/adr/0033-qualite-periode-remplace-data-complete-coverage.md))
-  et **statut de communication** (`communicante`/`non_communicante`, [ADR-0036](docs/adr/0036-statut-communication-routage-energie-grain-meta.md)) :
-  l'effet et la cause, deux axes jumeaux remplaçant les anciens `data_complete`/`coverage`.
-
-Détails : [docs/contrat-meta-periodes.md](docs/contrat-meta-periodes.md),
-[docs/conventions-dates-enedis.md](docs/conventions-dates-enedis.md),
-[docs/qualite-donnees-r151.md](docs/qualite-donnees-r151.md), et le glossaire
-[`electricore/core/CONTEXT.md`](electricore/core/CONTEXT.md).
-
----
-
-## 📡 API REST
-
-Authentification par en-tête **`X-API-Key`** (endpoints publics : `/`, `/health`, `/docs`,
-`/redoc`, `/openapi.json`). Pendant une ingestion, les routes de lecture renvoient `503` le temps
-que le writer DuckDB relâche le verrou.
-
-| Route | Rôle |
-|-------|------|
-| `GET /health`, `GET /` | Statut, fraîcheur de la base, tables disponibles (public) |
-| `GET /flux/{table}` · `/info` · `.xlsx` · `.arrow` | Flux Enedis bruts (JSON paginé, Arrow, XLSX) |
-| `GET /releves` · `/info` · `.xlsx` · `.arrow` | Mart canonique des relevés (ADR-0029) |
-| `GET /perimetre/affaires` | Cockpit des affaires SGE ouvertes (X12/X13) |
-| `POST /ingestion/run` · `GET /ingestion/jobs` · `/jobs/{id}` | Déclencher et suivre les jobs d'ingestion |
-| `GET /taxes/millesimes` · `/peremption` | Millésimes et péremption des taux régulés (sans ERP) |
-| `GET /taxes/accise/*` · `/cta/*` | Rapports & détails Accise / CTA (XLSX, Arrow) — *requiert Odoo* |
-| **`GET /facturation/meta-periodes`** | Méta-périodes mensuelles en **flux JSONL typé** |
-| **`GET /facturation/chronologie`** | Frise facturiste d'un `pdl` ou `rsc` (faits + verdicts, **sans montant**) |
-| **`POST /facturation/turpe-variable`** | Calculateur TURPE variable (RPC typé, l'appelant fournit l'assiette) |
-| `GET /facturation/rapport.xlsx` · `documents.xlsx` · `check/odoo` | Rapports & contrôles pré-facturation — *requiert Odoo* |
-| `GET /admin/api-keys` | Configuration des clés API |
-
-Les routes **JSONL** (`meta-periodes`, `chronologie`) répondent une ligne JSON par objet, **sans
-enveloppe ni pagination** ; les métadonnées (version de contrat, mois, grain) voyagent en en-têtes
-HTTP. Chaque ligne est validée en construisant le modèle pydantic — impossible d'émettre une ligne
-hors contrat. Les routes marquées *requiert Odoo* renvoient `501` et sont masquées du bot sur une
-instance sans ERP. Détails : [README de l'API](electricore/api/README.md).
-
----
-
-## 📓 Notebooks & lanceur opérateur
-
-Les notebooks [Marimo](notebooks/) (réactifs, Polars, [ADR-0002](docs/adr/0002-polars-uniquement.md))
-servent deux publics. En **dev** :
-
-```bash
-uv run marimo edit notebooks/   # édition complète (pipelines, validations TURPE, exploration Odoo)
-```
-
-Pour un **opérateur non-dev**, un pont transitoire ([#414](https://github.com/Energie-De-Nantes/electricore/issues/414))
-sert les notebooks Odoo opérationnels (`accueil`, `injection_rsc`, `facturation`) en applications
-marimo **lecture seule**, sans git ni code (le moteur est publié sur PyPI) :
-
-```bash
-uv tool install 'electricore[notebooks]'           # fournit la commande electricore-notebooks
-cd <dossier-contenant-le-.env-livré> && electricore-notebooks
-```
-
-L'opérateur reçoit un `.env` **livré à la main** (clé API partagée en lecture + **son propre**
-login Odoo `ODOO__*`) et le dépose dans son dossier de travail — le launcher lit le `.env` du
-**répertoire courant**. Les notebooks qui écrivent dans Odoo gardent un **mode simulation activé
-par défaut** et un bouton « Injecter dans Odoo » explicite. Ce lanceur est voué à disparaître à
-l'arrivée de `souscriptions_odoo`.
-
-> **Runbook complet** : [docs/operateur-notebook.md](docs/operateur-notebook.md) — install,
-> `.env`, lancement, et pourquoi l'opérateur ne rejoint pas le schéma secrets-as-code.
-
----
-
-## 📦 Déploiement en production
-
-ElectriCore tourne en **stack Docker Compose** sur un VPS, une instance par fournisseur
-([ADR-0011](docs/adr/0011-deploiement-vps-docker.md)/[0015](docs/adr/0015-deploiement-multi-instance.md)) :
-trois conteneurs (API + bot in-process, scheduler d'ingestion cron, reverse-proxy Caddy avec TLS
-automatique). L'ingestion n'est **pas** continue — c'est un cron nocturne qui appelle l'API.
-
-Un script provisionne tout depuis un VPS Ubuntu/Debian frais (~5-10 min), durcissement SSH inclus
-([ADR-0031](docs/adr/0031-durcissement-ssh-vps-utilisateur-ops.md)) :
-
-```bash
-ssh root@<vps>
-curl -fsSL https://raw.githubusercontent.com/Energie-De-Nantes/electricore/main/deploy/install.sh -o install.sh
-sudo bash install.sh \
-    --slug <slug> --domain <slug>.electricore.fr --email ops@example.com \
-    --deploy-repo git@github.com:Energie-De-Nantes/electricore-secrets.git
-```
-
-Le script crée un user système dédié, installe Docker, configure UFW, télécharge la stack
-tag-pinnée sous `/srv/<slug>/` ([ADR-0017](docs/adr/0017-layout-deploiement-srv-slug.md)), génère
-l'identité **age** de la box puis pull la config (`config.env` clair + `secrets.env` chiffré
-SOPS+age) depuis le dépôt de déploiement privé, **valide le split et déchiffre**, vérifie le DNS,
-démarre les conteneurs et lance une ingestion test. Sauvegardes DuckDB nocturnes (`EXPORT DATABASE`, rétention 14 jours).
-Relancer avec le même `--slug` = mode reconfiguration (rotation des clés AES, bump de version…),
-sans toucher à la base.
-
-Guide complet : [docs/deploiement.md](docs/deploiement.md).
-
-### Configuration & secrets-as-code
-
-La config runtime est un **registre pydantic-settings** par domaine (`sftp`/`aes`/`duckdb`/`api`/
-`bot`/`odoo`), avec validation fail-fast par point d'entrée
-([ADR-0024](docs/adr/0024-trois-registres-de-savoir.md)/[0025](docs/adr/0025-registre-runtime-pydantic-settings.md)).
-En **dev** (`uv run`), elle se lit depuis un simple `.env`.
-
-En **production**, les secrets passent en **secrets-as-code**
-([ADR-0044](docs/adr/0044-secrets-as-code-sops-age.md), récemment adopté — bascule de l'instance
-vivante à la prochaine release). Le `.env` se scinde en deux fichiers versionnés dans un dépôt de
-déploiement **privé**, et chaque box génère sa propre identité **age** :
-
-- **`config.env`** — config CLAIRE (substitutions compose `ELECTRICORE_VERSION`/`BACKUPS_PATH`,
-  `INSTANCE_SLUG`, `BOT__NOTIFY_CHAT_ID`) ;
-- **`secrets.env`** — credentials **chiffrés SOPS + age**, déchiffrés à l'**entrypoint de l'image**
-  (`sops exec-env` — jamais de fichier en clair). Le layout `providers/<slug>/` isole chaque
-  fournisseur cryptographiquement (une box ne déchiffre que les siens).
-
-```bash
-# config.env — CLAIR, versionné (substitutions compose + config non-secrète)
-INSTANCE_SLUG=monfournisseur
-ELECTRICORE_VERSION=latest
-BACKUPS_PATH=/srv/monfournisseur/backups
-BOT__NOTIFY_CHAT_ID=-1001234567890                # canal d'alerte du bot (optionnel)
-
-# secrets.env — CHIFFRÉ (SOPS + age) : uniquement des credentials
-API__TROUSSEAU__librewatt__KEY=cle_consommateur_32_caracteres   # 1 clé/consommateur, label dynamique
-SFTP__URL=sftp://utilisateur:mot_de_passe@hote:22/chemin
-BOT__TOKEN=token_botfather                        # bot = process de l'API
-ODOO__URL=https://votre-instance.odoo.com         # + __DB / __USERNAME / __PASSWORD
-# Trousseau de clés AES (ADR-0037/0040) : un <label> parlant par clé, sélection par essai.
-# __IV optionnel : absent ⇒ schéma IV-préfixé (AES-256) ; présent ⇒ IV-fixe (AES-128).
-AES__TROUSSEAU__aes256_2026__KEY=cle_hex_64        # AES-256 : pas de __IV
-# AES__TROUSSEAU__aes128_2024__KEY=ancienne_cle / __IV=ancien_iv   # AES-128 historique
-```
-
-Inventaire complet des variables : [docs/configuration.md](docs/configuration.md) · procédure de
-déploiement : [docs/deploiement.md](docs/deploiement.md) · gabarit d'exemple :
-[`deploy/providers/example/`](deploy/providers/example/).
-
-**Rotation des clés AES** : éditer le `secrets.env` chiffré (`sops providers/<slug>/secrets.env`),
-ajouter la nouvelle clé sous un nouveau label, garder les anciennes, commit → pull → restart — chaque
-fichier déchiffre par essai avec la clé qui marche ; un flux qui a des fichiers mais **0 déchiffrement
-réussi** fait passer le job à `failed` et alerte le bot
-([ADR-0037](docs/adr/0037-trousseau-cles-aes-n-cles-selection-par-essai.md)/[0040](docs/adr/0040-schema-dechiffrement-aes-iv-prefixe.md)).
-
----
-
-## 🧪 Développement & tests
-
-```bash
-# Setup dev recommandé
-uv sync --extra ingestion --extra dbt --group test --group typecheck
-
-uv run --group test pytest              # suite complète (~30 s)
-uv run --group test pytest -n auto      # exécution parallèle (pytest-xdist)
-uv run --group test pytest -m unit      # markers : unit/integration/slow/smoke/duckdb/odoo/hypothesis
-uv run --group test pytest --cov=electricore   # couverture (plancher CI : 45 %)
-
-uvx ruff check --fix ; uvx ruff format  # lint + format
-uv run --group typecheck mypy           # typage (surface publique core/)
-uvx pre-commit install                  # hooks ruff/gitleaks (+ --hook-type pre-push pour pytest)
-```
-
-Près de **800 fonctions de test** réparties sur 119 fichiers, sans secret requis (les tests
-dépendant d'Odoo s'auto-skippent). Couverture : fixtures + snapshots Syrupy (gros du filet),
-tests d'expressions Polars, contrats Pandera, et property-based Hypothesis ; **golden d'ingestion**
-générés depuis les XSD Enedis (parité dbt garantie en CI) ; **tests d'architecture** verrouillant
-la pureté ERP du cœur ([ADR-0016](docs/adr/0016-core-erp-agnostique.md)) et les imports par rôle
-([ADR-0019](docs/adr/0019-roles-loaders-pipelines-builds-integrations.md)).
-
-**CI** (GitHub Actions) : lint + typecheck + tests (matrice Python 3.12/3.13), plus un job
-`test-client` qui prouve en venv isolé que `electricore-client` ne tire ni polars ni duckdb ni
-fastapi. Les **releases** publient l'image `ghcr.io/energie-de-nantes/electricore` (sur tag `v*`,
-build → scan secrets → smoke → push) et le client sur PyPI via OIDC (sur tag `client-v*`, versionné
-indépendamment).
-
-**Contribution** : `main` est protégé. Brancher → commit (Conventional Commits en français) →
-pousser → ouvrir une PR → la CI tourne → **le merge est une étape humaine** sur le site. Détails :
-[CONTRIBUTING.md](CONTRIBUTING.md). Nouvel arrivant (profil Rust/Java) :
-[docs/transmission.md](docs/transmission.md).
-
----
-
-## 🗺️ Roadmap
-
-Le corps de ce README décrit la **réalité livrée** sur `main`. Les directions en cours :
-
-- **Protection des secrets au repos** — follow-ups de la bascule secrets-as-code
-  ([ADR-0044](docs/adr/0044-secrets-as-code-sops-age.md), déjà mergée pour le mécanisme) : chiffrement
-  disque (LUKS + Tang/NBDE), isolation `raw.db`/`serve.db`, durcissement DuckDB de l'API, et OpenBao
-  quand la flotte le justifiera.
-- **`souscriptions_odoo`** — addon qui consommera l'API via `electricore-client` et **remplacera**
-  le lanceur de notebooks opérateur transitoire.
-- **Régularisation des contrats lissés** — recalcul a posteriori des contrats facturés au lissé
-  ([#191](https://github.com/Energie-De-Nantes/electricore/issues/191)).
-- **Estimation des périodes non-communicantes via R15**
-  ([#322](https://github.com/Energie-De-Nantes/electricore/issues/322)).
-- **Nouvelles sources** — API SOAP Enedis (alternative SFTP), courbes Axpo, autres fournisseurs.
-
-Le suivi se fait en [issues GitHub](https://github.com/Energie-De-Nantes/electricore/issues) et en
-[décisions d'architecture](docs/adr/).
-
----
-
-## 📚 Documentation
-
-- **Décisions d'architecture** — [docs/adr/](docs/adr/) (45 ADR : monorepo, Polars, DuckDB, dlt+dbt,
-  API-centrique, core ERP-agnostique, spine/chronologie, client séparé, trousseau AES…)
-- **Carte des contextes** — [CONTEXT-MAP.md](CONTEXT-MAP.md) + `CONTEXT.md` par module
-- **Ingestion** — [README module](electricore/ingestion/README.md) · [docs/ingestion.md](docs/ingestion.md)
-- **API & client** — [README API](electricore/api/README.md) · [README client](packages/electricore-client/README.md)
-- **Bot** — [README bot](electricore/bot/README.md)
-- **Modèle de données** — [contrat méta-périodes](docs/contrat-meta-periodes.md) · [conventions de dates](docs/conventions-dates-enedis.md) · [qualité R151](docs/qualite-donnees-r151.md)
-- **Odoo** — [Query Builder Odoo](docs/odoo-query-builder.md)
-- **Déploiement & config** — [docs/deploiement.md](docs/deploiement.md) · [docs/configuration.md](docs/configuration.md)
-- **Onboarding** — [docs/transmission.md](docs/transmission.md)
-
----
+Détails d'installation, ingestion, pipelines et API : voir
+[Contribuer → Développer](https://energie-de-nantes.github.io/electricore/contribuer/developper/).
 
 ## 📄 Licence
 

--- a/docs/adr/0054-chemin-documentation-roles-escalier.md
+++ b/docs/adr/0054-chemin-documentation-roles-escalier.md
@@ -1,0 +1,82 @@
+# ADR-0054 — Chemin de documentation par rôles, en escalier
+
+## Statut
+
+Accepté — PRD [#555](https://github.com/Energie-De-Nantes/electricore/issues/555), tranche
+charpente [#556](https://github.com/Energie-De-Nantes/electricore/issues/556).
+
+- **Prolonge** [ADR-0024](0024-trois-registres-de-savoir.md) (trois registres de savoir : code,
+  ADRs, glossaires `CONTEXT.md`) — ce chantier les rend **découvrables**, il ne les déplace pas.
+- **S'appuie sur** la lecture « EDN est le premier prototype d'une fédération de communs de
+  l'électricité » (ADR-0024) : la documentation s'adresse à plusieurs publics d'un commun, pas
+  aux seuls contributeurs de code.
+
+## Contexte
+
+La documentation d'ElectriCore avait dérivé en deux masses sans porte d'entrée par public :
+
+- un `README.md` de 448 lignes qui mélange pitch, architecture, exemples de code, déploiement
+  VPS, secrets-as-code, notebooks, dev/tests et roadmap dans un seul document linéaire ;
+- un `docs/` d'une vingtaine de fichiers techniques, dont 4 seulement raccordés à une nav MkDocs
+  plate (`Accueil`, `Guide facturiste`, `Bot Telegram`, `Notebook opérateur`) — les ~15 autres
+  (déploiement, configuration, ingestion, conventions de dates…) n'existent que par lien croisé,
+  sans jamais apparaître dans le site publié.
+
+Aucun des deux ne répond à « je suis opérateur·ice, où est mon guide ? » ou « je veux déployer
+une instance, par où commencer ? » sans déjà savoir où chercher. Le PRD #555 pose 5 rôles de
+lecture (vocabulaire des communs) : usager·ère, opérateur·ice, déployeur·euse, contributeur·ice,
+mainteneur·e — et un principe d'**escalier** : un sujet transverse (ex. TURPE) existe à plusieurs
+étages, chaque étage racontant autre chose (quoi → comment s'en servir → comment c'est fait →
+comment le faire évoluer), avec des passerelles montantes en pied de page. Duplication assumée
+mais bornée par ces passerelles, plutôt que par une strate unique qui n'appartient à personne.
+
+## Décision
+
+1. **Nav MkDocs à 5 sections par rôle** — `Comprendre` (usager·ère), `Facturer` (opérateur·ice),
+   `Déployer` (déployeur·euse), `Contribuer` (contributeur·ice), `Maintenir` (mainteneur·e) — plus
+   `Accueil` en tête, hors section. Les 3 pages existantes du site (`changelog-facturiste`,
+   `guide-bot-facturiste`, `operateur-notebook`) rejoignent `Facturer` ; `index.md` devient la
+   porte d'entrée à 5 sorties plutôt qu'une 4ᵉ page métier.
+2. **L'accueil oriente, il n'explique pas** : une phrase par rôle, un lien vers sa section.
+3. **Une charte publiée dans `Contribuer`** fixe par écrit les 5 rôles et le principe d'escalier
+   (au lieu de les enterrer dans cet ADR), plus la charte éditoriale : point médian partout,
+   tutoiement dans les guides et pages d'orientation, tournures impersonnelles dans la référence
+   technique.
+4. **Une carte des domaines dans `Contribuer`**, miroir de [CONTEXT-MAP.md](../../CONTEXT-MAP.md),
+   qui **lie** les glossaires `CONTEXT.md` colocalisés au code sans les dupliquer ni les déplacer —
+   la couture entre le site publié et les registres agent, qui restent à leur place.
+5. **`Comprendre` / `Déployer` / `Maintenir` ouvrent avec une page d'index courte** (à qui s'adresse
+   la section, ce qui y vivra) : leur contenu réel vient de tranches suivantes (#557/#558/#559),
+   cette tranche ne pose que la charpente.
+6. **Le README maigrit en panneau indicateur** (~60-100 lignes) : pitch, 5 portes vers le site
+   publié, install minimale, licence. Sa matière développeur (architecture, exemples de code,
+   patterns) migre — sans dupliquer — vers une page `Développer` de `Contribuer`.
+
+### Alternatives écartées
+
+- **Strates dans la page** (un unique document par sujet, sections dépliables du « quoi » au
+  « comment ça évolue ») : pas de porte d'entrée par rôle — la page reste un mur que chacun doit
+  traverser en entier pour trouver son étage ; impossible de doser le tutoiement (guide) contre
+  l'impersonnel (référence) dans le même flux de texte.
+- **Diátaxis pur** (tutoriels / guides pratiques / référence / explications) : classe par *nature*
+  du contenu, pas par *public* — un tutoriel TURPE et une référence TURPE coexisteraient sans
+  jamais répondre « à qui ça s'adresse ». Le fil directeur d'ElectriCore-commun est le rôle dans
+  la fédération (ADR-0024), pas le type éditorial.
+- **Deux surfaces séparées** (site public de vulgarisation + wiki technique interne) : duplique la
+  maintenance et viole le principe « les 3 registres restent découvrables, pas déplacés » — un
+  site scindé recrée exactement la fragmentation que l'escalier corrige, avec une frontière en
+  plus à tenir synchronisée.
+- **Site d'éducation populaire autonome** (ex. Docusaurus dédié à la vulgarisation, hors MkDocs) :
+  chantier à part entière, démesuré pour cette PRD, qui ajouterait un **4ᵉ** emplacement de
+  documentation au lieu d'en résorber la fragmentation.
+
+## Conséquences
+
+- La validation MkDocs reste volontairement laxiste (`omitted_files: ignore`, liens non stricts) —
+  durcir ce garde-fou est le périmètre de [issue #560](https://github.com/Energie-De-Nantes/electricore/issues/560),
+  pas de cette tranche.
+- Les ~15 docs techniques restantes (`deploiement.md`, `configuration.md`, `ingestion.md`…) restent
+  hors nav ; leur affectation à une section est le périmètre de
+  [issue #557](https://github.com/Energie-De-Nantes/electricore/issues/557) (passe de lecture).
+- Chaque section vide aujourd'hui (`Comprendre`, `Déployer`, `Maintenir`) porte sa propre dette
+  documentée par sa page d'index — pas de fausse promesse datée, juste « ce qui y vivra ».

--- a/docs/comprendre/index.md
+++ b/docs/comprendre/index.md
@@ -1,0 +1,15 @@
+# Comprendre
+
+Cette section s'adresse à toi si tu es **usager·ère** d'ElectriCore : tu veux
+comprendre ce que le projet calcule et pourquoi, sans avoir besoin de lire du
+code ni d'administrer quoi que ce soit.
+
+Elle accueillera une présentation en clair du réseau électrique français, des
+notions clés (PDL, TURPE, facturation calendaire…) et de ce qu'ElectriCore
+change concrètement. Ce contenu arrive dans une tranche à venir du chemin de
+documentation par rôles.
+
+En attendant, la porte la plus proche est celle des personnes qui facturent
+au quotidien : [Facturer](../facturiste/changelog-facturiste.md).
+
+[Retour à l'accueil](../index.md).

--- a/docs/contribuer/carte-domaines.md
+++ b/docs/contribuer/carte-domaines.md
@@ -1,0 +1,42 @@
+# Carte des domaines
+
+Tu cherches un terme métier (PDL, RSC, FTA, cadran…) ou le vocabulaire propre à
+un module ? ElectriCore est organisé en **contextes**, chacun avec son
+glossaire colocalisé au code. Cette page est le miroir, côté site, de
+[CONTEXT-MAP.md](https://github.com/Energie-De-Nantes/electricore/blob/main/CONTEXT-MAP.md) —
+elle **lie** les glossaires, elle ne les déplace ni ne les copie : ils vivent
+avec le code qu'ils décrivent, et c'est là qu'il faut les modifier.
+
+## Les contextes
+
+- [**`electricore/core/`**](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/core/CONTEXT.md) —
+  vocabulaire métier ERP-agnostique : acteurs, PDL, RSC (concept Enedis), FTA, cadrans,
+  calendriers distributeur, tarification & taxes, événements C15, affaires SGE, mesures &
+  énergie, concepts pipeline. La **source unique** du vocabulaire métier.
+- [**`electricore/integrations/odoo/`**](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/integrations/odoo/CONTEXT.md) —
+  adaptateur vers l'ERP Odoo : modèles `sale.order` / `account.move`, champs `x_*`,
+  rapprochements Odoo ↔ Enedis.
+- [**`electricore/ingestion/`**](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/ingestion/CONTEXT.md) —
+  vocabulaire d'ingestion : flux Enedis, Mode, Job, Scheduler, transformers.
+- [**`electricore/api/`**](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/api/CONTEXT.md) —
+  vocabulaire du service REST : endpoints, services, `/health`.
+- [**`electricore/bot/`**](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/bot/CONTEXT.md) —
+  vocabulaire du bot Telegram : commandes, allowlist, client API.
+
+## Comment ils se parlent
+
+- `core` est la source unique du vocabulaire métier ERP-agnostique
+  ([ADR-0016](../adr/0016-core-erp-agnostique.md)) ; les autres contextes le référencent plutôt
+  que de redéfinir les mêmes termes.
+- `integrations/<erp>` orchestre les rapprochements entre `core` (calculs purs) et l'ERP (Odoo
+  aujourd'hui ; d'autres demain). N'est jamais importé depuis `core`.
+- `ingestion` ingère les flux Enedis dans DuckDB, consommés par `core`.
+- `api` expose `core` et `integrations/<erp>`, et orchestre `ingestion` (déclenchements + jobs).
+- `bot` consomme `api` exclusivement — jamais d'accès direct à `core`, `ingestion` ou
+  `integrations`.
+
+Les décisions d'architecture structurantes sont au niveau racine dans
+[docs/adr/](https://github.com/Energie-De-Nantes/electricore/tree/main/docs/adr) — aucun ADR
+par contexte pour l'instant.
+
+[Retour à l'accueil](../index.md).

--- a/docs/contribuer/charte-documentation.md
+++ b/docs/contribuer/charte-documentation.md
@@ -1,0 +1,50 @@
+# Charte de la documentation
+
+ElectriCore est un commun ([ADR-0024](../adr/0024-trois-registres-de-savoir.md) :
+« EDN est le premier prototype d'une fédération de communs de l'électricité »).
+Sa documentation s'adresse à plusieurs publics, pas aux seuls contributeurs de
+code — cette charte fixe qui ils sont et comment on écrit pour eux.
+Décision complète : [ADR-0054](../adr/0054-chemin-documentation-roles-escalier.md).
+
+## Les 5 rôles de lecture
+
+| Rôle | Ce qu'iel vient chercher | Sa section |
+|---|---|---|
+| **Usager·ère** | Comprendre ce qu'ElectriCore calcule et pourquoi, sans code | [Comprendre](../comprendre/index.md) |
+| **Opérateur·ice** | Facturer au quotidien avec le bot et les notebooks | [Facturer](../facturiste/changelog-facturiste.md) |
+| **Déployeur·euse** | Installer et administrer une instance | [Déployer](../deployer/index.md) |
+| **Contributeur·ice** | Coder en amont du projet | [Contribuer](index.md) |
+| **Mainteneur·e** | Tenir l'architecture, les releases, le réglementaire | [Maintenir](../maintenir/index.md) |
+
+Ce découpage vit **ici**, pas dans le glossaire métier
+([CONTEXT-MAP.md](https://github.com/Energie-De-Nantes/electricore/blob/main/CONTEXT-MAP.md)) :
+les rôles de lecture sont un concept de documentation, pas un concept métier Enedis.
+
+## Le principe d'escalier
+
+Un sujet transverse (le TURPE, par exemple) existe à plusieurs étages du site, et
+chaque étage raconte autre chose :
+
+1. **Comprendre** — quoi, en une phrase pour un public non technique.
+2. **Facturer** — comment s'en servir au quotidien.
+3. **Contribuer / Déployer** — comment c'est fait, comment l'installer.
+4. **Maintenir** — comment le faire évoluer, l'historique de la décision.
+
+La duplication entre étages est **assumée** — chaque étage doit se lire seul,
+sans renvoyer le lecteur ailleurs pour finir sa phrase — mais **bornée** par des
+**passerelles montantes** : chaque page pointe, en pied de page, vers l'étage du
+dessus pour qui veut creuser plus loin. Une page ne redescend jamais.
+
+## Charte éditoriale
+
+- **Point médian partout** dans le texte courant qui s'adresse à un rôle :
+  usager·ère, opérateur·ice, déployeur·euse, contributeur·ice, mainteneur·e.
+- **Tutoiement** dans les guides et les pages d'orientation (accueil, pages
+  d'index de section, cette charte) — on s'adresse à une personne.
+- **Tournures impersonnelles** dans la référence technique (ADR, docstrings,
+  contrats d'API, formats de données) — on décrit un système, pas une personne.
+- **Domaine métier en français** ; le vocabulaire reste celui du glossaire
+  ([CONTEXT-MAP.md](https://github.com/Energie-De-Nantes/electricore/blob/main/CONTEXT-MAP.md)),
+  jamais redéfini ici.
+
+[Retour à l'accueil](../index.md).

--- a/docs/contribuer/developper.md
+++ b/docs/contribuer/developper.md
@@ -1,0 +1,303 @@
+# Développer
+
+Architecture, patterns établis et exemples de code pour qui code en amont du
+projet. Contenu déménagé depuis le README (voir [ADR-0054](../adr/0054-chemin-documentation-roles-escalier.md)) :
+le README n'en garde qu'un renvoi.
+
+## Architecture
+
+```mermaid
+graph TB
+    SFTP[/SFTP Enedis<br/>flux chiffrés AES\]
+    ODOO[(Odoo ERP)]
+
+    SFTP -->|dlt : déchiffre · dézippe · parse| RAW[(DuckDB · flux_raw<br/>brut JSON, 1 ligne/fichier)]
+    RAW -->|dbt : linéarisation SQL| FLUX[(DuckDB · flux_enedis<br/>flux_* + marts spine/releves)]
+
+    FLUX -->|loaders SELECT *| CORE[Pipelines core<br/>Polars LazyFrame]
+    ODOO -->|OdooReader · lecture| CORE
+    CORE -->|builds| API
+    FLUX --> API[API REST<br/>FastAPI]
+
+    API -->|JSONL · Arrow · XLSX| CLIENT[electricore-client<br/>notebooks · souscriptions_odoo]
+    API <-->|in-process| BOT[Bot Telegram]
+    NB[Notebooks opérateur] -->|écriture validée à la main| ODOO
+
+    style API fill:#4CAF50,stroke:#2E7D32,color:#fff
+    style FLUX fill:#1976D2,stroke:#0D47A1,color:#fff
+    style RAW fill:#1976D2,stroke:#0D47A1,color:#fff
+    style ODOO fill:#FF9800,stroke:#E65100,color:#fff
+    style CORE fill:#9C27B0,stroke:#4A148C,color:#fff
+```
+
+Deux principes structurants :
+
+- **L'API est le hub.** Bot, notebooks, intégrations et clients externes passent tous par l'API
+  REST ; DuckDB, les pipelines `core/` et les adaptateurs ERP sont des composants internes
+  ([ADR-0009](../adr/0009-architecture-api-centrique.md)). L'API est en **lecture seule** vis-à-vis
+  d'Odoo : toute écriture est appliquée à la main par un opérateur, depuis un notebook
+  ([ADR-0012](../adr/0012-api-read-only-odoo.md)).
+- **`core/` est strictement ERP-agnostique.** Il ne dépend que de Polars/DuckDB/Pandera/stdlib —
+  garanti par un test de pureté CI. Tout adaptateur ERP vit dans `integrations/`
+  ([ADR-0016](../adr/0016-core-erp-agnostique.md)).
+
+### Les modules en un coup d'œil
+
+| Module | Rôle | Doc |
+|--------|------|-----|
+| 📥 **`ingestion/`** | ELT dlt + dbt : SFTP Enedis → DuckDB (déchiffrement AES, landing brut, linéarisation SQL) | [README](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/ingestion/README.md) · [docs/ingestion.md](../ingestion.md) |
+| 🧮 **`core/`** | Calculs énergétiques en Polars pur (`loaders` · `pipelines` · `builds` · `models`), ERP-agnostique | [CONTEXT.md](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/core/CONTEXT.md) |
+| 🔌 **`integrations/odoo/`** | Adaptateur Odoo : `OdooReader` / `OdooQuery` / `OdooWriter` | [Query Builder Odoo](../odoo-query-builder.md) |
+| 🌐 **`api/`** | API REST FastAPI : flux, relevés, taxes, facturation, chronologie, ingestion | [README](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/api/README.md) |
+| 🤖 **`bot/`** | Bot Telegram : UI opérationnelle, client de l'API (zéro logique métier) | [README](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/bot/README.md) |
+| ⚙️ **`config/`** | Registre runtime pydantic-settings + règles tarifaires CSV (TURPE, accise, CTA) | [ADR-0024](../adr/0024-trois-registres-de-savoir.md)/[0025](../adr/0025-registre-runtime-pydantic-settings.md) |
+| 📦 **`packages/electricore-client/`** | **Client léger distribué séparément** (PyPI) : httpx + pydantic, flux JSONL typé | [README](https://github.com/Energie-De-Nantes/electricore/blob/main/packages/electricore-client/README.md) · [ADR-0043](../adr/0043-electricore-client-paquet-separe.md) |
+
+> `electricore/operator_launcher.py` (commande `electricore-notebooks`) est un **pont
+> transitoire** vers les notebooks opérateur (voir plus bas). Le dossier `electricore/client/`
+> est un résidu vide : le vrai client est `packages/electricore-client/`.
+
+## Installer pour développer
+
+- Python 3.12+ et [uv](https://docs.astral.sh/uv/getting-started/installation/)
+
+```bash
+git clone https://github.com/Energie-De-Nantes/electricore.git
+cd electricore
+
+uv sync                                   # runtime : core + API + bot
+uv sync --extra ingestion --extra dbt     # + ingestion SFTP (dlt + dbt)
+uv sync --extra viz                        # + libs notebooks (marimo, altair, plotly)
+uv sync --extra ingestion --extra dbt --extra viz   # dev local complet
+```
+
+### 1. Ingérer les flux Enedis → DuckDB
+
+```bash
+uv run --extra ingestion --extra dbt python -m electricore.ingestion test   # smoke : 2 fichiers/flux
+uv run --extra ingestion --extra dbt python -m electricore.ingestion r151    # un flux
+uv run --extra ingestion --extra dbt python -m electricore.ingestion all     # production : tous les flux
+uv run --extra ingestion --extra dbt python -m electricore.ingestion rebuild # dbt seul (zéro réseau, ~13 s)
+```
+
+Résultat : la base `electricore/ingestion/flux_enedis_pipeline.duckdb` (schéma `flux_raw` pour le
+brut, `flux_enedis` pour les tables linéarisées et les marts). Voir [docs/ingestion.md](../ingestion.md).
+
+### 2. Calculer une facturation mensuelle (core)
+
+```python
+from electricore.core.builds.contexte_mensuel import contexte_du_mois
+
+# Compose : spine/chronologie (dbt) → historique → abonnements + énergie → facturation
+ctx = contexte_du_mois("2026-05-01")   # None → dernier mois disponible
+
+ctx.facturation_mensuelle   # méta-périodes mensuelles agrégées (validé Pandera)
+ctx.abonnements             # périodes d'abonnement + TURPE fixe
+ctx.energie                 # périodes d'énergie par cadran + TURPE variable
+ctx.releves_utilises        # relevés tracés = relevés utilisés (traçabilité d'index, ADR-0038)
+ctx.historique_enrichi      # substrat d'événements filtré sur l'horizon
+```
+
+Les loaders DuckDB sont des **query builders fluides immuables**
+([ADR-0007](../adr/0007-query-builders.md)) qui poussent les filtres dans le `WHERE` :
+
+```python
+from electricore.core.loaders import c15, r151, releves, spine, chronologie
+
+historique = c15().filter({"Date_Evenement": ">= '2024-01-01'"}).limit(100).collect()
+tous_releves = releves().filter({"prm": ["PDL123"]}).collect()   # mart canonique (ADR-0029)
+```
+
+> Fonctions disponibles : `c15()`, `r151()`, `r15()`, `f15()`, `r64()` (flux Enedis bruts) et
+> `releves()`, `spine()`, `chronologie()`, `affaires()` (marts transverses).
+
+### 3. Consommer l'API
+
+```bash
+uv run uvicorn electricore.api.main:app --reload
+curl http://localhost:8000/health
+curl -H "X-API-Key: <votre_cle>" "http://localhost:8000/releves?prm=12345678901234&limit=10"
+open http://localhost:8000/docs   # Swagger interactif
+```
+
+Depuis un consommateur externe, le **client léger** typé (paquet PyPI distinct) évite de tirer
+polars/duckdb/fastapi :
+
+```bash
+pip install electricore-client            # base : httpx + pydantic
+pip install "electricore-client[arrow]"   # + client Arrow (DataFrames polars)
+```
+
+```python
+from electricore_client import ElectricoreClient
+
+client = ElectricoreClient(url="https://electricore.example", api_key="…")
+
+# Méta-périodes : flux JSONL typé, sans enveloppe ni pagination
+with client.meta_periodes(mois="2026-05-01", rsc=["RSC1"]) as flux:
+    for periode in flux:        # PeriodeMeta (releves_utilises imbriqués, source_hash)
+        ...
+
+# Chronologie facturiste : faits + verdicts, sans montant
+with client.chronologie(pdl="12345678901234") as flux:
+    lignes = flux.collect()
+```
+
+### 4. Piloter via le bot Telegram
+
+L'exploitation quotidienne (ingestion, exports, taxes, contrôles pré-facturation) passe par un
+bot Telegram ([ADR-0010](../adr/0010-bot-telegram-ui-operationnelle.md)) démarré dans le process
+de l'API quand `BOT__TOKEN` est défini. Cinq domaines : `/ingestion`, `/flux`,
+`/perimetre`, `/taxes`, `/facturation` (sans argument = clavier découvrable ; avec argument =
+action directe). Voir le [README du bot](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/bot/README.md).
+
+## Modèle de données — la spine assemblée en dbt
+
+Le changement structurant récent ([ADR-0041](../adr/0041-chronologie-contrat-spine-relationnelle-dbt.md),
+[ADR-0045](../adr/0045-relations-spine-reference-cle-normalisation-chronologie-releves.md)) tient
+en une phrase : **le cœur consomme, dbt assemble**. La *Chronologie du contrat* — la séquence
+ordonnée des faits d'une situation contractuelle — n'est plus reconstruite dans des DataFrames
+Polars ; c'est une **spine relationnelle assemblée entièrement en dbt**, que le cœur se contente
+de **filtrer et découper**.
+
+Trois marts dbt forment le substrat (schéma `flux_enedis`, exposés hors du namespace `/flux`,
+[ADR-0032](../adr/0032-modeles-marts-hors-flux-namespace.md)) :
+
+- **`releves`** — la ligne de temps **canonique** des relevés : union arbitrée des sources
+  (priorité `C15 > R64 > R151`), dédupliquée par **identité métier** du relevé, harmonisation
+  R151 J→J+1 portée ici, `releve_id` = clé courte stable. Source de vérité unique des valeurs
+  d'index ([ADR-0028](../adr/0028-identite-releve-cle-metier-priorite-sources.md)/[0029](../adr/0029-modele-releves-canonique-dbt-assemble-coeur-arbitre.md)).
+- **`spine_contrat`** — l'épine `(pdl, ref_situation_contractuelle, date, source, type_fait)` :
+  événements C15 ∪ grille FACTURATION calendaire (1ᵉʳ de chaque mois), avec les **attributs de
+  situation forward-fillés en SQL** (FTA, puissance, niveau d'ouverture…).
+- **`chronologie_releves`** — la projection énergie de la spine : bornes FACTURATION appariées
+  aux relevés périodiques au **grain jour** (equi-join, l'ancien `join_asof` ±4 h a disparu du cœur).
+
+Les marts sont **indépendants de l'horizon** ; l'horizon n'est qu'un **filtre** posé au boundary du
+cœur, ce qui préserve la pureté (deux runs à horizon fixe découpent identiquement). Une seule
+spine, **N frises** : le substrat est partagé, mais les découpages **abonnement** et **énergie**
+restent séparés ([ADR-0023](../adr/0023-periodisations-separees-abonnement-energie.md)) — ils se
+croisent, ils ne s'imbriquent pas.
+
+### Vocabulaire essentiel
+
+- **PDL** : point de livraison physique (14 chiffres, un Linky). **RSC** : situation contractuelle
+  d'un PDL — c'est le **grain de facturation** (un PDL qui change de RSC en cours de mois porte deux
+  méta-périodes). **FTA** : formule tarifaire d'acheminement (sélectionne la grille TURPE et le
+  nombre de cadrans).
+- **Chronologie du contrat (RSC)** vs **Chronologie du point (PDL)** vs **Chronologie des relevés**
+  (projection énergie). Chaque périodisation est `filtre(spine) ⨝ relation`.
+- **Cadrans** (convention `grandeur_cadran_unité`) : `base` ; `hp`/`hc` ; `hph`/`hch`/`hpb`/`hcb`
+  (4 quadrants saison × heures). Index en kWh **entiers** (floor au boundary dbt,
+  [ADR-0034](../adr/0034-index-kwh-entiers-floor-au-boundary-dbt.md)).
+- **TURPE fixe** (part puissance) vs **variable** (part énergie). **Accise** (TICFE) et **CTA**
+  (taxe sur le TURPE fixe). Règle d'intégration : electricore livre le **montant €** quand il
+  possède l'assiette, le **taux** sinon ([ADR-0027](../adr/0027-endpoint-lecture-meta-periodes-odoo-tire.md)).
+- **Qualité de période** (`réelle`/`estimée`/`incalculable`, [ADR-0033](../adr/0033-qualite-periode-remplace-data-complete-coverage.md))
+  et **statut de communication** (`communicante`/`non_communicante`, [ADR-0036](../adr/0036-statut-communication-routage-energie-grain-meta.md)) :
+  l'effet et la cause, deux axes jumeaux remplaçant les anciens `data_complete`/`coverage`.
+
+Détails : [docs/contrat-meta-periodes.md](../contrat-meta-periodes.md),
+[docs/conventions-dates-enedis.md](../conventions-dates-enedis.md),
+[docs/qualite-donnees-r151.md](../qualite-donnees-r151.md), et le glossaire
+[`electricore/core/CONTEXT.md`](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/core/CONTEXT.md).
+
+## API REST
+
+Authentification par en-tête **`X-API-Key`** (endpoints publics : `/`, `/health`, `/docs`,
+`/redoc`, `/openapi.json`). Pendant une ingestion, les routes de lecture renvoient `503` le temps
+que le writer DuckDB relâche le verrou.
+
+| Route | Rôle |
+|-------|------|
+| `GET /health`, `GET /` | Statut, fraîcheur de la base, tables disponibles (public) |
+| `GET /flux/{table}` · `/info` · `.xlsx` · `.arrow` | Flux Enedis bruts (JSON paginé, Arrow, XLSX) |
+| `GET /releves` · `/info` · `.xlsx` · `.arrow` | Mart canonique des relevés (ADR-0029) |
+| `GET /perimetre/affaires` | Cockpit des affaires SGE ouvertes (X12/X13) |
+| `POST /ingestion/run` · `GET /ingestion/jobs` · `/jobs/{id}` | Déclencher et suivre les jobs d'ingestion |
+| `GET /taxes/millesimes` · `/peremption` | Millésimes et péremption des taux régulés (sans ERP) |
+| `GET /taxes/accise/*` · `/cta/*` | Rapports & détails Accise / CTA (XLSX, Arrow) — *requiert Odoo* |
+| **`GET /facturation/meta-periodes`** | Méta-périodes mensuelles en **flux JSONL typé** |
+| **`GET /facturation/chronologie`** | Frise facturiste d'un `pdl` ou `rsc` (faits + verdicts, **sans montant**) |
+| **`POST /facturation/turpe-variable`** | Calculateur TURPE variable (RPC typé, l'appelant fournit l'assiette) |
+| `GET /facturation/rapport.xlsx` · `documents.xlsx` · `check/odoo` | Rapports & contrôles pré-facturation — *requiert Odoo* |
+| `GET /admin/api-keys` | Configuration des clés API |
+
+Les routes **JSONL** (`meta-periodes`, `chronologie`) répondent une ligne JSON par objet, **sans
+enveloppe ni pagination** ; les métadonnées (version de contrat, mois, grain) voyagent en en-têtes
+HTTP. Chaque ligne est validée en construisant le modèle pydantic — impossible d'émettre une ligne
+hors contrat. Les routes marquées *requiert Odoo* renvoient `501` et sont masquées du bot sur une
+instance sans ERP. Détails : [README de l'API](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/api/README.md).
+
+## Notebooks (édition dev)
+
+Les notebooks [Marimo](https://github.com/Energie-De-Nantes/electricore/tree/main/notebooks)
+(réactifs, Polars, [ADR-0002](../adr/0002-polars-uniquement.md)) s'éditent en dev :
+
+```bash
+uv run marimo edit notebooks/   # édition complète (pipelines, validations TURPE, exploration Odoo)
+```
+
+Le runbook de l'**opérateur non-dev** (lanceur `electricore-notebooks`, notebooks lecture seule
+publiés sur PyPI) est documenté côté opérateur : [docs/operateur-notebook.md](../operateur-notebook.md).
+
+## Développement & tests
+
+```bash
+# Setup dev recommandé
+uv sync --extra ingestion --extra dbt --group test --group typecheck
+
+uv run --group test pytest              # suite complète (~30 s)
+uv run --group test pytest -n auto      # exécution parallèle (pytest-xdist)
+uv run --group test pytest -m unit      # markers : unit/integration/slow/smoke/duckdb/odoo/hypothesis
+uv run --group test pytest --cov=electricore   # couverture (plancher CI : 45 %)
+
+uvx ruff check --fix ; uvx ruff format  # lint + format
+uv run --group typecheck mypy           # typage (surface publique core/)
+uvx pre-commit install                  # hooks ruff/gitleaks (+ --hook-type pre-push pour pytest)
+```
+
+Près de **800 fonctions de test** réparties sur 119 fichiers, sans secret requis (les tests
+dépendant d'Odoo s'auto-skippent). Couverture : fixtures + snapshots Syrupy (gros du filet),
+tests d'expressions Polars, contrats Pandera, et property-based Hypothesis ; **golden d'ingestion**
+générés depuis les XSD Enedis (parité dbt garantie en CI) ; **tests d'architecture** verrouillant
+la pureté ERP du cœur ([ADR-0016](../adr/0016-core-erp-agnostique.md)) et les imports par rôle
+([ADR-0019](../adr/0019-roles-loaders-pipelines-builds-integrations.md)).
+
+**CI** (GitHub Actions) : lint + typecheck + tests (matrice Python 3.12/3.13), plus un job
+`test-client` qui prouve en venv isolé que `electricore-client` ne tire ni polars ni duckdb ni
+fastapi. Les **releases** publient l'image `ghcr.io/energie-de-nantes/electricore` (sur tag `v*`,
+build → scan secrets → smoke → push) et le client sur PyPI via OIDC (sur tag `client-v*`, versionné
+indépendamment).
+
+**Contribution** : `main` est protégé. Brancher → commit (Conventional Commits en français) →
+pousser → ouvrir une PR → la CI tourne → **le merge est une étape humaine** sur le site. Détails :
+[CONTRIBUTING.md](https://github.com/Energie-De-Nantes/electricore/blob/main/CONTRIBUTING.md).
+Nouvel arrivant (profil Rust/Java) : [docs/transmission.md](../transmission.md).
+
+## Feuille de route
+
+Ce qui précède décrit la **réalité livrée** sur `main`. Les directions en cours :
+
+- **Protection des secrets au repos** — follow-ups de la bascule secrets-as-code
+  ([ADR-0044](../adr/0044-secrets-as-code-sops-age.md), déjà mergée pour le mécanisme) : chiffrement
+  disque (LUKS + Tang/NBDE), isolation `raw.db`/`serve.db`, durcissement DuckDB de l'API, et OpenBao
+  quand la flotte le justifiera.
+- **`souscriptions_odoo`** — addon qui consommera l'API via `electricore-client` et **remplacera**
+  le lanceur de notebooks opérateur transitoire.
+- **Régularisation des contrats lissés** — recalcul a posteriori des contrats facturés au lissé
+  ([#191](https://github.com/Energie-De-Nantes/electricore/issues/191)).
+- **Estimation des périodes non-communicantes via R15**
+  ([#322](https://github.com/Energie-De-Nantes/electricore/issues/322)).
+- **Nouvelles sources** — API SOAP Enedis (alternative SFTP), courbes Axpo, autres fournisseurs.
+
+Le suivi se fait en [issues GitHub](https://github.com/Energie-De-Nantes/electricore/issues) et en
+[décisions d'architecture](../adr/0001-monorepo.md).
+
+## Pour aller plus loin
+
+[Carte des domaines](carte-domaines.md) · [charte de la documentation](charte-documentation.md) ·
+[guide de déploiement](https://github.com/Energie-De-Nantes/electricore/blob/main/docs/deploiement.md) ·
+[configuration complète](https://github.com/Energie-De-Nantes/electricore/blob/main/docs/configuration.md).
+
+[Retour à l'accueil](../index.md).

--- a/docs/contribuer/index.md
+++ b/docs/contribuer/index.md
@@ -1,0 +1,19 @@
+# Contribuer
+
+Cette section s'adresse à toi si tu es **contributeur·ice** : tu codes en
+amont du projet, tu proposes des correctifs ou des évolutions.
+
+- **[Charte de la documentation](charte-documentation.md)** — les 5 rôles de
+  lecture, le principe d'escalier, et la charte éditoriale à respecter dans
+  tes propres contributions à la doc.
+- **[Carte des domaines](carte-domaines.md)** — où vivent les glossaires
+  métier par module, et comment s'y repérer.
+- **[Développer](developper.md)** — architecture, exemples de code, patterns
+  établis, installation dev et tests.
+
+Pour le protocole concret (branches, PR, style de commit), voir
+[CONTRIBUTING.md](https://github.com/Energie-De-Nantes/electricore/blob/main/CONTRIBUTING.md).
+Nouvel·le arrivant·e avec un profil Rust/Java : le
+[guide de transmission](../transmission.md).
+
+[Retour à l'accueil](../index.md).

--- a/docs/deployer/index.md
+++ b/docs/deployer/index.md
@@ -1,0 +1,13 @@
+# Déployer
+
+Cette section s'adresse à toi si tu es **déployeur·euse** : tu installes et tu
+administres une instance ElectriCore pour un fournisseur (VPS, Docker
+Compose, secrets, sauvegardes).
+
+Elle rassemblera à terme le guide de déploiement, l'inventaire de
+configuration et les procédures d'exploitation (rotation de clés, mise à
+jour de version, sauvegarde). Ce contenu existe déjà dans `docs/` sous forme
+de pages techniques ; leur rattachement à cette section arrive dans une
+tranche à venir du chemin de documentation par rôles.
+
+[Retour à l'accueil](../index.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,24 @@
-# Documentation ElectriCore
+# ElectriCore
 
 **ElectriCore** transforme les flux bruts d'Enedis en données de facturation
-structurées, traçables et vérifiables.
+structurées, traçables et vérifiables — un commun pour reprendre la main sur les
+données du réseau électrique français.
 
-## Par où commencer
+La documentation est rangée par rôle, en escalier : choisis ta porte.
 
-- **[Guide facturiste](facturiste/changelog-facturiste.md)** — la lecture côté métier :
-  le cycle de facturation, l'anatomie d'un mois facturable, les verdicts de qualité,
-  et ce qui se prépare.
+## Les 5 portes
+
+- **[Comprendre](comprendre/index.md)** — tu es usager·ère et tu veux savoir ce
+  qu'ElectriCore calcule et pourquoi, sans lire une ligne de code.
+- **[Facturer](facturiste/changelog-facturiste.md)** — tu es opérateur·ice, tu
+  factures au quotidien avec le bot Telegram et les notebooks.
+- **[Déployer](deployer/index.md)** — tu es déployeur·euse, tu installes et
+  administres une instance ElectriCore.
+- **[Contribuer](contribuer/index.md)** — tu es contributeur·ice, tu codes en
+  amont du projet.
+- **[Maintenir](maintenir/index.md)** — tu es mainteneur·e, tu tiens
+  l'architecture, les releases et le réglementaire.
 
 ---
 
-Code source et détails techniques : [dépôt GitHub](https://github.com/Energie-De-Nantes/electricore).
+Code source : [dépôt GitHub](https://github.com/Energie-De-Nantes/electricore).

--- a/docs/maintenir/index.md
+++ b/docs/maintenir/index.md
@@ -1,0 +1,13 @@
+# Maintenir
+
+Cette section s'adresse à toi si tu es **mainteneur·e** : tu tiens
+l'architecture du projet dans la durée, tu pilotes les releases et le suivi
+réglementaire (grilles TURPE, taux, évolutions Enedis).
+
+Elle rassemblera à terme les décisions d'architecture structurantes vues
+depuis leur ensemble, le processus de release et les procédures de suivi
+réglementaire. Ce contenu arrive dans une tranche à venir du chemin de
+documentation par rôles ; les décisions elles-mêmes existent déjà, une par
+une, dans les [ADR](../adr/0001-monorepo.md).
+
+[Retour à l'accueil](../index.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,18 @@ exclude_docs: "*.excalidraw"
 
 nav:
   - Accueil: index.md
-  - Guide facturiste: facturiste/changelog-facturiste.md
-  - Bot Telegram (facturiste): guide-bot-facturiste.md
-  - Notebook opérateur: operateur-notebook.md
+  - Comprendre:
+      - comprendre/index.md
+  - Facturer:
+      - Guide facturiste: facturiste/changelog-facturiste.md
+      - Bot Telegram (facturiste): guide-bot-facturiste.md
+      - Notebook opérateur: operateur-notebook.md
+  - Déployer:
+      - deployer/index.md
+  - Contribuer:
+      - contribuer/index.md
+      - Charte de la documentation: contribuer/charte-documentation.md
+      - Carte des domaines: contribuer/carte-domaines.md
+      - Développer: contribuer/developper.md
+  - Maintenir:
+      - maintenir/index.md


### PR DESCRIPTION
## Résumé

- **ADR-0054** consigne le chemin de documentation par rôles en escalier et les alternatives réellement écartées (strates dans la page, Diátaxis pur, deux surfaces séparées, site d'éducation populaire autonome).
- **Nav MkDocs à 5 sections par rôle** (Comprendre / Facturer / Déployer / Contribuer / Maintenir) ; les 3 pages facturiste existantes rejoignent *Facturer*, l'accueil devient un **portail à 5 portes** (une phrase + lien par rôle).
- **Section Contribuer** : charte de la documentation (5 rôles + charte éditoriale — point médian, tutoiement dans les guides, impersonnel en référence), carte des domaines (miroir de `CONTEXT-MAP.md`, glossaires liés **sans être déplacés**), page Développer reprenant la matière développeur du README.
- **README réduit de 448 à 64 lignes** : panneau indicateur vers le site, sans duplication de contenu.
- Registres agent (`CLAUDE.md`, `docs/agents/*`, glossaires `CONTEXT.md`) et ADRs existants inchangés ; validation MkDocs laissée laxiste (durcissement = #560) ; docs techniques existants laissés hors nav (affectation = #557).

Tranche charpente du PRD #555 — débloque #557, #558, #559, #560.

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)
