### PR TITLE
feat(odoo): check pré-campagne — brouillons énergie hors date-ancre (#564)

### DIFF
--- a/electricore/api/routers/facturation.py
+++ b/electricore/api/routers/facturation.py
@@ -84,11 +84,13 @@ async def check_facturation_odoo(api_key: str = Depends(get_current_api_key)):
 
     **Authentification requise. Nécessite Odoo configuré.**
 
-    Pour tous les sale.order avec state='sale', retourne :
+    Pour tous les sale.order énergie (`x_pdl` renseigné) avec state='sale', retourne :
     - `rsc_manquante` : liste des sale.order sans `x_ref_situation_contractuelle`
     - `cfne_manquante` : liste des sale.order sans `x_date_cfne`
     - `invoicing_state_counts` : répartition des `x_invoicing_state`
     - `factures_draft` : factures encore en draft (anomalie après campagne)
+    - `brouillons_hors_ancre` : brouillons datés hors de l'ancre courante ou
+      sans date (check pré-campagne, #564, ADR-0054)
 
     Chaque entrée contient un lien direct vers l'enregistrement Odoo (champ `url`).
     """

--- a/electricore/api/services/check_facturation_service.py
+++ b/electricore/api/services/check_facturation_service.py
@@ -26,6 +26,7 @@ def verifier_odoo() -> dict:
         "invoicing_state_counts": dict(r.invoicing_state_counts.iter_rows()),
         "factures_draft": enrichir_liens(r.factures_draft, base_url, "account.move").to_dicts(),
         "lisses_quantite_1": _serialize_lisses(r.lisses_quantite_1, base_url),
+        "brouillons_hors_ancre": enrichir_liens(r.brouillons_hors_ancre, base_url, "account.move").to_dicts(),
     }
 
 

--- a/electricore/bot/handlers/facturation.py
+++ b/electricore/bot/handlers/facturation.py
@@ -116,6 +116,14 @@ def _format_check_odoo(result: dict) -> tuple[str, bool]:
         lambda r: f"{r['name']} ({', '.join(r['categ_names'])})",
         "Aucun contrat lissé avec qty=1 sur Base/HP/HC",
     )
+    lines.append("")
+
+    _bloc(
+        "brouillons énergie hors date-ancre courante (#564)",
+        result.get("brouillons_hors_ancre", []),
+        lambda r: f"{r['name']} — {r['name_account_move']} (date : {r['invoice_date'] or 'absente'})",
+        "Aucun brouillon énergie hors date-ancre",
+    )
 
     all_ok = not any(
         [
@@ -123,6 +131,7 @@ def _format_check_odoo(result: dict) -> tuple[str, bool]:
             result["cfne_manquante"],
             result["factures_draft"],
             result.get("lisses_quantite_1", []),
+            result.get("brouillons_hors_ancre", []),
         ]
     )
     if all_ok:

--- a/electricore/integrations/odoo/verification.py
+++ b/electricore/integrations/odoo/verification.py
@@ -1,11 +1,13 @@
 """Vérifications pré-facturation : détecte les anomalies sur les données Odoo."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import date
 
 import polars as pl
 
 from .helpers import query
 from .reader import OdooReader
+from .sources import date_ancre
 
 
 @dataclass(frozen=True, slots=True)
@@ -15,6 +17,7 @@ class ResultatVerification:
     invoicing_state_counts: pl.DataFrame
     factures_draft: pl.DataFrame
     lisses_quantite_1: pl.DataFrame
+    brouillons_hors_ancre: pl.DataFrame = field(default_factory=pl.DataFrame)
 
 
 # Discriminant commande énergie (#564) : solde les faux positifs hors énergie (ex. S00583).
@@ -28,7 +31,23 @@ def verifier(odoo: OdooReader) -> ResultatVerification:
         invoicing_state_counts=_invoicing_state_counts(odoo),
         factures_draft=_factures_draft(odoo),
         lisses_quantite_1=_lisses_quantite_1(odoo),
+        brouillons_hors_ancre=_brouillons_hors_ancre(odoo),
     )
+
+
+def ancre_courante(aujourd_hui: date) -> str:
+    """Ancre de la campagne en cours : le 05 du mois courant (#564, ADR-0054).
+
+    = `date_ancre(dernier mois révolu)` — réutilise le calcul de la sélection
+    (#561) pour ne jamais diverger. Relative à l'ancre plutôt qu'au mois
+    facturé : elle attrape aussi un brouillon périmé d'une campagne antérieure
+    qui traînerait encore en draft.
+    """
+    annee, mois = aujourd_hui.year, aujourd_hui.month - 1
+    if mois == 0:
+        annee, mois = annee - 1, 12
+    dernier_mois_revolu = date(annee, mois, 1).isoformat()
+    return date_ancre(dernier_mois_revolu)
 
 
 def _rsc_manquante(odoo: OdooReader) -> pl.DataFrame:
@@ -107,3 +126,37 @@ def _lisses_quantite_1(odoo: OdooReader) -> pl.DataFrame:
         .agg(pl.col("name_product_category").unique().sort().alias("categ_names"))
         .sort("name")
     )
+
+
+def _brouillons_hors_ancre(odoo: OdooReader) -> pl.DataFrame:
+    """Brouillons de facture d'une commande énergie hors date-ancre courante (#564).
+
+    La convention date-ancre (ADR-0054) pose `invoice_date = 05/(M+1)` sur tous
+    les brouillons de la campagne du mois M. Un brouillon énergie encore en
+    draft, daté ailleurs qu'à l'ancre courante ou pas daté du tout, est une
+    violation de la convention — détectée ici avant le lancement de la
+    campagne suivante, plutôt qu'absorbée silencieusement par la sélection
+    (`sources.lignes_factures_du_mois`).
+    """
+    ancre = ancre_courante(date.today())
+    raw = (
+        query(
+            odoo,
+            "sale.order",
+            domain=[("state", "=", "sale"), _ENERGIE],
+            fields=["name", "invoice_ids"],
+        )
+        .follow(
+            "invoice_ids",
+            domain=[("state", "=", "draft"), "|", ("invoice_date", "!=", ancre), ("invoice_date", "=", False)],
+            fields=["name", "invoice_date"],
+        )
+        .collect()
+    )
+    if raw.is_empty():
+        return (
+            raw.rename({"invoice_ids": "account_move_id"})
+            if "invoice_ids" in raw.columns
+            else raw.with_columns(pl.lit(None, dtype=pl.Int64).alias("account_move_id"))
+        )
+    return raw.rename({"invoice_ids": "account_move_id"})

--- a/electricore/integrations/odoo/verification.py
+++ b/electricore/integrations/odoo/verification.py
@@ -17,7 +17,11 @@ class ResultatVerification:
     invoicing_state_counts: pl.DataFrame
     factures_draft: pl.DataFrame
     lisses_quantite_1: pl.DataFrame
-    brouillons_hors_ancre: pl.DataFrame = field(default_factory=pl.DataFrame)
+    brouillons_hors_ancre: pl.DataFrame = field(
+        default_factory=lambda: pl.DataFrame(
+            schema={"account_move_id": pl.Int64, "name": pl.Utf8, "name_account_move": pl.Utf8, "invoice_date": pl.Utf8}
+        )
+    )
 
 
 # Discriminant commande énergie (#564) : solde les faux positifs hors énergie (ex. S00583).

--- a/electricore/integrations/odoo/verification.py
+++ b/electricore/integrations/odoo/verification.py
@@ -17,6 +17,10 @@ class ResultatVerification:
     lisses_quantite_1: pl.DataFrame
 
 
+# Discriminant commande énergie (#564) : solde les faux positifs hors énergie (ex. S00583).
+_ENERGIE = ("x_pdl", "!=", False)
+
+
 def verifier(odoo: OdooReader) -> ResultatVerification:
     return ResultatVerification(
         rsc_manquante=_rsc_manquante(odoo),
@@ -31,7 +35,7 @@ def _rsc_manquante(odoo: OdooReader) -> pl.DataFrame:
     return query(
         odoo,
         "sale.order",
-        domain=[("state", "=", "sale"), ("x_ref_situation_contractuelle", "=", False)],
+        domain=[("state", "=", "sale"), _ENERGIE, ("x_ref_situation_contractuelle", "=", False)],
         fields=["name", "x_pdl"],
     ).collect()
 
@@ -40,7 +44,7 @@ def _cfne_manquante(odoo: OdooReader) -> pl.DataFrame:
     return query(
         odoo,
         "sale.order",
-        domain=[("state", "=", "sale"), ("x_date_cfne", "=", False)],
+        domain=[("state", "=", "sale"), _ENERGIE, ("x_date_cfne", "=", False)],
         fields=["name", "x_pdl"],
     ).collect()
 
@@ -49,7 +53,7 @@ def _invoicing_state_counts(odoo: OdooReader) -> pl.DataFrame:
     raw = query(
         odoo,
         "sale.order",
-        domain=[("state", "=", "sale")],
+        domain=[("state", "=", "sale"), _ENERGIE],
         fields=["x_invoicing_state"],
     ).collect()
     state_col = pl.col("x_invoicing_state").fill_null("(non défini)")
@@ -61,7 +65,7 @@ def _factures_draft(odoo: OdooReader) -> pl.DataFrame:
         query(
             odoo,
             "sale.order",
-            domain=[("state", "=", "sale")],
+            domain=[("state", "=", "sale"), _ENERGIE],
             fields=["name", "invoice_ids"],
         )
         .follow("invoice_ids", domain=[("state", "=", "draft")], fields=["name"])
@@ -81,7 +85,7 @@ def _lisses_quantite_1(odoo: OdooReader) -> pl.DataFrame:
         query(
             odoo,
             "sale.order",
-            domain=[("state", "=", "sale"), ("x_lisse", "=", True)],
+            domain=[("state", "=", "sale"), _ENERGIE, ("x_lisse", "=", True)],
             fields=["name", "order_line"],
         )
         .follow("order_line", domain=[("product_uom_qty", "=", 1)], fields=["product_id", "product_uom_qty"])

--- a/tests/unit/integrations/odoo/test_verification.py
+++ b/tests/unit/integrations/odoo/test_verification.py
@@ -1,17 +1,21 @@
 """Tests pour integrations/odoo/verification.py."""
 
+from datetime import date
 from unittest.mock import MagicMock, patch
 
 import polars as pl
 from polars.testing import assert_frame_equal
 
 from electricore.integrations.odoo.verification import (
+    _ENERGIE,
     ResultatVerification,
+    _brouillons_hors_ancre,
     _cfne_manquante,
     _factures_draft,
     _invoicing_state_counts,
     _lisses_quantite_1,
     _rsc_manquante,
+    ancre_courante,
     verifier,
 )
 
@@ -187,19 +191,87 @@ class TestLissesQuantite1:
         assert ("x_pdl", "!=", False) in kwargs["domain"]
 
 
+class TestAncreCourante:
+    """#564 : ancre courante = 05 du mois courant = date_ancre(dernier mois révolu)."""
+
+    def test_05_du_mois_courant(self):
+        assert ancre_courante(date(2026, 7, 4)) == "2026-07-05"
+
+    def test_rollover_janvier(self):
+        """Rollover décembre → janvier : ancre = 05/01/(N+1) (partagé avec #561)."""
+        assert ancre_courante(date(2027, 1, 15)) == "2027-01-05"
+
+
+class TestBrouillonsHorsAncre:
+    @patch(f"{MODULE}.ancre_courante")
+    @patch(f"{MODULE}.query")
+    def test_domaine_capture_energie_brouillon_hors_ancre_ou_sans_date(self, mock_query, mock_ancre):
+        mock_ancre.return_value = "2026-07-05"
+        odoo = MagicMock()
+        chain = _chain_mock(pl.DataFrame())
+        mock_query.return_value = chain
+
+        _brouillons_hors_ancre(odoo)
+
+        _, kwargs = mock_query.call_args
+        assert _ENERGIE in kwargs["domain"]
+        _, follow_kwargs = chain.follow.call_args
+        assert follow_kwargs["domain"] == [
+            ("state", "=", "draft"),
+            "|",
+            ("invoice_date", "!=", "2026-07-05"),
+            ("invoice_date", "=", False),
+        ]
+
+    @patch(f"{MODULE}.query")
+    def test_retourne_dataframe_avec_account_move_id(self, mock_query):
+        odoo = MagicMock()
+        raw = pl.DataFrame(
+            {
+                "sale_order_id": [1],
+                "name": ["SO1"],
+                "invoice_ids": [10],
+                "name_account_move": ["INV/001"],
+                "invoice_date": [None],
+            }
+        )
+        mock_query.return_value = _chain_mock(raw)
+        result = _brouillons_hors_ancre(odoo)
+        assert "account_move_id" in result.columns
+        assert result["account_move_id"][0] == 10
+
+    @patch(f"{MODULE}.query")
+    def test_df_vide_retourne_colonnes_attendues(self, mock_query):
+        odoo = MagicMock()
+        raw = pl.DataFrame(
+            {
+                "sale_order_id": pl.Series([], dtype=pl.Int64),
+                "name": pl.Series([], dtype=pl.Utf8),
+                "invoice_ids": pl.Series([], dtype=pl.Int64),
+                "name_account_move": pl.Series([], dtype=pl.Utf8),
+            }
+        )
+        mock_query.return_value = _chain_mock(raw)
+        result = _brouillons_hors_ancre(odoo)
+        assert result.is_empty()
+        assert "account_move_id" in result.columns
+
+
 class TestVerifier:
+    @patch(f"{MODULE}._brouillons_hors_ancre")
     @patch(f"{MODULE}._lisses_quantite_1")
     @patch(f"{MODULE}._factures_draft")
     @patch(f"{MODULE}._invoicing_state_counts")
     @patch(f"{MODULE}._cfne_manquante")
     @patch(f"{MODULE}._rsc_manquante")
-    def test_compose_les_5_checks(self, mock_rsc, mock_cfne, mock_counts, mock_draft, mock_lisses):
+    def test_compose_les_6_checks(self, mock_rsc, mock_cfne, mock_counts, mock_draft, mock_lisses, mock_hors_ancre):
         odoo = MagicMock()
         mock_rsc.return_value = pl.DataFrame({"sale_order_id": [1]})
         mock_cfne.return_value = pl.DataFrame({"sale_order_id": [2]})
         mock_counts.return_value = pl.DataFrame({"state": ["a"], "n": [1]})
         mock_draft.return_value = pl.DataFrame({"account_move_id": [10]})
         mock_lisses.return_value = pl.DataFrame({"sale_order_id": [3]})
+        mock_hors_ancre.return_value = pl.DataFrame({"account_move_id": [11]})
 
         result = verifier(odoo)
 
@@ -207,5 +279,6 @@ class TestVerifier:
         assert result.rsc_manquante["sale_order_id"][0] == 1
         assert result.cfne_manquante["sale_order_id"][0] == 2
         assert result.factures_draft["account_move_id"][0] == 10
+        assert result.brouillons_hors_ancre["account_move_id"][0] == 11
         mock_rsc.assert_called_once_with(odoo)
         mock_cfne.assert_called_once_with(odoo)

--- a/tests/unit/integrations/odoo/test_verification.py
+++ b/tests/unit/integrations/odoo/test_verification.py
@@ -38,6 +38,15 @@ class TestRscManquante:
         result = _rsc_manquante(odoo)
         assert_frame_equal(result, expected)
 
+    @patch(f"{MODULE}.query")
+    def test_domaine_restreint_aux_commandes_energie(self, mock_query):
+        """#564 : discriminant x_pdl généralisé — solde les faux positifs hors énergie (S00583)."""
+        odoo = MagicMock()
+        mock_query.return_value = _chain_mock(pl.DataFrame())
+        _rsc_manquante(odoo)
+        _, kwargs = mock_query.call_args
+        assert ("x_pdl", "!=", False) in kwargs["domain"]
+
 
 class TestCfneManquante:
     @patch(f"{MODULE}.query")
@@ -47,6 +56,14 @@ class TestCfneManquante:
         mock_query.return_value = _chain_mock(expected)
         result = _cfne_manquante(odoo)
         assert_frame_equal(result, expected)
+
+    @patch(f"{MODULE}.query")
+    def test_domaine_restreint_aux_commandes_energie(self, mock_query):
+        odoo = MagicMock()
+        mock_query.return_value = _chain_mock(pl.DataFrame())
+        _cfne_manquante(odoo)
+        _, kwargs = mock_query.call_args
+        assert ("x_pdl", "!=", False) in kwargs["domain"]
 
 
 class TestInvoicingStateCounts:
@@ -69,6 +86,14 @@ class TestInvoicingStateCounts:
         mock_query.return_value = _chain_mock(raw)
         result = _invoicing_state_counts(odoo)
         assert result["state"].to_list() == ["a_state", "z_state"]
+
+    @patch(f"{MODULE}.query")
+    def test_domaine_restreint_aux_commandes_energie(self, mock_query):
+        odoo = MagicMock()
+        mock_query.return_value = _chain_mock(pl.DataFrame({"x_invoicing_state": pl.Series([], dtype=pl.Utf8)}))
+        _invoicing_state_counts(odoo)
+        _, kwargs = mock_query.call_args
+        assert ("x_pdl", "!=", False) in kwargs["domain"]
 
 
 class TestFacturesDraft:
@@ -104,6 +129,14 @@ class TestFacturesDraft:
         assert result.is_empty()
         assert "account_move_id" in result.columns
 
+    @patch(f"{MODULE}.query")
+    def test_domaine_restreint_aux_commandes_energie(self, mock_query):
+        odoo = MagicMock()
+        mock_query.return_value = _chain_mock(pl.DataFrame())
+        _factures_draft(odoo)
+        _, kwargs = mock_query.call_args
+        assert ("x_pdl", "!=", False) in kwargs["domain"]
+
 
 class TestLissesQuantite1:
     @patch(f"{MODULE}.query")
@@ -136,6 +169,22 @@ class TestLissesQuantite1:
         result = _lisses_quantite_1(odoo)
         assert result.is_empty()
         assert "categ_names" in result.columns
+
+    @patch(f"{MODULE}.query")
+    def test_domaine_restreint_aux_commandes_energie(self, mock_query):
+        odoo = MagicMock()
+        mock_query.return_value = _chain_mock(
+            pl.DataFrame(
+                {
+                    "sale_order_id": pl.Series([], dtype=pl.Int64),
+                    "name": pl.Series([], dtype=pl.Utf8),
+                    "name_product_category": pl.Series([], dtype=pl.Utf8),
+                }
+            )
+        )
+        _lisses_quantite_1(odoo)
+        _, kwargs = mock_query.call_args
+        assert ("x_pdl", "!=", False) in kwargs["domain"]
 
 
 class TestVerifier:

--- a/tests/unit/test_bot_check_format.py
+++ b/tests/unit/test_bot_check_format.py
@@ -14,6 +14,7 @@ def _resultat(**surcharges) -> dict:
         "invoicing_state_counts": {},
         "factures_draft": [],
         "lisses_quantite_1": [],
+        "brouillons_hors_ancre": [],
     }
     return {**base, **surcharges}
 
@@ -63,6 +64,63 @@ def test_lisses_rendus_avec_les_colonnes_reelles():
     )
 
     assert "S00043" in msg and "Base, HP" in msg
+
+
+def test_brouillons_hors_ancre_rendus_avec_la_date():
+    """#564 : le check pré-campagne signale la commande, la facture et la date fautive."""
+    msg, xlsx_needed = _format_check_odoo(
+        _resultat(
+            brouillons_hors_ancre=[
+                {
+                    "name": "S00099",
+                    "account_move_id": 9,
+                    "name_account_move": "INV/2026/0099",
+                    "invoice_date": "2026-06-05",
+                    "url": "https://o/9",
+                }
+            ]
+        )
+    )
+
+    assert "S00099" in msg and "INV/2026/0099" in msg and "2026-06-05" in msg
+    assert xlsx_needed is False
+
+
+def test_brouillon_sans_date_affiche_absente():
+    msg, _ = _format_check_odoo(
+        _resultat(
+            brouillons_hors_ancre=[
+                {
+                    "name": "S00100",
+                    "account_move_id": 10,
+                    "name_account_move": "INV/2026/0100",
+                    "invoice_date": None,
+                    "url": "https://o/10",
+                }
+            ]
+        )
+    )
+
+    assert "absente" in msg
+
+
+def test_brouillons_hors_ancre_comptent_dans_le_feu_vert():
+    """Une anomalie hors-ancre à elle seule empêche le feu vert."""
+    msg, _ = _format_check_odoo(
+        _resultat(
+            brouillons_hors_ancre=[
+                {
+                    "name": "S00099",
+                    "account_move_id": 9,
+                    "name_account_move": "INV/0099",
+                    "invoice_date": None,
+                    "url": "https://o/9",
+                }
+            ]
+        )
+    )
+
+    assert "OK pour lancer le cycle de facturation" not in msg
 
 
 def test_message_trop_long_bascule_sur_le_xlsx():


### PR DESCRIPTION
## Résumé

Nouveau check pré-facturation `_brouillons_hors_ancre` : tout brouillon de
facture d'une commande énergie (`x_pdl` renseigné) encore en draft, daté hors
de l'ancre courante ou sans date, remonte désormais dans `/check odoo` avant
le lancement de la campagne suivante. L'ancre courante (le 05 du mois
courant) réutilise le même calcul que la sélection (#561, ADR-0054) —
aucun risque de dérive entre les deux. Au passage, le discriminant
`x_pdl != False` est généralisé aux 5 checks pré-facturation existants
(commit dédié), ce qui règle les faux positifs sur les commandes hors
énergie (ex. S00583).

> **Stackée sur la PR #562** (base = `fix/lignes-factures-brouillons`) : à
> merger après elle ; GitHub reciblera automatiquement sur `main`.

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)
