### PR TITLE
docs : socle Comprendre — 5 pages d'éducation populaire + passerelles montantes

### DIFF
--- a/docs/comprendre/anatomie-facture.md
+++ b/docs/comprendre/anatomie-facture.md
@@ -1,0 +1,110 @@
+---
+fraicheur: 2026-07-04
+---
+
+# L'anatomie d'une facture
+
+Une facture d'électricité paraît opaque parce qu'elle empile plusieurs choses qui
+n'ont rien à voir entre elles. Une fois que tu sais les séparer, elle devient lisible.
+Prenons une facture fictive et décortiquons-la, ligne par ligne.
+
+## Les quatre étages de ta facture
+
+Ce que tu paies se range en quatre grandes familles :
+
+1. **L'abonnement** — un forfait fixe, que tu consommes ou non.
+2. **L'énergie** — ce que tu as réellement consommé, en kWh.
+3. **Le TURPE** — le péage du réseau.
+4. **Les taxes** — la part qui va à l'État et à des fonds publics.
+
+Reprenons chacune.
+
+## 1. L'abonnement : le forfait d'accès
+
+L'abonnement est un montant **fixe par mois** (ou par an), indépendant de ta
+consommation. Tu le paies même en partant en vacances.
+
+Il dépend d'un paramètre : ta **puissance souscrite**, exprimée en **kVA** (une mesure
+de « débit » électrique maximal). Plus tu peux tirer de puissance en même temps —
+four, plaques, chauffe-eau, voiture qui charge — plus ta puissance souscrite est
+élevée, et plus ton abonnement coûte cher. Un petit studio n'a pas la même puissance
+qu'une maison tout-électrique.
+
+## 2. L'énergie : ce que tu as consommé
+
+C'est le cœur variable de la facture, et c'est là que reviennent les **index** vus à la
+page précédente : ton énergie du mois, c'est la **différence entre deux relevés**,
+multipliée par un prix au kWh.
+
+### Base, ou heures pleines / heures creuses ?
+
+Selon ton contrat, l'énergie est comptée dans un ou plusieurs **compteurs internes**,
+qu'on appelle des **cadrans** :
+
+- **Base** : un seul prix, 24 h/24. Simple. Tu consommes, c'est le même tarif jour et nuit.
+- **Heures pleines / heures creuses (HP/HC)** : deux prix. La nuit et à certaines heures
+  creuses, le kWh est **moins cher** ; le reste du temps (heures pleines), il est plus
+  cher. L'idée : t'inciter à décaler certains usages (chauffe-eau, lave-linge) vers les
+  heures où le réseau est moins sollicité.
+
+Concrètement, ton compteur tient un total **séparé** pour chaque cadran :
+
+> Heures creuses : 180 kWh × prix bas
+> Heures pleines : 160 kWh × prix haut
+> → deux lignes, une seule consommation de 340 kWh.
+
+Il existe des découpages plus fins encore (par saison, par jour de pointe), mais le
+principe ne change pas : **un cadran = un compteur interne avec son propre prix.**
+
+## 3. Le TURPE : le péage du réseau
+
+Le **TURPE** (Tarif d'Utilisation des Réseaux Publics d'Électricité) est le **péage**
+que tu paies pour faire passer ton électricité sur les fils d'Enedis et de RTE. Comme
+un péage d'autoroute : peu importe qui t'a vendu la voiture, tu paies la route.
+
+- Il ne va **pas** à ton fournisseur, mais au **réseau**.
+- Il est **fixé par la CRE**, le régulateur — ton fournisseur ne le décide pas, il ne
+  fait que le collecter pour le reverser.
+- Il a lui-même une part **fixe** (liée à ta puissance souscrite) et une part
+  **variable** (liée à tes kWh consommés).
+
+En général, le TURPE n'apparaît pas en ligne séparée sur ta facture : il est **fondu**
+dans le prix de l'abonnement et de l'énergie que ton fournisseur t'affiche. Il est bien
+là, mais caché. Le sortir de l'ombre est l'une des choses qu'ElectriCore sait faire.
+
+## 4. Les taxes : la part publique
+
+Enfin, l'État et des fonds publics prélèvent plusieurs taxes :
+
+- **L'accise sur l'électricité** (anciennement appelée TICFE) : une taxe sur chaque kWh
+  consommé. Elle a absorbé l'ancienne CSPE. C'est le gros de la fiscalité sur l'énergie.
+- **La CTA** (Contribution Tarifaire d'Acheminement) : une contribution calculée sur la
+  **part fixe du réseau**, qui finance les retraites des salarié·es des industries
+  électriques et gazières.
+- **La TVA** : comme sur tout achat. Particularité de l'électricité, elle s'applique à
+  **deux taux** — un taux réduit sur l'abonnement, un taux plein sur l'énergie.
+
+Les montants de ces taxes changent par décision publique (loi de finances, arrêtés).
+On ne les fige donc pas ici : retiens leur **rôle**, pas un chiffre qui périmerait.
+
+## Le récapitulatif
+
+| Étage | Ce que c'est | À qui ça va | Ça dépend de |
+|---|---|---|---|
+| Abonnement | Forfait d'accès | Ton fournisseur | Ta puissance souscrite |
+| Énergie | Tes kWh consommés | Ton fournisseur | Tes relevés d'index |
+| TURPE | Le péage du réseau | Le réseau (Enedis/RTE) | Puissance **et** kWh |
+| Taxes | Accise, CTA, TVA | L'État / fonds publics | kWh, part fixe, tout |
+
+La leçon : **ton fournisseur ne garde qu'une partie** de ce que tu paies. Le reste
+transite par lui vers le réseau et vers l'État. Une facture, c'est un empilement — et
+chaque étage se calcule séparément.
+
+## Pour aller plus loin
+
+Tu sais lire une facture. L'étape suivante, c'est de voir comment on la **fabrique**
+et on la **vérifie**, mois après mois, côté métier :
+[la section Facturer](../facturiste/changelog-facturiste.md) raconte le cycle de
+facturation tel qu'il tourne réellement avec ElectriCore.
+
+[Retour à l'accueil](../index.md).

--- a/docs/comprendre/compteur-pdl.md
+++ b/docs/comprendre/compteur-pdl.md
@@ -1,0 +1,85 @@
+---
+fraicheur: 2026-07-04
+---
+
+# Le compteur et le PDL
+
+Ta facture repose sur une poignée de chiffres relevés chez toi. Cette page explique
+d'où ils viennent, qui les touche, et lesquels te concernent vraiment.
+
+## Ton point de livraison a un numéro
+
+Le boîtier accroché à ton mur — souvent un **Linky** aujourd'hui — mesure ce que tu
+consommes. Mais l'identité qui compte administrativement n'est pas l'appareil : c'est
+l'**endroit** où tu es raccordé·e au réseau, ton **point de livraison**, désigné par
+un numéro à **14 chiffres**, le **PDL**.
+
+- Le **compteur**, c'est l'appareil physique. On peut le remplacer.
+- Le **PDL**, c'est l'emplacement. Il reste le même, même si on change le compteur.
+
+Ce numéro figure sur ta facture. C'est la clé qui relie tout : ton contrat, tes
+relevés, tes consommations. Quand ElectriCore ou ton fournisseur parle de « ton PDL »,
+c'est de ce numéro qu'il s'agit.
+
+## Deux sortes de données
+
+Le compteur produit deux choses très différentes, à ne pas confondre.
+
+### L'index : le compteur qui tourne
+
+L'**index**, c'est le nombre affiché qui **ne fait qu'augmenter**, comme le compteur
+kilométrique d'une voiture. Il se lit en **kilowattheures (kWh)**.
+
+Un index seul ne dit rien de ta consommation. Ce qui compte, c'est la **différence
+entre deux relevés** :
+
+> Index au 1ᵉʳ juin : 12 000 kWh
+> Index au 1ᵉʳ juillet : 12 340 kWh
+> → Tu as consommé **340 kWh** en juin.
+
+C'est ce simple calcul — deux relevés, une soustraction — qui fonde toute ta facture
+d'énergie. Retiens-le : il revient partout.
+
+### La courbe de charge : le film de tes journées
+
+Le Linky sait aussi enregistrer, plus finement, **combien tu consommes heure par
+heure** (ou par demi-heure). C'est la **courbe de charge** : non plus un total qui
+monte, mais le détail de tes pics et tes creux dans la journée.
+
+Cette donnée est plus intime — elle raconte tes habitudes — donc elle n'est collectée
+que si **tu y consens**. Pour la facturation courante, elle n'est pas nécessaire :
+les index suffisent. Elle sert surtout à mieux comprendre ou piloter ta consommation.
+
+## Qui touche à ces données ?
+
+La chaîne est toujours la même.
+
+1. **Ton compteur** mesure et enregistre.
+2. **Enedis** collecte ces mesures (le Linky les remonte automatiquement) et en est le
+   gardien. Enedis ne te vend rien : il mesure et transmet.
+3. **Ton fournisseur** reçoit ces données d'Enedis, sous forme de fichiers standardisés,
+   et s'en sert pour calculer ta facture.
+
+Tu es tout au bout de cette chaîne : les chiffres qui décident de ce que tu paies sont
+mesurés chez toi, mais **passent d'abord par Enedis puis par ton fournisseur** avant de
+revenir sur ta facture. Tu ne les vois, en général, que sous forme agrégée.
+
+## Ce qui te concerne vraiment
+
+- **Ton numéro de PDL** : ta clé d'identification, sur ta facture.
+- **Tes index** au début et à la fin de chaque période : ils fixent ton énergie facturée.
+- **La nature du relevé** : un index peut être *réellement mesuré* ou *estimé* (quand la
+  mesure n'a pas pu être collectée). Cette mention doit figurer sur ta facture — un
+  chiffre estimé n'a pas la même valeur qu'un chiffre réel, et tu as le droit de le savoir.
+
+Tout l'enjeu, ensuite, est de vérifier que le chemin « mesure chez toi → Enedis →
+fournisseur → facture » n'a rien déformé. C'est exactement ce qu'ElectriCore permet de
+refaire soi-même.
+
+## Pour aller plus loin
+
+Tu sais maintenant d'où viennent les chiffres. Voyons ce qu'on en fait :
+[L'anatomie d'une facture](anatomie-facture.md) — comment tes index et ton abonnement
+deviennent une somme à payer.
+
+[Retour à l'accueil](../index.md).

--- a/docs/comprendre/electricore-vu-de-loin.md
+++ b/docs/comprendre/electricore-vu-de-loin.md
@@ -1,0 +1,93 @@
+---
+fraicheur: 2026-07-04
+---
+
+# ElectriCore vu de loin
+
+Tu es peut-être dans un collectif énergie, une coopérative, un groupe qui se demande
+s'il pourrait s'approprier cet outil. Avant de passer la main à une personne technique,
+tu veux une image claire de **ce que fait ElectriCore**, sans jargon et sans code.
+
+La voici.
+
+## En une phrase
+
+**Des fichiers de données brutes arrivent d'Enedis ; ElectriCore les range et refait
+tous les calculs ; il en sort des factures qu'on peut vérifier ligne à ligne.**
+
+C'est tout. Le reste n'est que le détail de ces trois temps.
+
+## Les trois temps
+
+### 1. Des fichiers arrivent
+
+Enedis ne t'envoie pas une jolie facture : il dépose, régulièrement, des **fichiers
+techniques** — des relevés d'index, des changements de contrat, des informations de
+facturation du réseau. Illisibles tels quels pour un humain, et déposés en vrac.
+
+ElectriCore va **chercher ces fichiers automatiquement** et les **déchiffre** (Enedis les
+protège pour la confidentialité).
+
+### 2. L'outil range et recalcule
+
+Une fois les fichiers récupérés, ElectriCore fait deux choses.
+
+- **Il range.** Le fouillis brut devient des tables propres et cohérentes : chaque relevé
+  à sa place, chaque contrat suivi dans le temps, les doublons et corrections démêlés.
+- **Il recalcule.** À partir de ces données rangées, il refait **tout** le calcul de
+  facturation vu dans les pages précédentes : l'énergie par cadran (différences d'index),
+  l'abonnement au prorata des jours, le TURPE, les taxes. Sur des **mois calendaires nets**,
+  pas sur les découpages d'Enedis.
+
+Point important : le calcul est **rejouable**. Repars des mêmes fichiers de base, tu
+obtiens exactement le même résultat. Rien n'est bricolé à la main dans un coin.
+
+### 3. Des factures vérifiables sortent
+
+Le résultat n'est pas juste un montant. Pour chaque mois et chaque point de livraison,
+ElectriCore produit une facturation **rattachée à ses preuves** :
+
+- le montant, décomposé par étage (énergie, abonnement, TURPE, taxes) ;
+- **les relevés exacts** qui l'ont justifié — quelles dates, quels index, mesurés ou estimés ;
+- un **verdict de confiance** : ce mois s'appuie-t-il sur des mesures réelles, ou sur des
+  estimations à surveiller ?
+
+Autrement dit, chaque facture arrive avec le « pourquoi » attaché. C'est ce qui la rend
+**vérifiable**, et c'est la promesse de la page précédente tenue concrètement.
+
+## Ce qu'ElectriCore n'est pas
+
+Pour évaluer justement, autant savoir où sont les bords.
+
+- **Ce n'est pas un fournisseur.** ElectriCore ne vend pas d'électricité et n'a pas de
+  client à lui. C'est un **moteur de calcul** au service de qui facture.
+- **Ce n'est pas magique.** Il recalcule à partir des données d'Enedis ; si une mesure
+  manque à la source, il le **signale** plutôt que d'inventer.
+- **Ça ne décide pas à ta place.** Aujourd'hui, l'outil **propose** une facturation ;
+  c'est un·e humain·e qui la valide avant qu'elle parte dans le logiciel de gestion. Rien
+  n'est envoyé sans qu'une personne ait regardé.
+
+## Qui met les mains dedans ?
+
+Trois cercles, du plus large au plus technique :
+
+- **Toi, qui évalues** : cette page suffit. Tu sais maintenant ce que fait l'outil et ce
+  qu'il ne fait pas.
+- **La personne qui facture** au quotidien : elle pilote l'outil via un bot de messagerie
+  et des feuilles de calcul interactives, sans coder — c'est la section *Facturer*.
+- **La personne technique** qui installe, adapte, ou contribue au code — c'est la section
+  *Développer*.
+
+Passer d'un cercle à l'autre, c'est le principe de cette documentation : chacun·e monte
+d'une marche quand iel est prêt·e.
+
+## Pour aller plus loin
+
+Deux marches au-dessus, selon qui prend le relais :
+
+- Pour voir l'outil **au travail** au quotidien :
+  [la section Facturer](../facturiste/changelog-facturiste.md).
+- Pour la **mécanique technique** (architecture, code, données) :
+  [Développer](../contribuer/developper.md).
+
+[Retour à l'accueil](../index.md).

--- a/docs/comprendre/index.md
+++ b/docs/comprendre/index.md
@@ -1,15 +1,36 @@
+---
+fraicheur: 2026-07-04
+---
+
 # Comprendre
 
-Cette section s'adresse à toi si tu es **usager·ère** d'ElectriCore : tu veux
-comprendre ce que le projet calcule et pourquoi, sans avoir besoin de lire du
-code ni d'administrer quoi que ce soit.
+Cette section s'adresse à toi si tu es **usager·ère** : tu veux comprendre ce
+qu'ElectriCore calcule et pourquoi, sans lire une ligne de code ni administrer quoi que
+ce soit. On part du décor le plus large — le système électrique français — pour arriver,
+marche après marche, à ce que fait l'outil.
 
-Elle accueillera une présentation en clair du réseau électrique français, des
-notions clés (PDL, TURPE, facturation calendaire…) et de ce qu'ElectriCore
-change concrètement. Ce contenu arrive dans une tranche à venir du chemin de
-documentation par rôles.
+Aucun prérequis : tu peux lire ces pages même si tu n'as rien installé et que tu ne
+connais pas encore ElectriCore.
 
-En attendant, la porte la plus proche est celle des personnes qui facturent
-au quotidien : [Facturer](../facturiste/changelog-facturiste.md).
+## L'ordre de lecture conseillé
+
+1. **[Le système électrique français](systeme-electrique.md)** — production, réseau,
+   fournisseurs, régulateur : qui fait quoi entre la centrale et ta prise.
+2. **[Le compteur et le PDL](compteur-pdl.md)** — quelles données existent chez toi
+   (index, courbe de charge), qui les manipule, et ce qui te concerne.
+3. **[L'anatomie d'une facture](anatomie-facture.md)** — abonnement, énergie, TURPE,
+   taxes : ce que tu paies, à qui, et pourquoi.
+4. **[Pourquoi recalculer soi-même](pourquoi-recalculer.md)** — le sens, technique et
+   politique, de reprendre la main sur ses propres calculs.
+5. **[ElectriCore vu de loin](electricore-vu-de-loin.md)** — la vue d'ensemble non
+   technique : des fichiers Enedis aux factures vérifiables.
+
+Tu peux les lire d'affilée, ou piocher : chaque page se lit seule et se termine par une
+passerelle vers la marche du dessus.
+
+## D'autres pages arriveront
+
+Cette section grandira : les flux Enedis racontés en clair, le détail des heures
+pleines / heures creuses, le mécanisme des contrats lissés… Le socle, lui, est là.
 
 [Retour à l'accueil](../index.md).

--- a/docs/comprendre/pourquoi-recalculer.md
+++ b/docs/comprendre/pourquoi-recalculer.md
@@ -1,0 +1,72 @@
+---
+fraicheur: 2026-07-04
+---
+
+# Pourquoi recalculer soi-même
+
+À ce stade, une question honnête se pose : Enedis mesure, le fournisseur facture, tout
+ça est encadré par un régulateur — **pourquoi refaire les calculs ?** N'est-ce pas de la
+défiance inutile ?
+
+Non. C'est une histoire de **reprise en main**, et elle est autant technique que
+politique.
+
+## On te livre des totaux, pas la mesure
+
+Enedis ne se contente pas de mesurer : il **découpe et agrège** les données avant de les
+transmettre. Il te renvoie des totaux mensuels, calés sur *sa* logique de découpage —
+souvent la date d'anniversaire de ton contrat, pas des mois calendaires nets.
+
+Le problème, ce n'est pas la mauvaise foi : c'est que **tu reçois un résultat déjà
+mâché, sans pouvoir refaire l'opération**. Si un total te paraît bizarre, tu n'as pas la
+prise pour vérifier. Tu es prié·e de faire confiance à une boîte noire.
+
+## Recalculer, c'est vérifier
+
+Reprendre les **relevés bruts** — les index à des dates précises — et refaire soi-même
+l'addition, ça change tout :
+
+- Tu peux **contrôler** que la consommation facturée correspond à une vraie différence
+  d'index, à des dates que tu maîtrises.
+- Tu peux **repérer** un relevé estimé qui aurait dû être réel, un mois qui s'appuie sur
+  une donnée manquante, un découpage qui gonfle ou rabote une période.
+- Tu peux **expliquer** chaque euro : d'où vient l'énergie, d'où vient le TURPE, d'où
+  vient chaque taxe.
+
+Une facture qu'on peut **rejouer** depuis les données de base n'est plus une boîte noire.
+C'est une facture **vérifiable** — et une facture vérifiable est une facture sur laquelle
+on peut discuter d'égal à égal.
+
+## Le sens politique : reprendre un bien commun
+
+Va un cran plus loin. Les données de ton compteur, c'est **ta** consommation, mais tu ne
+les possèdes pas vraiment : elles vivent chez Enedis, transitent chez ton fournisseur, et
+te reviennent en résumé. La capacité de **comprendre et de recalculer** ta propre facture
+est, aujourd'hui, concentrée entre quelques mains outillées.
+
+ElectriCore part d'un pari différent : cette capacité doit être **un bien commun**, pas
+un privilège technique. Un outil libre, partagé, que des collectifs et des fournisseurs
+coopératifs peuvent s'approprier pour ne plus dépendre des agrégats qu'on leur sert.
+
+L'idée dépasse une seule structure. Le projet se pense comme le **premier prototype
+d'une fédération** : plusieurs acteurs de l'énergie qui mettent en commun le même moteur
+de calcul, la même veille sur les tarifs réglementés, les mêmes vérifications. Ce que
+l'un corrige ou met à jour profite à tou·tes. La règle de facturation cesse d'être la
+propriété d'un logiciel privé : elle devient un savoir partagé, lisible, contestable.
+
+Recalculer soi-même, ce n'est donc pas seulement traquer une erreur d'arrondi. C'est
+**refuser la dépendance** : ne plus prendre pour argent comptant ce qu'une boîte noire
+affirme, et se redonner collectivement les moyens de vérifier.
+
+## En une phrase
+
+Recalculer, c'est transformer « on te dit que tu dois payer ça » en « voici, étape par
+étape, pourquoi tu paies ça — et tu peux le refaire toi-même ».
+
+## Pour aller plus loin
+
+Reste à voir **comment** un outil concret fait ce travail, sans que tu aies à coder :
+[ElectriCore vu de loin](electricore-vu-de-loin.md) — la vue d'ensemble, des fichiers
+Enedis jusqu'aux factures vérifiables.
+
+[Retour à l'accueil](../index.md).

--- a/docs/comprendre/systeme-electrique.md
+++ b/docs/comprendre/systeme-electrique.md
@@ -1,0 +1,74 @@
+---
+fraicheur: 2026-07-04
+---
+
+# Le système électrique français
+
+Quand tu allumes une lampe, l'électricité qui arrive vient de loin et passe entre
+plusieurs mains avant d'atteindre ta prise. Comprendre qui fait quoi t'aide à lire
+ta facture et à voir où ElectriCore intervient. Tu n'as rien à installer pour lire
+cette page : c'est le décor commun à tout le monde.
+
+## Le voyage d'un kilowattheure
+
+L'électricité fait un trajet en trois grandes étapes.
+
+1. **La production.** Des centrales fabriquent l'électricité : nucléaire (la plus
+   grosse part en France), barrages hydrauliques, éolien, solaire, gaz. On ne peut
+   presque pas la stocker : ce que tu consommes à l'instant T est produit à l'instant T,
+   quelque part sur le réseau.
+2. **Le transport.** L'électricité part des centrales sur de très hautes tensions,
+   à travers les grandes lignes qui traversent le pays. C'est le rôle de **RTE**
+   (Réseau de Transport d'Électricité) : les autoroutes de l'électricité.
+3. **La distribution.** Près de chez toi, la tension est abaissée et l'électricité
+   est amenée jusqu'à ton compteur par les lignes du quartier. C'est le rôle
+   d'**Enedis** dans la plus grande partie du territoire : les routes et rues qui
+   desservent chaque maison. (Dans quelques territoires, ce sont de petites
+   entreprises locales de distribution qui tiennent ce rôle.)
+
+Une image simple : RTE, c'est l'autoroute ; Enedis, c'est la voirie locale qui
+t'amène l'électricité jusqu'à ta porte.
+
+## Qui te vend l'électricité ?
+
+Le transport et la distribution sont des **monopoles** : il n'y a qu'un seul réseau
+de fils, et tout le monde le partage. Tu ne choisis donc pas ton distributeur —
+dans ta commune, c'est Enedis (ou l'entreprise locale) et personne d'autre.
+
+Ce que tu **choisis**, c'est ton **fournisseur** : l'acteur commercial qui t'envoie
+ta facture et te vend les kilowattheures. EDF, mais aussi des dizaines d'autres, dont
+des fournisseurs coopératifs et locaux. Change de fournisseur autant que tu veux :
+les fils dans la rue, eux, ne changent pas.
+
+Ton fournisseur, lui, ne va pas relever ton compteur à la main. Il s'appuie sur les
+**données de mesure** qu'Enedis lui transmet — c'est là que se joue tout le reste de
+cette section.
+
+## Qui fixe les règles du jeu ?
+
+Comme les réseaux sont des monopoles, quelqu'un doit s'assurer que le prix du passage
+sur les fils reste juste. C'est la **CRE** (Commission de Régulation de l'Énergie),
+le régulateur public. Elle fixe notamment le **TURPE**, le péage que tout le monde
+paie pour utiliser le réseau (on y revient dans l'anatomie de la facture). Elle ne te
+vend rien : elle arbitre.
+
+## Les acteurs en une phrase chacun
+
+- **Producteur·rice** — fabrique l'électricité (centrales, barrages, éoliennes…).
+- **RTE** — transporte l'électricité sur les grandes lignes à très haute tension.
+- **Enedis** — distribue l'électricité jusqu'à ton compteur ; gère aussi ses données.
+- **Fournisseur·euse** — te vend l'électricité et t'envoie ta facture ; tu peux en changer.
+- **CRE** — le régulateur : fixe le péage du réseau et arbitre les règles.
+- **Toi, usager·ère** — tu consommes, et tu paies chaque maillon de cette chaîne.
+
+Retiens surtout une chose : **le réseau (Enedis, RTE) et la vente (le fournisseur)
+sont deux métiers séparés.** Ta facture mélange les deux, et savoir les distinguer
+est la clé pour la comprendre.
+
+## Pour aller plus loin
+
+Maintenant que tu vois la chaîne, la porte suivante est celle de **tes** données :
+[Le compteur et le PDL](compteur-pdl.md) — quelles données Enedis mesure chez toi, et
+qui les manipule.
+
+[Retour à l'accueil](../index.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,11 @@ nav:
   - Accueil: index.md
   - Comprendre:
       - comprendre/index.md
+      - Le système électrique français: comprendre/systeme-electrique.md
+      - Le compteur et le PDL: comprendre/compteur-pdl.md
+      - L'anatomie d'une facture: comprendre/anatomie-facture.md
+      - Pourquoi recalculer soi-même: comprendre/pourquoi-recalculer.md
+      - ElectriCore vu de loin: comprendre/electricore-vu-de-loin.md
   - Facturer:
       - Guide facturiste: facturiste/changelog-facturiste.md
       - Bot Telegram (facturiste): guide-bot-facturiste.md


### PR DESCRIPTION
## Résumé

Socle de la section *Comprendre* : **5 pages d'éducation populaire** écrites à hauteur d'usager·ère et de citoyen·ne, sans jargon non défini — le système électrique français, le compteur et le PDL, l'anatomie d'une facture, pourquoi recalculer soi-même (le récit du commun, ADR-0024), et ElectriCore vu de loin.

- Chaque page tutoie, applique le point médian et se termine par une **passerelle montante** vers l'étage du dessus (escalier de la charte) — aucune passerelle ne redescend.
- L'index de section est réécrit en vraie page d'entrée avec un ordre de lecture conseillé ; les 5 pages entrent dans la nav (**section Comprendre uniquement** — merge-friendly avec #559/#560).
- Aucun tarif chiffré daté (ça périme) ; front-matter `fraicheur: 2026-07-04` sur les 6 fichiers (convention transversale du chantier, exigée par le test de parité de #560).
- Hors périmètre respecté : exactement 5 pages (pas de flux racontés / HP-HC approfondi / lissé), ADRs et registres agent intouchés.

Tranche du PRD #555.

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
