### PR TITLE
docs : section Maintenir — index ADR thématique, processus de release, gouvernance du registre réglementaire

### DIFF
--- a/docs/maintenir/gouvernance-reglementaire.md
+++ b/docs/maintenir/gouvernance-reglementaire.md
@@ -1,0 +1,75 @@
+---
+fraicheur: 2026-07-04
+---
+
+# Gouvernance du registre réglementaire
+
+Le **registre réglementaire** est l'un des [trois registres de savoir](../adr/0024-trois-registres-de-savoir.md)
+du dépôt (avec le runtime et le structurel) : les **taux régulés** — TURPE (fixe et
+variable), Accise (TICFE), CTA — versionnés dans des CSV du dépôt et **appliqués par date
+d'entrée en vigueur**, pas lus à runtime depuis un système externe.
+
+## Ce que contient le registre
+
+Trois fichiers dans `electricore/config/` :
+
+| fichier | grille | lu par |
+|---|---|---|
+| `turpe_rules.csv` | 2D — `Formule_Tarifaire_Acheminement` (FTA) × fenêtre `start`/`end` | lecteur dédié dans `core/pipelines/turpe.py` (grille propre, hors périmètre du lecteur partagé) |
+| `accise_rules.csv` | 1D — historique `start` → `taux_accise_eur_mwh` | `charger_regles_taux()` (`core/pipelines/taux.py`) |
+| `cta_rules.csv` | 1D — historique `start` → `taux_cta_pct` | `charger_regles_taux()` (`core/pipelines/taux.py`) |
+
+Chaque ligne porte une colonne **`reference`** — la délibération CRE ou l'article de loi de
+finances qui la justifie, texte libre + URL. `ajouter_taux_en_vigueur()` attache à chaque
+période de consommation le taux applicable à sa date par une jointure `join_asof`
+(stratégie `backward` : chaque ligne du registre remplace la précédente jusqu'à la
+suivante). Le **millésime** d'un fichier — sa dernière ligne entrée en vigueur, avec sa
+référence — se dérive de ce même historique et ne se déclare jamais à part
+(`core/millesimes.py`, exposé via `GET /taxes/millesimes`).
+
+## Qui met à jour, et comment
+
+**La lib — le commun ElectriCore — est l'autorité sur le contenu des taux régulés**, pas
+une instance ni un ERP particulier :
+
+1. Un taux change (délibération CRE, loi de finances) → une **PR** qui édite la ou les
+   lignes concernées des CSV, avec sa `reference` renseignée.
+2. Cette PR se relit **comme du code** — même circuit que n'importe quelle contribution
+   ([CONTRIBUTING.md](https://github.com/Energie-De-Nantes/electricore/blob/main/CONTRIBUTING.md)) :
+   revue humaine, merge humain.
+3. La **distribution** est une [release](release.md) — les instances récupèrent le
+   nouveau taux à leur prochaine mise à jour d'image, pas avant.
+
+La **surveillance** (repérer qu'une réglementation a changé) est déléguée — un membre non
+technique de la fédération, une alerte automatisée, peu importe le canal : le point
+d'entrée reste toujours la contribution, jamais un flux de données lu en direct par les
+pipelines. Un **check de péremption** heuristique existe déjà comme filet
+(`core/peremption.py`, exposé via `GET /taxes/peremption`) : il compare la dernière ligne
+connue de chaque registre à un rythme attendu (TURPE ~1ᵉʳ août, Accise ~1ᵉʳ janvier ; la
+CTA n'a pas de rythme connu, donc pas de check) et **avertit sans jamais corriger** —
+un changement hors calendrier reste invisible tant qu'un humain ne le signale pas.
+
+Un ERP peut offrir un **chemin de saisie** qui aboutit à une contribution (une PR
+proposée), mais jamais une source de taux lue à runtime par les pipelines — sans quoi une
+facture ne serait plus rejouable depuis une version donnée de la lib, et l'instance
+no-ERP se retrouverait sans taux.
+
+## Où vivent les exceptions déclaratives
+
+Le registre réglementaire ne connaît qu'un **taux national standard** par taxe et par
+date. Les **catégories d'accise réduites ou exonérées** (certains usages professionnels,
+certaines puissances) ne sont **pas** modélisées dans les CSV du dépôt : elles vivent
+**côté Odoo**, de façon déclarative — portées par la catégorie de produit facturée
+(`agreger_consommations_mensuelles()` dans `core/pipelines/accise.py` filtre et agrège les
+lignes de factures telles qu'Odoo les a déjà qualifiées ; le pipeline n'encode lui-même
+aucune règle de taux réduit). C'est un choix cohérent avec la frontière ERP-agnostique du
+cœur ([ADR-0016](../adr/0016-core-erp-agnostique.md)) : le taux national est un savoir du
+commun, l'éligibilité d'un client donné à une exception est un savoir de l'instance.
+
+## Pour aller plus loin
+
+[ADR-0024 — Trois registres de savoir](../adr/0024-trois-registres-de-savoir.md) ·
+[Configuration — inventaire complet](https://github.com/Energie-De-Nantes/electricore/blob/main/docs/configuration.md) ·
+[Carte des domaines](../contribuer/carte-domaines.md).
+
+[Retour à Maintenir](index.md).

--- a/docs/maintenir/index-adr.md
+++ b/docs/maintenir/index-adr.md
@@ -1,0 +1,101 @@
+---
+fraicheur: 2026-07-04
+---
+
+# Index thématique des ADRs
+
+Le [registre des décisions d'architecture](../adr/0001-monorepo.md) (`docs/adr/`) est
+**immuable** : une décision ne se corrige ni ne se supprime, elle se remplace par un
+nouvel ADR qui la **supersède** explicitement (voir par exemple
+[ADR-0037](../adr/0037-trousseau-cles-aes-n-cles-selection-par-essai.md), qui supersède
+[ADR-0008](../adr/0008-rotation-cles-aes.md)). Cette page ne réécrit aucun ADR — elle les
+regroupe par thème pour retrouver une décision sans grep. Un ADR peut apparaître dans
+deux thèmes quand la décision touche vraiment aux deux.
+
+## Architecture & rôles des modules
+
+- [ADR-0001 — Monorepo](../adr/0001-monorepo.md) — un seul dépôt pour ingestion/core/api/bot/integrations, pas de paquets séparés.
+- [ADR-0002 — Polars exclusivement](../adr/0002-polars-uniquement.md) — pas de pandas ; Polars pur sur toute la couche calcul.
+- [ADR-0004 — Langue française](../adr/0004-langue-francaise.md) — code, documentation et domaine métier en français.
+- [ADR-0005 — DuckDB comme stockage](../adr/0005-duckdb-stockage.md) — DuckDB comme couche de stockage analytique entre ingestion et pipelines.
+- [ADR-0007 — Query builders](../adr/0007-query-builders.md) — `DuckDBQuery`/`OdooQuery` : builders fluents, immuables, filtres poussés au `WHERE`.
+- [ADR-0009 — Architecture API-centrique](../adr/0009-architecture-api-centrique.md) — l'API FastAPI est le hub ; bot, notebooks et intégrations passent tous par elle.
+- [ADR-0016 — `core/` ERP-agnostique](../adr/0016-core-erp-agnostique.md) — `core/` ne dépend que de Polars/DuckDB/Pandera/stdlib ; tout adaptateur ERP vit dans `integrations/`.
+- [ADR-0018 — Classes justifiées par l'état](../adr/0018-classes-justifiees-par-l-etat.md) — une classe se justifie par un état interne réel ; sinon fonctions + dataclasses frozen.
+- [ADR-0019 — Rôles des dossiers](../adr/0019-roles-loaders-pipelines-builds-integrations.md) — un rôle par dossier (loaders/pipelines/builds/writers/integrations/api), imports par rôle vérifiés en CI.
+- [ADR-0032 — Marts hors namespace `/flux`](../adr/0032-modeles-marts-hors-flux-namespace.md) — les marts transverses (relevés, spine…) sortent du namespace `/flux/*`.
+- [ADR-0043 — `electricore-client` séparé](../adr/0043-electricore-client-paquet-separe.md) — client léger httpx+pydantic distribué à part (PyPI), JSONL streamé, modèles single-source.
+- [ADR-0050 — Deux entrées du contexte mensuel](../adr/0050-entrees-contexte-mensuel-parc-et-point-distinctes.md) — parc complet et point unique restent des entrées distinctes de `contexte_du_mois`.
+
+## Ingestion & flux Enedis
+
+- [ADR-0006 — DLT pour l'ETL](../adr/0006-dlt-etl.md) — dlt orchestre l'ELT SFTP → DuckDB (landing brut).
+- [ADR-0008 — Rotation des clés AES (stopgap)](../adr/0008-rotation-cles-aes.md) — format `secrets.toml` à deux clés, **superseded par ADR-0037**.
+- [ADR-0020 — Linéarisation en dbt (prototype)](../adr/0020-linearisation-en-dbt.md) — prototype de linéarisation SQL des flux Enedis en dbt.
+- [ADR-0021 — Bascule production dbt](../adr/0021-bascule-production-dbt.md) — dbt devient le chemin de production de la linéarisation.
+- [ADR-0035 — Typage de la chaîne ingestion↔cœur](../adr/0035-typage-chaine-ingestion-coeur-proprietaire-par-fait.md) — un propriétaire par fait, parité vérifiée aux frontières.
+- [ADR-0037 — Trousseau de clés AES N-clés](../adr/0037-trousseau-cles-aes-n-cles-selection-par-essai.md) — sélection par essai (oracle PKCS7/ZIP), escalade d'échec per-flux.
+- [ADR-0040 — Schéma de déchiffrement AES à IV préfixé](../adr/0040-schema-dechiffrement-aes-iv-prefixe.md) — réalise le seam ouvert par l'ADR-0037 (AES-256).
+- [ADR-0047 — Flux R67](../adr/0047-flux-r67-energie-par-periode-distributeur-hors-releves.md) — énergie par période livrée par le distributeur, asset parallèle hors union `releves`.
+- [ADR-0051 — Flux C12](../adr/0051-flux-c12-spine-c4.md) — ingestion du flux C12 (PRM > 36 kVA) + spine contractuelle C4.
+- [ADR-0053 — Parité des sites de déclaration d'un flux connu](../adr/0053-parite-sites-declaration-flux-connu.md) — vérifie que les quatre sites où se déclare un flux restent en phase.
+
+## Données & conventions
+
+- [ADR-0003 — Harmonisation des dates R151](../adr/0003-r151-date-harmonisation.md) — ajustement +1 jour du R151 pour s'harmoniser avec R64/R15/C15.
+- [ADR-0013 — Renommage Périmètre → Historique](../adr/0013-renommage-perimetre-historique.md) — le vocabulaire du cœur adopte « Historique ».
+- [ADR-0023 — Périodisations séparées](../adr/0023-periodisations-separees-abonnement-energie.md) — abonnement et énergie restent deux frises séparées, jamais imbriquées.
+- [ADR-0026 — Facturation calendaire](../adr/0026-facturation-calendaire-pas-moisniversaire.md) — facturation du 1ᵉʳ au 1ᵉʳ, pas au « moisniversaire » Enedis.
+- [ADR-0028 — Identité de relevé](../adr/0028-identite-releve-cle-metier-priorite-sources.md) — clé métier stable + priorité explicite des sources (C15 > R64 > R151).
+- [ADR-0029 — Modèle de relevés canonique](../adr/0029-modele-releves-canonique-dbt-assemble-coeur-arbitre.md) — le mart `releves` assemble en dbt, le cœur se contente d'arbitrer/filtrer.
+- [ADR-0033 — Qualité de période](../adr/0033-qualite-periode-remplace-data-complete-coverage.md) — remplace `data_complete`/`coverage` par un axe réelle/estimée/incalculable.
+- [ADR-0034 — Index en kWh entiers](../adr/0034-index-kwh-entiers-floor-au-boundary-dbt.md) — normalisation floor au boundary dbt.
+- [ADR-0036 — Statut de communication](../adr/0036-statut-communication-routage-energie-grain-meta.md) — axe jumeau de la qualité, porté par `Niveau_Ouverture_Services`.
+- [ADR-0038 — Relevés utilisés imbriqués](../adr/0038-releves-utilises-imbriques-meta-periodes.md) — trace d'index légale imbriquée dans chaque méta-période.
+- [ADR-0039 — Chronologie : attributs de situation hors mart](../adr/0039-chronologie-substrat-attributs-situation-hors-mart.md) — attributs (FTA, puissance…) forward-fillés en SQL, hors du mart relevés.
+- [ADR-0041 — Chronologie du contrat en spine dbt](../adr/0041-chronologie-contrat-spine-relationnelle-dbt.md) — la chronologie devient une spine relationnelle assemblée entièrement en dbt.
+- [ADR-0042 — Convention de date instant/jour civil](../adr/0042-convention-date-instant-jour-civil-boundary-flux.md) — TIMESTAMPTZ vs DATE harmonisés au boundary `flux_*`, fuseau Europe/Paris à la lecture.
+- [ADR-0045 — Relations de la spine par clé naturelle](../adr/0045-relations-spine-reference-cle-normalisation-chronologie-releves.md) — `releve_id` référencé tel quel, pas de surrogate/FK.
+- [ADR-0052 — Présence au périmètre](../adr/0052-presence-perimetre-spans-rsc-fermeture-code-sortie.md) — spans `[début, fin)` par RSC, fermeture sur le code de sortie.
+
+## Facturation & taxes
+
+- [ADR-0014 — Lignes de factures du mois avec flags](../adr/0014-lignes-factures-du-mois-avec-flags.md) — expose les lignes avec des flags d'état plutôt que de filtrer à zéro hors période.
+- [ADR-0024 — Trois registres de savoir](../adr/0024-trois-registres-de-savoir.md) — distingue runtime / structurel / réglementaire ; gouvernance détaillée dans [gouvernance-reglementaire.md](gouvernance-reglementaire.md).
+- [ADR-0027 — Odoo tire les méta-périodes](../adr/0027-endpoint-lecture-meta-periodes-odoo-tire.md) — `GET /facturation/meta-periodes`, cœur read-only, pas de `POST recompute`.
+- [ADR-0030 — Calculateur TURPE variable](../adr/0030-calculateur-turpe-variable-odoo-fournit-assiette.md) — Odoo fournit l'assiette de consommation, electricore livre le montant.
+- [ADR-0048 — Estimation de provision des lissés](../adr/0048-estimation-provision-lisses-coeur-kwh-cold-start-r67.md) — dérivation cœur-pure en kWh, amorcée par R67 (cold-start).
+
+## Déploiement & secrets
+
+- [ADR-0011 — Déploiement VPS Docker](../adr/0011-deploiement-vps-docker.md) — VPS + Docker Compose comme socle de déploiement.
+- [ADR-0015 — Déploiement multi-instance](../adr/0015-deploiement-multi-instance.md) — un VPS par fournisseur, pas de mutualisation multi-tenant.
+- [ADR-0017 — Layout `/srv/<slug>/`](../adr/0017-layout-deploiement-srv-slug.md) — une instance vit sous `/srv/<slug>/`, avec un utilisateur système dédié.
+- [ADR-0025 — Registre runtime pydantic-settings](../adr/0025-registre-runtime-pydantic-settings.md) — `runtime.py`, domaines indépendants, validation fail-fast par point d'entrée.
+- [ADR-0031 — Durcissement SSH du VPS](../adr/0031-durcissement-ssh-vps-utilisateur-ops.md) — utilisateur admin `ops`, root sans accès SSH.
+- [ADR-0037 — Trousseau de clés AES N-clés](../adr/0037-trousseau-cles-aes-n-cles-selection-par-essai.md) — voir aussi thème Ingestion ci-dessus.
+- [ADR-0040 — Schéma de déchiffrement AES à IV préfixé](../adr/0040-schema-dechiffrement-aes-iv-prefixe.md) — voir aussi thème Ingestion ci-dessus.
+- [ADR-0044 — Secrets-as-code SOPS + age](../adr/0044-secrets-as-code-sops-age.md) — secrets chiffrés versionnés, déchiffrement en image, identité par instance.
+- [ADR-0046 — Convention de nommage env](../adr/0046-convention-noms-env-par-domaine-identite-secrets.md) — `<DOMAINE>__<CHAMP>` + modèle d'identité/accès des secrets.
+- [ADR-0049 — Schéma des secrets en SSOT pydantic](../adr/0049-schema-secrets-ssot-pydantic-deploy-valide-le-split.md) — le schéma pydantic fait autorité, le bash de déploiement ne valide que la politique de split.
+
+## Bot & API
+
+- [ADR-0009 — Architecture API-centrique](../adr/0009-architecture-api-centrique.md) — voir aussi thème Architecture ci-dessus.
+- [ADR-0010 — Bot Telegram, UI opérationnelle](../adr/0010-bot-telegram-ui-operationnelle.md) — le bot est l'UI opérationnelle quotidienne du·de la facturiste, client de l'API.
+- [ADR-0012 — API read-only sur Odoo](../adr/0012-api-read-only-odoo.md) — l'API n'écrit jamais dans Odoo ; toute écriture reste un acte humain via notebook.
+- [ADR-0022 — Surface du bot par domaines hybrides](../adr/0022-surface-bot-domaines-hybrides.md) — commandes organisées par domaine métier (ingestion, flux, périmètre, taxes, facturation).
+- [ADR-0027 — Odoo tire les méta-périodes](../adr/0027-endpoint-lecture-meta-periodes-odoo-tire.md) — voir aussi thème Facturation & taxes ci-dessus.
+
+## Documentation & savoir
+
+- [ADR-0024 — Trois registres de savoir](../adr/0024-trois-registres-de-savoir.md) — voir aussi thème Facturation & taxes ci-dessus.
+- [ADR-0054 — Chemin de documentation par rôles](../adr/0054-chemin-documentation-roles-escalier.md) — 5 sections par rôle de lecture, principe d'escalier et passerelles montantes ; décision fondatrice de cette section Maintenir.
+
+## Pour aller plus loin
+
+[Registre des ADR](../adr/0001-monorepo.md) (ordre chronologique, `docs/adr/`) ·
+[Trois registres de savoir](../adr/0024-trois-registres-de-savoir.md) ·
+[Gouvernance du registre réglementaire](gouvernance-reglementaire.md).
+
+[Retour à Maintenir](index.md).

--- a/docs/maintenir/index.md
+++ b/docs/maintenir/index.md
@@ -1,13 +1,18 @@
+---
+fraicheur: 2026-07-04
+---
+
 # Maintenir
 
 Cette section s'adresse à toi si tu es **mainteneur·e** : tu tiens
 l'architecture du projet dans la durée, tu pilotes les releases et le suivi
 réglementaire (grilles TURPE, taux, évolutions Enedis).
 
-Elle rassemblera à terme les décisions d'architecture structurantes vues
-depuis leur ensemble, le processus de release et les procédures de suivi
-réglementaire. Ce contenu arrive dans une tranche à venir du chemin de
-documentation par rôles ; les décisions elles-mêmes existent déjà, une par
-une, dans les [ADR](../adr/0001-monorepo.md).
+- **[Index thématique des ADRs](index-adr.md)** — les décisions d'architecture
+  structurantes regroupées par thème, pour retrouver un choix passé sans grep.
+- **[Processus de release](release.md)** — bump, changelog, tag, workflow
+  publiant, promotion rc → stable, et la frontière avec le déploiement d'instance.
+- **[Gouvernance du registre réglementaire](gouvernance-reglementaire.md)** — qui
+  met à jour les taux régulés (TURPE, Accise, CTA) et comment.
 
 [Retour à l'accueil](../index.md).

--- a/docs/maintenir/release.md
+++ b/docs/maintenir/release.md
@@ -50,7 +50,7 @@ publication.
 
 ## 3. Promotion rc → stable : une PR, pas un rebuild
 
-Passer d'une release candidate validée à la stable correspondant est une **promotion
+Passer d'une release candidate validée à la stable correspondante est une **promotion
 pure** : le même arbre de fichiers, où **seuls les fichiers de version** changent
 (`pyproject.toml`, `uv.lock`, `CHANGELOG.md` qui documente la stable et son historique
 rc-par-rc). Pas de nouveau commit fonctionnel entre la dernière rc et la stable — la

--- a/docs/maintenir/release.md
+++ b/docs/maintenir/release.md
@@ -1,0 +1,76 @@
+---
+fraicheur: 2026-07-04
+---
+
+# Processus de release
+
+Deux cycles de publication distincts et indépendants : le **moteur** (paquet
+`electricore`, tags `vX.Y.Z…`) et le **client léger** (paquet `electricore-client`, tags
+`client-vX.Y.Z…`, [ADR-0043](../adr/0043-electricore-client-paquet-separe.md)). Ce qui suit
+décrit le moteur ; le client suit le même principe (tag = action publiante) avec un
+paquet PyPI en moins de sortie (pas d'image Docker).
+
+## 1. Avant de taguer : bump en PR, comme tout le reste
+
+Une release commence par une **PR ordinaire**, relue et mergée humainement comme
+n'importe quelle autre :
+
+- version bumpée dans `pyproject.toml` (`[project].version`) ;
+- `uv.lock` régénéré en cohérence ;
+- une entrée `CHANGELOG.md` (format [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/),
+  [Semantic Versioning](https://semver.org/lang/fr/)) décrivant la release.
+
+Le tag n'est posé **qu'après** le merge de cette PR sur `main`.
+
+## 2. Le tag est l'action publiante
+
+Le workflow [`.github/workflows/release.yml`](https://github.com/Energie-De-Nantes/electricore/blob/main/.github/workflows/release.yml)
+se déclenche sur un `push` de tag matchant :
+
+- **stable** : `vX.Y.Z` (ex. `v3.5.0`) ;
+- **pré-release** (PEP 440) : `vX.Y.ZaN`, `vX.Y.ZbN`, `vX.Y.ZrcN`, `vX.Y.Z.devN` (ex. `v3.5.0rc3`).
+
+À partir de là, tout est automatique :
+
+1. **Build** — `uv build` (sdist + wheel), puis un garde-fou vérifie que
+   `dist/electricore-<version>.tar.gz`/`.whl` existe bien pour la version du tag
+   (le nom du fichier doit correspondre — sinon la publication s'arrête là).
+2. **PyPI** — publication en Trusted Publishing (OIDC), `skip-existing: true`.
+3. **GitHub release** — créée avec notes auto-générées ; `--prerelease` posé
+   automatiquement si le tag n'est pas de la forme stricte `vX.Y.Z`.
+4. **Image Docker → ghcr.io** — le gate build → scan de secrets → smoke test → push
+   (workflow réutilisable `docker-image.yml`, partagé avec la CI où il tourne sans
+   push sur chaque PR) publie :
+   - **stable** : `ghcr.io/energie-de-nantes/electricore:X.Y.Z` **+** `:X.Y` **+** `:latest` ;
+   - **pré-release** : uniquement `:X.Y.Z...` exact — jamais `:latest` ni `:X.Y`, pour ne
+     pas rediriger une instance qui suit la stable vers une rc.
+
+Aucun bloc `concurrency` sur ce workflow : une release ne s'annule jamais en cours de
+publication.
+
+## 3. Promotion rc → stable : une PR, pas un rebuild
+
+Passer d'une release candidate validée à la stable correspondant est une **promotion
+pure** : le même arbre de fichiers, où **seuls les fichiers de version** changent
+(`pyproject.toml`, `uv.lock`, `CHANGELOG.md` qui documente la stable et son historique
+rc-par-rc). Pas de nouveau commit fonctionnel entre la dernière rc et la stable — la
+discipline attendue est un diff strictement limité à ces trois fichiers, vérifiable par
+comparaison d'arbre. Cette discipline est un **usage de mainteneur**, pas une règle
+qu'un job CI vérifie aujourd'hui.
+
+## 4. Frontière : la release s'arrête à l'image publiée
+
+Le cycle décrit ici se termine à la publication du paquet PyPI et de l'image
+`ghcr.io/energie-de-nantes/electricore`. **Déployer une instance** (tirer la nouvelle
+image sur un VPS, `docker compose up -d`) est un acte **séparé**, à la charge du·de la
+déployeur·euse d'une instance donnée ([ADR-0011](../adr/0011-deploiement-vps-docker.md),
+[ADR-0015](../adr/0015-deploiement-multi-instance.md)) — jamais automatique ni piloté
+depuis ce dépôt.
+
+## Pour aller plus loin
+
+[Section Développer](../contribuer/developper.md) (installation dev,
+tests, CI) · [guide de déploiement](https://github.com/Energie-De-Nantes/electricore/blob/main/docs/deploiement.md) ·
+[ADR-0043 — `electricore-client` paquet séparé](../adr/0043-electricore-client-paquet-separe.md).
+
+[Retour à Maintenir](index.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,3 +32,6 @@ nav:
       - Développer: contribuer/developper.md
   - Maintenir:
       - maintenir/index.md
+      - Index thématique des ADRs: maintenir/index-adr.md
+      - Processus de release: maintenir/release.md
+      - Gouvernance du registre réglementaire: maintenir/gouvernance-reglementaire.md


### PR DESCRIPTION
## Résumé

Contenu de la section *Maintenir* du chemin de documentation par rôles :

- **Index thématique des 54 ADRs** (`index-adr.md`) : 7 thèmes (architecture & rôles, ingestion & flux, données & conventions, facturation & taxes, déploiement & secrets, bot & API, documentation & savoir), 5 ADRs double-classés là où c'est réellement dual. Tous les liens vérifiés contre `docs/adr/` — **aucun ADR modifié** (registre immuable, convention de supersession rappelée en tête avec l'exemple vivant ADR-0008 → ADR-0037).
- **Processus de release** (`release.md`) : bump en PR avant le tag, patterns de tags, ce que fait réellement `release.yml` (garde artefact=tag, PyPI OIDC, Docker `:latest`+`:X.Y` pour une stable), promotion rc → stable, cycle séparé `electricore-client`, et la frontière release / déploiement d'instance. Écart consigné honnêtement : la promotion byte-identique rc→stable est une **convention humaine, pas un check CI** — documentée comme telle.
- **Gouvernance du registre réglementaire** (`gouvernance-reglementaire.md`) : CSV TURPE/Accise/CTA versionnés (ADR-0024), mise à jour par PR relue comme du code, millésime/péremption, exceptions déclaratives d'accise côté Odoo (hors dépôt).
- Page d'entrée de section réécrite + nav (**bloc Maintenir uniquement** — merge-friendly avec #558/#560). Front-matter `fraicheur: 2026-07-04` posé (convention transversale, exigée par le test de parité de #560).

Tranche du PRD #555.

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)
