### PR TITLE
docs : garde-fous anti-pourrissement — build strict sur PR, parité nav, fraîcheur, règle CONTRIBUTING

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install dependencies (locked)
         # --extra dbt : active le filet d'ingestion (golden dbt + fixtures XSD) —
         # sans lui, les tests dbt sont skippés (importorskip).
-        run: uv sync --locked --extra ingestion --extra dbt --group test
+        run: uv sync --locked --extra ingestion --extra dbt --group test --group docs
 
       # sops + age : binaires statiques pinnés (mêmes versions que l'image, cf.
       # deploy/docker/Dockerfile) pour que le test de déchiffrement à l'entrypoint

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,20 +3,28 @@ name: Docs
 on:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "README.md"
   workflow_dispatch:
 
+# Défaut minimal (lecture seule) : le job build n'a besoin de rien de plus, y
+# compris quand il tourne sur une PR. `pages`/`id-token` sont réservés au job
+# deploy (garde-fou #560 : pas de permission Pages ni de lock `pages` depuis une PR).
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
+# Un seul build en vol par ref (PR ou main) : dédiée au job build, distincte du
+# lock `pages` du déploiement (job deploy, plus bas).
 concurrency:
-  group: pages
+  group: docs-build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
-    name: build (mkdocs)
+    name: build (mkdocs --strict)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -31,10 +39,13 @@ jobs:
       - name: Install docs dependencies
         run: uv sync --locked --group docs
 
-      - name: Build site
-        run: uv run --group docs mkdocs build
+      # --strict sur PR (garde-fou anti-pourrissement, #560) ET sur main : un lien
+      # interne mort casse la CI, où qu'il soit introduit.
+      - name: Build site (strict)
+        run: uv run --group docs mkdocs build --strict
 
       - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: site/
@@ -42,7 +53,14 @@ jobs:
   deploy:
     name: deploy (pages)
     needs: build
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    concurrency:
+      group: pages
+      cancel-in-progress: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,14 @@ La CI ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) exécute les troi
    - `refactor(scope): ...` — refactor sans changement de comportement
 3. **Garder les PRs focalisées** — un sujet par PR, plus facile à reviewer.
 4. **Pousser la branche et ouvrir une PR** vers `main`. La CI s'exécute automatiquement.
+5. **Documentation à jour** — une PR qui change un comportement visible d'un rôle
+   (usager·ère, opérateur·ice, déployeur·euse, contributeur·ice, mainteneur·e) met à
+   jour la page correspondante du site dans la même PR (voir la
+   [charte de la documentation](docs/contribuer/charte-documentation.md) pour qui
+   sont ces rôles et où vit leur page). Règle opposable en revue : le test de parité
+   (`tests/unit/test_parite_docs.py`) garantit qu'aucune page n'est orpheline de la
+   nav, pas que son contenu a suivi le changement — ça reste à la reviewer·euse de
+   vérifier.
 
 ## Conventions techniques
 

--- a/docs/comprendre/index.md
+++ b/docs/comprendre/index.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-04
+---
+
 # Comprendre
 
 Cette section s'adresse à toi si tu es **usager·ère** d'ElectriCore : tu veux

--- a/docs/contrat-meta-periodes.md
+++ b/docs/contrat-meta-periodes.md
@@ -2,7 +2,7 @@
 
 > Contrat d'intégration pour le consommateur (addon `souscriptions_odoo`).
 > Décision et justifications : [ADR-0027](adr/0027-endpoint-lecture-meta-periodes-odoo-tire.md).
-> Vocabulaire : [`electricore/core/CONTEXT.md`](../electricore/core/CONTEXT.md) (entrées *Méta-période mensuelle*, *Accise physique vs Accise de déclaration*).
+> Vocabulaire : [`electricore/core/CONTEXT.md`](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/core/CONTEXT.md) (entrées *Méta-période mensuelle*, *Accise physique vs Accise de déclaration*).
 
 `GET /facturation/meta-periodes` expose les **méta-périodes mensuelles** d'electricore :
 des quantités physiques et des montants réseau **non valorisés aux prix fournisseur**.

--- a/docs/contrat-rsc.md
+++ b/docs/contrat-rsc.md
@@ -3,7 +3,7 @@
 > Contrat d'intégration **figé** pour le consommateur (addon `souscriptions_odoo`).
 > Périmètre : [issue #282](https://github.com/Energie-De-Nantes/electricore/issues/282)
 > (endpoint #3), réconciliation par `id_Affaire` (souscriptions_odoo ADR-0010, issue #5).
-> Vocabulaire : [`electricore/core/CONTEXT.md`](../electricore/core/CONTEXT.md) (entrées
+> Vocabulaire : [`electricore/core/CONTEXT.md`](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/core/CONTEXT.md) (entrées
 > *Affaire*, *Id_Affaire*, *Ref_Situation_Contractuelle*).
 
 `POST /facturation/rsc` est une **résolution sans état** : l'appelant prête un lot

--- a/docs/contrat-turpe-variable.md
+++ b/docs/contrat-turpe-variable.md
@@ -2,7 +2,7 @@
 
 > Contrat d'intégration **figé** pour le consommateur (addon `souscriptions_odoo`).
 > Décision et justifications : [ADR-0030](adr/0030-calculateur-turpe-variable-odoo-fournit-assiette.md).
-> Vocabulaire : [`electricore/core/CONTEXT.md`](../electricore/core/CONTEXT.md) (entrées *Cadran*, *FTA*, *TURPE*).
+> Vocabulaire : [`electricore/core/CONTEXT.md`](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/core/CONTEXT.md) (entrées *Cadran*, *FTA*, *TURPE*).
 
 `POST /facturation/turpe-variable` est un **calculateur sans état** : l'appelant **fournit
 l'assiette** (énergies par cadran + FTA + `debut`) et electricore renvoie le **montant**
@@ -114,7 +114,7 @@ par 0 → **pas de double comptage**.
 Cette correction **repose sur un invariant load-bearing** : *chaque FTA a des coefficients
 `c_*` non-nuls à **exactement une** granularité* (`base`, `hp_hc`, ou `4_cadrans`). Si une
 règle en portait deux, envoyer les 7 énergies **double-compterait en silence**. L'invariant
-est **figé sous test** : [`tests/unit/test_turpe_rules_granularite.py`](../tests/unit/test_turpe_rules_granularite.py)
+est **figé sous test** : [`tests/unit/test_turpe_rules_granularite.py`](https://github.com/Energie-De-Nantes/electricore/blob/main/tests/unit/test_turpe_rules_granularite.py)
 (#252) casse, en nommant la FTA fautive, si une future ligne de `turpe_rules.csv` le viole.
 
 ## Succès partiel (un calculateur n'omet jamais une réponse demandée)

--- a/docs/contribuer/carte-domaines.md
+++ b/docs/contribuer/carte-domaines.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-04
+---
+
 # Carte des domaines
 
 Tu cherches un terme métier (PDL, RSC, FTA, cadran…) ou le vocabulaire propre à

--- a/docs/contribuer/charte-documentation.md
+++ b/docs/contribuer/charte-documentation.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-04
+---
+
 # Charte de la documentation
 
 ElectriCore est un commun ([ADR-0024](../adr/0024-trois-registres-de-savoir.md) :

--- a/docs/contribuer/developper.md
+++ b/docs/contribuer/developper.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-04
+---
+
 # Développer
 
 Architecture, patterns établis et exemples de code pour qui code en amont du

--- a/docs/contribuer/index.md
+++ b/docs/contribuer/index.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-04
+---
+
 # Contribuer
 
 Cette section s'adresse à toi si tu es **contributeur·ice** : tu codes en

--- a/docs/conventions-dates-enedis.md
+++ b/docs/conventions-dates-enedis.md
@@ -85,6 +85,6 @@ propriété de domaine.
 
 ## Implémentation
 
-Voir [electricore/core/loaders/duckdb/sql.py](../electricore/core/loaders/duckdb/sql.py) :
+Voir [electricore/core/loaders/duckdb/sql.py](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/core/loaders/duckdb/sql.py) :
 - Spécification de la table R151 : ajustement `+ INTERVAL '1 day'` sur `date_releve`
 - Requêtes unifiées `releves()` / `releves_harmonises()` : traçabilité via `flux_origine` et `date_ajustee`

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -1,9 +1,9 @@
 # Déploiement VPS
 
 Guide opérationnel pour déployer ElectriCore sur un VPS via la stack Docker
-([`deploy/docker/`](../deploy/docker/)).
+([`deploy/docker/`](https://github.com/Energie-De-Nantes/electricore/tree/main/deploy/docker/)).
 
-Le script [`deploy/install.sh`](../deploy/install.sh) automatise la mise en place
+Le script [`deploy/install.sh`](https://github.com/Energie-De-Nantes/electricore/blob/main/deploy/install.sh) automatise la mise en place
 de bout en bout. Ce document décrit son usage, puis ce qu'il fait sous le capot
 (annexe « déploiement manuel »).
 
@@ -101,9 +101,9 @@ fichiers versionnés** dans le dépôt de déploiement privé sous `providers/<s
 
 - **`config.env`** — clair, versionné, **aucun secret** : config non secrète +
   substitutions `${...}` de `docker compose`. Modèle :
-  [`deploy/providers/example/config.env.example`](../deploy/providers/example/config.env.example).
+  [`deploy/providers/example/config.env.example`](https://github.com/Energie-De-Nantes/electricore/blob/main/deploy/providers/example/config.env.example).
 - **`secrets.env`** — **chiffré** (SOPS + age), **uniquement** des credentials. Modèle :
-  [`deploy/providers/example/secrets.env.example`](../deploy/providers/example/secrets.env.example)
+  [`deploy/providers/example/secrets.env.example`](https://github.com/Energie-De-Nantes/electricore/blob/main/deploy/providers/example/secrets.env.example)
   (montré en clair à titre pédagogique — il vit chiffré dans le dépôt).
 
 La colonne **Bloc** ci-dessous indique dans quel fichier chaque variable vit.
@@ -418,7 +418,7 @@ sudo bash /srv/<slug>/deploy/install.sh \
 Côté **machine admin**, dans le dépôt de déploiement privé :
 
 1. ajouter la **age pub** aux destinataires de `providers/<slug>/.sops.yaml` (cf.
-   [`add-provider.sh`](../deploy/add-provider.sh)), puis `sops updatekeys providers/<slug>/secrets.env` ;
+   [`add-provider.sh`](https://github.com/Energie-De-Nantes/electricore/blob/main/deploy/add-provider.sh)), puis `sops updatekeys providers/<slug>/secrets.env` ;
 2. enregistrer la **SSH pub** comme **deploy key RO** du dépôt (réglages GitHub/GitLab) ;
 3. commit + push.
 
@@ -534,7 +534,7 @@ Pourquoi 04:30 et pourquoi rebooter :
 ### Rétro-durcir un VPS existant
 
 Pour durcir une instance **déjà déployée** sans relancer un reconfigure complet,
-le script autonome [`deploy/harden.sh`](../deploy/harden.sh) source la même
+le script autonome [`deploy/harden.sh`](https://github.com/Energie-De-Nantes/electricore/blob/main/deploy/harden.sh) source la même
 logique (`harden_vps`) et l'applique seule. **Aucune hypothèse de layout** : la
 clé de `ops` est amorcée depuis `~root/.ssh/authorized_keys` quel que soit
 l'emplacement de la stack (`/srv/<slug>/` comme l'ancien `/opt/electricore/`).
@@ -556,7 +556,7 @@ Le même **garde-fou anti-verrouillage** s'applique (refus de couper root SSH si
 ### Réverser le durcissement (désinstallation)
 
 Pour revenir en arrière — repasser sur un accès root classique, ou annuler en cas
-de souci — [`deploy/unharden.sh`](../deploy/unharden.sh) défait ce que le
+de souci — [`deploy/unharden.sh`](https://github.com/Energie-De-Nantes/electricore/blob/main/deploy/unharden.sh) défait ce que le
 durcissement a posé :
 
 - retire le drop-in sshd → **SSH root rétabli** (défaut de l'image) ;
@@ -733,7 +733,7 @@ n'est (re)téléchargeable depuis le SFTP.
 
 > **`sops updatekeys` ≠ rotation de secret** (ADR-0044) : `updatekeys` ne rote que
 > l'**enveloppe** (re-wrap vers le jeu de destinataires, ex. ajout d'une box via
-> [`add-provider.sh`](../deploy/add-provider.sh)). Si une **clé AES a pu fuiter**, il
+> [`add-provider.sh`](https://github.com/Energie-De-Nantes/electricore/blob/main/deploy/add-provider.sh)). Si une **clé AES a pu fuiter**, il
 > faut la changer **à la source** (nouvelle clé Enedis) — `updatekeys` ne la protège pas.
 
 ## Sauvegarde et restauration
@@ -741,8 +741,8 @@ n'est (re)téléchargeable depuis le SFTP.
 ### Sauvegarde automatique
 
 Le scheduler crée un snapshot complet chaque nuit à 03:30 (Europe/Paris) — voir
-[`deploy/docker/crontab.example`](../deploy/docker/crontab.example) et
-[`deploy/docker/backup_duckdb.sh`](../deploy/docker/backup_duckdb.sh).
+[`deploy/docker/crontab.example`](https://github.com/Energie-De-Nantes/electricore/blob/main/deploy/docker/crontab.example) et
+[`deploy/docker/backup_duckdb.sh`](https://github.com/Energie-De-Nantes/electricore/blob/main/deploy/docker/backup_duckdb.sh).
 
 - Format : `EXPORT DATABASE` (SQL + parquet), compressé en `tar.gz`.
 - Emplacement : `/srv/<slug>/backups/` (bind-mount, lisible directement côté host).

--- a/docs/deployer/index.md
+++ b/docs/deployer/index.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-04
+---
+
 # Déployer
 
 Cette section s'adresse à toi si tu es **déployeur·euse** : tu installes et tu

--- a/docs/facturiste/changelog-facturiste.md
+++ b/docs/facturiste/changelog-facturiste.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-04
+---
+
 # Ce qui a changé pour le facturiste (juin 2026)
 
 > Lecture côté métier du [CHANGELOG technique](https://github.com/Energie-De-Nantes/electricore/blob/main/CHANGELOG.md), de la première

--- a/docs/guide-bot-facturiste.md
+++ b/docs/guide-bot-facturiste.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-04
+---
+
 # Guide du bot Telegram (facturiste)
 
 > Le bot Telegram est votre **cockpit** ElectriCore : surveiller l'ingestion, contrôler
@@ -7,7 +11,7 @@
 > **À retenir d'emblée :** le bot est **en lecture seule**. Il **n'écrit jamais dans
 > Odoo**. L'écriture dans Odoo (injection des lignes, RSC) reste le travail des
 > **notebooks marimo** que vous validez à la main (voir
-> [Ce qui a changé pour le facturiste](changelog-facturiste.md)). Le bot sert à
+> [Ce qui a changé pour le facturiste](facturiste/changelog-facturiste.md)). Le bot sert à
 > **savoir** et à **contrôler**, pas à pousser.
 
 ![Le bot facturiste en un coup d'œil — cycle de facturation, frontière lecture/écriture et outils à la demande](facturiste-bot-cockpit.png)
@@ -165,5 +169,5 @@ HC), la **couverture** disponible (✅ suffisante / ⚠️ insuffisante), la **q
 
 ⁽ᵉʳᵖ⁾ masqué quand aucun Odoo n'est configuré.
 
-*Détail de la surface et de l'architecture : [README du bot](../electricore/bot/README.md).
-Ce qui a changé côté métier : [changelog facturiste](changelog-facturiste.md).*
+*Détail de la surface et de l'architecture : [README du bot](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/bot/README.md).
+Ce qui a changé côté métier : [changelog facturiste](facturiste/changelog-facturiste.md).*

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-04
+---
+
 # ElectriCore
 
 **ElectriCore** transforme les flux bruts d'Enedis en données de facturation

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -115,7 +115,7 @@ plomberie JSON de R64 (landing → `stg_r67` → `flux_r67`) mais **n'est jamais
 les marts de relevés (`releves`/`chronologie_releves`) — l'y verser ferait calculer une
 « énergie d'énergie » et casserait le grain/la priorité des relevés. Modèle figé en
 [ADR-0047](adr/0047-flux-r67-energie-par-periode-distributeur-hors-releves.md) ; glossaire
-*Mesures facturantes (R67)* dans [`electricore/ingestion/CONTEXT.md`](../electricore/ingestion/CONTEXT.md).
+*Mesures facturantes (R67)* dans [`electricore/ingestion/CONTEXT.md`](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/ingestion/CONTEXT.md).
 
 Le modèle `flux_r67` (wide, 1 ligne par `(pdl, debut, fin)`) : union de tous les
 `contexte[]` (les motifs partitionnent le temps sans recouvrement) ; **coalesce d'une

--- a/docs/maintenir/index.md
+++ b/docs/maintenir/index.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-04
+---
+
 # Maintenir
 
 Cette section s'adresse à toi si tu es **mainteneur·e** : tu tiens

--- a/docs/operateur-notebook.md
+++ b/docs/operateur-notebook.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-04
+---
+
 # Onboarding d'un opérateur notebook (pont transitoire #414)
 
 > **Pont transitoire.** Les notebooks opérateur (`facturation`, `injection_rsc`)

--- a/docs/qualite-donnees-r151.md
+++ b/docs/qualite-donnees-r151.md
@@ -161,7 +161,7 @@ Liste des PDL à exclure de la validation :
 
 ## Références
 
-- Glossaire métier : [CONTEXT-MAP.md](../CONTEXT-MAP.md) (vocabulaire ingestion/flux dans [`electricore/ingestion/CONTEXT.md`](../electricore/ingestion/CONTEXT.md))
+- Glossaire métier : [CONTEXT-MAP.md](https://github.com/Energie-De-Nantes/electricore/blob/main/CONTEXT-MAP.md) (vocabulaire ingestion/flux dans [`electricore/ingestion/CONTEXT.md`](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/ingestion/CONTEXT.md))
 - Conventions de dates : [docs/conventions-dates-enedis.md](conventions-dates-enedis.md)
 - Calendriers distributeur Enedis :
   - `DI000001` : Base (tarif simple)

--- a/docs/transmission.md
+++ b/docs/transmission.md
@@ -254,7 +254,7 @@ Les pipelines chargent ces règles via `load_turpe_rules()` / `load_accise_rules
 
 ## 9. Domaine : glossaire
 
-Le vocabulaire métier est éclaté par module : voir [CONTEXT-MAP.md](../CONTEXT-MAP.md) à la racine. L'essentiel (PDL, FTA, C5/C4, HP/HC, TURPE, accise, événements C15, périmètre, abonnement…) vit dans [`electricore/core/CONTEXT.md`](../electricore/core/CONTEXT.md).
+Le vocabulaire métier est éclaté par module : voir [CONTEXT-MAP.md](https://github.com/Energie-De-Nantes/electricore/blob/main/CONTEXT-MAP.md) à la racine. L'essentiel (PDL, FTA, C5/C4, HP/HC, TURPE, accise, événements C15, périmètre, abonnement…) vit dans [`electricore/core/CONTEXT.md`](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/core/CONTEXT.md).
 
 ---
 
@@ -299,8 +299,8 @@ Marimo est à Python ce qu'un Jupyter notebook est à R — mais avec une réact
 
 Pour comprendre le code dans l'ordre :
 
-1. [electricore/core/pipelines/historique.py](../electricore/core/pipelines/historique.py) — pipeline le plus simple, bien testé
-2. [electricore/core/pipelines/turpe.py](../electricore/core/pipelines/turpe.py) — expressions composables, bonne illustration du pattern
-3. [electricore/core/builds/contexte_mensuel.py](../electricore/core/builds/contexte_mensuel.py) — comment tout s'assemble
-4. [tests/unit/test_turpe.py](../tests/unit/test_turpe.py) — tests = documentation exécutable
+1. [electricore/core/pipelines/historique.py](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/core/pipelines/historique.py) — pipeline le plus simple, bien testé
+2. [electricore/core/pipelines/turpe.py](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/core/pipelines/turpe.py) — expressions composables, bonne illustration du pattern
+3. [electricore/core/builds/contexte_mensuel.py](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/core/builds/contexte_mensuel.py) — comment tout s'assemble
+4. [tests/unit/test_turpe.py](https://github.com/Energie-De-Nantes/electricore/blob/main/tests/unit/test_turpe.py) — tests = documentation exécutable
 5. [docs/conventions-dates-enedis.md](conventions-dates-enedis.md) — convention critique pour les dates

--- a/docs/turpe-usage-standalone.md
+++ b/docs/turpe-usage-standalone.md
@@ -564,10 +564,10 @@ result = ajouter_turpe_fixe(periodes_df.lazy()).collect()
 
 ## Ressources complémentaires
 
-- **Code source** : [electricore/core/pipelines/turpe.py](../electricore/core/pipelines/turpe.py)
-- **Tests exhaustifs** : [tests/unit/test_turpe.py](../tests/unit/test_turpe.py)
+- **Code source** : [electricore/core/pipelines/turpe.py](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/core/pipelines/turpe.py)
+- **Tests exhaustifs** : [tests/unit/test_turpe.py](https://github.com/Energie-De-Nantes/electricore/blob/main/tests/unit/test_turpe.py)
 - **Documentation C4** : [turpe-fixe-c4-btsup36kva.md](./turpe-fixe-c4-btsup36kva.md)
-- **Tarifs CRE officiels** : [electricore/config/turpe_rules.csv](../electricore/config/turpe_rules.csv)
+- **Tarifs CRE officiels** : [electricore/config/turpe_rules.csv](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/config/turpe_rules.csv)
 - **Nomenclature CRE** : Délibération CRE 2025-40 du 30 janvier 2025
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,12 +6,25 @@ theme:
 plugins:
   - search
 
+hooks:
+  - scripts/mkdocs_hooks.py
+
+# validation.links n'a pas de niveau `error` dans cette version de MkDocs (seulement
+# warn/info/ignore) : `warn` est le niveau le plus strict disponible, et c'est bien
+# `mkdocs build --strict` (garde-fou CI, #560) qui transforme un warning en échec.
+# `not_found` (lien interne mort) est donc désormais bloquant partout SAUF dans
+# docs/adr/** et docs/agents/** (registres figés, cf. scripts/mkdocs_hooks.py) : ces
+# deux répertoires portent ~55 liens vers du code/des fichiers hors docs/ (légitimes,
+# mais non résolvables par MkDocs) ou, pour deux ADRs, une coquille de nommage vers un
+# autre ADR — corriger le contenu d'un ADR publié est un interdit dur (#560), même pour
+# un lien.
 validation:
   nav:
     omitted_files: ignore
   links:
-    absolute_links: ignore
-    unrecognized_links: ignore
+    not_found: warn
+    absolute_links: warn
+    unrecognized_links: warn
 
 exclude_docs: "*.excalidraw"
 

--- a/scripts/mkdocs_hooks.py
+++ b/scripts/mkdocs_hooks.py
@@ -1,0 +1,38 @@
+"""Hook MkDocs (natif, sans dépendance) — tolère les liens déjà connus des registres figés.
+
+`docs/adr/**` (contenu immuable — une fois publié, un ADR ne se retouche pas, pas même
+pour un lien) et `docs/agents/**` (registres agent, hors périmètre de ce chantier)
+référencent souvent du code ou des fichiers hors `docs/` (CONTEXT.md, CONTRIBUTING.md,
+scripts de déploiement…), ou pour deux ADRs, une coquille de nommage vers un autre ADR.
+MkDocs classe tout ça en liens « non résolus » — mais retoucher le contenu de ces
+fichiers rien que pour faire taire le validateur est interdit (#560).
+
+On démote donc les warnings de validation de lien dont la PAGE SOURCE vit dans un de ces
+deux répertoires. Tout le reste — y compris un nouveau lien mort introduit ailleurs,
+ou dans ces répertoires eux-mêmes via un futur canal qui ne serait pas ce filtre —
+reste bloquant sous `--strict`.
+
+ponytail: filtre pinné au libellé mkdocs actuel ("Doc file '<src>' contains a link...").
+Si mkdocs change ce libellé, le filtre cesse de matcher et le strict redevient bloquant
+partout — échec sûr (trop de warnings), jamais silencieux.
+"""
+
+import logging
+import re
+
+_PAGE_TOLEREE = re.compile(r"^Doc file '(?:adr|agents)/")
+
+
+def _tolerer_registres_figes(record: logging.LogRecord) -> bool:
+    if record.levelno == logging.WARNING and _PAGE_TOLEREE.match(record.getMessage()):
+        record.levelno = logging.INFO
+        record.levelname = "INFO"
+    return True
+
+
+def on_startup(*, command: str, dirty: bool) -> None:
+    # Un logging.Filter attaché à un logger ne s'applique qu'aux appels faits SUR ce
+    # logger précis (pas ceux des enfants qui remontent par les handlers) : la
+    # validation de liens vit dans `mkdocs.structure.pages`, donc c'est là qu'on
+    # branche le filtre, pas sur le logger racine `mkdocs`.
+    logging.getLogger("mkdocs.structure.pages").addFilter(_tolerer_registres_figes)

--- a/tests/unit/test_parite_docs.py
+++ b/tests/unit/test_parite_docs.py
@@ -1,0 +1,141 @@
+"""Garde-fous anti-pourrissement du site (#560) : parité nav + fraîcheur.
+
+Deux garanties sur le même seam — le site publié (`mkdocs.yml` + `docs/**`) — sans
+linter de prose ni seam par page (cf. #560) :
+
+1. **Parité nav** : tout `.md` sous `docs/` est soit référencé dans la nav de
+   `mkdocs.yml`, soit dans la liste d'exclusions EXPLICITE ci-dessous (ADRs, spikes,
+   registres agent, docs techniques en attente d'affectation #557). Un doc ajouté
+   hors nav sans y être ajouté ici fait échouer le test — pas d'orphelin silencieux.
+2. **Fraîcheur** : toute page EN NAV porte un front-matter `fraicheur: YYYY-MM-DD`
+   (convention du chantier #555/#560). Un check minimal liste (sans échouer) les
+   pages de plus de 12 mois — pas de machinerie de rapport, juste un print.
+
+Le parsing (nav YAML + front-matter) réutilise les mêmes outils que MkDocs lui-même
+(`mkdocs.utils.yaml.yaml_load`, `mkdocs.utils.meta.get_data`) plutôt que de
+réinventer un mini-parseur : même tolérance aux tags YAML mkdocs (`!ENV`…) et même
+notion de « front-matter » que ce que le site construit réellement.
+
+Prior art (style) : tests/unit/test_parite_typage.py, tests/unit/test_contexte_filtre_parite.py.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mkdocs", reason="mkdocs absent — uv sync --group docs")
+
+from mkdocs.utils.meta import get_data
+from mkdocs.utils.yaml import yaml_load
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_DIR = REPO_ROOT / "docs"
+MKDOCS_YML = REPO_ROOT / "mkdocs.yml"
+
+# ---------------------------------------------------------------------------
+# Exclusions nav — versionnées et explicites (#560). Un doc ajouté hors nav SANS
+# être ajouté ici fait échouer `test_tout_doc_est_en_nav_ou_exclu`.
+# ---------------------------------------------------------------------------
+
+# Répertoires entiers hors périmètre de la parité nav.
+_PREFIXES_EXCLUS = (
+    "adr/",  # registre immuable, publié hors nav — indexé par #559
+    "spikes/",  # archives de spikes (répertoire vide pour l'instant)
+    "agents/",  # registres agent (CLAUDE.md-adjacent), hors chemin doc-par-rôles
+)
+
+# Docs techniques à la racine de docs/, en attente d'affectation à une section du
+# chemin par rôles (#557) — liste NOMMÉE, a vocation à fondre au fil des tranches
+# suivantes (chaque doc affecté à une section doit sortir de cette liste).
+_FICHIERS_EN_ATTENTE_557 = {
+    "configuration.md",  # en attente d'affectation — #557
+    "contrat-meta-periodes.md",  # en attente d'affectation — #557
+    "contrat-rsc.md",  # en attente d'affectation — #557
+    "contrat-turpe-variable.md",  # en attente d'affectation — #557
+    "conventions-dates-enedis.md",  # en attente d'affectation — #557
+    "deploiement.md",  # en attente d'affectation — #557
+    "electricore-client-design.md",  # en attente d'affectation — #557
+    "ingestion.md",  # en attente d'affectation — #557
+    "odoo-query-builder.md",  # en attente d'affectation — #557
+    "qualite-donnees-r151.md",  # en attente d'affectation — #557
+    "transmission.md",  # en attente d'affectation — #557
+    "turpe-fixe-c4-btsup36kva.md",  # en attente d'affectation — #557
+    "turpe-usage-standalone.md",  # en attente d'affectation — #557
+}
+
+_AGE_MAX_FRAICHEUR_JOURS = 365
+
+
+def _est_exclu(chemin_relatif: str) -> bool:
+    if chemin_relatif in _FICHIERS_EN_ATTENTE_557:
+        return True
+    return any(chemin_relatif.startswith(prefixe) for prefixe in _PREFIXES_EXCLUS)
+
+
+def _config_mkdocs() -> dict:
+    with MKDOCS_YML.open("rb") as f:
+        return yaml_load(f)
+
+
+def _chemins_nav(entree) -> list[str]:
+    """Aplatit récursivement un bloc `nav:` de mkdocs.yml en chemins `.md` (relatifs à docs/)."""
+    if isinstance(entree, str):
+        return [entree] if entree.endswith(".md") else []
+    if isinstance(entree, dict):
+        return [c for valeur in entree.values() for c in _chemins_nav(valeur)]
+    if isinstance(entree, list):
+        return [c for item in entree for c in _chemins_nav(item)]
+    return []
+
+
+def _pages_en_nav() -> list[str]:
+    return sorted(set(_chemins_nav(_config_mkdocs()["nav"])))
+
+
+def _tous_les_docs() -> set[str]:
+    return {str(p.relative_to(DOCS_DIR)) for p in DOCS_DIR.rglob("*.md")}
+
+
+def _meta(chemin_relatif: str) -> dict:
+    texte = (DOCS_DIR / chemin_relatif).read_text(encoding="utf-8")
+    _, meta = get_data(texte)
+    return meta
+
+
+def test_tout_doc_est_en_nav_ou_exclu():
+    en_nav = set(_pages_en_nav())
+    orphelins = {d for d in _tous_les_docs() if d not in en_nav and not _est_exclu(d)}
+
+    assert not orphelins, (
+        "Docs hors nav sans exclusion explicite (#560) — ajoute-les à la nav de "
+        "mkdocs.yml ou à la liste d'exclusions versionnée de ce module : "
+        f"{sorted(orphelins)}"
+    )
+
+
+def test_toute_page_en_nav_porte_une_fraicheur():
+    sans_fraicheur = [p for p in _pages_en_nav() if "fraicheur" not in _meta(p)]
+
+    assert not sans_fraicheur, f"Pages en nav sans front-matter `fraicheur: YYYY-MM-DD` (#560) : {sans_fraicheur}"
+
+
+def test_pages_perimees_signalees_sans_echouer():
+    """Check minimal (#560) : liste — sans jamais échouer — les pages en nav dont la
+    fraîcheur a plus de 12 mois. Pas de machinerie de rapport, juste un print."""
+    aujourdhui = date.today()
+    perimees = []
+    for chemin_relatif in _pages_en_nav():
+        brut = _meta(chemin_relatif).get("fraicheur")
+        if not brut:
+            continue
+        fraicheur = brut if isinstance(brut, date) else datetime.strptime(str(brut), "%Y-%m-%d").date()
+        if (aujourdhui - fraicheur).days > _AGE_MAX_FRAICHEUR_JOURS:
+            perimees.append(f"{chemin_relatif} (fraicheur: {fraicheur})")
+
+    if perimees:
+        print(f"\n[fraîcheur #560] {len(perimees)} page(s) de plus de 12 mois :")
+        for ligne in perimees:
+            print(f"  - {ligne}")


### PR DESCRIPTION
## Résumé

Branche les 4 garde-fous anti-pourrissement du chantier doc sur les deux seams existants (build MkDocs + pytest) :

1. **Build `--strict` sur toute PR touchant la doc** (`docs/**`, `mkdocs.yml`, `README.md`) et sur main — le deploy Pages reste limité à main. Preuve faite : un lien mort injecté → `EXIT=1` en strict.
2. **Test de parité nav + fraîcheur** (`tests/unit/test_parite_docs.py`) : tout `.md` du site est en nav ou dans la liste d'exclusions explicite (`adr/**`, `spikes/**`, `agents/**` + les docs techniques nommés un à un « en attente d'affectation #557 ») ; toute page en nav porte `fraicheur: YYYY-MM-DD` ; les pages de plus de 12 mois sont listées sans échec. Chaque garde-fou prouvé par un échec provoqué.
3. **Règle CONTRIBUTING** : « une PR qui change un comportement visible d'un rôle met à jour la page correspondante » — opposable en revue, renvoie à la charte et au test de parité.
4. **Front-matter `fraicheur: 2026-07-04`** posé sur les 11 pages en nav ; liens morts/sortants des docs non-ADR réparés au passage.

## Compromis de validation (documenté)

MkDocs 1.6 n'a **pas** de niveau `error` pour `validation.links` (seulement warn/info/ignore — vérifié, `ConfigurationError` sinon) : le resserrage maximal est `warn` + `--strict`. Inventaire initial : 84 warnings, dont ~55 confinés à `docs/adr/**` et `docs/agents/**` (liens vers du code hors `docs/`) — contenu immuable/hors périmètre qu'il est interdit de retoucher. Un hook MkDocs natif (`scripts/mkdocs_hooks.py`, zéro dépendance) démote ces warnings **par répertoire source** sans toucher leur contenu ; tout lien mort ailleurs reste bloquant.

Suite complète : 793 passed / 6 skipped (pré-existants). Tranche du PRD #555.

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)
