### PR TITLE
feat(notebooks): flag --edit sur electricore-notebooks

### DIFF
--- a/electricore/operator_launcher.py
+++ b/electricore/operator_launcher.py
@@ -167,11 +167,20 @@ def construire_app(directory: str | Path, *, prefixe: str = _PREFIXE_APPS):
 
 
 def main() -> None:
-    """Point d'entrée `electricore-notebooks` : charge le .env, valide, sert, ouvre le navigateur."""
+    """Point d'entrée `electricore-notebooks` : charge le .env, valide, sert, ouvre le navigateur.
+
+    `--edit` : sert les notebooks en mode édition au lieu du mode run. L'API ASGI
+    marimo est run-only → on remplace le process par `python -m marimo edit`
+    (même venv), l'env étant déjà chargé et validé.
+    """
     charger_env()
     valider_environnement()
 
     dossier = dossier_notebooks()
+
+    if "--edit" in sys.argv[1:]:
+        os.execv(sys.executable, [sys.executable, "-m", "marimo", "edit", str(dossier)])
+
     app = construire_app(dossier)
 
     base = f"http://{_HOTE}:{_PORT}{_PREFIXE_APPS}"

--- a/tests/unit/test_operator_launcher.py
+++ b/tests/unit/test_operator_launcher.py
@@ -8,6 +8,7 @@ Le smoke navigateur/serveur est une vérif MANUELLE (non automatisée).
 """
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,7 @@ from electricore.operator_launcher import (
     charger_env,
     construire_app,
     dossier_notebooks,
+    main,
     url_navigateur,
     valider_environnement,
 )
@@ -205,6 +207,28 @@ def test_url_navigateur_repli_sur_le_premier_sans_accueil():
 def test_url_navigateur_aucun_notebook():
     """Dossier vide → aucune URL à ouvrir."""
     assert url_navigateur(_BASE, []) is None
+
+
+def test_main_edit_delegue_a_marimo_edit(monkeypatch):
+    """`--edit` remplace le process par `python -m marimo edit <dossier>` (ASGI = run-only)."""
+    _poser_env(monkeypatch, _ENV_COMPLET)
+    monkeypatch.setattr(sys, "argv", ["electricore-notebooks", "--edit"])
+
+    appels = {}
+
+    def faux_execv(exe, argv):
+        appels["exe"], appels["argv"] = exe, argv
+        # execv ne retourne jamais : lever ici stoppe main() comme le ferait le vrai exec.
+        raise RuntimeError("exec simulé")
+
+    monkeypatch.setattr(os, "execv", faux_execv)
+
+    with pytest.raises(RuntimeError, match="exec simulé"):
+        main()
+
+    assert appels["exe"] == sys.executable
+    assert appels["argv"][:4] == [sys.executable, "-m", "marimo", "edit"]
+    assert Path(appels["argv"][4]).is_dir()
 
 
 def test_construire_app_monte_le_dossier_embarque(tmp_path: Path):


### PR DESCRIPTION
## Quoi

`electricore-notebooks --edit` sert les notebooks opérateur en **mode édition** au lieu du mode run (lecture seule).

## Comment

L'API ASGI marimo est run-only par design → pas de serveur custom : après le même chargement `.env` + validation d'environnement que le mode run, `os.execv` remplace le process par `python -m marimo edit <dossier>` (même venv, marimo gère port/token/navigateur).

- Un seul flag → `in sys.argv`, pas d'argparse (à introduire au 2ᵉ flag).
- Test unitaire : la délégation execv (`-m marimo edit` + dossier existant), env complet requis comme en mode run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)