### PR TITLE
fix(notebooks): zéro traceback pour le facturiste + rapport d'injection OdooWriter

### DIFF
--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -25,6 +25,14 @@ _Note_ : « Fournisseur » est générique — il désigne aussi bien le fournis
 Déploiement ElectriCore dédié à un *fournisseur* particulier (EDN, Enargia…). Chaque instance a sa propre base DuckDB, ses clés AES, sa config Odoo, sa source SFTP, son sous-domaine. Identifiée par un slug court (`edn`, `enargia`).
 _Éviter_ : tenant (anglicisme), déploiement (confus avec l'opération de release).
 
+**Commun** :
+Mode d'organisation d'EDN : une ressource (le service de fourniture d'électricité et son outillage) gérée collectivement par ses usager·ère·s, sans salariés. ElectriCore est l'outillage logiciel de ce commun.
+_Éviter_ : coopérative (statut différent), entreprise.
+
+**Usager·ère** :
+Souscripteur·ice d'EDN, dans le vocabulaire des communs. Côté domaine Enedis c'est le *client final* / titulaire du contrat sur un *PDL*.
+_Éviter_ : client (relation marchande, à réserver aux contextes Odoo/facturation), adhérent, sociétaire (vocabulaire coopératif).
+
 **Gestionnaire de réseau** :
 Synonyme métier d'Enedis dans la majeure partie du territoire. À distinguer du *transporteur* (RTE, haute tension).
 

--- a/electricore/integrations/odoo/writers.py
+++ b/electricore/integrations/odoo/writers.py
@@ -7,11 +7,36 @@ Ce module fournit OdooWriter pour créer et modifier des données dans Odoo ERP.
 import copy
 import logging
 from collections.abc import Hashable
+from dataclasses import dataclass, field
 from typing import Any
 
 from .reader import OdooReader
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class EchecEcriture:
+    """Échec d'écriture sur un record : id Odoo visé + raison XML-RPC."""
+
+    id: int
+    raison: str
+
+
+@dataclass(frozen=True, slots=True)
+class RapportEcriture:
+    """Rapport de `OdooWriter.update()` (#571).
+
+    Un échec XML-RPC sur un record n'interrompt plus la boucle : chaque record
+    restant est quand même tenté, et chaque catégorie est rapportée plutôt que
+    de stopper net ou de finir en simple log. Relancer `update()` est sûr
+    (écriture idempotente, mêmes valeurs sur les mêmes ids) : le rapport sert
+    à décider quoi corriger avant de relancer, pas à empêcher de relancer.
+    """
+
+    ids_reussis: list[int] = field(default_factory=list)
+    echecs: list[EchecEcriture] = field(default_factory=list)
+    sans_id: list[dict[Hashable, Any]] = field(default_factory=list)
 
 
 class OdooWriter(OdooReader):
@@ -77,7 +102,7 @@ class OdooWriter(OdooReader):
         logger.info(f"{model} #{created_ids} created in Odoo db.")
         return created_ids
 
-    def update(self, model: str, records: list[dict[Hashable, Any]]) -> None:
+    def update(self, model: str, records: list[dict[Hashable, Any]]) -> RapportEcriture:
         """
         Met à jour des enregistrements dans Odoo.
 
@@ -85,18 +110,25 @@ class OdooWriter(OdooReader):
             model: Modèle Odoo
             records: Liste des enregistrements à mettre à jour (doivent contenir 'id')
 
+        Returns:
+            RapportEcriture : ids réussis, échecs (id + raison), records sans 'id'.
+            Un échec XML-RPC sur un record n'interrompt pas la boucle (#571) — les
+            appelants qui ignorent le retour (ex. `injection_rsc.py`) continuent de
+            fonctionner sans modification.
+
         Note:
             Les valeurs None sont filtrées : un champ à None ne sera pas modifié dans Odoo.
             Pour effacer explicitement un champ, passer False.
             Attention : OdooReader._normalize_for() convertit les False Odoo en None,
             donc un round-trip read→update ne modifiera jamais les champs vides.
         """
-        updated_ids = []
+        rapport = RapportEcriture()
         records_copy = copy.deepcopy(records)
 
         for record in records_copy:
             if "id" not in record:
                 logger.warning(f"Record missing 'id' field, skipping: {record}")
+                rapport.sans_id.append(record)
                 continue
 
             record_id = int(record["id"])
@@ -107,9 +139,17 @@ class OdooWriter(OdooReader):
                 k: v for k, v in record.items() if v is not None and not (hasattr(v, "__len__") and len(v) == 0)
             }
 
-            if not self._sim:
-                self.execute(model, "write", [[record_id], clean_data])
-            updated_ids.append(record_id)
+            try:
+                if not self._sim:
+                    self.execute(model, "write", [[record_id], clean_data])
+                rapport.ids_reussis.append(record_id)
+            except Exception as e:
+                logger.warning(f"{model} #{record_id} write failed: {e}")
+                rapport.echecs.append(EchecEcriture(id=record_id, raison=str(e)))
 
         mode_text = " [simulated]" if self._sim else ""
-        logger.info(f"{len(records_copy)} {model} #{updated_ids} written in Odoo db.{mode_text}")
+        logger.info(f"{len(rapport.ids_reussis)} {model} #{rapport.ids_reussis} written in Odoo db.{mode_text}")
+        if rapport.echecs:
+            logger.warning(f"{len(rapport.echecs)} {model} write(s) failed: {rapport.echecs}")
+
+        return rapport

--- a/notebooks/facturation.py
+++ b/notebooks/facturation.py
@@ -20,6 +20,7 @@ with app.setup:
 
     from datetime import date, timedelta
 
+    from electricore_client import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
     from electricore_client.arrow import ElectricoreArrowClient as ElectricoreClient
 
     # Configuration du logging
@@ -59,12 +60,13 @@ def _():
 
 @app.cell(hide_code=True)
 def _():
+    # Le serveur calcule le rapprochement Odoo × Enedis et les flags a_facturer /
+    # a_supprimer indépendamment de l'état de facturation courant dans Odoo (ADR-0014).
     mo.md(r"""
-    # Mois cible
+    # Mois à traiter
 
-    Toutes les requêtes portent sur ce mois. `client.facturation(mois)` retourne le
-    rapprochement Odoo × Enedis du mois avec les flags `a_facturer` / `a_supprimer`
-    (calculés côté serveur, cf. ADR-0014), sans dépendre de l'état de facturation actuel.
+    Choisissez ci-dessous le mois à facturer (format AAAA-MM). Par défaut : le dernier
+    mois terminé — le mois en cours n'a jamais de données prêtes à facturer.
     """)
     return
 
@@ -82,21 +84,98 @@ def _():
 @app.cell(hide_code=True)
 def _():
     mo.md(r"""
-    # Récupération des données Enedis
+    # Récupération des données du mois
 
-    `client.facturation(mois)` retourne `lignes_facture_rapprochees` (Odoo × Enedis × compteur)
-    calculé côté serveur, incluant les flags `a_facturer` / `a_supprimer`. Le notebook filtre
-    côté client en prod via `.filter(pl.col("a_facturer"))`.
+    Le notebook interroge le serveur electricore pour le mois choisi et ne garde que
+    les lignes à facturer ce mois-ci.
+
+    **Si un encadré d'erreur apparaît ci-dessous** : suivez l'action qu'il indique. Les
+    étapes suivantes du notebook ne s'exécutent pas tant que le problème n'est pas réglé —
+    c'est voulu, pas un bug.
     """)
     return
 
 
 @app.cell
 def _(mois_input):
+    # Fail-fast config (#571) : sans clé API, inutile de tenter l'appel réseau —
+    # message actionnable immédiat plutôt qu'un 401 différé.
+    mo.stop(
+        not client.api_key,
+        mo.callout(
+            mo.md(
+                "**Configuration API manquante**\n\n"
+                "`ELECTRICORE_API_KEY` (ou `API_KEYS`) n'est pas définie. "
+                "Renseignez-la dans `.env` puis relancez ce notebook."
+            ),
+            kind="danger",
+        ),
+    )
+
     _mois = f"{mois_input.value.strip()[:7]}-01"  # YYYY-MM → YYYY-MM-01 (tolère un YYYY-MM-DD saisi par habitude)
-    fact_mois_brut = client.facturation(mois=_mois)
-    fact_mois = fact_mois_brut.filter(pl.col("a_facturer"))
-    mo.md(f"**{len(fact_mois_brut)}** lignes du mois côté serveur · **{len(fact_mois)}** à facturer (a_facturer=True)")
+
+    # Zéro traceback pour le facturiste (#571, cf. #554) : chaque échec connu du
+    # transport client (X-Error-Kind, #424) devient un message métier + arrêt propre
+    # de l'aval (mo.stop empêche les cellules suivantes de tourner sur des données
+    # absentes/périmées).
+    try:
+        fact_mois_brut = client.facturation(mois=_mois)
+        # a_facturer / a_supprimer : flags calculés côté serveur (ADR-0014), indépendants
+        # de l'état de facturation actuel dans Odoo. lignes_facture_rapprochees = rapprochement
+        # Odoo × Enedis × compteur ; on ne garde que ce qui reste à facturer.
+        fact_mois = fact_mois_brut.filter(pl.col("a_facturer"))
+    except IngestionEnCours:
+        mo.stop(
+            True,
+            mo.callout(mo.md("**Ingestion en cours** — réessayez dans environ 15 minutes."), kind="warn"),
+        )
+    except PreconditionNonRemplie as e:
+        mo.stop(True, mo.callout(mo.md(f"**Précondition non remplie**\n\n{e}"), kind="warn"))
+    except ContractVersionError:
+        mo.stop(
+            True,
+            mo.callout(mo.md("**Mise à jour requise** — prévenez Virgile."), kind="danger"),
+        )
+    except httpx.TransportError:
+        mo.stop(
+            True,
+            mo.callout(
+                mo.md(
+                    "**Serveur electricore injoignable** — vérifiez `/ingestion` sur le bot "
+                    "Telegram, sinon prévenez Virgile."
+                ),
+                kind="danger",
+            ),
+        )
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code in (401, 403):
+            mo.stop(True, mo.callout(mo.md("**Clé API invalide** — prévenez Virgile."), kind="danger"))
+        mo.stop(
+            True,
+            mo.callout(
+                mo.md(f"**Erreur serveur inattendue** (HTTP {e.response.status_code}) — prévenez Virgile."),
+                kind="danger",
+            ),
+        )
+    except Exception as e:
+        mo.stop(True, mo.callout(mo.md(f"**Erreur inattendue** — prévenez Virgile.\n\n`{e}`"), kind="danger"))
+
+    # Complément #554 : le défaut « dernier mois révolu » évite déjà le cas courant,
+    # ce garde-fou couvre le résiduel (mois saisi à la main, ingestion pas encore passée…).
+    mo.stop(
+        len(fact_mois_brut) == 0,
+        mo.callout(
+            mo.md(
+                f"**Aucune donnée renvoyée par le serveur pour {_mois[:7]}.**\n\n"
+                "À vérifier : l'ingestion du mois est-elle passée ? le mois est-il terminé ? "
+                "la réconciliation des contrats a-t-elle été faite (notebook *Attribution des "
+                "contrats*) ?"
+            ),
+            kind="warn",
+        ),
+    )
+
+    mo.md(f"**{len(fact_mois_brut)}** lignes du mois côté serveur · **{len(fact_mois)}** à facturer")
     return (fact_mois,)
 
 
@@ -109,17 +188,19 @@ def _(fact_mois):
 @app.cell(hide_code=True)
 def _():
     mo.md(r"""
-    ## Déménagements
+    ## Clients ayant changé de contrat en cours de mois
 
-    PDLs avec plusieurs `ref_situation_contractuelle` distinctes dans le mois.
-    Dédoublonnage sur `(pdl, ref_situation_contractuelle)` requis (la table
-    `fact_mois` a une ligne par invoice_line, pas par RSC).
+    Un point de livraison peut changer de contrat pendant le mois (déménagement,
+    renégociation…). Le tableau ci-dessous les repère : à vérifier avant validation,
+    un cas peut demander un traitement à la main.
     """)
     return
 
 
 @app.cell
 def _(fact_mois):
+    # Une ligne par invoice_line dans fact_mois : dédoublonner sur (pdl, contrat) pour
+    # repérer les PDL à plusieurs situations contractuelles distinctes dans le mois.
     _pdl_rsc = fact_mois.select(["pdl", "ref_situation_contractuelle"]).unique()
     _pdl_counts = _pdl_rsc.group_by("pdl").agg(pl.len().alias("n"))
     pdls_doublons = _pdl_counts.filter(pl.col("n") > 1)["pdl"].to_list()
@@ -131,13 +212,14 @@ def _(fact_mois):
 
 @app.cell(hide_code=True)
 def _():
+    # invoice_line_ids / sale_order_id / invoice_ids / x_lisse : identifiants Odoo
+    # passe-plat conservés par `rapprocher` (core) — aucune lecture Odoo séparée ici,
+    # tout vient déjà de l'API dans fact_mois.
     mo.md(r"""
-    # Réconciliation Enedis → Odoo
+    # Comparaison avec Odoo
 
-    `fact_mois` (= `lignes_facture_rapprochees`) contient déjà le rapprochement
-    par `invoice_line_ids` **et** les identifiants Odoo passe-plat
-    (`sale_order_id`, `invoice_ids`, `x_lisse`), conservés par `rapprocher`.
-    Aucune lecture Odoo séparée : tout vient de l'API.
+    Les données chargées plus haut contiennent déjà le rapprochement complet entre
+    Odoo et Enedis : pas de connexion Odoo séparée à cette étape.
     """)
     return
 
@@ -362,15 +444,40 @@ def _(
 ):
     mo.stop(not run_button.value, mo.md("Vérifiez les données ci-dessus puis cliquez sur **Injecter**."))
 
+    # Un échec par record n'interrompt plus la boucle : chaque update() rapporte ce
+    # qui a réussi / échoué / a été ignoré (sans id) au lieu de stopper net (#571).
     with OdooWriter(config=config, sim=sim_mode.value) as _writer:
-        _writer.update("account.move.line", lines_records)
-        _writer.update("account.move", invoices_records)
-        _writer.update("sale.order", orders_records)
+        _rapport_lignes = _writer.update("account.move.line", lines_records)
+        _rapport_factures = _writer.update("account.move", invoices_records)
+        _rapport_orders = _writer.update("sale.order", orders_records)
 
-    _label = "simulées" if sim_mode.value else "mises à jour"
+    _mode_label = "**simulation** (aucune écriture réelle)" if sim_mode.value else "**écriture réelle** dans Odoo"
+
+    def _resume(nom, rapport):
+        texte = f"- **{nom}** : {len(rapport.ids_reussis)} OK"
+        if rapport.echecs:
+            details = ", ".join(f"#{e.id} ({e.raison})" for e in rapport.echecs)
+            texte += f", **{len(rapport.echecs)} échec(s)** → {details}"
+        if rapport.sans_id:
+            texte += f", {len(rapport.sans_id)} ignoré(s) (sans id)"
+        return texte
+
+    _rapports = (
+        ("Lignes de facture", _rapport_lignes),
+        ("Factures", _rapport_factures),
+        ("Commandes", _rapport_orders),
+    )
+    _a_des_echecs = any(rapport.echecs for _, rapport in _rapports)
+
     mo.callout(
-        mo.md(f"✅ **{len(lines_records)} lignes** account.move.line {_label} (`quantity`)."),
-        kind="success",
+        mo.md(
+            f"Injection en {_mode_label}.\n\n"
+            + "\n".join(_resume(nom, rapport) for nom, rapport in _rapports)
+            + "\n\n**Relancer cette étape ne risque rien** : les écritures sont idempotentes "
+            "(mêmes valeurs réappliquées sur les mêmes lignes). Si des échecs apparaissent "
+            "ci-dessus, corrigez la cause côté Odoo puis relancez l'injection."
+        ),
+        kind="danger" if _a_des_echecs else "success",
     )
     return
 

--- a/tests/unit/integrations/odoo/test_writers.py
+++ b/tests/unit/integrations/odoo/test_writers.py
@@ -1,0 +1,87 @@
+"""Tests pour `OdooWriter.update()` : rapport d'injection par-record (#571).
+
+Avant #571, la boucle d'écriture s'arrêtait à la première exception XML-RPC :
+Odoo restait à moitié injecté. Ces tests couvrent le nouveau comportement :
+un échec par record ne casse pas la boucle, et chaque catégorie (réussi,
+échoué, sans id) est rapportée — plus seulement loguée.
+"""
+
+from unittest.mock import MagicMock
+
+from electricore.integrations.odoo.writers import OdooWriter
+
+_CONFIG = {"url": "https://fake.odoo", "db": "fake", "username": "u", "password": "p"}
+
+
+def _writer(execute_side_effect):
+    writer = OdooWriter(config=_CONFIG, sim=False)
+    # Contourne la connexion XML-RPC réelle : on mocke `execute` directement,
+    # comme le ferait un appelant qui teste `update()` en isolation.
+    writer.execute = MagicMock(side_effect=execute_side_effect)
+    return writer
+
+
+def test_update_continue_apres_echec_xmlrpc_sur_un_record():
+    """Un échec XML-RPC sur le record 2 n'interrompt pas la boucle (#571)."""
+
+    def _execute(model, method, args=None, kwargs=None):
+        record_id = args[0][0]
+        if record_id == 2:
+            raise Exception("XML-RPC fault: access denied")
+        return [True]
+
+    writer = _writer(_execute)
+    rapport = writer.update(
+        "sale.order",
+        [
+            {"id": 1, "x_field": "a"},
+            {"id": 2, "x_field": "b"},
+            {"id": 3, "x_field": "c"},
+        ],
+    )
+
+    # Les records 1 et 3 sont écrits malgré l'échec du 2 (plus d'arrêt net).
+    assert writer.execute.call_count == 3
+    assert rapport.ids_reussis == [1, 3]
+    assert len(rapport.echecs) == 1
+    assert rapport.echecs[0].id == 2
+    assert "access denied" in rapport.echecs[0].raison
+    assert rapport.sans_id == []
+
+
+def test_update_liste_les_records_sans_id_dans_le_rapport():
+    """Un record sans 'id' apparaît dans le rapport, plus seulement dans les logs (#571)."""
+    writer = _writer(lambda *a, **k: [True])
+
+    rapport = writer.update(
+        "sale.order",
+        [
+            {"x_field": "sans id"},
+            {"id": 5, "x_field": "ok"},
+        ],
+    )
+
+    assert rapport.ids_reussis == [5]
+    assert rapport.echecs == []
+    assert len(rapport.sans_id) == 1
+    assert rapport.sans_id[0]["x_field"] == "sans id"
+
+
+def test_update_retour_ignorable_retrocompatible():
+    """Un appelant qui ignore le retour (`injection_rsc.py`) continue de fonctionner (#571)."""
+    writer = _writer(lambda *a, **k: [True])
+
+    # Pas de capture du retour : simule l'appel existant `_writer.update(model, records)`.
+    writer.update("sale.order", [{"id": 1}])
+
+
+def test_update_mode_simulation_n_appelle_jamais_execute():
+    """Mode simulation : aucun XML-RPC, mais le rapport liste quand même les ids visés."""
+    writer = OdooWriter(config=_CONFIG, sim=True)
+    writer.execute = MagicMock()
+
+    rapport = writer.update("sale.order", [{"id": 1}, {"id": 2}])
+
+    writer.execute.assert_not_called()
+    assert rapport.ids_reussis == [1, 2]
+    assert rapport.echecs == []


### PR DESCRIPTION
Closes #571

Deux volets, tests-first :

- `OdooWriter.update()` n'interrompt plus la boucle sur un échec XML-RPC : elle
  continue par record et retourne un `RapportEcriture` (ids réussis, échecs
  id+raison, records sans id) — signature rétrocompatible, `injection_rsc.py`
  continue de fonctionner sans modification.
- Le notebook `facturation.py` n'affiche plus jamais de traceback : chaque
  échec connu (ingestion en cours, précondition, serveur injoignable, clé
  invalide, version de contrat, plus un filet générique) devient un callout
  métier + arrêt propre de l'aval ; 0 ligne serveur devient un diagnostic
  actionnable ; clé API absente est détectée dès l'ouverture. Après
  injection, le rapport des 3 modèles s'affiche (simulé/réel, consigne de
  relance sans risque). Les cellules markdown sont réécrites en langage
  facturiste, le jargon dev migre en commentaires.

Empiriquement vérifié via `marimo export html` : les cellules avales d'un
`mo.stop` s'affichent bien comme "ancestor was stopped" avec une traceback
vide.

**Stackée sur #570** (base `fix/554-mois-notebook`) : se retargettera
automatiquement sur `main` une fois #570 mergée — merger #570 d'abord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
