### PR TITLE
fix(notebooks): lire api_version dans la réponse /health

### DIFF
--- a/notebooks/facturation.py
+++ b/notebooks/facturation.py
@@ -67,7 +67,7 @@ with app.setup:
             api_msg = mo.md(
                 "**API electricore joignable**\n\n"
                 f"- URL: `{client.url}`\n"
-                f"- Version serveur: `{_health.json().get('version', '?')}`\n"
+                f"- Version serveur: `{_health.json().get('api_version', '?')}`\n"
                 f"- Clé API: `***`"
             )
         except Exception:


### PR DESCRIPTION
Correctif de #577 : `/health` expose la version sous la clé `api_version` ([main.py:232](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/api/main.py)), pas `version` — le bloc d'ouverture affichait donc toujours `Version serveur: ?` même serveur joignable (constaté par Virgile en conditions opérateur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)