### PR TITLE
fix(notebooks): règle draft null-safe, attribution RSC en service, signalement post-mois facturé

### DIFF
--- a/notebooks/facturation.py
+++ b/notebooks/facturation.py
@@ -394,10 +394,17 @@ def _(fact_mois, taux_verification):
     # (passe-plat de `rapprocher`) → 1 ligne par order après déduplication. L'ancienne
     # lecture Odoo directe + jointure sur la RSC était redondante (#417).
     # « à jour » ≡ énergie calculable (ADR-0033 : ancien data_complete=True ⇒ qualite ≠ incalculable).
+    # Harmonisé avec filtre_a_injecter (#579) : x_lisse arrive NULL (jamais false) d'Odoo, et
+    # qualite NULL (sans correspondance Enedis) n'est jamais « à jour », même lissé — sans
+    # is_not_null/fill_null explicites, pl.when(null) est traité comme faux et la commande
+    # passait à tort en checked/populated (23 draft attendues en juin 2026 au lieu de 0).
     _orders = fact_mois.select(["sale_order_id", "x_lisse", "qualite", "ref_situation_contractuelle"]).unique()
 
     _df = _orders.with_columns(
-        ((pl.col("qualite") != "incalculable") | pl.col("x_lisse")).alias("a_jour")
+        (
+            pl.col("qualite").is_not_null()
+            & ((pl.col("qualite") != "incalculable") | pl.col("x_lisse").fill_null(False))
+        ).alias("a_jour")
     ).with_columns(pl.Series("rand", np.random.rand(len(_orders))))
 
     orders_records = (

--- a/notebooks/facturation.py
+++ b/notebooks/facturation.py
@@ -440,6 +440,76 @@ def _(fact_mois, taux_verification):
 @app.cell(hide_code=True)
 def _():
     mo.md(r"""
+    ### Brouillons dont le contrat démarre après le mois facturé
+
+    Odoo génère un brouillon pour tout abonnement actif, y compris ceux dont la mise en
+    service Enedis est postérieure au mois facturé (cf. #579/#564) : rien à facturer ce
+    mois-ci, mais la règle draft ci-dessus ne nomme pas la cause. Le tableau ci-dessous la
+    nomme — **signalement seul, aucune écriture Odoo**.
+
+    Un contrat entré **en cours de mois** (prorata légitime) n'est pas signalé : seule une
+    mise en service **après la fin du mois facturé** l'est.
+    """)
+    return
+
+
+@app.cell
+def _(fact_mois, mois_input):
+    # Contrat cible #581 : parmi les brouillons sans correspondance Enedis (qualite null),
+    # ceux dont le PDL entre au C15 après la fin du mois facturé n'ont rien à facturer ce
+    # mois — cette cellule nomme la cause. `date_evenement` du 1er événement C15 de la RSC
+    # = date de mise en service (même mécanique que `contrats_par_pdl` dans injection_rsc.py).
+    _mois_str = mois_input.value.strip()[:7]  # YYYY-MM
+    _debut_mois = date.fromisoformat(f"{_mois_str}-01")
+    _fin_mois = (_debut_mois.replace(day=28) + timedelta(days=4)).replace(day=1) - timedelta(days=1)
+
+    _brouillons_sans_match = (
+        fact_mois.filter(pl.col("qualite").is_null())
+        .select(["sale_order_id", "x_pdl", "ref_situation_contractuelle"])
+        .unique()
+    )
+
+    _debuts_contrat = (
+        client.flux("c15")
+        .group_by(["pdl", "ref_situation_contractuelle"])
+        .agg(pl.col("date_evenement").min().alias("date_mise_en_service"))
+        .with_columns(pl.col("date_mise_en_service").dt.replace_time_zone(None).dt.date())
+    )
+
+    _signalement_post_mois = (
+        _brouillons_sans_match.join(
+            _debuts_contrat,
+            left_on=["x_pdl", "ref_situation_contractuelle"],
+            right_on=["pdl", "ref_situation_contractuelle"],
+            how="left",
+        )
+        .filter(pl.col("date_mise_en_service") > _fin_mois)
+        .with_columns(
+            (
+                pl.lit(
+                    "contrat mis en service après le mois facturé — brouillon à écarter, "
+                    "la facturation démarre à la campagne suivante (mise en service le "
+                )
+                + pl.col("date_mise_en_service").dt.strftime("%Y-%m-%d")
+                + pl.lit(")")
+            ).alias("motif")
+        )
+    )
+
+    mo.vstack(
+        [
+            mo.md(
+                f"**{len(_signalement_post_mois)}** brouillon(s) signalé(s) — contrat mis en service après le mois"
+            ),
+            mo.ui.table(_signalement_post_mois) if not _signalement_post_mois.is_empty() else mo.md("✅ Aucun"),
+        ]
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
     ## Préparation données factures
 
     Chaque facture du mois reçoit ses informations d'en-tête : la période facturée

--- a/notebooks/injection_rsc.py
+++ b/notebooks/injection_rsc.py
@@ -47,10 +47,17 @@ def _():
     # Attribution des ref_situation_contractuelle aux sale.order
 
     Ce notebook identifie la `ref_situation_contractuelle` (RSC) Enedis correspondant
-    à chaque `sale.order` Odoo, via un **asof join temporel** sur le PDL et la date.
+    à chaque `sale.order` Odoo actif (`state = sale`).
 
-    **Mécanisme** : pour un order créé à `date_order` sur le PDL `x_pdl`,
-    la RSC active est celle dont la date d'entrée C15 est la plus récente avant `date_order`.
+    **Règle d'attribution (#580)** : la RSC du PDL dont le **dernier état C15** n'est pas
+    `RESILIE`. Un PDL dont le contrat a été re-créé (RES→MES le même jour, CFN entrant…)
+    change de RSC active sans que la commande ne bouge — un asof join sur `date_order`
+    fige à tort la RSC contemporaine de la souscription et ne se répare jamais. L'asof
+    reste affiché ci-dessous à titre de **diagnostic/départage**, plus comme source
+    d'attribution.
+
+    0 ou plusieurs RSC en service sur le PDL → commande listée à part, **jamais
+    d'écriture silencieuse**.
 
     **Lecture seule** — aucune écriture dans Odoo.
     """)
@@ -68,11 +75,23 @@ def _():
 @app.cell(hide_code=True)
 def _():
     # Lecture C15 via l'API (cf. ADR-0009). Le serveur retourne un DataFrame collecté ;
-    # on agrège ensuite localement.
+    # on agrège ensuite localement. `dernier_etat_contractuel` (#580) : l'état C15 à
+    # l'événement le plus récent de la RSC (EN SERVICE / RESILIE) — `.unique(keep="last")`
+    # sur un flux trié par date_evenement, même pattern que `compteur_par_rsc` dans
+    # contexte_mensuel.py.
+    _c15 = client.flux("c15").sort("date_evenement")
+
+    _debuts = _c15.group_by(["pdl", "ref_situation_contractuelle"]).agg(
+        pl.col("date_evenement").min().alias("date_debut_contrat")
+    )
+    _derniers_etats = (
+        _c15.unique(subset=["pdl", "ref_situation_contractuelle"], keep="last")
+        .select(["pdl", "ref_situation_contractuelle", "etat_contractuel"])
+        .rename({"etat_contractuel": "dernier_etat_contractuel"})
+    )
+
     contrats_par_pdl = (
-        client.flux("c15")
-        .group_by(["pdl", "ref_situation_contractuelle"])
-        .agg(pl.col("date_evenement").min().alias("date_debut_contrat"))
+        _debuts.join(_derniers_etats, on=["pdl", "ref_situation_contractuelle"], how="left")
         # Supprimer la timezone pour compatibilité avec les dates Odoo
         .with_columns(pl.col("date_debut_contrat").dt.replace_time_zone(None))
         .sort(["pdl", "date_debut_contrat"])
@@ -117,7 +136,10 @@ def _():
 @app.cell
 def _():
     mo.md("""
-    ## 3. Asof join : PDL + date_order → RSC
+    ## 3. Asof join : PDL + date_order → RSC (diagnostic)
+
+    Contemporain de la souscription, pas de l'état actuel du PDL — gardé pour le
+    départage visuel, plus utilisé comme source d'attribution (#580, cf. section 3bis).
     """)
     return
 
@@ -186,6 +208,80 @@ def _(orders_avec_rsc):
 
 @app.cell
 def _():
+    mo.md(r"""
+    ## 3bis. RSC en service par PDL (règle d'attribution, #580)
+
+    Pour chaque PDL, les RSC dont le **dernier état C15** n'est pas `RESILIE`. Exactement
+    une candidate → attribuée à la commande. Zéro ou plusieurs → **à traiter à part**,
+    jamais d'écriture silencieuse.
+    """)
+    return
+
+
+@app.cell
+def _(contrats_par_pdl):
+    _en_service = contrats_par_pdl.filter(pl.col("dernier_etat_contractuel") != "RESILIE")
+    rsc_en_service_par_pdl = _en_service.group_by("pdl").agg(
+        pl.col("ref_situation_contractuelle").alias("rsc_en_service"),
+        pl.len().alias("nb_rsc_en_service"),
+    )
+    return (rsc_en_service_par_pdl,)
+
+
+@app.cell
+def _(orders_avec_rsc, rsc_en_service_par_pdl):
+    # Attribution cible (#580) : ignore l'asof (`rsc_asof`, gardé en diagnostic) — une seule
+    # RSC en service sur le PDL est attribuée ; 0 ou plusieurs → ref_situation_contractuelle
+    # null (jamais d'écriture silencieuse, cf. cellules 4 ci-dessous).
+    orders_attribution = (
+        orders_avec_rsc.rename({"ref_situation_contractuelle": "rsc_asof"})
+        .join(rsc_en_service_par_pdl, left_on="x_pdl", right_on="pdl", how="left")
+        .with_columns(pl.col("nb_rsc_en_service").fill_null(0))
+        .with_columns(
+            pl.when(pl.col("nb_rsc_en_service") == 1)
+            .then(pl.col("rsc_en_service").list.first())
+            .otherwise(None)
+            .alias("ref_situation_contractuelle")
+        )
+    )
+    return (orders_attribution,)
+
+
+@app.cell
+def _(orders_attribution):
+    _attribuees = orders_attribution.filter(pl.col("nb_rsc_en_service") == 1)
+    _a_part = orders_attribution.filter(pl.col("nb_rsc_en_service") != 1).with_columns(
+        pl.when(pl.col("nb_rsc_en_service") == 0)
+        .then(pl.lit("aucune RSC en service sur le PDL"))
+        .otherwise(pl.lit("plusieurs RSC en service sur le PDL"))
+        .alias("motif")
+    )
+    mo.vstack(
+        [
+            mo.md(f"""
+        ### Résultats de l'attribution
+
+        | | |
+        |---|---|
+        | ✅ Attribuées (1 RSC en service) | **{len(_attribuees)}** orders |
+        | ⚠️ À traiter à part (0 ou plusieurs) | **{len(_a_part)}** orders |
+        """),
+            mo.ui.table(
+                _attribuees.select(["sale_order_id", "name", "x_pdl", "rsc_asof", "ref_situation_contractuelle"])
+            ),
+            mo.md("### Commandes à traiter à part (jamais d'écriture silencieuse)")
+            if not _a_part.is_empty()
+            else mo.md(""),
+            mo.ui.table(_a_part.select(["sale_order_id", "name", "x_pdl", "motif", "nb_rsc_en_service"]))
+            if not _a_part.is_empty()
+            else mo.md(""),
+        ]
+    )
+    return
+
+
+@app.cell
+def _():
     mo.md("""
     ## 4. Injection RSC → Odoo
     """)
@@ -193,18 +289,21 @@ def _():
 
 
 @app.cell
-def _(orders_avec_rsc):
+def _(orders_attribution):
     from electricore.integrations.odoo import OdooWriter
 
-    _a_injecter = orders_avec_rsc.filter(pl.col("ref_situation_contractuelle").is_not_null())
-    _sans_rsc = orders_avec_rsc.filter(pl.col("ref_situation_contractuelle").is_null())
+    _a_injecter = orders_attribution.filter(pl.col("nb_rsc_en_service") == 1)
+    _a_part = orders_attribution.filter(pl.col("nb_rsc_en_service") != 1)
 
     sim_mode = mo.ui.checkbox(label="Mode simulation (aucune écriture réelle)", value=True)
     run_button = mo.ui.run_button(label="Injecter dans Odoo")
 
     mo.vstack(
         [
-            mo.md(f"**{len(_a_injecter)}** orders à mettre à jour · **{len(_sans_rsc)}** sans RSC (ignorés)"),
+            mo.md(
+                f"**{len(_a_injecter)}** orders à mettre à jour · "
+                f"**{len(_a_part)}** à traiter à part (ignorés, jamais d'écriture silencieuse)"
+            ),
             mo.ui.table(_a_injecter.select(["name", "x_pdl", "date_order", "ref_situation_contractuelle"])),
             sim_mode,
             run_button,
@@ -214,11 +313,11 @@ def _(orders_avec_rsc):
 
 
 @app.cell
-def _(OdooWriter, orders_avec_rsc, run_button, sim_mode):
+def _(OdooWriter, orders_attribution, run_button, sim_mode):
     mo.stop(not run_button.value, mo.md("Vérifiez les données ci-dessus puis cliquez sur **Injecter**."))
 
     _records = (
-        orders_avec_rsc.filter(pl.col("ref_situation_contractuelle").is_not_null())
+        orders_attribution.filter(pl.col("nb_rsc_en_service") == 1)
         .rename({"sale_order_id": "id", "ref_situation_contractuelle": "x_ref_situation_contractuelle"})
         .select(["id", "x_ref_situation_contractuelle"])
         .to_dicts()

--- a/tests/unit/test_notebook_facturation_statut.py
+++ b/tests/unit/test_notebook_facturation_statut.py
@@ -1,0 +1,67 @@
+"""Tests pour `notebooks/facturation.py` : la règle `a_jour` harmonisée (#579).
+
+Cette cellule marimo n'est pas importable (fonction locale à `@app.cell`) : la garde
+combine (a) une table de vérité sur une reproduction fidèle de l'expression et (b) une
+assertion de source statique — même approche que
+`tests/integration/test_operator_notebooks_bundle.py` — pour détecter tout drift entre
+le notebook et l'expression vérifiée.
+"""
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+_RACINE = Path(__file__).resolve().parents[2]
+_SOURCE_FACTURATION = (_RACINE / "notebooks" / "facturation.py").read_text()
+
+# Expression harmonisée (#579), reproduite mot pour mot depuis notebooks/facturation.py.
+_EXPR_A_JOUR = (
+    'pl.col("qualite").is_not_null()\n'
+    '            & ((pl.col("qualite") != "incalculable") | pl.col("x_lisse").fill_null(False))'
+)
+
+
+def _a_jour_expr() -> pl.Expr:
+    """Reproduction fidèle de l'expression `a_jour` de facturation.py (#579)."""
+    return pl.col("qualite").is_not_null() & (
+        (pl.col("qualite") != "incalculable") | pl.col("x_lisse").fill_null(False)
+    )
+
+
+class TestReglesAJourFacturation:
+    """#579 : draft ⟺ qualite null OU (incalculable ET non lissé)."""
+
+    @pytest.mark.parametrize(
+        "qualite,x_lisse,attendu_a_jour",
+        [
+            # incalculable + x_lisse null/false → PAS à jour (draft)
+            ("incalculable", None, False),
+            ("incalculable", False, False),
+            # qualite null (sans correspondance Enedis) → PAS à jour, même lissé
+            (None, True, False),
+            (None, None, False),
+            (None, False, False),
+            # incalculable + lissé (avec correspondance) → à jour (provision, ADR-0033/0048)
+            ("incalculable", True, True),
+            # réelle/estimée non lissé → à jour, inchangé
+            ("réelle", False, True),
+            ("estimée", False, True),
+            ("réelle", None, True),
+            ("estimée", True, True),
+        ],
+    )
+    def test_table_de_verite_qualite_x_lisse(self, qualite, x_lisse, attendu_a_jour):
+        data = pl.DataFrame(
+            {"qualite": [qualite], "x_lisse": [x_lisse]},
+            schema={"qualite": pl.Utf8, "x_lisse": pl.Boolean},
+        )
+        result = data.with_columns(_a_jour_expr().alias("a_jour"))
+        assert result["a_jour"][0] == attendu_a_jour
+
+    def test_notebook_porte_expression_harmonisee(self):
+        """Garde anti-drift : facturation.py doit utiliser l'expression a_jour vérifiée."""
+        assert _EXPR_A_JOUR in _SOURCE_FACTURATION, (
+            "facturation.py doit utiliser l'expression a_jour harmonisée (#579) : "
+            "qualite non-null ET (qualite != incalculable OU x_lisse.fill_null(False))."
+        )

--- a/tests/unit/test_notebook_facturation_statut.py
+++ b/tests/unit/test_notebook_facturation_statut.py
@@ -1,12 +1,14 @@
-"""Tests pour `notebooks/facturation.py` : la règle `a_jour` harmonisée (#579).
+"""Tests pour `notebooks/facturation.py` : la règle `a_jour` harmonisée (#579) et le
+signalement des brouillons dont le contrat démarre après le mois facturé (#581).
 
-Cette cellule marimo n'est pas importable (fonction locale à `@app.cell`) : la garde
-combine (a) une table de vérité sur une reproduction fidèle de l'expression et (b) une
-assertion de source statique — même approche que
+Ces cellules marimo ne sont pas importables (fonctions locales à `@app.cell`) : la
+garde combine (a) une table de vérité sur une reproduction fidèle de l'expression et
+(b) une assertion de source statique — même approche que
 `tests/integration/test_operator_notebooks_bundle.py` — pour détecter tout drift entre
 le notebook et l'expression vérifiée.
 """
 
+from datetime import date, timedelta
 from pathlib import Path
 
 import polars as pl
@@ -65,3 +67,44 @@ class TestReglesAJourFacturation:
             "facturation.py doit utiliser l'expression a_jour harmonisée (#579) : "
             "qualite non-null ET (qualite != incalculable OU x_lisse.fill_null(False))."
         )
+
+
+def _fin_mois(mois: str) -> date:
+    """Dernier jour du mois AAAA-MM (même calcul que la cellule de signalement)."""
+    debut = date.fromisoformat(f"{mois}-01")
+    return (debut.replace(day=28) + timedelta(days=4)).replace(day=1) - timedelta(days=1)
+
+
+class TestSignalementPostMois:
+    """#581 : signaler les brouillons (qualite null) dont le contrat démarre après le
+    mois facturé — pas ceux entrés en cours de mois (prorata légitime)."""
+
+    @pytest.mark.parametrize(
+        "date_mise_en_service,attendu_signale",
+        [
+            (date(2026, 5, 15), False),  # avant le mois facturé
+            (date(2026, 6, 1), False),  # début du mois (prorata)
+            (date(2026, 6, 15), False),  # en cours de mois (prorata)
+            (date(2026, 6, 30), False),  # dernier jour du mois — edge exact, pas signalé
+            (date(2026, 7, 1), True),  # lendemain de la fin du mois → signalé
+            (date(2026, 7, 2), True),  # cas réel juin 2026 (S01070-S01076)
+        ],
+    )
+    def test_table_de_verite_date_boundary(self, date_mise_en_service, attendu_signale):
+        fin_mois = _fin_mois("2026-06")
+        assert (date_mise_en_service > fin_mois) is attendu_signale
+
+    def test_notebook_calcule_la_fin_de_mois(self):
+        assert "replace(day=28) + timedelta(days=4)" in _SOURCE_FACTURATION
+
+    def test_notebook_nomme_la_cause_et_la_date(self):
+        assert "contrat mis en service après le mois facturé" in _SOURCE_FACTURATION
+        assert "date_mise_en_service" in _SOURCE_FACTURATION
+
+    def test_signalement_post_mois_est_lecture_seule(self):
+        """Signalement seul (#581) : ce bloc ne doit écrire dans Odoo nulle part."""
+        debut = _SOURCE_FACTURATION.index("### Brouillons dont le contrat démarre après le mois facturé")
+        fin = _SOURCE_FACTURATION.index("## Préparation données factures")
+        bloc = _SOURCE_FACTURATION[debut:fin]
+        assert "OdooWriter" not in bloc
+        assert "_writer.update" not in bloc

--- a/tests/unit/test_notebook_injection_rsc_attribution.py
+++ b/tests/unit/test_notebook_injection_rsc_attribution.py
@@ -1,0 +1,126 @@
+"""Tests pour la règle d'attribution RSC de `notebooks/injection_rsc.py` (#580).
+
+L'asof join (PDL, date_order) fige la RSC contemporaine de la souscription : pour un
+PDL dont le contrat a été re-créé (RES→MES le même jour, CFN entrant…), l'asof re-choisit
+indéfiniment la RSC résiliée. La règle cible attribue, pour chaque commande active
+(`state = sale`, déjà filtré côté requête Odoo), la RSC du PDL dont le **dernier état
+C15** n'est pas `RESILIE` — 0 ou plusieurs candidates → à traiter à part, jamais
+d'écriture silencieuse.
+
+Cette fonction est une reproduction fidèle du couple de cellules
+`rsc_en_service_par_pdl` / `orders_attribution` de injection_rsc.py (cf. garde de
+source statique en fin de fichier) — même approche que
+`tests/integration/test_operator_notebooks_bundle.py`.
+"""
+
+from pathlib import Path
+
+import polars as pl
+
+_RACINE = Path(__file__).resolve().parents[2]
+_SOURCE_INJECTION_RSC = (_RACINE / "notebooks" / "injection_rsc.py").read_text()
+
+
+def _attribuer_rsc_en_service(orders: pl.DataFrame, contrats: pl.DataFrame) -> pl.DataFrame:
+    """Reproduction fidèle de la règle d'attribution #580.
+
+    `orders` : une ligne par commande active, colonnes `pdl` (+ tout identifiant).
+    `contrats` : une ligne par (pdl, ref_situation_contractuelle), colonne
+    `dernier_etat_contractuel`.
+    """
+    en_service = contrats.filter(pl.col("dernier_etat_contractuel") != "RESILIE")
+    rsc_en_service_par_pdl = en_service.group_by("pdl").agg(
+        pl.col("ref_situation_contractuelle").alias("rsc_en_service"),
+        pl.len().alias("nb_rsc_en_service"),
+    )
+    return (
+        orders.join(rsc_en_service_par_pdl, on="pdl", how="left")
+        .with_columns(pl.col("nb_rsc_en_service").fill_null(0))
+        .with_columns(
+            pl.when(pl.col("nb_rsc_en_service") == 1)
+            .then(pl.col("rsc_en_service").list.first())
+            .otherwise(None)
+            .alias("ref_situation_contractuelle")
+        )
+    )
+
+
+class TestAttributionRscEnService:
+    """Les 4 patterns de l'acceptance criteria #580."""
+
+    def test_les_quatre_patterns(self):
+        orders = pl.DataFrame(
+            {"sale_order_id": [1, 2, 3, 4], "pdl": ["PDL_8ORDERS", "PDL_SORTI", "PDL_AMBIGU", "PDL_NORMAL"]}
+        )
+
+        contrats = pl.DataFrame(
+            {
+                "pdl": ["PDL_8ORDERS", "PDL_8ORDERS", "PDL_SORTI", "PDL_AMBIGU", "PDL_AMBIGU", "PDL_NORMAL"],
+                "ref_situation_contractuelle": ["RSC_OLD", "RSC_NEW", "RSC_R1", "RSC_A1", "RSC_A2", "RSC_UNIQUE"],
+                "dernier_etat_contractuel": [
+                    "RESILIE",
+                    "EN SERVICE",
+                    "RESILIE",
+                    "EN SERVICE",
+                    "EN SERVICE",
+                    "EN SERVICE",
+                ],
+            }
+        )
+
+        result = _attribuer_rsc_en_service(orders, contrats).sort("sale_order_id")
+
+        # Pattern 1 (forme des 8 commandes réelles) : résiliée + en service sur le même
+        # PDL → la RSC EN SERVICE est attribuée, pas celle contemporaine de l'asof.
+        pdl_8orders = result.filter(pl.col("pdl") == "PDL_8ORDERS")
+        assert pdl_8orders["ref_situation_contractuelle"][0] == "RSC_NEW"
+        assert pdl_8orders["nb_rsc_en_service"][0] == 1
+
+        # Pattern 2 : seule une RSC résiliée sur le PDL → aucune en service, à part.
+        pdl_sorti = result.filter(pl.col("pdl") == "PDL_SORTI")
+        assert pdl_sorti["ref_situation_contractuelle"][0] is None
+        assert pdl_sorti["nb_rsc_en_service"][0] == 0
+
+        # Pattern 3 : deux RSC en service sur le même PDL → ambigu, à part.
+        pdl_ambigu = result.filter(pl.col("pdl") == "PDL_AMBIGU")
+        assert pdl_ambigu["ref_situation_contractuelle"][0] is None
+        assert pdl_ambigu["nb_rsc_en_service"][0] == 2
+
+        # Pattern 4 : cas normal, une seule RSC en service → attribuée sans ambiguïté.
+        pdl_normal = result.filter(pl.col("pdl") == "PDL_NORMAL")
+        assert pdl_normal["ref_situation_contractuelle"][0] == "RSC_UNIQUE"
+        assert pdl_normal["nb_rsc_en_service"][0] == 1
+
+    def test_jamais_decriture_silencieuse_sur_pdl_ambigu_ou_sorti(self):
+        """0 ou plusieurs candidates → ref_situation_contractuelle null (rien à écrire)."""
+        orders = pl.DataFrame({"sale_order_id": [1, 2], "pdl": ["PDL_SORTI", "PDL_AMBIGU"]})
+        contrats = pl.DataFrame(
+            {
+                "pdl": ["PDL_SORTI", "PDL_AMBIGU", "PDL_AMBIGU"],
+                "ref_situation_contractuelle": ["RSC_R1", "RSC_A1", "RSC_A2"],
+                "dernier_etat_contractuel": ["RESILIE", "EN SERVICE", "EN SERVICE"],
+            }
+        )
+        result = _attribuer_rsc_en_service(orders, contrats)
+        assert result["ref_situation_contractuelle"].null_count() == 2
+
+
+class TestSourceInjectionRsc:
+    """Garde anti-drift : le notebook implémente bien la règle #580 (pas l'asof seul)."""
+
+    def test_regle_dattribution_presente(self):
+        assert 'pl.col("dernier_etat_contractuel") != "RESILIE"' in _SOURCE_INJECTION_RSC
+        assert "nb_rsc_en_service" in _SOURCE_INJECTION_RSC
+
+    def test_injection_utilise_orders_attribution_pas_lasof_seul(self):
+        """La cellule d'écriture Odoo doit dépendre de `orders_attribution` (règle #580),
+        pas directement de `orders_avec_rsc` (asof brut) — sinon la RSC résiliée repart."""
+        assert "def _(OdooWriter, orders_attribution, run_button, sim_mode):" in _SOURCE_INJECTION_RSC
+
+    def test_asof_reste_present_en_diagnostic(self):
+        """L'asof n'est pas supprimé : diagnostic/départage, cf. #580."""
+        assert 'strategy="nearest"' in _SOURCE_INJECTION_RSC
+        assert "diagnostic" in _SOURCE_INJECTION_RSC.lower()
+
+    def test_jamais_ecriture_silencieuse_mentionne(self):
+        assert "jamais d'écriture silencieuse" in _SOURCE_INJECTION_RSC


### PR DESCRIPTION
Corrige deux bugs de propagation de null Polars dans les notebooks facturistes et ajoute un
signalement pour les contrats démarrant après le mois facturé. Les trois issues viennent de
la même enquête sur la campagne de juin 2026 (23 brouillons attendus, 8 RSC périmées, 7 MES
post-mois).

## #579 — a_jour ignore qualite/x_lisse null
`a_jour` traitait `qualite` null et `x_lisse` null comme « à jour » (pl.when(null) = faux).
Nouvelle règle harmonisée avec `filtre_a_injecter` : draft ⟺ qualite null OU (incalculable ET
non lissé). Table de vérité complète en test.

## #580 — injection_rsc attribue la RSC en service du PDL
L'asof (PDL, date_order) figeait la RSC contemporaine de la souscription et ne se réparait
jamais après re-création de contrat (RES→MES, CFN entrant). Nouvelle règle : la RSC du PDL
dont le dernier état C15 n'est pas RESILIE. 0 ou plusieurs candidates → à part, jamais
d'écriture silencieuse. L'asof reste en diagnostic.

## #581 — signalement des brouillons post-mois facturé
Nouvelle section (lecture seule) qui nomme la cause des brouillons sans correspondance
Enedis dont le contrat démarre après la fin du mois facturé, en s'appuyant sur la première
date C15 du PDL. Un contrat entré en cours de mois (prorata) n'est pas signalé.

Closes #579
Closes #580
Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)
