### PR TITLE
docs(claude): gh en keyring natif hors sandbox — le token .gh-token n'existe plus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,23 +385,14 @@ Multi-context layout: [CONTEXT-MAP.md](CONTEXT-MAP.md) at root pointing to per-m
 
 ## GitHub auth & PR workflow
 
-Inside the Claude Code sandbox the global `gh` keyring login is unreachable, so plain `gh`
-commands — including the issue-tracker workflow above — fail with an authentication error.
-This repo carries a **repo-scoped** fine-grained token at `.gh-token` (gitignored). Read it
-at runtime, anchored to the repo root so it works from any subfolder:
-
-```bash
-GH_TOKEN=$(cat "$(git rev-parse --show-toplevel)/.gh-token") gh pr create --fill
-GH_TOKEN=$(cat "$(git rev-parse --show-toplevel)/.gh-token") gh issue create ...
-```
-
-The token is scoped to **only this repo** (Contents / Pull requests / Issues; no
-Administration, no CI secrets) — never copy it into `~/.config/gh`. Regenerate it with the
-token-setup helper (run from inside this repo) if it expires.
+`gh` and `git push` authenticate via the native keyring/SSH login, which is unreachable from
+inside the Claude Code sandbox — run them as plain commands **outside the sandbox**. There is
+no repo token: the former `.gh-token` file is gone; do not recreate it or export `GH_TOKEN`.
+For CI checks, prefer a one-off `gh run view` over `gh run watch`.
 
 **Branch & PR model** — push freely to feature branches; the default branch is protected by
 a ruleset (PR required; force-push & deletion blocked):
 
 - Never push to or merge the default branch directly.
-- For any change: branch → commit → push → `gh pr create --fill` (with the token above), then stop.
+- For any change: branch → commit → push → `gh pr create --fill`, then stop.
 - Merging the PR is a human step on the website.


### PR DESCRIPTION
Le fichier .gh-token (token fine-grained repo-scoped) a été retiré ; la section
« GitHub auth & PR workflow » de CLAUDE.md continuait de le prescrire, faisant
échouer les commandes gh des agents en 401. Nouvelle consigne : gh et git push
en commandes nues hors du sandbox (keyring/SSH natifs), ne jamais recréer de
token ni exporter GH_TOKEN.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
