### PR TITLE
docs(facturiste): basculer le cycle de facturation dans la page d'accueil Facturer

### DIFF
--- a/docs/facturiste/changelog-facturiste.md
+++ b/docs/facturiste/changelog-facturiste.md
@@ -1,5 +1,5 @@
 ---
-fraicheur: 2026-07-04
+fraicheur: 2026-07-05
 ---
 
 # Ce qui a changé pour le facturiste (juin 2026)
@@ -35,25 +35,8 @@ cher, donc aucun automate ne pousse de modification sans contrôle. Le **bot Tel
 votre cockpit (état de l'ingestion, contrôles, exports) — en **lecture seule**, il n'écrit
 jamais dans Odoo.
 
-![Comment la facturation arrive dans Odoo aujourd'hui](facturiste-vue-ensemble.png)
-
-### Le cycle de facturation, pas à pas
-
-Concrètement, voici le déroulé actuel — un poste à préparer **une fois**, puis un cycle
-**chaque mois** qui reste largement manuel (c'est temporaire, le temps qu'Odoo sache tirer
-ses données). À gauche, les étapes dans l'ordre ; à droite, la commande ou l'artefact concret.
-
-![Le cycle de facturation actuel, pas à pas](facturiste-cycle-actuel.png)
-
-**Préparer le poste (une fois) :** récupérez vos accès dans un fichier `.env` (connexion
-Odoo `ODOO__*` + `ELECTRICORE_API_URL` / `ELECTRICORE_API_KEY`), installez l'outil opérateur
-(`uv tool install "electricore[notebooks]"`), puis lancez `electricore-notebooks` — il sert
-les notebooks marimo en **lecture seule** sur `http://127.0.0.1:2718/apps/accueil`.
-
-**Le filet de sécurité :** chaque notebook qui écrit dans Odoo (`injection_rsc`,
-`facturation`) garde une **double garde** — mode *simulation* coché par défaut, et écriture
-réelle bloquée derrière le bouton « Injecter dans Odoo ». Rien ne part dans Odoo tant que
-vous n'avez pas regardé puis cliqué.
+Le déroulé complet du cycle (vue d'ensemble, préparation du poste, garde-fous) est
+décrit sur la [page d'accueil de la section Facturer](index.md).
 
 ---
 

--- a/docs/facturiste/index.md
+++ b/docs/facturiste/index.md
@@ -23,8 +23,30 @@ facturation mensuelle des contrats énergie.
 Chaque mois : ElectriCore ingère les flux Enedis, calcule une proposition de
 facturation vérifiable (énergie, abonnement, TURPE, taxes), puis **toi** — via un
 notebook que tu valides à vue — l'écris dans Odoo. Aucune écriture n'a lieu sans que
-tu aies regardé et cliqué. Le détail pas à pas (préparation du poste, déroulé mensuel)
-est dans le [guide d'onboarding notebook](../operateur-notebook.md).
+tu aies regardé et cliqué.
+
+![Comment la facturation arrive dans Odoo aujourd'hui](facturiste-vue-ensemble.png)
+
+## Le cycle de facturation, pas à pas
+
+Concrètement, voici le déroulé — un poste à préparer **une fois**, puis un cycle
+**chaque mois** qui reste largement manuel (c'est temporaire, le temps qu'Odoo sache
+tirer ses données). À gauche, les étapes dans l'ordre ; à droite, la commande ou
+l'artefact concret.
+
+![Le cycle de facturation actuel, pas à pas](facturiste-cycle-actuel.png)
+
+**Préparer le poste (une fois) :** récupère tes accès dans un fichier `.env`
+(connexion Odoo `ODOO__*` + `ELECTRICORE_API_URL` / `ELECTRICORE_API_KEY`), installe
+l'outil opérateur (`uv tool install "electricore[notebooks]"`), puis lance
+`electricore-notebooks` — il sert les notebooks marimo en **lecture seule** sur
+`http://127.0.0.1:2718/apps/accueil`. Le détail est dans le
+[guide d'onboarding notebook](../operateur-notebook.md).
+
+**Le filet de sécurité :** chaque notebook qui écrit dans Odoo (`injection_rsc`,
+`facturation`) garde une **double garde** — mode *simulation* coché par défaut, et
+écriture réelle bloquée derrière le bouton « Injecter dans Odoo ». Rien ne part dans
+Odoo tant que tu n'as pas regardé puis cliqué.
 
 ## Tes outils aujourd'hui
 


### PR DESCRIPTION
Suite de #586. Le changelog « Ce qui a changé » portait encore du contenu de guide durable : la vue d'ensemble et « Le cycle de facturation, pas à pas » (préparation du poste, filet de sécurité, schémas `facturiste-vue-ensemble.png` + `facturiste-cycle-actuel.png`).

- Ces sections migrent dans `docs/facturiste/index.md`, réécrites au **tutoiement** (convention des index de section, chantier #555).
- Le changelog garde un renvoi d'une ligne vers la page d'accueil et redevient un pur changelog sur cette partie ; sa `fraicheur` est bumpée.
- `mkdocs build --strict` vert, aucun nouveau warning ; les images ne bougent pas (mêmes chemins relatifs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)