### PR TITLE
fix(client): typer les verdicts qualite/statut_communication en Literal (#589)

### DIFF
--- a/packages/electricore-client/src/electricore_client/models/chronologie.py
+++ b/packages/electricore-client/src/electricore_client/models/chronologie.py
@@ -82,8 +82,9 @@ class LignePeriodeEnergie(_LigneBase):
     debut: str | None = None
     fin: str | None = None
     nb_jours: int | None = None
-    qualite: str | None = None
-    statut_communication: str | None = None
+    # Verdicts jumeaux — valeurs closes du contrat (#589), accents et underscore exacts.
+    qualite: Literal["réelle", "estimée", "incalculable"] | None = None
+    statut_communication: Literal["communicante", "non_communicante"] | None = None
 
     # Énergies (energie_*_kwh) — flottants (ADR-0034), non-nulles uniquement.
     energie_base_kwh: float | None = None

--- a/packages/electricore-client/src/electricore_client/models/meta_periodes.py
+++ b/packages/electricore-client/src/electricore_client/models/meta_periodes.py
@@ -11,6 +11,8 @@ plus récent qui ajoute une colonne ne casse pas un client plus ancien.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict
 
 # Version du contrat (cf. meta_periodes_service.CONTRAT_VERSION). Source unique.
@@ -77,9 +79,10 @@ class PeriodeMeta(BaseModel):
 
     has_changement: bool | None = None
 
-    # Verdicts méta jumeaux (qualité ADR-0033 / communication ADR-0036).
-    qualite: str | None = None
-    statut_communication: str | None = None
+    # Verdicts méta jumeaux (qualité ADR-0033 / communication ADR-0036) — valeurs
+    # closes du contrat (#589), accents et underscore exacts.
+    qualite: Literal["réelle", "estimée", "incalculable"] | None = None
+    statut_communication: Literal["communicante", "non_communicante"] | None = None
 
     # Trace d'index légale (ADR-0038) — imbriquée, requise (peut être vide).
     releves_utilises: list[ObjetReleve] = []

--- a/packages/electricore-client/tests/test_chronologie.py
+++ b/packages/electricore-client/tests/test_chronologie.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 
 import httpx
+import pydantic
 import pytest
 from electricore_client import ElectricoreClient
 from electricore_client.models import LigneEvenement, LignePeriodeEnergie, LigneReleve
@@ -143,6 +144,13 @@ def test_chronologie_refuse_les_deux_grains():
     with pytest.raises(ValueError):
         client.chronologie(pdl="PDL_X", rsc="REF_1")
     assert appels == []
+
+
+def test_chronologie_rejette_qualite_desaccentuee():
+    """`qualite='reelle'` (désaccentué) échoue au parse pydantic (#589)."""
+    ligne = {**_LIGNES[2], "qualite": "reelle"}
+    with pytest.raises(pydantic.ValidationError):
+        LignePeriodeEnergie.model_validate(ligne)
 
 
 def test_chronologie_pas_de_montant_tarifaire():

--- a/packages/electricore-client/tests/test_meta_periodes.py
+++ b/packages/electricore-client/tests/test_meta_periodes.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 
 import httpx
+import pydantic
 import pytest
 from electricore_client import ElectricoreClient
 from electricore_client.exceptions import ContractVersionError
@@ -185,6 +186,32 @@ def test_meta_periodes_propage_filtres_en_query():
     url = captures[0]
     assert url.params.get("mois") == "2026-05-01"
     assert url.params.get_list("rsc") == ["RSC-1", "RSC-2"]
+
+
+def test_meta_periodes_rejette_qualite_desaccentuee():
+    """`qualite='reelle'` (désaccentué) échoue au parse pydantic (#589)."""
+    ligne = {**_LIGNES[0], "qualite": "reelle"}
+    with pytest.raises(pydantic.ValidationError):
+        PeriodeMeta.model_validate(ligne)
+
+
+def test_meta_periodes_rejette_statut_communication_invalide():
+    """`statut_communication='non-communicante'` (tiret) échoue au parse pydantic (#589)."""
+    ligne = {**_LIGNES[0], "statut_communication": "non-communicante"}
+    with pytest.raises(pydantic.ValidationError):
+        PeriodeMeta.model_validate(ligne)
+
+
+def test_meta_periodes_accepte_les_verdicts_valides_ou_absents():
+    """Valeurs accentuées valides et absence (None) restent acceptées."""
+    p = PeriodeMeta.model_validate(_LIGNES[0])
+    assert p.qualite == "réelle"
+    assert p.statut_communication == "communicante"
+
+    ligne_sans_verdicts = {k: v for k, v in _LIGNES[0].items() if k not in ("qualite", "statut_communication")}
+    p_sans = PeriodeMeta.model_validate(ligne_sans_verdicts)
+    assert p_sans.qualite is None
+    assert p_sans.statut_communication is None
 
 
 def test_meta_periodes_libere_le_flux_mi_consomme():


### PR DESCRIPTION
Closes #589

Typage strict des verdicts jumeaux `qualite` / `statut_communication` en
`Literal` (au lieu de `str | None`) dans `PeriodeMeta` et
`LignePeriodeEnergie` — valeurs exactes du contrat serveur (accents et
underscore compris), sourcées des schémas pandera
(`electricore/core/models/periode_meta.py`). Une valeur hors contrat
(désaccentuée ou mal formée) échoue désormais au parse pydantic côté
client, plutôt que de passer silencieusement jusqu'à un rejet applicatif
en prod.

Pas de bump de `contract_version` (les valeurs servies ne changent pas).
Version du paquet `electricore-client` bumpée 0.2.0 → 0.2.1 pour que les
consommateurs puissent l'épingler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)