### PR TITLE
feat(api+client): famille_cadrans par relevé sur ObjetReleve (contrat méta-périodes v3)

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -12,7 +12,7 @@ jamais sa valeur — ce fichier est commité.
 mode: afk
 when: tout changement de code Python (core, api, bot, ingestion)
 do: uv run --group test pytest -q  # ciblé : uv run --group test pytest {chemin_test} -v
-observe: sortie pytest — référence saine ~671 passed, 35 skipped ; tout failed/error est à examiner
+observe: sortie pytest — référence saine ~1180 passed, 3 skipped (juillet 2026) ; tout failed/error est à examiner
 
 ## lint
 
@@ -94,6 +94,20 @@ when: changement sous deploy/ (install.sh, lib/, docker/)
 do: bash deploy/tests/unit.sh
 look: sortie du script
 expect: exit 0 (même gate que le job CI deploy ; secrets_roundtrip.sh en plus côté CI)
+
+## client-release
+
+mode: human
+when: publier electricore-client sur PyPI (après merge dans main du bump de version : pyproject + `__version__` + uv.lock)
+do:
+```
+git fetch origin main
+git tag client-v{version} origin/main   # {version} = celle du pyproject mergé, ex. 0.4.0 (pré-releases PEP 440 : a1/b1/rc1/.devN)
+git push origin client-v{version}       # hors sandbox ; le tag déclenche .github/workflows/release-client.yml
+gh run view --workflow release-client.yml
+```
+look: le run "Release electricore-client" et https://pypi.org/project/electricore-client/
+expect: job vert (build uv → vérif artefacts vs tag → Trusted Publishing OIDC, aucun token PyPI) ; la version apparaît sur PyPI, puis souscriptions_odoo peut bumper son pin
 
 ## docs-eyeball
 

--- a/docs/contrat-meta-periodes.md
+++ b/docs/contrat-meta-periodes.md
@@ -59,6 +59,7 @@ GET /facturation/meta-periodes?mois=YYYY-MM-DD&rsc=RSC-A&rsc=RSC-B&limit=500&off
           "date_releve": "2025-03-01T00:00:00+01:00",
           "nature_index": "réel",
           "origine_releve": "périodique",
+          "famille_cadrans": "hp_hc",
           "index_hp_kwh": 1000,
           "index_hc_kwh": 500
         },
@@ -68,6 +69,7 @@ GET /facturation/meta-periodes?mois=YYYY-MM-DD&rsc=RSC-A&rsc=RSC-B&limit=500&off
           "nature_index": "réel",
           "origine_releve": "événementiel",
           "evenement": "MCT",
+          "famille_cadrans": "hp_hc",
           "index_hp_kwh": 1312,
           "index_hc_kwh": 645
         }
@@ -132,6 +134,7 @@ Chaque entrée du tableau :
 | `nature_index` | `str` | non | Mention légale : `réel` / `estimé` / `corrigé`. |
 | `origine_releve` | `str` | non | Origine du relevé : `périodique` (télérelevé automatique R151/R64) ou `événementiel` (relevé pris à un événement contractuel C15). |
 | `evenement` | `str` | — | **Présent uniquement si `origine_releve = événementiel`** : code C15 `Nature_Evenement` qui a déclenché le relevé (ex. `MCT` = modification contractuelle / changement, `MES` = mise en service, `RES` = résiliation). Clé absente pour un relevé périodique. |
+| `famille_cadrans` | `str` | — | **Calendrier de comptage de CE relevé** (#603) : `base` / `hp_hc` / `4_cadrans` — cf. glossaire *Famille de cadrans*. Grain **relevé**, pas période : un changement de compteur en cours de mois donne deux relevés de familles différentes dans le même tableau. Clé **absente** si le calendrier est inconnu ou `null` (Odoo garde son inférence en repli). À ne pas confondre avec la FTA (structure acheminement/TURPE, par période). |
 | `index_<cadran>_kwh` | `int` | — | **Registres réels** (kWh) du relevé, pour les 7 cadrans canoniques : `base`, `hp`, `hc` (C5) **et** `hph`/`hch`/`hpb`/`hcb` (4 quadrants C4/Tempo). **Seuls les registres présents** sur le compteur ressortent (clé non émise sinon) — jamais de cadran agrégé synthétisé (le mart ne pose un index que pour les cadrans réellement portés par le flux). |
 
 **Invariant « vide ssi incalculable ».** `releves_utilises` non vide **⟺**
@@ -140,10 +143,11 @@ d'ADR-0033/0036 : un mois incalculable n'est pas facturé en réel, donc ne port
 paire d'index à imprimer). Un mois à **MCT** (changement de config mid-mois) porte ses
 relevés intermédiaires — le tableau n'est **pas** borné à 2 entrées.
 
-**`source_hash` couvre le tableau.** Toute dérive d'un index **imprimé**, de sa nature ou de
-son identité flippe `source_hash` — **même à delta kWh du mois constant** (reset compteur,
-correction ±k aux deux bornes). C'est ce qui rend `source_hash` = *déclencheur* +
-`releve_id` = *reprise* fidèle à la promesse de régularisation.
+**`source_hash` couvre le tableau.** Toute dérive d'un index **imprimé**, de sa nature, de
+son identité **ou de sa `famille_cadrans`** flippe `source_hash` — **même à delta kWh du
+mois constant** (reset compteur, correction ±k aux deux bornes, calendrier corrigé
+rétroactivement). C'est ce qui rend `source_hash` = *déclencheur* + `releve_id` = *reprise*
+fidèle à la promesse de régularisation.
 
 #### Pourquoi un taux pour l'accise mais des montants pour le reste
 

--- a/electricore/api/services/meta_periodes_service.py
+++ b/electricore/api/services/meta_periodes_service.py
@@ -17,7 +17,7 @@ import json
 import polars as pl
 
 from electricore.core.builds.contexte_mensuel import contexte_du_mois
-from electricore.core.models.cadrans import CADRANS, col_index
+from electricore.core.models.cadrans import CADRANS, col_index, famille_cadrans
 from electricore.core.pipelines.accise import load_accise_rules
 from electricore.core.pipelines.cta import ajouter_cta
 from electricore.core.pipelines.taux import ajouter_taux_en_vigueur
@@ -74,6 +74,9 @@ _COLONNES_RELEVE: tuple[str, ...] = (
     # `evenement_declencheur` (porté nativement au mart depuis flux_c15) en précise la cause.
     "source",
     "evenement_declencheur",
+    # Calendrier de comptage du compteur au moment du relevé — source de `famille_cadrans`
+    # (#603), déjà porté par la chronologie pour toutes les sources, aucun changement dbt.
+    "id_calendrier_distributeur",
     *REGISTRES_REELS,
 )
 
@@ -87,13 +90,17 @@ def _objet_releve(ligne: dict) -> dict:
     """Projette une ligne de relevé sur l'objet de contrat (ADR-0038).
 
     `{ releve_id, date_releve (ISO), nature_index, origine_releve, [evenement],
-    <registres réels non nuls> }`.
+    [famille_cadrans], <registres réels non nuls> }`.
 
     - `origine_releve` (label, demande Virgile) : `événementiel` si le relevé vient d'un
       événement contractuel C15 (`source = flux_C15`), `périodique` pour un télérelevé
       automatique (R151/R64). Pour un relevé **événementiel**, `evenement` précise la cause
       (code C15 brut `Nature_Evenement`, ex. `MCT` = changement) ; un périodique n'a pas de
       clé `evenement`.
+    - `famille_cadrans` (#603) : calendrier de comptage du compteur au moment de **ce**
+      relevé (grain relevé, pas période — cf. glossaire *Famille de cadrans*, CONTEXT.md),
+      mappé depuis `id_calendrier_distributeur` par `cadrans.famille_cadrans` (source
+      unique DI→famille, ADR-0035 §1). Absente si le calendrier est inconnu ou `null`.
     - Un registre nul n'est pas exposé (registres réels uniquement — jamais de cadran
       synthétisé). `date_releve` est rendue en ISO8601 pour un payload + un `source_hash`
       déterministes.
@@ -108,6 +115,9 @@ def _objet_releve(ligne: dict) -> dict:
     }
     if evenementiel and ligne.get("evenement_declencheur") is not None:
         objet["evenement"] = ligne["evenement_declencheur"]
+    famille = famille_cadrans(ligne.get("id_calendrier_distributeur"))
+    if famille is not None:
+        objet["famille_cadrans"] = famille
     for registre in REGISTRES_REELS:
         if ligne.get(registre) is not None:
             objet[registre] = ligne[registre]

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -92,6 +92,10 @@ Calendrier HP / HC (deux cadrans).
 **DI000003** :
 Calendrier 4 cadrans (HPH / HCH / HPB / HCB).
 
+**Famille de cadrans** :
+Découpage en cadrans d'un calendrier distributeur, débarrassé de l'identifiant Enedis : `base` (DI000001), `hp_hc` (DI000002), `4_cadrans` (DI000003). C'est le *calendrier de comptage* d'un relevé vu par les consommateurs du contrat méta-périodes (`ObjetReleve.famille_cadrans`) — au grain **relevé**, pas période : un changement de compteur en cours de mois donne deux relevés de familles différentes. Absente quand le calendrier du relevé est inconnu ou hors des trois DI connus. À ne pas confondre avec la **FTA** (structure acheminement/TURPE, par période), corrélée mais distincte.
+_Éviter_ : type de calendrier, structure de comptage.
+
 ---
 
 ## Tarification réseau et taxes

--- a/electricore/core/models/cadrans.py
+++ b/electricore/core/models/cadrans.py
@@ -42,3 +42,25 @@ def col_energie(cadran: str) -> str:
 def col_index(cadran: str) -> str:
     """Nom de la colonne d'index d'un cadran (ex : `index_hp_kwh`)."""
     return f"index_{_verifier(cadran)}_kwh"
+
+
+# Table DI→famille (ADR-0035 §1, #603) : SOURCE UNIQUE du mapping entre l'identifiant
+# calendrier distributeur Enedis (`Id_Calendrier_Distributeur`, natif C15/R151/R64/R15) et
+# la *Famille de cadrans* du glossaire (CONTEXT.md) — le calendrier de comptage débarrassé
+# de l'identifiant Enedis. Les 3 valeurs connues ; tout DI hors de cette table est inconnu.
+FAMILLES_CADRANS: dict[str, str] = {
+    "DI000001": "base",
+    "DI000002": "hp_hc",
+    "DI000003": "4_cadrans",
+}
+
+
+def famille_cadrans(id_calendrier_distributeur: str | None) -> str | None:
+    """Famille de cadrans d'un relevé, dérivée de son `id_calendrier_distributeur`.
+
+    `None` si le calendrier est absent (null) ou hors des trois DI connus — au consommateur
+    (Odoo) de garder son inférence en repli dans ce cas.
+    """
+    if id_calendrier_distributeur is None:
+        return None
+    return FAMILLES_CADRANS.get(id_calendrier_distributeur)

--- a/packages/electricore-client/pyproject.toml
+++ b/packages/electricore-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore-client"
-version = "0.3.0"
+version = "0.4.0"
 description = "Client Python léger (httpx + pydantic) vers l'API facturiste electricore — sans polars/duckdb/fastapi"
 authors = [
     {name = "Virgile"}

--- a/packages/electricore-client/src/electricore_client/__init__.py
+++ b/packages/electricore-client/src/electricore_client/__init__.py
@@ -34,7 +34,7 @@ from .models import (
 )
 from .streaming import JsonlStream
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     "ElectricoreClient",

--- a/packages/electricore-client/src/electricore_client/models/meta_periodes.py
+++ b/packages/electricore-client/src/electricore_client/models/meta_periodes.py
@@ -24,7 +24,8 @@ class ObjetReleve(BaseModel):
 
     Seuls les registres réellement affichés par le compteur ressortent (les
     autres sont absents, pas null). `evenement` n'est présent que pour un relevé
-    d'origine événementielle (C15).
+    d'origine événementielle (C15). `famille_cadrans` (#603) porte le calendrier de
+    comptage de CE relevé (grain relevé, pas période) ; absent si inconnu.
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -34,6 +35,12 @@ class ObjetReleve(BaseModel):
     nature_index: str | None = None
     origine_releve: str | None = None
     evenement: str | None = None
+
+    # Calendrier de comptage du compteur au moment de CE relevé (grain relevé, pas
+    # période — glossaire *Famille de cadrans*, CONTEXT.md, #603). Absent si le calendrier
+    # est inconnu ou hors des trois DI connus (DI000001/2/3) — Odoo garde son inférence en
+    # repli dans ce cas.
+    famille_cadrans: Literal["base", "hp_hc", "4_cadrans"] | None = None
 
     # Registres réels (index_*_kwh) — entiers (ADR-0034), seuls les non-nuls émis.
     index_base_kwh: int | None = None

--- a/packages/electricore-client/tests/test_meta_periodes.py
+++ b/packages/electricore-client/tests/test_meta_periodes.py
@@ -21,7 +21,7 @@ import pydantic
 import pytest
 from electricore_client import ElectricoreClient
 from electricore_client.exceptions import ContractVersionError
-from electricore_client.models import PeriodeMeta
+from electricore_client.models import ObjetReleve, PeriodeMeta
 
 # Deux méta-périodes représentatives (RSC-1 réelle avec relevés bornants ;
 # RSC-2 incalculable, trace vide) — copie fidèle de la sortie du service.
@@ -51,6 +51,7 @@ _LIGNES = [
                 "date_releve": "2026-05-01T00:00:00+02:00",
                 "nature_index": "réel",
                 "origine_releve": "périodique",
+                "famille_cadrans": "hp_hc",
                 "index_hp_kwh": 1000,
                 "index_hc_kwh": 500,
             },
@@ -131,6 +132,10 @@ def test_meta_periodes_streame_des_periodes_typees():
     assert isinstance(p0.releves_utilises[0].index_hp_kwh, int)
     assert p0.releves_utilises[1].evenement == "MCT"
     assert periodes[1].releves_utilises == []
+    # famille_cadrans (#603) : présente et typée si le calendrier était connu côté service,
+    # absente (None) sinon — même style que `evenement`.
+    assert p0.releves_utilises[0].famille_cadrans == "hp_hc"
+    assert p0.releves_utilises[1].famille_cadrans is None
 
 
 def test_meta_periodes_expose_les_metadonnees_den_tete():
@@ -212,6 +217,28 @@ def test_meta_periodes_accepte_les_verdicts_valides_ou_absents():
     p_sans = PeriodeMeta.model_validate(ligne_sans_verdicts)
     assert p_sans.qualite is None
     assert p_sans.statut_communication is None
+
+
+def test_objet_releve_famille_cadrans_valeurs_closes():
+    """`famille_cadrans` n'accepte que `base` / `hp_hc` / `4_cadrans`, ou l'absence (#603)."""
+    ligne = {**_LIGNES[0]["releves_utilises"][0], "famille_cadrans": "base"}
+    assert ObjetReleve.model_validate(ligne).famille_cadrans == "base"
+
+    ligne_absente = {k: v for k, v in ligne.items() if k != "famille_cadrans"}
+    assert ObjetReleve.model_validate(ligne_absente).famille_cadrans is None
+
+    with pytest.raises(pydantic.ValidationError):
+        ObjetReleve.model_validate({**ligne, "famille_cadrans": "quelque_chose_dautre"})
+
+
+def test_objet_releve_retrocompat_champ_inconnu_ignore():
+    """Rétro-compat contrat additif (#603) : un client qui reçoit un champ qu'il ne connaît
+    pas encore (ex. le serveur en ajoute un futur, symétrique de `famille_cadrans` avant ce
+    changement) ne lève pas — `extra='ignore'` avale la clé au lieu de la rejeter."""
+    ligne = {**_LIGNES[0]["releves_utilises"][0], "un_futur_champ_pas_encore_connu": 42}
+    objet = ObjetReleve.model_validate(ligne)
+    assert not hasattr(objet, "un_futur_champ_pas_encore_connu")
+    assert objet.releve_id == "a1b2c3d4e5f60718"
 
 
 def test_meta_periodes_libere_le_flux_mi_consomme():

--- a/tests/integration/test_meta_periodes_service.py
+++ b/tests/integration/test_meta_periodes_service.py
@@ -80,6 +80,9 @@ def _releves_utilises_synthetiques(decalage_index: int = 0) -> pl.LazyFrame:
             "evenement_declencheur": [None, "MCT", None, None],
             "releve_id": ["a1b2c3d4e5f60718", "1122334455667788", "99aabbccddeeff00", "deadbeefdeadbeef"],
             "nature_index": ["réel", "réel", "réel", "réel"],
+            # Calendrier distributeur : RSC-1 compteur HP/HC (DI000002) tout du long ; RSC-2
+            # Base (DI000001) — cf. `famille_cadrans` (#603).
+            "id_calendrier_distributeur": ["DI000002", "DI000002", "DI000002", "DI000001"],
             # Compteur HP/HC : seuls hp/hc portés (le mart ne synthétise jamais → les
             # 4 cadrans saisonniers restent nuls, donc non exposés).
             "index_base_kwh": [None, None, None, 420],
@@ -193,16 +196,19 @@ def test_releves_utilises_present_si_calculable_vide_si_incalculable(monkeypatch
     # RSC-2 (incalculable) → [] même si un relevé existe dans le frame.
     assert ru[1] == []
 
-    # Objet relevé = { releve_id, date_releve, nature_index, origine_releve, registres réels }.
+    # Objet relevé = { releve_id, date_releve, nature_index, origine_releve, famille_cadrans,
+    # registres réels }.
     premier = ru[0][0]
     assert set(premier) == {
         "releve_id",
         "date_releve",
         "nature_index",
         "origine_releve",
+        "famille_cadrans",
         "index_hp_kwh",
         "index_hc_kwh",
     }
+    assert premier["famille_cadrans"] == "hp_hc"
     assert "index_base_kwh" not in premier  # registre nul → jamais exposé
     assert premier["releve_id"] == "a1b2c3d4e5f60718"
     assert premier["nature_index"] == "réel"
@@ -246,6 +252,7 @@ def test_releves_utilises_expose_tous_les_cadrans_reels(monkeypatch):
             "evenement_declencheur": [None, None],
             "releve_id": ["1111111111111111", "2222222222222222"],
             "nature_index": ["réel", "réel"],
+            "id_calendrier_distributeur": ["DI000003", "DI000003"],
             "index_base_kwh": [None, None],
             "index_hp_kwh": [None, None],
             "index_hc_kwh": [None, None],
@@ -274,11 +281,13 @@ def test_releves_utilises_expose_tous_les_cadrans_reels(monkeypatch):
         "date_releve",
         "nature_index",
         "origine_releve",
+        "famille_cadrans",
         "index_hph_kwh",
         "index_hch_kwh",
         "index_hpb_kwh",
         "index_hcb_kwh",
     }
+    assert objet["famille_cadrans"] == "4_cadrans"
     assert objet["index_hph_kwh"] == 100 and objet["index_hcb_kwh"] == 400
     # Jamais de cadran agrégé absent du compteur (hp/hc nuls non synthétisés).
     assert "index_hp_kwh" not in objet and "index_hc_kwh" not in objet
@@ -338,3 +347,92 @@ def test_source_hash_couvre_releves_utilises_a_delta_kwh_constant(monkeypatch):
     h_apres = apres.sort("ref_situation_contractuelle")["source_hash"][0]
 
     assert h_avant != h_apres, "une dérive d'index imprimé à delta constant doit flipper source_hash"
+
+
+# --- Famille de cadrans par relevé (#603) -------------------------------------------
+
+
+def test_famille_cadrans_absente_si_calendrier_inconnu_ou_null(monkeypatch):
+    """`famille_cadrans` n'est émise que pour un calendrier connu (DI000001/2/3) — un
+    calendrier `null` ou hors des trois DI connus n'émet pas la clé (Odoo garde son
+    inférence en repli, #603)."""
+    # Remplace le calendrier de la borne milieu (DI000002) par un DI inconnu, et de la
+    # borne fin par null.
+    releves = _releves_utilises_synthetiques().with_columns(
+        pl.when(pl.col("releve_id") == "1122334455667788")
+        .then(pl.lit("DI999999"))
+        .when(pl.col("releve_id") == "99aabbccddeeff00")
+        .then(pl.lit(None, dtype=pl.Utf8))
+        .otherwise(pl.col("id_calendrier_distributeur"))
+        .alias("id_calendrier_distributeur")
+    )
+    ctx = _contexte_synthetique(releves)
+    monkeypatch.setattr(meta_periodes_service, "contexte_du_mois", lambda mois=None: ctx)
+
+    _, df = meta_periodes_service.meta_periodes("2025-03-01")
+    ru = df.sort("ref_situation_contractuelle")["releves_utilises"].to_list()[0]
+    par_id = {o["releve_id"]: o for o in ru}
+
+    assert par_id["a1b2c3d4e5f60718"]["famille_cadrans"] == "hp_hc"  # DI000002 connu
+    assert "famille_cadrans" not in par_id["1122334455667788"]  # DI inconnu
+    assert "famille_cadrans" not in par_id["99aabbccddeeff00"]  # calendrier null
+
+
+def test_grain_releve_changement_compteur_en_cours_de_periode(monkeypatch):
+    """Grain **relevé**, pas période (#603) : un changement de compteur en cours de mois
+    produit deux relevés de familles différentes dans la même méta-période — la famille
+    n'est jamais rollupée sur la période, contrairement à la FTA."""
+    releves = pl.DataFrame(
+        {
+            "ref_situation_contractuelle": ["RSC-1", "RSC-1"],
+            "date_releve": [
+                datetime(2025, 3, 1, tzinfo=PARIS),
+                datetime(2025, 4, 1, tzinfo=PARIS),
+            ],
+            "ordre_index": [False, False],
+            "source": ["flux_R151", "flux_R151"],
+            "evenement_declencheur": [None, None],
+            "releve_id": ["a1b2c3d4e5f60718", "99aabbccddeeff00"],
+            "nature_index": ["réel", "réel"],
+            # Compteur base au début, remplacé par un compteur HP/HC au relevé de fin.
+            "id_calendrier_distributeur": ["DI000001", "DI000002"],
+            "index_base_kwh": [420, None],
+            "index_hp_kwh": [None, 1312],
+            "index_hc_kwh": [None, 645],
+            "index_hph_kwh": [None, None],
+            "index_hch_kwh": [None, None],
+            "index_hpb_kwh": [None, None],
+            "index_hcb_kwh": [None, None],
+        }
+    ).lazy()
+    ctx = _contexte_synthetique(releves)
+    monkeypatch.setattr(meta_periodes_service, "contexte_du_mois", lambda mois=None: ctx)
+
+    _, df = meta_periodes_service.meta_periodes("2025-03-01")
+    ru = df.sort("ref_situation_contractuelle")["releves_utilises"].to_list()[0]
+
+    familles = [o["famille_cadrans"] for o in ru]
+    assert familles == ["base", "hp_hc"], "les deux relevés de la même méta-période portent chacun leur famille"
+
+
+def test_source_hash_sensible_au_changement_de_famille_cadrans(monkeypatch):
+    """`source_hash` change si `id_calendrier_distributeur` change — même index, même
+    delta kWh — car `famille_cadrans` fait partie du repli canonicalisé du tableau (#603)."""
+    releves_base = _releves_utilises_synthetiques()
+    ctx = _contexte_synthetique(releves_base)
+    monkeypatch.setattr(meta_periodes_service, "contexte_du_mois", lambda mois=None: ctx)
+    _, avant = meta_periodes_service.meta_periodes("2025-03-01")
+    h_avant = avant.sort("ref_situation_contractuelle")["source_hash"][0]
+
+    releves_modifie = releves_base.with_columns(
+        pl.when(pl.col("releve_id") == "a1b2c3d4e5f60718")
+        .then(pl.lit("DI000003"))
+        .otherwise(pl.col("id_calendrier_distributeur"))
+        .alias("id_calendrier_distributeur")
+    )
+    ctx_modifie = _contexte_synthetique(releves_modifie)
+    monkeypatch.setattr(meta_periodes_service, "contexte_du_mois", lambda mois=None: ctx_modifie)
+    _, apres = meta_periodes_service.meta_periodes("2025-03-01")
+    h_apres = apres.sort("ref_situation_contractuelle")["source_hash"][0]
+
+    assert h_avant != h_apres

--- a/tests/unit/test_cadrans.py
+++ b/tests/unit/test_cadrans.py
@@ -6,7 +6,7 @@ Le module porte la liste canonique des cadrans et la convention de nommage
 
 import pytest
 
-from electricore.core.models.cadrans import CADRANS, SOUS_CADRANS, col_energie, col_index
+from electricore.core.models.cadrans import CADRANS, SOUS_CADRANS, col_energie, col_index, famille_cadrans
 
 
 class TestCadrans:
@@ -37,3 +37,22 @@ class TestConstructeursDeColonnes:
             col_energie("hpc")
         with pytest.raises(ValueError, match="HP"):
             col_index("HP")  # les cadrans sont en minuscules
+
+
+class TestFamilleCadrans:
+    """Table DI→famille (ADR-0035 §1, #603) : source unique du glossaire *Famille de cadrans*."""
+
+    def test_di000001_base(self):
+        assert famille_cadrans("DI000001") == "base"
+
+    def test_di000002_hp_hc(self):
+        assert famille_cadrans("DI000002") == "hp_hc"
+
+    def test_di000003_4_cadrans(self):
+        assert famille_cadrans("DI000003") == "4_cadrans"
+
+    def test_di_inconnu_absent(self):
+        assert famille_cadrans("DI999999") is None
+
+    def test_none_absent(self):
+        assert famille_cadrans(None) is None

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ typecheck = [{ name = "mypy", specifier = ">=1.13" }]
 
 [[package]]
 name = "electricore-client"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "packages/electricore-client" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #603

Expose `famille_cadrans` (base / hp_hc / 4_cadrans) per reading on `ObjetReleve`
inside `releves_utilises` (contrat méta-périodes v3), mapped from
`id_calendrier_distributeur` — already carried by the *Chronologie des relevés*
for every source, so this is a pure exposition-time projection (no dbt/loader/
pipeline change). The DI→famille table lives as a single-source constant in
`core/models/cadrans.py` (ADR-0035 §1). Key is absent when the calendar is
unknown/null, and is included in `source_hash` (deliberate: makes a retroactive
calendar drift detectable, per the 08/07 grill arbitration).

electricore-client bumped 0.3.0 → 0.4.0 for the additive field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)