### PR TITLE
docs : passe de lecture — 6 docs à jour en nav, issues filles de mise à jour (#557)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ uv run --group test pytest -n auto
 uv run --group test pytest --cov=electricore
 ```
 
-La suite compte ~671 tests qui passent en une trentaine de secondes. 35 tests sont volontairement skippés (intégration Odoo nécessitant des secrets, génération de snapshots).
+La suite complète passe en une trentaine de secondes. Quelques tests sont volontairement skippés (intégration Odoo nécessitant des secrets, génération de snapshots).
 
 Le hook **pre-push** exécute automatiquement la suite avant chaque `git push` (cf. installation ci-dessus). Pour le lancer manuellement sans pousser :
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ de lecture, en escalier (quoi → comment s'en servir → comment c'est fait →
 
 - **[Comprendre](https://energie-de-nantes.github.io/electricore/comprendre/)** — ce qu'ElectriCore
   calcule et pourquoi, pour un public non technique.
-- **[Facturer](https://energie-de-nantes.github.io/electricore/facturiste/changelog-facturiste/)** —
+- **[Facturer](https://energie-de-nantes.github.io/electricore/facturiste/)** —
   le cycle de facturation au quotidien, bot Telegram et notebooks.
 - **[Déployer](https://energie-de-nantes.github.io/electricore/deployer/)** — installer et
   administrer une instance (VPS, Docker Compose, secrets).

--- a/docs/contrat-meta-periodes.md
+++ b/docs/contrat-meta-periodes.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-08
+---
+
 # Contrat — endpoint de lecture des méta-périodes
 
 > Contrat d'intégration pour le consommateur (addon `souscriptions_odoo`).

--- a/docs/contrat-prestations.md
+++ b/docs/contrat-prestations.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-08
+---
+
 # Contrat — prestations F15
 
 > Contrat d'intégration **figé** pour le consommateur (addon `souscriptions_odoo`).

--- a/docs/contrat-rsc.md
+++ b/docs/contrat-rsc.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-08
+---
+
 # Contrat — résolution RSC
 
 > Contrat d'intégration **figé** pour le consommateur (addon `souscriptions_odoo`).

--- a/docs/contrat-turpe-variable.md
+++ b/docs/contrat-turpe-variable.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-08
+---
+
 # Contrat — calculateur TURPE variable
 
 > Contrat d'intégration **figé** pour le consommateur (addon `souscriptions_odoo`).

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-08
+---
+
 # Déploiement VPS
 
 Guide opérationnel pour déployer ElectriCore sur un VPS via la stack Docker
@@ -87,8 +91,9 @@ du layout `/srv/<slug>/` + user dédié.
   [Durcissement du VPS](#durcissement-du-vps).
 - **Un nom de domaine** avec un A-record pointant vers l'IP publique du VPS.
 - **Ports 80 et 443** ouverts dans le pare-feu cloud (ACME HTTP-01 + HTTPS).
-- **Les clés AES Enedis** (clé + IV en hexadécimal) — fournies par Enedis au
-  fournisseur.
+- **Les clés AES Enedis** (clé en hexadécimal ; IV seulement si Enedis en
+  fournit un — schéma IV-fixe, sans IV ⇒ IV-préfixé, ADR-0040) — fournies par
+  Enedis au fournisseur.
 - **Source SFTP Enedis** :
   - Soit identifiants SFTP distants (mode A).
   - Soit le dépôt Enedis collocé sur le VPS (mode B — recommandé si possible).

--- a/docs/deployer/index.md
+++ b/docs/deployer/index.md
@@ -8,10 +8,9 @@ Cette section s'adresse à toi si tu es **déployeur·euse** : tu installes et t
 administres une instance ElectriCore pour un fournisseur (VPS, Docker
 Compose, secrets, sauvegardes).
 
-Elle rassemblera à terme le guide de déploiement, l'inventaire de
-configuration et les procédures d'exploitation (rotation de clés, mise à
-jour de version, sauvegarde). Ce contenu existe déjà dans `docs/` sous forme
-de pages techniques ; leur rattachement à cette section arrive dans une
-tranche à venir du chemin de documentation par rôles.
+Le [guide de déploiement VPS](../deploiement.md) couvre l'installation,
+les secrets, la rotation de clés, la mise à jour de version et la
+sauvegarde. L'inventaire de configuration rejoindra cette section une fois
+remis à jour (issue #605, passe de lecture #557).
 
 [Retour à l'accueil](../index.md).

--- a/docs/odoo-query-builder.md
+++ b/docs/odoo-query-builder.md
@@ -1,3 +1,7 @@
+---
+fraicheur: 2026-07-08
+---
+
 # Odoo Query Builder - Philosophie et Architecture
 
 ## Vue d'ensemble

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,11 +53,18 @@ nav:
       - Notebook opérateur: operateur-notebook.md
   - Déployer:
       - deployer/index.md
+      - Déploiement VPS: deploiement.md
   - Contribuer:
       - contribuer/index.md
       - Charte de la documentation: contribuer/charte-documentation.md
       - Carte des domaines: contribuer/carte-domaines.md
       - Développer: contribuer/developper.md
+      - Query builder Odoo: odoo-query-builder.md
+      - Contrats d'intégration:
+          - Méta-périodes: contrat-meta-periodes.md
+          - Prestations F15: contrat-prestations.md
+          - Résolution RSC: contrat-rsc.md
+          - TURPE variable: contrat-turpe-variable.md
   - Maintenir:
       - maintenir/index.md
       - Index thématique des ADRs: maintenir/index-adr.md

--- a/tests/unit/test_parite_docs.py
+++ b/tests/unit/test_parite_docs.py
@@ -47,24 +47,18 @@ _PREFIXES_EXCLUS = (
     "agents/",  # registres agent (CLAUDE.md-adjacent), hors chemin doc-par-rôles
 )
 
-# Docs techniques à la racine de docs/, en attente d'affectation à une section du
-# chemin par rôles (#557) — liste NOMMÉE, a vocation à fondre au fil des tranches
-# suivantes (chaque doc affecté à une section doit sortir de cette liste).
+# Docs techniques à la racine de docs/, jugés périmés ou à fusionner par la passe
+# de lecture #557 — chacun a son issue fille de mise à jour ; un doc remis à jour
+# entre en nav et sort de cette liste (elle a vocation à fondre).
 _FICHIERS_EN_ATTENTE_557 = {
-    "configuration.md",  # en attente d'affectation — #557
-    "contrat-meta-periodes.md",  # en attente d'affectation — #557
-    "contrat-prestations.md",  # en attente d'affectation — #557
-    "contrat-rsc.md",  # en attente d'affectation — #557
-    "contrat-turpe-variable.md",  # en attente d'affectation — #557
-    "conventions-dates-enedis.md",  # en attente d'affectation — #557
-    "deploiement.md",  # en attente d'affectation — #557
-    "electricore-client-design.md",  # en attente d'affectation — #557
-    "ingestion.md",  # en attente d'affectation — #557
-    "odoo-query-builder.md",  # en attente d'affectation — #557
-    "qualite-donnees-r151.md",  # en attente d'affectation — #557
-    "transmission.md",  # en attente d'affectation — #557
-    "turpe-fixe-c4-btsup36kva.md",  # en attente d'affectation — #557
-    "turpe-usage-standalone.md",  # en attente d'affectation — #557
+    "configuration.md",  # périmé (§3 pré-secrets-as-code) — issue fille #605
+    "conventions-dates-enedis.md",  # périmé (pointeurs impl. pré-ADR-0042) — issue fille #606
+    "electricore-client-design.md",  # à fusionner (note de conception ADR-0043) — issue fille #611
+    "ingestion.md",  # périmé (footer dates pré-ADR-0042) — issue fille #607
+    "qualite-donnees-r151.md",  # rapport daté, candidat archives — issue fille #608
+    "transmission.md",  # à fusionner (recouvre contribuer/developper.md) — issue fille #618
+    "turpe-fixe-c4-btsup36kva.md",  # périmé (colonnes/coefficients) — issue fille #609
+    "turpe-usage-standalone.md",  # périmé (colonnes _kva/_eur) — issue fille #610
 }
 
 _AGE_MAX_FRAICHEUR_JOURS = 365


### PR DESCRIPTION
## Quoi

Tranche « passe de lecture » du PRD #555 : chaque doc technique et README a reçu un verdict (à jour / périmé / à fusionner) et une affectation de section — inventaire complet publié en commentaire de #557.

Cette PR livre la partie démoable :

- **6 docs à jour entrent en nav** avec leur front-matter `fraicheur:` :
  - Déployer → `deploiement.md` (« Déploiement VPS »)
  - Contribuer → `odoo-query-builder.md` + groupe « Contrats d'intégration » (méta-périodes, prestations F15, résolution RSC, TURPE variable)
- **La liste d'exclusions de parité fond de 14 à 8 entrées**, chacune annotée de son issue fille de mise à jour (#605–#611, #618).
- Retouches ponctuelles au passage : bullet AES/IV des prérequis de `deploiement.md` aligné sur ADR-0040 ; porte Facturer du README → index de section ; décompte de tests dé-chiffré dans CONTRIBUTING ; `deployer/index.md` pointe le guide au lieu de l'annoncer.

Les issues filles #605–#618 (14, une par doc périmé/à fusionner, READMEs compris) sont rattachées en sous-issues du PRD #555. ADRs, spikes et registres agent : non touchés, conformément au PRD.

## Vérification

- `mkdocs build --strict` ✅
- `pytest tests/unit/test_parite_docs.py` ✅ (parité nav + fraîcheur)

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)
