### PR TITLE
docs(contrat-prestations) : attachement Odoo par RSC seule, pas par PDL

### DIFF
--- a/docs/contrat-prestations.md
+++ b/docs/contrat-prestations.md
@@ -33,7 +33,7 @@ représentation du payload.
 | `libelle_ev` | Une retouche de libellé Enedis (texte affiché) n'est pas une nouvelle prestation. |
 | `taux_tva_applicable` | Même raison : une correction de taux affichée n'est pas un nouveau fait facturable. |
 | `nature_ev` | Fonctionnellement **déterminé** par `id_ev` — vérifié empiriquement : 0 `id_ev` porte plusieurs `nature_ev` distincts dans les flux réels. L'inclure serait redondant, pas plus précis. |
-| `ref_situation_contractuelle` | Métadonnée d'attachement, pas de contenu de la prestation. L'attachement Odoo se fait par **PDL**, pas par RSC (un PDL peut changer de RSC sans que la prestation change). |
+| `ref_situation_contractuelle` | Métadonnée d'attachement, pas de contenu de la prestation. C'est justement la clé par laquelle l'addon Odoo rattache la ligne (résolution **par RSC seule**, arbitrage souscriptions_odoo#147), pas un attribut du fait facturable. |
 | `date_facture` | Métadonnée de facturation, pas de contenu de la prestation — deux ré-émissions de la même ligne sur deux factures F15 différentes (retard de traitement Enedis) doivent fusionner. |
 
 ## Canonicalisation — Python pur, pas `pl.concat_str`


### PR DESCRIPTION
## Résumé

Corrige la justification de l'exclusion de `ref_situation_contractuelle` dans le contrat des prestations (§ exclusions de l'assiette) : la remarque « L'attachement Odoo se fait par **PDL**, pas par RSC » était périmée — la résolution côté addon a été arbitrée **par RSC seule** (grill souscriptions_odoo du 2026-07-08, ADR 0010 §4 addon ; 0 RSC nulle dans le F15).

L'exclusion elle-même reste inchangée : la RSC est la clé de rattachement (métadonnée), pas un attribut du fait facturable.

Réf. souscriptions_odoo#147.

Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)