### PR TITLE
docs : resynchroniser 5 READMEs colocalisés (passe de lecture #557)

### DIFF
--- a/deploy/lib/README.md
+++ b/deploy/lib/README.md
@@ -1,10 +1,21 @@
 # `deploy/lib/`
 
 Helpers bash sourcés par [`../install.sh`](../install.sh) (et, pour le sous-ensemble
-durcissement, par le wrapper autonome [`../harden.sh`](../harden.sh)).
+durcissement, par le wrapper autonome [`../harden.sh`](../harden.sh)). Ordre de chargement
+canonique : `LIB_FILES` dans `install.sh`.
 
-- [`validate.sh`](validate.sh) — validateurs purs (slug, AES, URL, email, domaine). Renvoient 0/1, pas de sortie.
+- [`log.sh`](log.sh) — helpers de sortie (couleurs ANSI désactivables via `NO_COLOR`, étapes numérotées).
+- [`cli.sh`](cli.sh) — parsing des arguments de `install.sh`. Pure, pas de side-effect.
+- [`validate.sh`](validate.sh) — `validate_slug` + `validate_domain` uniquement. Renvoient 0/1, pas de sortie ; le format des secrets (AES/URL/email) n'est plus validé ici, voir `env_validate.sh` ci-dessous.
 - [`os.sh`](os.sh) — détection OS via `/etc/os-release`, mockable avec `OS_RELEASE_PATH=...` (utilisé par les tests).
+- [`system.sh`](system.sh) — provisioning OS idempotent (paquets apt, Docker, UFW).
+- [`user.sh`](user.sh) — création du user système `<slug>`, home `/srv/<slug>/`, groupe docker, clé SSH (ADR-0017).
 - [`harden.sh`](harden.sh) — durcissement VPS (ADR-0031) : `harden_vps()` orchestre admin `ops` + sudo, verrouillage sshd (root-off, clé only), fail2ban, unattended-upgrades. Réversion `unharden_vps()` (retire le drop-in sshd, la jail, la conf upgrades ; `ops` conservé sauf `--purge-ops`). Fonctions de rendu pures (`render_sshd_hardening`, `render_fail2ban_jail`, …) testables, side-effects idempotents. Wrappers autonomes : [`../harden.sh`](../harden.sh) / [`../unharden.sh`](../unharden.sh).
+- [`config.sh`](config.sh) — téléchargement et patch des fichiers de configuration de l'instance depuis `raw.githubusercontent.com`.
+- [`env_validate.sh`](env_validate.sh) — valide la *politique* du split config/secrets (secrets-as-code, ADR-0044) : la moitié claire `config.env` (versionnée) ne porte aucun secret en clair. Le *contenu* de `secrets.env` (format des clés AES/API, URL SFTP) n'est pas validé ici mais par la SSOT pydantic (`electricore/config/runtime.py`), vérifiée par le vrai conteneur aux étapes 11-12 d'`install.sh` (ADR-0049).
+- [`secrets.sh`](secrets.sh) — cœur du modèle secrets-as-code (ADR-0044) : installation des outils crypto sur l'hôte, génération des identités age + SSH de la box (clés privées nées sur la box, jamais exportées), pull du dépôt de déploiement privé, validation du split config/secret. Commandes externes (`sops`, `age`, `age-keygen`, `ssh-keygen`, `git`) appelées par leur nom → stubbées en fake-binaries par les tests.
+- [`dns.sh`](dns.sh) — vérification que `<domain>` résout vers l'IP publique du VPS.
+- [`stack.sh`](stack.sh) — démarrage de la stack docker compose (en tant que `<slug>`) et attente du healthcheck.
+- [`ingestion.sh`](ingestion.sh) — lancement d'un test ingestion (échantillon 2 fichiers/flux) pour vérifier la chaîne SFTP → déchiffrement AES → DuckDB.
 
 Tests : [`../tests/unit.sh`](../tests/unit.sh).

--- a/electricore/bot/README.md
+++ b/electricore/bot/README.md
@@ -81,6 +81,7 @@ bot/
 ├── auth.py            # @require_allowed (allowlist), @require_odoo (no-ERP)
 ├── client.py          # client HTTP async vers l'API (X-API-Key)
 ├── format.py          # rendu HTML (escape) — parse_mode=HTML partout
+├── livraison.py       # primitives etape()/envoyer_document() — remise d'un livrable (#174)
 ├── surveillance.py    # alertes proactives (polling /ingestion/jobs, péremption des taux)
 ├── tasks.py           # tâches de fond (annulées au shutdown)
 └── handlers/          # un module par domaine de commande
@@ -89,7 +90,8 @@ bot/
     ├── flux.py
     ├── perimetre.py
     ├── taxes.py
-    └── facturation.py
+    ├── facturation.py
+    └── provision.py   # /provision — estimation de provision d'un lissé par PDL (#487, ADR-0048)
 ```
 
 Un seul poller Telegram par token : pour tester en local avec le token de prod,

--- a/electricore/ingestion/README.md
+++ b/electricore/ingestion/README.md
@@ -11,16 +11,22 @@ electricore/ingestion/
 ├── transformers/
 │   ├── crypto.py           # Déchiffrement AES (chaîne de clés, rotation)
 │   ├── archive.py          # Extraction ZIP
-│   └── parsers.py          # Parsing XML/CSV/JSON
+│   └── chaine.py           # Discipline « attraper → compter → continuer » (ADR-0037)
+├── parsing/
+│   └── xml.py               # Conversion XML → dict générique (landing brut, ADR-0020)
 ├── sources/
-│   └── sftp_enedis.py      # Source DLT SFTP multi-flux
+│   ├── sftp_enedis_brut.py # Source DLT « brut » (landing JSON, ADR-0020) — production
+│   └── sftp_enedis.py      # Brique SFTP partagée (listing incrémental, mouvement)
 ├── tools/
-│   └── reset_incremental_state.py  # Reset curseurs DLT
+│   ├── reset_incremental_state.py   # Reset curseurs DLT
+│   ├── check_incremental_state.py   # Inspecte les curseurs incrémentaux par namespace
+│   └── diagnostic_flux.py           # Diagnostic SFTP read-only (que livre Enedis ?)
 ├── config/
-│   ├── flux.yaml           # Configuration des flux
-│   └── settings.py
+│   └── flux.yaml           # Configuration de mouvement des flux
+├── raw_landing.py       # Landing brut : document Enedis intégral en colonne JSON
 ├── runner.py            # Ingestion (landing brut → dbt build)
 ├── __main__.py          # CLI : python -m electricore.ingestion
+├── CONTEXT.md            # Vocabulaire spécifique à l'ingestion
 └── dbt/                    # Modèles dbt (staging + flux_*)
 
 # Secrets (trousseau AES, URL SFTP) : variables d'environnement / .env à la racine
@@ -64,6 +70,9 @@ AES__TROUSSEAU__aes128_2024__IV=iv_hex_32     # IV-fixe
 | **R15** | Relevés index | `flux_r15`, `flux_r15_acc` |
 | **R151** | Relevés périodiques Linky | `flux_r151` |
 | **R64** | Timeseries JSON | `flux_r64` |
+| **R67** | Mesures facturantes (ponctuel, ADR-0047) | `flux_r67` |
+| **C12** | Spine contractuelle C4 (>36 kVA, ADR-0051) | `flux_c12` |
+| **X12/X13** | Affaires SGE (initiées/reçues) | `flux_affaires` |
 
 ## Rotation des clés AES (trousseau N-clés, ADR-0037)
 
@@ -86,10 +95,10 @@ DLT stocke l'état dans deux endroits (fichier local + DuckDB). Pour réinitiali
 uv run --extra ingestion --extra dbt python -m electricore.ingestion resync
 
 # Reset des curseurs uniquement (conserve les données)
-uv run --extra ingestion python tools/reset_incremental_state.py --clear
+uv run --extra ingestion python -m electricore.ingestion.tools.reset_incremental_state --clear
 
 # Recul à une date précise (retraite les fichiers depuis cette date)
-uv run --extra ingestion python tools/reset_incremental_state.py 2026-03-17
+uv run --extra ingestion python -m electricore.ingestion.tools.reset_incremental_state 2026-03-17
 ```
 
 ## Vérification de l'état

--- a/packages/electricore-client/README.md
+++ b/packages/electricore-client/README.md
@@ -39,6 +39,10 @@ resultats = client.turpe_variable([...])  # résultats indexés par id opaque
 with client.prestations() as stream:
     for prestation in stream:             # itère des PrestationF15 typés
         ...
+
+# Résolution RSC : lot d'id_Affaire (X12) → ref_situation_contractuelle (POST RPC)
+resultats = client.resoudre_rsc(["id_affaire_1", "id_affaire_2"])
+par_id = {r.id_affaire: r for r in resultats}   # chaque résultat porte ref ou error
 ```
 
 Le client Arrow historique (`flux/releves/facturation/accise/cta` → `pl.DataFrame`)

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,12 +4,15 @@
 
 ElectriCore suit une approche de traitement de données **fonctionnelle** utilisant Polars. La stratégie de test doit être **pragmatique** et **maintenable**, sans devenir plus complexe que le code testé.
 
-**✨ Mise à jour 2025** : La batterie de tests a été modernisée avec :
+**Modernisation 2025** : la batterie de tests a été modernisée avec :
 - Configuration pytest centralisée avec markers
 - Fixtures partagées via `conftest.py`
 - Tests paramétrés pour réduire la duplication
 - Tests snapshot avec Syrupy pour détection de régression automatique
 - Script d'anonymisation pour fixtures basées sur données réelles
+
+**Reprise 2026** : property-based testing via `polars.testing.parametric` (issue #194,
+[tests/property/](property/)) — voir « Niveau 4 » ci-dessous.
 
 ## Problématique initiale
 
@@ -365,7 +368,10 @@ uv run --group test pytest -q
 - Extraire et anonymiser les 4 cas métier restants
 
 ### 📋 À venir
-- Coverage report automatique en CI (mesure locale : ~77%, juin 2026)
+- Coverage report automatique en CI (mesure locale : ~77%, juin 2026) — [ci.yml](../.github/workflows/ci.yml)
+  lance `pytest` sans `--cov` : la couverture n'est pour l'instant pas mesurée ni appliquée comme
+  gate en CI, malgré le « plancher CI : 45 % » mentionné dans
+  [docs/contribuer/developper.md](../docs/contribuer/developper.md)
 - Tests de performance (benchmarks)
 - Documentation auto-générée des cas métier
 


### PR DESCRIPTION
Closes #612
Closes #613
Closes #615
Closes #616
Closes #617

Resynchronise 5 READMEs colocalisés au code (hors nav mkdocs) avec l'état réel du dépôt : inventaire complet des helpers deploy/lib/ et correction de validate.sh (ADR-0049), structure et tableau des flux d'ingestion (9 flux dont C12/R67/X12-X13), arborescence bot/ (provision.py, livraison.py), documentation de resoudre_rsc() dans electricore-client, et mise à jour du bandeau de stratégie de test (2025→2026) avec clarification sur la couverture non enforcée en CI. Toutes les affirmations ont été vérifiées contre le disque plutôt que recopiées depuis les issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)