### PR TITLE
chore: release moteur 3.7.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.7.0rc1] - 2026-07-09
+
+Release candidate : **endpoint prestations** pour souscriptions_odoo, `famille_cadrans`
+par relevé, date de bascule dans `memo_puissance`, et réparation de l'export bot.
+
+### ✨ Ajouté
+
+- **`GET /facturation/prestations`** (souscriptions_odoo#37) : pull-tout des refacturables
+  F15, `resoudre_rsc()` côté client. Consommé par le client `electricore-client` 0.4.0.
+- **`famille_cadrans` par relevé** dans `releves_utilises` (#603) : la famille de cadrans
+  est exposée relevé par relevé côté API.
+- **Date de bascule intercalée dans `memo_puissance`** (#598) : la bascule de puissance
+  est tracée dans le mémo de facturation.
+
+### 🐛 Corrigé
+
+- **Export bot réparé** (#596) : le registre des flux est keyé par extraction (f15→f15_detail,
+  +r15_acc) et non par flux, ce qui répare l'export « flux → N extractions ».
+- **Canon `reference` prestations en Python pur** (#600).
+
+### ✅ Tests
+
+- Garde anti-drift : `construire_dbt` matérialise tous les marts dbt (#553).
+
 ## [3.6.1] - 2026-07-05
 
 Patch **documentaire** : la frontière **actuel (legacy) / futur (ERP tire)** est

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.6.1"
+version = "3.7.0rc1"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.6.1"
+version = "3.7.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Bump moteur **3.6.1 → 3.7.0rc1** (pyproject + uv.lock + CHANGELOG), premier maillon de la release qui débloque **souscriptions_odoo** (endpoint prestations).

## Contenu (depuis v3.6.1)

### ✨ Ajouté
- `GET /facturation/prestations` — pull-tout des refacturables F15 (souscriptions_odoo#37), consommé par `electricore-client` 0.4.0
- `famille_cadrans` par relevé dans `releves_utilises` (#603)
- Date de bascule intercalée dans `memo_puissance` (#598)

### 🐛 Corrigé
- Export bot réparé — registre keyé par extraction (#596)
- Canon `reference` prestations en Python pur (#600)

## Suite (après merge)
1. `git tag v3.7.0rc1 origin/main && git push` → image `:3.7.0rc1` (pas de `:latest`)
2. Déploiement rc + validation empirique prestations/export bot (Virgile)
3. PR de promotion rc → stable `3.7.0`

Le client `electricore-client` 0.4.0 est déjà tagué/publié en parallèle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)