### PR TITLE
feat(api): empreinte de contenu — kernel unique de hash canonique (source_hash + reference)

### DIFF
--- a/electricore/api/serializers/__init__.py
+++ b/electricore/api/serializers/__init__.py
@@ -10,6 +10,8 @@ import io
 import polars as pl
 import xlsxwriter
 
+from electricore.api.serializers.hash import empreinte_contenu
+
 
 def xlsx_multi_sheet(onglets: dict[str, pl.DataFrame]) -> bytes:
     """Construit un fichier XLSX multi-onglets à partir d'un dict {nom: DataFrame}.
@@ -46,4 +48,4 @@ def arrow_stream(df: pl.DataFrame) -> bytes:
     return buf.getvalue()
 
 
-__all__ = ["xlsx_multi_sheet", "arrow_stream"]
+__all__ = ["xlsx_multi_sheet", "arrow_stream", "empreinte_contenu"]

--- a/electricore/api/serializers/hash.py
+++ b/electricore/api/serializers/hash.py
@@ -1,0 +1,61 @@
+"""Kernel unique de hash de contenu canonique (#625).
+
+Remplace les deux canonicaliseurs divergents historiques — `_ajouter_source_hash`
+(méta-périodes) et `_ajouter_reference` (prestations F15) — par une seule politique
+dtype→string, robuste aux versions de Polars.
+
+**Pourquoi une boucle Python pure plutôt qu'une expression Polars** : sha256 n'existe
+pas en expression Polars native, `pl.Expr.hash()` est instable entre versions, et un
+blob `pl.Object` (cas `releves_utilises`) est opaque aux expressions — une expr pure
+est impossible sans plugin, de toute façon. La boucle Python est le *mécanisme* de la
+garantie (repr texte stable du langage), pas un détail de perf : `str(float)` est un
+contrat du langage, `pl.col(c).cast(pl.Utf8)` ne l'est pas — le formateur float de
+Polars peut dériver entre versions (cf. `docs/contrat-prestations.md`), re-keyant
+silencieusement des lignes déjà upsertées côté Odoo (ADR-0027/0038).
+"""
+
+import hashlib
+import json
+from datetime import date, datetime
+
+import polars as pl
+
+
+def _canon_valeur(valeur: object) -> str:
+    """Rend une valeur de cellule en texte canonique, stable inter-versions Polars."""
+    if valeur is None:
+        return "∅"
+    if isinstance(valeur, (date, datetime)):
+        return valeur.isoformat()
+    if isinstance(valeur, float):
+        return str(valeur)
+    if isinstance(valeur, (list, dict)):
+        return json.dumps(valeur, sort_keys=True, ensure_ascii=False, default=str)
+    return str(valeur)
+
+
+def empreinte_contenu(df: pl.DataFrame, colonnes: list[str]) -> pl.Series:
+    """Hash de contenu déterministe des `colonnes` de `df`, une ligne à la fois.
+
+    Politique dtype→string (boucle Python pure, pas `pl.concat_str(cast(Utf8))`) :
+    `null` → `∅`, `date`/`datetime` → `.isoformat()`, `float` → `str()` (repr Python,
+    stable par le langage — jamais le formateur `Utf8` de Polars), `list`/`dict`/
+    `Object` → JSON à clés triées, sinon `str()`. Champs joints par `␟`
+    (séparateur d'unité, improbable dans les données Enedis), sha256 tronqué à 16.
+
+    Args:
+        df: DataFrame source.
+        colonnes: colonnes à inclure dans le canon, dans l'ordre — l'ordre fait
+            partie du contrat d'octets (une colonne `pl.Object` en dernière position
+            se comporte comme les autres : sérialisée par la même politique).
+
+    Returns:
+        `pl.Series` (`Utf8`) de même longueur que `df`, un hash hex 16 caractères
+        par ligne.
+    """
+    valeurs_par_colonne = [df[c].to_list() for c in colonnes]
+    hashes = [
+        hashlib.sha256("␟".join(_canon_valeur(v) for v in ligne).encode()).hexdigest()[:16]
+        for ligne in zip(*valeurs_par_colonne, strict=True)
+    ]
+    return pl.Series(hashes, dtype=pl.Utf8)

--- a/electricore/api/services/meta_periodes_service.py
+++ b/electricore/api/services/meta_periodes_service.py
@@ -11,11 +11,9 @@ facturé, possédé par l'ERP — pas d'`accise_eur` ici). ERP-agnostique : aucu
 `integrations/odoo` (ADR-0016). L'intégrité (`source_hash`) arrive en #229.
 """
 
-import hashlib
-import json
-
 import polars as pl
 
+from electricore.api.serializers import empreinte_contenu
 from electricore.core.builds.contexte_mensuel import contexte_du_mois
 from electricore.core.models.cadrans import CADRANS, col_index, famille_cadrans
 from electricore.core.pipelines.accise import load_accise_rules
@@ -199,32 +197,11 @@ def meta_periodes(mois: str | None = None, rsc: list[str] | None = None) -> tupl
     traces = _slicer_releves_utilises(contexte.releves_utilises, df)
     df = df.with_columns(pl.Series("releves_utilises", traces, dtype=pl.Object))
 
-    return contexte.mois, _ajouter_source_hash(df)
-
-
-def _ajouter_source_hash(df: pl.DataFrame) -> pl.DataFrame:
-    """Ajoute `source_hash` : sha256 (tronqué) de la ligne canonique du contrat (#229).
-
-    Hash de contenu sur **toutes** les colonnes du contrat **et le tableau imbriqué
-    `releves_utilises`** (ADR-0038, #360) — déterministe (même état DuckDB → même hash) et
-    robuste aux versions de Polars (repr texte stable, pas le hash interne). Le repli du
-    tableau (canonicalisation JSON à clés triées : `releve_id`, `date_releve`,
-    `nature_index`, registres) rend le hash sensible à toute dérive d'un index **imprimé**,
-    d'une nature ou d'une identité — **même à delta kWh du mois constant** (reset compteur,
-    correction ±k aux deux bornes). Outille l'upsert non destructif côté Odoo : skip-si-
-    inchangé + détection de dérive sous verrou (ADR-0027/0038).
-    """
-    canon = df.select(
-        pl.concat_str(
-            [pl.col(c).cast(pl.Utf8).fill_null("∅") for c in COLONNES_CONTRAT],
-            separator="␟",
-        ).alias("_canon")
-    ).to_series()
-    traces = df["releves_utilises"].to_list() if "releves_utilises" in df.columns else [None] * df.height
-    hashes = [
-        hashlib.sha256(
-            f"{ligne}␟{json.dumps(trace, sort_keys=True, ensure_ascii=False, default=str)}".encode()
-        ).hexdigest()[:16]
-        for ligne, trace in zip(canon.to_list(), traces, strict=True)
-    ]
-    return df.with_columns(pl.Series("source_hash", hashes, dtype=pl.Utf8))
+    # `source_hash` : kernel commun (#625, `api/serializers/hash.py`) — hash de contenu
+    # sur toutes les colonnes du contrat **et le tableau imbriqué `releves_utilises`**
+    # (ADR-0038, #360), en dernière colonne. Sensible à toute dérive d'un index
+    # **imprimé**, d'une nature ou d'une identité — même à delta kWh du mois constant
+    # (reset compteur, correction ±k aux deux bornes). Outille l'upsert non destructif
+    # côté Odoo : skip-si-inchangé + détection de dérive sous verrou (ADR-0027/0038).
+    hash_source = empreinte_contenu(df, [*COLONNES_CONTRAT, "releves_utilises"])
+    return contexte.mois, df.with_columns(hash_source.alias("source_hash"))

--- a/electricore/api/services/prestations_service.py
+++ b/electricore/api/services/prestations_service.py
@@ -16,10 +16,9 @@ strictement identiques d'une même facture fusionnent en une seule prestation
 5 exclusions motivées et preuve de collision : `docs/contrat-prestations.md`.
 """
 
-import hashlib
-
 import polars as pl
 
+from electricore.api.serializers import empreinte_contenu
 from electricore.core.loaders import f15_detail
 
 # Version du contrat exposée dans les en-têtes. Bump sur rupture (une évolution
@@ -77,21 +76,6 @@ def prestations(rsc: list[str] | None = None) -> pl.DataFrame:
     df = lf.select(COLONNES_CONTRAT).collect()
     # Dates F15 = jours civils : ISO déterministe pour le payload ET l'assiette du hash.
     df = df.with_columns(pl.col("date_debut", "date_fin", "date_facture").cast(pl.Utf8))
-    return _ajouter_reference(df)
-
-
-def _ajouter_reference(df: pl.DataFrame) -> pl.DataFrame:
-    """Ajoute `reference` : sha256 (tronqué à 16) du contenu canonique de la ligne.
-
-    Canon construit en **Python pur** (`str()` par champ, séparateur `␟`, nuls
-    rendus `∅`) plutôt que via `pl.concat_str(cast(Utf8))` : sortie déterministe,
-    indépendante du formateur float de Polars (peut varier entre versions —
-    cf. `docs/contrat-prestations.md`). Assiette de 8 colonnes : voir
-    `_COLONNES_REFERENCE`.
-    """
-    colonnes = [df[c].to_list() for c in _COLONNES_REFERENCE]
-    hashes = [
-        hashlib.sha256("␟".join("∅" if v is None else str(v) for v in ligne).encode()).hexdigest()[:16]
-        for ligne in zip(*colonnes, strict=True)
-    ]
-    return df.with_columns(pl.Series("reference", hashes, dtype=pl.Utf8))
+    # `reference` : kernel commun (#625, `api/serializers/hash.py`) sur l'assiette de
+    # 8 colonnes — le `cast(Utf8)` ci-dessus sert le payload JSON, pas le hash.
+    return df.with_columns(empreinte_contenu(df, list(_COLONNES_REFERENCE)).alias("reference"))

--- a/electricore/core/CONTEXT.md
+++ b/electricore/core/CONTEXT.md
@@ -256,6 +256,19 @@ Matérialisation de la *Traçabilité des index* : la liste des relevés effecti
 **Exposé à l'ERP** imbriqué dans chaque *méta-période* (l'ERP tire et stocke les relevés bornants pour satisfaire l'exigence légale d'index sur la facture et l'affichage en espace usager) : chaque relevé porte son *identité* (`releve_id`, **handle de reprise** pour la *régularisation*), sa *date*, sa *nature d'index* (mention légale), son *origine de relevé* et ses registres réels (les 7 cadrans canoniques, registres présents seulement). Le cœur reste **sans état** — il ne persiste rien : l'ERP stocke une copie de travail, le gel légal vit dans la facture postée ; une dérive ultérieure d'un index est un signal de *régularisation*, pas une réécriture.
 _Éviter_ : journal des relevés (connote un log append-only / event-sourcing, alors que le cœur est sans état et **recalcule**).
 
+**Empreinte de contenu** (kernel `empreinte_contenu`, `api/serializers/hash.py`, #625) :
+Hash de contenu déterministe (sha256 tronqué à 16 caractères) d'une ligne de *livrable*,
+utilisé comme handle d'intégrité (`source_hash` des *méta-périodes*, `reference` des
+prestations F15) ou de dédup — jamais un identifiant Enedis. Politique dtype→string en
+**Python pur** (pas `pl.concat_str(cast(Utf8))`) : `null` → `∅`, `date`/`datetime` →
+ISO, `float` → `str()` (repr du langage, stable — le formateur `Utf8` de Polars, lui,
+peut dériver entre versions et re-keyer silencieusement des lignes déjà upsertées côté
+Odoo), `list`/`dict`/`Object` → JSON à clés triées ; champs joints par `␟`. Kernel unique
+qui remplace deux canonicaliseurs divergents historiques (`_ajouter_source_hash` /
+`_ajouter_reference`, cf. `docs/contrat-prestations.md`).
+_Éviter_ : hash Polars natif (`pl.Expr.hash()`, instable entre versions, ne couvre pas
+les colonnes `pl.Object`).
+
 **Origine de relevé** :
 Axe qui distingue **comment** un relevé a été pris : *périodique* (télérelevé automatique R151/R64, à cadence régulière) ou *événementiel* (relevé pris à un *événement* contractuel C15 — `evenement_declencheur` en précise la cause : `MES` mise en service, `MCT` modification/changement, `RES` résiliation…). Porté aux champs `origine_releve` (+ `evenement` si événementiel) des *Relevés utilisés* exposés ; dérivé à l'exposition de la `source` du relevé et de l'`evenement_declencheur` que le mart `releves` porte **nativement** depuis les relevés C15 (non forward-fillé — un télérelevé n'est déclenché par aucun événement ; comme RSC/FTA/niveau, désormais natifs eux aussi, plus recopiés, [ADR-0039](../../docs/adr/0039-chronologie-substrat-attributs-situation-hors-mart.md)). Axe **orthogonal** à la *nature d'index* (réel/estimé/corrigé, qui qualifie la *valeur* lue, pas l'origine).
 _Éviter_ : « quotidien » (un R151 est périodique sans être quotidien), confondre avec la *nature d'index*.

--- a/tests/api/test_empreinte_contenu.py
+++ b/tests/api/test_empreinte_contenu.py
@@ -1,0 +1,60 @@
+"""Tests du kernel `empreinte_contenu` (#625) : hash de contenu canonique unique.
+
+Remplace les deux canonicaliseurs divergents `_ajouter_source_hash` (méta-périodes)
+et `_ajouter_reference` (prestations) — cf. `docs/contrat-prestations.md` pour le
+concept de dérive du formateur float Polars que ce kernel évite.
+"""
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+import polars as pl
+
+from electricore.api.serializers import empreinte_contenu
+
+PARIS = ZoneInfo("Europe/Paris")
+
+
+def test_empreinte_contenu_golden_ligne_mixte():
+    """Ligne mélangeant float (sensible au formateur Polars), datetime tz-aware,
+    null et dict à clés désordonnées — golden 16 caractères épinglé en dur. Casse si
+    le canon glisse vers `pl.concat_str(cast(Utf8))` (dérive du formateur float)."""
+    df = pl.DataFrame(
+        {
+            "montant_eur": [10.2],
+            "horodatage": [datetime(2025, 3, 1, tzinfo=PARIS)],
+            "commentaire": [None],
+            "detail": pl.Series([{"b": 2, "a": 1}], dtype=pl.Object),
+        }
+    )
+    empreinte = empreinte_contenu(df, ["montant_eur", "horodatage", "commentaire", "detail"])
+    assert empreinte.to_list() == ["cafa70cdd2f3c3d8"]
+
+
+def test_empreinte_contenu_invariante_a_l_ordre_des_cles_dict():
+    """Deux dicts au contenu identique mais aux clés dans un ordre différent
+    produisent la même empreinte (JSON à clés triées)."""
+    df1 = pl.DataFrame({"detail": pl.Series([{"b": 2, "a": 1}], dtype=pl.Object)})
+    df2 = pl.DataFrame({"detail": pl.Series([{"a": 1, "b": 2}], dtype=pl.Object)})
+
+    assert empreinte_contenu(df1, ["detail"]).to_list() == empreinte_contenu(df2, ["detail"]).to_list()
+
+
+def test_empreinte_contenu_deterministe_sur_double_appel():
+    df = pl.DataFrame(
+        {
+            "a": [1, 2, None],
+            "b": ["x", "y", "z"],
+            "c": [date(2025, 1, 1), None, date(2025, 1, 3)],
+        }
+    )
+    h1 = empreinte_contenu(df, ["a", "b", "c"]).to_list()
+    h2 = empreinte_contenu(df, ["a", "b", "c"]).to_list()
+    assert h1 == h2
+    assert len(h1[0]) == 16
+
+
+def test_empreinte_contenu_null_devient_symbole_vide():
+    avec_null = empreinte_contenu(pl.DataFrame({"a": [None]}), ["a"]).item()
+    avec_symbole = empreinte_contenu(pl.DataFrame({"a": ["∅"]}), ["a"]).item()
+    assert avec_null == avec_symbole


### PR DESCRIPTION
Closes #625

Introduit un kernel unique de hash de contenu canonique (`empreinte_contenu`, `api/serializers/hash.py`) et retire les deux canonicaliseurs divergents `_ajouter_source_hash` (méta-périodes) et `_ajouter_reference` (prestations F15).

**Bug corrigé** : `_ajouter_source_hash` hashait ses colonnes float via `cast(Utf8)` Polars, dont le formateur n'est pas garanti stable entre versions — un upgrade pouvait re-keyer silencieusement les lignes et déclencher une fausse « dérive détectée » à l'upsert Odoo (ADR-0027/0038). Le kernel stringifie tout en boucle Python pure (`str()` pour les floats, ISO pour les dates, JSON à clés triées pour list/dict/Object), alignant méta-périodes sur la garantie que `prestations_service` documentait déjà.

Les deux appelants se réduisent à une ligne ; `releves_utilises` devient simplement la dernière colonne (structure d'octets préservée). Tous les tests golden/déterminisme existants passent inchangés ; ajout de `tests/api/test_empreinte_contenu.py` pour le kernel. Entrée « Empreinte de contenu » ajoutée au glossaire `electricore/core/CONTEXT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)