### PR TITLE
chore: release moteur 3.7.0rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.7.0rc2] - 2026-07-11
+
+Release candidate : **empreinte de contenu** — kernel unique de hash canonique,
+embarqué avant toute utilisation prod du canon `reference` des prestations.
+
+### ♻️ Modifié
+
+- **`empreinte_contenu`** (#625) : kernel Python pur de hash de contenu canonique,
+  remplace `_ajouter_source_hash` (meta_periodes_service) et `_ajouter_reference`
+  (prestations_service). Corrige le bug de canonisation des flottants
+  (`cast(Utf8)` Polars) : les valeurs de `source_hash` et `reference` changent
+  par rapport à la rc1 — aucune n'a encore été consommée en prod.
+
+### 📝 Documentation
+
+- ADR-0056 : secrets dev via Proton Pass par espace.
+- Glossaire core : « Empreinte de contenu » (#625).
+
 ## [3.7.0rc1] - 2026-07-09
 
 Release candidate : **endpoint prestations** pour souscriptions_odoo, `famille_cadrans`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.7.0rc1"
+version = "3.7.0rc2"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.7.0rc1"
+version = "3.7.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Contexte

La rc1 (09/07) a été taguée **avant** l'atterrissage de l'empreinte de contenu (#625, PR #626). Or ce kernel **change les valeurs** de `source_hash` et `reference` (bug de canonisation des flottants corrigé), et le canon `reference` des prestations sert d'idempotence à l'attachement Odoo. Aucune valeur n'a encore été consommée en prod : il faut figer le bon canon **avant** la première utilisation, donc rc2 depuis main courant plutôt que promotion de rc1.

## Contenu (rc1 → rc2)

- **`empreinte_contenu`** (#625) : kernel Python pur, remplace `_ajouter_source_hash` et `_ajouter_reference`
- ADR-0056 : secrets dev via Proton Pass par espace
- Glossaire core « Empreinte de contenu »

## Après merge

Tag `v3.7.0rc2` sur le commit de merge → workflow release (image ghcr.io + PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)