### PR TITLE
electricore-client 0.5.0 : provision_estimation(pdl) typé + 503 flux R67 absent tagué precondition

### DIFF
--- a/electricore/api/routers/provision.py
+++ b/electricore/api/routers/provision.py
@@ -65,6 +65,10 @@ async def get_estimation_provision(
             "Données R67 indisponibles : le flux flux_r67 n'est pas matérialisé (aucune "
             "mesure facturante M023 ingérée). Déclencher une demande M023 sur le portail "
             "SGE, l'ingérer, puis réessayer.",
+            # Précondition métier actionnable (#630, X-Error-Kind #424) : le client public
+            # la mappe en PreconditionNonRemplie. Code HTTP inchangé (503, pas 422) — le bot
+            # (lecture brute du status) n'est pas affecté.
+            headers={"X-Error-Kind": "precondition"},
         ) from e
     except FileNotFoundError as e:
         logger.warning("provision/estimation: base DuckDB absente — %s", e)

--- a/packages/electricore-client/pyproject.toml
+++ b/packages/electricore-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore-client"
-version = "0.4.0"
+version = "0.5.0"
 description = "Client Python léger (httpx + pydantic) vers l'API facturiste electricore — sans polars/duckdb/fastapi"
 authors = [
     {name = "Virgile"}

--- a/packages/electricore-client/src/electricore_client/__init__.py
+++ b/packages/electricore-client/src/electricore_client/__init__.py
@@ -36,7 +36,7 @@ from .models import (
 )
 from .streaming import JsonlStream
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 __all__ = [
     "ElectricoreClient",

--- a/packages/electricore-client/src/electricore_client/__init__.py
+++ b/packages/electricore-client/src/electricore_client/__init__.py
@@ -20,6 +20,7 @@ from .exceptions import (
 )
 from .headers import EnTetesMeta
 from .models import (
+    EstimationProvision,
     LigneChronologie,
     LigneEvenement,
     LignePeriodeEnergie,
@@ -27,6 +28,7 @@ from .models import (
     LigneTurpeVariable,
     ObjetReleve,
     PeriodeMeta,
+    RapportProvision,
     ResolutionRscRequest,
     ResultatResolutionRsc,
     ResultatTurpeVariable,
@@ -55,5 +57,7 @@ __all__ = [
     "ResultatTurpeVariable",
     "ResolutionRscRequest",
     "ResultatResolutionRsc",
+    "EstimationProvision",
+    "RapportProvision",
     "__version__",
 ]

--- a/packages/electricore-client/src/electricore_client/client.py
+++ b/packages/electricore-client/src/electricore_client/client.py
@@ -23,6 +23,10 @@ from .models.prestations import (
     CONTRAT_VERSION_PRESTATIONS,
     PrestationF15,
 )
+from .models.provision import (
+    CONTRAT_VERSION_PROVISION,
+    RapportProvision,
+)
 from .models.rsc import (
     CONTRAT_VERSION_RSC,
     ResolutionRscRequest,
@@ -257,3 +261,35 @@ class ElectricoreClient(_BaseClient):
 
         corps = response.json()
         return [ResultatResolutionRsc.model_validate(r) for r in corps["results"]]
+
+    def provision_estimation(self, pdl: str) -> RapportProvision:
+        """Estime la provision d'énergie d'un lissé depuis R67 — **GET RPC** (#487/#630).
+
+        Petite lecture stateless, un round-trip : le serveur dérive l'estimation
+        **cœur-pure** depuis `flux_r67` (cold-start, ADR-0048), en kWh (annuel par
+        cadran + provision mensuelle `/12` plate) + couverture / profondeur / qualité
+        / signal alertable. `trouve == False` (estimation `None`) si le PDL n'a aucune
+        période R67 dans la fenêtre de 12 mois. **Zéro €** (ADR-0016/0027).
+
+        Si `flux_r67` n'est pas (encore) matérialisé, le serveur répond 503 avec
+        `X-Error-Kind: precondition` — `_raise_for_status` lève `PreconditionNonRemplie`
+        (message actionnable : déclencher une demande M023 sur le portail SGE).
+
+        Args:
+            pdl: point de livraison à estimer.
+
+        Returns:
+            `RapportProvision` : `{pdl, as_of, trouve, estimation}`.
+        """
+        response = self._http.get(
+            f"{self.url}/provision/estimation",
+            params={"pdl": pdl},
+            headers=self._headers,
+        )
+        self._raise_for_status(response)
+
+        version_servie = response.headers.get("X-Contract-Version")
+        if version_servie is not None:
+            self._verifier_version(attendue=CONTRAT_VERSION_PROVISION, servie=int(version_servie))
+
+        return RapportProvision.model_validate(response.json())

--- a/packages/electricore-client/src/electricore_client/exceptions.py
+++ b/packages/electricore-client/src/electricore_client/exceptions.py
@@ -6,8 +6,9 @@ Toutes dérivent d'`ElectricoreClientError` pour qu'un appelant puisse attraper
 Contrat X-Error-Kind (#424) — les erreurs sont discriminées par l'en-tête de
 réponse `X-Error-Kind`, pas par le code HTTP seul :
 - `ingestion-lock` (503) → `IngestionEnCours` : verrou writer, réessayable.
-- `precondition`  (422) → `PreconditionNonRemplie` : précondition métier non
-  remplie, l'appelant doit agir (pas retryable).
+- `precondition` (422 **ou** 503, #630) → `PreconditionNonRemplie` : précondition
+  métier non remplie, l'appelant doit agir (pas retryable). Le code HTTP varie
+  selon l'endpoint — c'est le *kind* qui discrimine, pas le code.
 - header absent → `httpx.HTTPStatusError` : erreur inattendue.
 """
 
@@ -28,8 +29,8 @@ class IngestionEnCours(ElectricoreClientError):
 
 
 class PreconditionNonRemplie(ElectricoreClientError):
-    """L'API a répondu 422 + X-Error-Kind: precondition : une précondition métier
-    n'est pas remplie (#424).
+    """L'API a répondu X-Error-Kind: precondition (422 ou 503 selon l'endpoint, #630) :
+    une précondition métier n'est pas remplie (#424).
 
     Non retryable — l'appelant doit corriger la situation côté Odoo/données avant
     de réessayer (ex. : réconcilier les RSC avant de facturer le mois).

--- a/packages/electricore-client/src/electricore_client/models/__init__.py
+++ b/packages/electricore-client/src/electricore_client/models/__init__.py
@@ -17,6 +17,11 @@ from .chronologie import (
 )
 from .meta_periodes import CONTRAT_VERSION_META_PERIODES, ObjetReleve, PeriodeMeta
 from .prestations import CONTRAT_VERSION_PRESTATIONS, PrestationF15
+from .provision import (
+    CONTRAT_VERSION_PROVISION,
+    EstimationProvision,
+    RapportProvision,
+)
 from .rsc import (
     CONTRAT_VERSION_RSC,
     ResolutionRscRequest,
@@ -48,4 +53,7 @@ __all__ = [
     "CONTRAT_VERSION_RSC",
     "PrestationF15",
     "CONTRAT_VERSION_PRESTATIONS",
+    "EstimationProvision",
+    "RapportProvision",
+    "CONTRAT_VERSION_PROVISION",
 ]

--- a/packages/electricore-client/src/electricore_client/models/provision.py
+++ b/packages/electricore-client/src/electricore_client/models/provision.py
@@ -1,0 +1,81 @@
+"""Modèles de contrat de l'estimation de provision (GET RPC, ADR-0048, #487/#630).
+
+`GET /provision/estimation?pdl=…` dérive en cœur-pur, depuis `flux_r67` (cold-start),
+la *provision d'énergie* d'un lissé en **kWh** (annuel par cadran + provision mensuelle
+`/12` plate) + métadonnées de couverture / profondeur / qualité / signal alertable.
+**Aucun €** (prix fournisseur = ERP, ADR-0016/0027).
+
+Single-sourcés ici (ADR-0043) : le router FastAPI (`provision_service.serialiser_rapport`)
+émet ce même gabarit, pas de redéfinition.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict
+
+# Version du contrat (cf. provision_service.CONTRAT_VERSION). Source unique.
+CONTRAT_VERSION_PROVISION = 1
+
+
+class EstimationProvision(BaseModel):
+    """Estimation de provision d'un PDL : sortie WIDE en kWh + métadonnées (ADR-0048).
+
+    `energie_<cadran>_kwh` = estimation **annuelle** ; `energie_<cadran>_mensuel_kwh` =
+    la provision mensuelle `/12` plate. `base` porte toujours le total ; les cadrans fins
+    sont `None` hors de la `profondeur_cadran` déclarée.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    pdl: str
+
+    # --- Estimation annuelle (kWh) — WIDE, base = total ---
+    energie_base_kwh: float
+    energie_hp_kwh: float | None = None
+    energie_hc_kwh: float | None = None
+    energie_hph_kwh: float | None = None
+    energie_hpb_kwh: float | None = None
+    energie_hch_kwh: float | None = None
+    energie_hcb_kwh: float | None = None
+
+    # --- Provision mensuelle (kWh) — `/12` plate ---
+    energie_base_mensuel_kwh: float
+    energie_hp_mensuel_kwh: float | None = None
+    energie_hc_mensuel_kwh: float | None = None
+    energie_hph_mensuel_kwh: float | None = None
+    energie_hpb_mensuel_kwh: float | None = None
+    energie_hch_mensuel_kwh: float | None = None
+    energie_hcb_mensuel_kwh: float | None = None
+
+    # --- Couverture (fenêtre de 12 mois glissants) ---
+    couverture_debut: date | None = None
+    couverture_fin: date | None = None
+    couverture_mois: float
+    couverture_suffisante: bool
+
+    # --- Profondeur cadran déclarée ---
+    profondeur_cadran: str
+
+    # --- Qualité dérivée du mix R/E/C ---
+    qualite: str
+    presence_regularisation: bool
+
+    # --- Signal alertable (la lib expose, l'aval alerte — ADR-0037) ---
+    signal_alertable: bool
+
+
+class RapportProvision(BaseModel):
+    """Enveloppe JSON de `GET /provision/estimation` : `{pdl, as_of, trouve, estimation}`.
+
+    `estimation` est `None` quand `trouve` est `False` (aucune période R67 dans la
+    fenêtre de 12 mois pour ce PDL).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    pdl: str
+    as_of: date
+    trouve: bool
+    estimation: EstimationProvision | None = None

--- a/packages/electricore-client/src/electricore_client/transport.py
+++ b/packages/electricore-client/src/electricore_client/transport.py
@@ -7,7 +7,9 @@ d'erreur HTTP et la garde de version de contrat.
 Contrat X-Error-Kind (#424) — `_raise_for_status` discrimine les erreurs via
 l'en-tête `X-Error-Kind` de la réponse, pas le code HTTP seul :
 - `ingestion-lock` (503) → `IngestionEnCours` : verrou writer DuckDB, réessayable.
-- `precondition`  (422) → `PreconditionNonRemplie` : précondition métier, actionnable.
+- `precondition` (422 **ou** 503, #630) → `PreconditionNonRemplie` : précondition
+  métier, actionnable. Le code HTTP varie selon l'endpoint (ex. 422 RSC non
+  réconcilié, 503 flux R67 absent) — c'est le *kind* qui discrimine, pas le code.
 - header absent → `httpx.HTTPStatusError` (raise_for_status standard).
 
 Les méthodes d'endpoint (méta-périodes, chronologie, turpe variable, Arrow)
@@ -64,7 +66,8 @@ class _BaseClient:
 
         Priorité à l'en-tête `X-Error-Kind` pour discriminer les cas :
         - `ingestion-lock` → `IngestionEnCours` (503 verrou writer, réessayable).
-        - `precondition`   → `PreconditionNonRemplie` (422, action requise côté Odoo).
+        - `precondition`   → `PreconditionNonRemplie` (422 ou 503 selon l'endpoint,
+          #630 ; action requise côté Odoo).
         - absent           → `httpx.HTTPStatusError` (raise_for_status standard).
         """
         kind = response.headers.get("X-Error-Kind")

--- a/packages/electricore-client/tests/test_provision.py
+++ b/packages/electricore-client/tests/test_provision.py
@@ -1,0 +1,130 @@
+"""Tests du client `provision_estimation` (GET RPC, sans serveur, #487/#630).
+
+L'estimation de provision est une lecture GET simple (pas un stream) : on envoie un
+`pdl`, on reçoit un rapport typé `{pdl, as_of, trouve, estimation}`. MockTransport sert
+la réponse ; on vérifie le typage, le paramètre envoyé, la garde de version, et les
+deux mappings d'erreur (précondition flux R67 absent, verrou d'ingestion).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from electricore_client import ElectricoreClient
+from electricore_client.exceptions import ContractVersionError, IngestionEnCours, PreconditionNonRemplie
+from electricore_client.models import EstimationProvision, RapportProvision
+
+_ESTIMATION = {
+    "pdl": "12345678901234",
+    "energie_base_kwh": 1200.0,
+    "energie_hp_kwh": None,
+    "energie_hc_kwh": None,
+    "energie_hph_kwh": None,
+    "energie_hpb_kwh": None,
+    "energie_hch_kwh": None,
+    "energie_hcb_kwh": None,
+    "energie_base_mensuel_kwh": 100.0,
+    "energie_hp_mensuel_kwh": None,
+    "energie_hc_mensuel_kwh": None,
+    "energie_hph_mensuel_kwh": None,
+    "energie_hpb_mensuel_kwh": None,
+    "energie_hch_mensuel_kwh": None,
+    "energie_hcb_mensuel_kwh": None,
+    "couverture_debut": "2025-06-01",
+    "couverture_fin": "2026-06-01",
+    "couverture_mois": 12.0,
+    "couverture_suffisante": True,
+    "profondeur_cadran": "base",
+    "qualite": "réelle",
+    "presence_regularisation": False,
+    "signal_alertable": False,
+}
+
+
+def _handler(body, *, version="1"):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=body, headers={"X-Contract-Version": version})
+
+    return handler
+
+
+def _client(handler) -> ElectricoreClient:
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    return ElectricoreClient(url="http://testserver", api_key="key", http_client=http)
+
+
+def test_provision_estimation_retourne_rapport_type():
+    """Le client GET et renvoie un `RapportProvision` typé, `estimation` incluse."""
+    body = {"pdl": "12345678901234", "as_of": "2026-06-27", "trouve": True, "estimation": _ESTIMATION}
+    client = _client(_handler(body))
+    rapport = client.provision_estimation("12345678901234")
+    assert isinstance(rapport, RapportProvision)
+    assert rapport.pdl == "12345678901234"
+    assert rapport.trouve is True
+    assert isinstance(rapport.estimation, EstimationProvision)
+    assert rapport.estimation.energie_base_kwh == 1200.0
+    assert rapport.estimation.energie_base_mensuel_kwh == 100.0
+    assert rapport.estimation.couverture_suffisante is True
+
+
+def test_provision_estimation_pdl_non_trouve_estimation_none():
+    """`trouve == False` → `estimation` reste `None` (aucune période R67 dans la fenêtre)."""
+    body = {"pdl": "00000000000000", "as_of": "2026-06-27", "trouve": False, "estimation": None}
+    client = _client(_handler(body))
+    rapport = client.provision_estimation("00000000000000")
+    assert rapport.trouve is False
+    assert rapport.estimation is None
+
+
+def test_provision_estimation_envoie_le_pdl_en_parametre():
+    """Le `pdl` est envoyé en query param (pas dans un corps — GET, pas POST)."""
+    capture = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        capture["params"] = dict(request.url.params)
+        body = {"pdl": "X", "as_of": "2026-06-27", "trouve": False, "estimation": None}
+        return httpx.Response(200, json=body, headers={"X-Contract-Version": "1"})
+
+    client = _client(handler)
+    client.provision_estimation("X")
+    assert capture["params"] == {"pdl": "X"}
+
+
+def test_provision_estimation_garde_de_version():
+    """Un serveur **en retard** (contrat servi < attendu) lève `ContractVersionError`."""
+    body = {"pdl": "X", "as_of": "2026-06-27", "trouve": False, "estimation": None}
+    client = _client(_handler(body, version="0"))
+    with pytest.raises(ContractVersionError):
+        client.provision_estimation("X")
+
+
+def test_provision_estimation_flux_r67_absent_leve_precondition_non_remplie():
+    """503 + X-Error-Kind: precondition (flux_r67 non matérialisé) → `PreconditionNonRemplie`,
+    détail du message serveur préservé (#630 : precondition n'est plus 422-only)."""
+    detail_serveur = (
+        "Données R67 indisponibles : le flux flux_r67 n'est pas matérialisé. "
+        "Déclencher une demande M023 sur le portail SGE, l'ingérer, puis réessayer."
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            503,
+            headers={"X-Error-Kind": "precondition"},
+            json={"detail": detail_serveur},
+        )
+
+    client = _client(handler)
+    with pytest.raises(PreconditionNonRemplie, match="M023"):
+        client.provision_estimation("12345678901234")
+
+
+def test_provision_estimation_verrou_ingestion_leve_ingestion_en_cours():
+    """Non-régression : le 503 verrou d'ingestion (handler d'app, main.py) continue
+    d'arriver en `IngestionEnCours`, pas affecté par le tag `precondition` du flux R67."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, headers={"X-Error-Kind": "ingestion-lock"})
+
+    client = _client(handler)
+    with pytest.raises(IngestionEnCours):
+        client.provision_estimation("12345678901234")

--- a/packages/electricore-client/tests/test_transport.py
+++ b/packages/electricore-client/tests/test_transport.py
@@ -8,7 +8,10 @@ retard). Tout est testé via `httpx.MockTransport` (aucun serveur réel).
 Contrat X-Error-Kind (3 familles, #424) :
 1. 503 + X-Error-Kind: ingestion-lock → IngestionEnCours (verrou, réessayable).
 2. 503 sans header               → httpx.HTTPStatusError (erreur générique).
-3. 422 + X-Error-Kind: precondition → PreconditionNonRemplie (actionnable).
+3. X-Error-Kind: precondition (422 ou 503) → PreconditionNonRemplie (actionnable).
+   Le mapping est **header-first, pas code-first** (#630) : une précondition métier
+   peut être portée par un 422 (RSC non réconcilié) ou un 503 (flux R67 absent) — c'est
+   `X-Error-Kind` qui discrimine, jamais le code HTTP seul.
 """
 
 import json
@@ -74,6 +77,25 @@ def test_raise_for_status_mappe_422_precondition_sur_precondition_non_remplie():
     client = _client(handler)
     response = client._http.get("http://testserver/x")
     with pytest.raises(PreconditionNonRemplie, match="RSC"):
+        client._raise_for_status(response)
+
+
+def test_raise_for_status_mappe_503_precondition_sur_precondition_non_remplie():
+    """503 + X-Error-Kind: precondition → PreconditionNonRemplie aussi (#630) : le mapping
+    suit le header, pas le code — precondition n'est plus 422-only (flux R67 absent,
+    ADR-0048/#487, remonte en 503)."""
+    detail_serveur = "Données R67 indisponibles : ... Déclencher une demande M023 ..."
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            503,
+            headers={"X-Error-Kind": "precondition", "Content-Type": "application/json"},
+            content=json.dumps({"detail": detail_serveur}).encode(),
+        )
+
+    client = _client(handler)
+    response = client._http.get("http://testserver/x")
+    with pytest.raises(PreconditionNonRemplie, match="M023"):
         client._raise_for_status(response)
 
 

--- a/tests/integration/test_provision_endpoint.py
+++ b/tests/integration/test_provision_endpoint.py
@@ -90,6 +90,9 @@ def test_flux_r67_absent_renvoie_503_actionnable(client, monkeypatch):
     assert response.status_code == 503
     detail = response.json()["detail"]
     assert "flux_r67" in detail and "M023" in detail  # message qui dit quoi faire
+    # #630 : précondition actionnable typée — le client public la mappe en
+    # PreconditionNonRemplie (X-Error-Kind, pas le code HTTP qui reste 503).
+    assert response.headers["X-Error-Kind"] == "precondition"
 
 
 def test_erreur_inattendue_renvoie_503_pas_500(client, monkeypatch):
@@ -102,6 +105,9 @@ def test_erreur_inattendue_renvoie_503_pas_500(client, monkeypatch):
     monkeypatch.setattr("electricore.api.routers.provision._estimer", _boom)
     response = client.get("/provision/estimation", params={"pdl": "12345678901234"})
     assert response.status_code == 503
+    # #630 : ce 503 générique (erreur inattendue) reste NU — pas de X-Error-Kind, à
+    # la différence du flux_r67 absent (précondition actionnable).
+    assert "X-Error-Kind" not in response.headers
 
 
 def _rapport_4_cadrans(pdl: str) -> RapportProvision:

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ typecheck = [{ name = "mypy", specifier = ">=1.13" }]
 
 [[package]]
 name = "electricore-client"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/electricore-client" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Closes #630

Expose l'estimation de provision (`GET /provision/estimation`, ADR-0048, #487) dans
electricore-client : `provision_estimation(pdl)` typé (pydantic, garde de version),
et le 503 « flux R67 absent » porte désormais `X-Error-Kind: precondition` (code HTTP
inchangé) pour remonter en `PreconditionNonRemplie` côté client plutôt qu'en
httpx.HTTPStatusError brut. Le 503 verrou d'ingestion continue d'arriver en
`IngestionEnCours` (non-régression testée). Bump 0.4.0 → 0.5.0 ; tag `client-v0.5.0`
et publication PyPI restent le geste humain post-merge (release-client.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)