### PR TITLE
feat(api): POST /perimetre/sorties — sorties C15 par lot de RSC + client typé (#632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### ✨ Ajouté
+
+- **`POST /perimetre/sorties`** (#632) : sorties du périmètre par lot de RSC
+  (événement C15 `RES`/`CFNS`), filtre à la requête (l'autorité du « à
+  nous » est la souscription Odoo). Consommé par le client
+  `electricore-client` 0.5.0 (`sorties(rsc=...)`).
+
 ## [3.7.0rc2] - 2026-07-11
 
 Release candidate : **empreinte de contenu** — kernel unique de hash canonique,

--- a/electricore/api/README.md
+++ b/electricore/api/README.md
@@ -47,6 +47,7 @@ API__TROUSSEAU__bot__KEY=une-autre-cle-pour-le-bot
 - `POST /facturation/turpe-variable` - Calculateur TURPE variable (RPC typé)
 - `GET /facturation/rapport.xlsx` · `/documents.xlsx` · `/check/odoo` - Rapports & contrôles pré-facturation — *requiert Odoo*
 - `GET /perimetre/affaires` - Cockpit des affaires SGE ouvertes (X12/X13)
+- `POST /perimetre/sorties` - Sorties du périmètre par lot de RSC (RPC typé, ADR-0052)
 - `GET /admin/api-keys` - Configuration des clés API
 
 Pour la liste exhaustive et à jour (schémas, paramètres, exemples) : `/docs`.
@@ -115,10 +116,10 @@ electricore/api/
 ├── security.py      # Système d'authentification
 ├── models.py        # Modèles Pydantic
 ├── decorators.py    # Décorateurs transverses (gestion d'erreurs)
-├── routers/         # Un router par domaine (13, issue #82) :
+├── routers/         # Un router par domaine (14, issue #82) :
 │                    #   admin, affaires, chronologie, facturation, flux, ingestion,
-│                    #   meta_periodes, prestations, provision, releves, rsc, taxes,
-│                    #   turpe_variable — liste vivante : electricore/api/routers/
+│                    #   meta_periodes, prestations, provision, releves, rsc, sorties,
+│                    #   taxes, turpe_variable — liste vivante : electricore/api/routers/
 ├── serializers/     # Sérialisation des réponses (Arrow, XLSX)
 ├── services/        # Services métier : duckdb, ingestion, taxes, facturation, check_facturation
 └── README.md        # Cette documentation

--- a/electricore/api/main.py
+++ b/electricore/api/main.py
@@ -23,6 +23,7 @@ from electricore.api.routers import prestations as prestations_router
 from electricore.api.routers import provision as provision_router
 from electricore.api.routers import releves as releves_router
 from electricore.api.routers import rsc as rsc_router
+from electricore.api.routers import sorties as sorties_router
 from electricore.api.routers import taxes as taxes_router
 from electricore.api.routers import turpe_variable as turpe_variable_router
 from electricore.api.serializers.jsonl import lever_defs_itemschema_jsonl
@@ -165,6 +166,7 @@ app.include_router(chronologie_router.router)
 app.include_router(turpe_variable_router.router)
 app.include_router(affaires_router.router)
 app.include_router(rsc_router.router)
+app.include_router(sorties_router.router)
 app.include_router(provision_router.router)
 
 

--- a/electricore/api/routers/sorties.py
+++ b/electricore/api/routers/sorties.py
@@ -1,0 +1,62 @@
+"""Router des sorties du périmètre : Odoo POST un lot de RSC (#632, ADR-0052).
+
+`POST /perimetre/sorties` sert la fin de souscription gouvernée par le fait C15
+(souscriptions_odoo#21, ADR 0031 côté addon) : à chaque campagne, Odoo interroge quelles
+de ses souscriptions sont sorties du périmètre — événement C15 `{RES, CFNS}`, symétrique
+pour le fournisseur. Le filtre RSC est **à la requête**, la liste vient du consommateur :
+les périmètres Enedis peuvent être partagés entre entités, indistinguables dans les
+flux — l'autorité du « à nous » est la souscription Odoo. Réponse en JSON enveloppé avec
+`contract_version`, auth `X-API-Key` — mêmes conventions que `POST /facturation/rsc`.
+
+Le modèle (`SortiesRequest`) est **single-sourcé** dans `electricore_client`
+(ADR-0043) : importé ici, plus aucune définition inline.
+"""
+
+import polars as pl
+
+# Modèle single-sourcé dans le paquet client (ADR-0043).
+from electricore_client.models import SortiesRequest
+from fastapi import APIRouter, Depends, Response
+
+from electricore.api.security import get_current_api_key
+from electricore.api.services.sorties_service import CONTRAT_VERSION, lister_sorties
+
+router = APIRouter(tags=["perimetre"])
+
+
+def _charger_c15_sorties(rsc: list[str]) -> pl.DataFrame:
+    """Événements C15 de sortie (RES/CFNS) dont `ref_situation_contractuelle ∈ rsc`
+    (seam IO, monkeypatché en test).
+
+    Le filtre RSC **et** le filtre code de sortie sont poussés dans la requête DuckDB :
+    on ne ramène ni tout le C15, ni les RSC hors du lot demandé.
+    """
+    from electricore.core.loaders.duckdb import c15
+
+    return c15().filter({"ref_situation_contractuelle": rsc}).sorties().collect()
+
+
+@router.post("/perimetre/sorties")
+async def post_perimetre_sorties(
+    requete: SortiesRequest,
+    response: Response,
+    api_key: str = Depends(get_current_api_key),
+) -> dict:
+    """Sorties du périmètre pour un lot de RSC (JSON enveloppé).
+
+    **Authentification requise** (`X-API-Key`).
+
+    Une ligne par RSC **sortie** (code C15 `RES`/`CFNS`) ; une RSC encore présente ou
+    inconnue n'apparaît simplement pas dans la réponse — pas d'erreur, c'est le cas
+    nominal « pas sortie ». Le `contract_version` est porté à la fois dans l'enveloppe
+    et dans l'en-tête `X-Contract-Version` (cohérent avec les autres endpoints
+    facturiste).
+    """
+    response.headers["X-Contract-Version"] = str(CONTRAT_VERSION)
+    rsc = requete.rsc
+    # Court-circuit : un lot vide ne touche pas DuckDB (un `IN ()` casserait le SQL).
+    if not rsc:
+        return {"contract_version": CONTRAT_VERSION, "sorties": []}
+
+    sorties = lister_sorties(_charger_c15_sorties(rsc))
+    return {"contract_version": CONTRAT_VERSION, "sorties": sorties}

--- a/electricore/api/services/sorties_service.py
+++ b/electricore/api/services/sorties_service.py
@@ -1,0 +1,54 @@
+"""Sorties du périmètre par RSC, **sans état** (#632, ADR-0052).
+
+`POST /perimetre/sorties` sert la fin de souscription gouvernée par le fait C15
+(souscriptions_odoo#21, ADR 0031 côté addon) : à chaque campagne, Odoo interroge un lot
+de `ref_situation_contractuelle` et ne reçoit que celles qui sont **sorties** du
+périmètre — événement C15 de code `{RES, CFNS}`, symétrique pour le fournisseur. Une RSC
+encore présente ou inconnue du fournisseur n'apparaît simplement pas dans la réponse
+(pas d'erreur : c'est le cas nominal « pas sortie »).
+
+ERP-agnostique ([ADR-0016](docs/adr/0016-core-erp-agnostique.md)) : le filtre RSC vient
+du consommateur (les périmètres Enedis peuvent être partagés entre entités,
+indistinguables dans les flux — l'autorité du « à nous » est la souscription Odoo).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+# Version du contrat exposée dans l'enveloppe (cf. rsc_service / turpe-variable). Bump
+# sur rupture ; un ajout de champ optionnel reste additif et ne change pas la version.
+CONTRAT_VERSION = 1
+
+
+def lister_sorties(c15_sorties: pl.DataFrame) -> list[dict]:
+    """Une ligne par RSC sortie, projetée depuis des événements C15 déjà filtrés.
+
+    Args:
+        c15_sorties: événements `flux_c15` déjà filtrés aux codes de sortie canoniques
+            (`RES`/`CFNS`, cf. `c15().sorties()`) et aux RSC demandées — colonnes
+            `ref_situation_contractuelle`, `pdl`, `evenement_declencheur`, `date_evenement`
+            (instant `TIMESTAMPTZ`, ADR-0042).
+
+    Returns:
+        Une ligne `{ref_situation_contractuelle, pdl, evenement_declencheur,
+        date_sortie}` par RSC, triée par RSC. `date_sortie` est le jour civil (jour du
+        code sortie) — convention demi-ouverte (ADR-0042/0052) : la RSC est absente du
+        périmètre dès ce jour, la conversion en « dernier jour servi » appartient au
+        consommateur. Dédupliquée par RSC (une sortie au plus par RSC au spike
+        ADR-0052 ; défense contre un doublon de ré-ingestion).
+    """
+    if c15_sorties.height == 0:
+        return []
+    return (
+        c15_sorties.lazy()
+        .group_by("ref_situation_contractuelle")
+        .agg(
+            pl.col("pdl").first(),
+            pl.col("evenement_declencheur").sort_by("date_evenement").first(),
+            pl.col("date_evenement").min().dt.date().alias("date_sortie"),
+        )
+        .sort("ref_situation_contractuelle")
+        .collect()
+        .to_dicts()
+    )

--- a/packages/electricore-client/CHANGELOG.md
+++ b/packages/electricore-client/CHANGELOG.md
@@ -4,6 +4,21 @@ Toutes les évolutions notables de ce paquet sont consignées ici.
 Le format suit [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/) ;
 le versionnage suit [SemVer](https://semver.org/lang/fr/).
 
+## [0.5.0] — 2026-07-12
+
+### Ajouté
+- Méthode `provision_estimation(pdl)` : GET RPC typé `/provision/estimation`,
+  estimation de provision d'un lissé dérivée de R67 (cold-start, ADR-0048,
+  #630). `RapportProvision` en kWh, zéro € ; `flux_r67` absent → 503
+  `precondition` → `PreconditionNonRemplie`.
+- Méthode `sorties(rsc=...)` : POST `/perimetre/sorties`, fin de souscription
+  gouvernée par le fait C15 (souscriptions_odoo#21, ADR 0031 côté addon,
+  #632). Renvoie une `LigneSortie` (code `RES`/`CFNS`, `date_sortie` jour
+  civil demi-ouvert ADR-0042/0052) pour chaque RSC **sortie** du lot demandé
+  — une RSC encore présente ou inconnue n'apparaît simplement pas (pas
+  d'erreur, cas nominal). Modèles `SortiesRequest` / `LigneSortie`
+  single-sourcés.
+
 ## [0.3.0] — 2026-07-08
 
 ### Ajouté

--- a/packages/electricore-client/src/electricore_client/__init__.py
+++ b/packages/electricore-client/src/electricore_client/__init__.py
@@ -25,6 +25,7 @@ from .models import (
     LigneEvenement,
     LignePeriodeEnergie,
     LigneReleve,
+    LigneSortie,
     LigneTurpeVariable,
     ObjetReleve,
     PeriodeMeta,
@@ -32,6 +33,7 @@ from .models import (
     ResolutionRscRequest,
     ResultatResolutionRsc,
     ResultatTurpeVariable,
+    SortiesRequest,
     TurpeVariableRequest,
 )
 from .streaming import JsonlStream
@@ -59,5 +61,7 @@ __all__ = [
     "ResultatResolutionRsc",
     "EstimationProvision",
     "RapportProvision",
+    "SortiesRequest",
+    "LigneSortie",
     "__version__",
 ]

--- a/packages/electricore-client/src/electricore_client/client.py
+++ b/packages/electricore-client/src/electricore_client/client.py
@@ -32,6 +32,11 @@ from .models.rsc import (
     ResolutionRscRequest,
     ResultatResolutionRsc,
 )
+from .models.sorties import (
+    CONTRAT_VERSION_SORTIES,
+    LigneSortie,
+    SortiesRequest,
+)
 from .models.turpe_variable import (
     CONTRAT_VERSION_TURPE_VARIABLE,
     LigneTurpeVariable,
@@ -293,3 +298,36 @@ class ElectricoreClient(_BaseClient):
             self._verifier_version(attendue=CONTRAT_VERSION_PROVISION, servie=int(version_servie))
 
         return RapportProvision.model_validate(response.json())
+
+    def sorties(self, rsc: list[str]) -> list[LigneSortie]:
+        """Sorties du périmètre pour un lot de RSC — **POST RPC** (pas un stream).
+
+        Fin de souscription gouvernée par le fait C15 (souscriptions_odoo#21, ADR 0031
+        côté addon) : une RSC encore présente ou inconnue **n'apparaît simplement pas**
+        dans la réponse — pas d'erreur, c'est le cas nominal « pas sortie ». Le filtre
+        RSC est à la requête : la liste vient de l'appelant (l'autorité du « à nous »
+        est la souscription Odoo). `date_sortie` est un jour civil demi-ouvert
+        (ADR-0042/0052) : la RSC est absente du périmètre dès ce jour — la conversion
+        en « dernier jour servi » appartient à l'appelant.
+
+        Args:
+            rsc: lot de `ref_situation_contractuelle` à interroger.
+
+        Returns:
+            Une `LigneSortie` par RSC **sortie** — sous-ensemble du lot envoyé, jamais
+            plus, jamais dans un ordre garanti par rapport à l'entrée.
+        """
+        requete = SortiesRequest(rsc=list(rsc))
+        response = self._http.post(
+            f"{self.url}/perimetre/sorties",
+            content=requete.model_dump_json(),
+            headers={**self._headers, "Content-Type": "application/json"},
+        )
+        self._raise_for_status(response)
+
+        version_servie = response.headers.get("X-Contract-Version")
+        if version_servie is not None:
+            self._verifier_version(attendue=CONTRAT_VERSION_SORTIES, servie=int(version_servie))
+
+        corps = response.json()
+        return [LigneSortie.model_validate(r) for r in corps["sorties"]]

--- a/packages/electricore-client/src/electricore_client/models/__init__.py
+++ b/packages/electricore-client/src/electricore_client/models/__init__.py
@@ -27,6 +27,11 @@ from .rsc import (
     ResolutionRscRequest,
     ResultatResolutionRsc,
 )
+from .sorties import (
+    CONTRAT_VERSION_SORTIES,
+    LigneSortie,
+    SortiesRequest,
+)
 from .turpe_variable import (
     CONTRAT_VERSION_TURPE_VARIABLE,
     LigneTurpeVariable,
@@ -56,4 +61,7 @@ __all__ = [
     "EstimationProvision",
     "RapportProvision",
     "CONTRAT_VERSION_PROVISION",
+    "SortiesRequest",
+    "LigneSortie",
+    "CONTRAT_VERSION_SORTIES",
 ]

--- a/packages/electricore-client/src/electricore_client/models/sorties.py
+++ b/packages/electricore-client/src/electricore_client/models/sorties.py
@@ -1,0 +1,41 @@
+"""Modèles de contrat des sorties du périmètre (POST RPC, #632, ADR-0052).
+
+`POST /perimetre/sorties` : l'appelant prête un lot de `ref_situation_contractuelle`,
+electricore renvoie une ligne par RSC **sortie** du périmètre (événement C15 de code
+`RES`/`CFNS`) — une RSC encore présente, ou inconnue, n'apparaît simplement pas dans la
+réponse (pas d'erreur : c'est le cas nominal). `date_sortie` est un **jour civil** `DATE`
+demi-ouvert (ADR-0042/0052) : la RSC est absente du périmètre dès ce jour-là — la
+conversion en « dernier jour servi » appartient au consommateur.
+
+Single-sourcés ici (ADR-0043) : le router FastAPI les importe, ne les redéfinit pas.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Version du contrat (cf. sorties_service.CONTRAT_VERSION). Source unique.
+CONTRAT_VERSION_SORTIES = 1
+
+
+class SortiesRequest(BaseModel):
+    """Lot de RSC à interroger en une passe (le cas mono est `n = 1`)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    rsc: list[str] = Field(..., description="Situations contractuelles (ref_situation_contractuelle) à interroger")
+
+
+class LigneSortie(BaseModel):
+    """Une RSC sortie du périmètre : son PDL, le code déclencheur et la date (jour civil)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    ref_situation_contractuelle: str
+    pdl: str
+    evenement_declencheur: str = Field(..., description="Code de sortie C15 : RES ou CFNS")
+    date_sortie: date = Field(
+        ..., description="Jour civil demi-ouvert (ADR-0042/0052) : absente du périmètre dès ce jour"
+    )

--- a/packages/electricore-client/tests/test_sorties.py
+++ b/packages/electricore-client/tests/test_sorties.py
@@ -1,0 +1,98 @@
+"""Tests du client `sorties` (POST RPC, sans serveur, #632).
+
+Fin de souscription gouvernée par le fait C15 (souscriptions_odoo#21, ADR 0031 côté
+addon) : on envoie un lot de RSC, on reçoit une ligne par RSC **sortie** — une RSC
+encore présente ou inconnue n'apparaît simplement pas. MockTransport échoue/réussit
+l'écho ; on vérifie le typage, le corps envoyé, et la garde de version.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from electricore_client import ElectricoreClient
+from electricore_client.exceptions import ContractVersionError
+from electricore_client.models import LigneSortie
+
+
+def _handler(sorties, *, version="1"):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"contract_version": int(version), "sorties": sorties},
+            headers={"X-Contract-Version": version},
+        )
+
+    return handler
+
+
+def _client(handler) -> ElectricoreClient:
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    return ElectricoreClient(url="http://testserver", api_key="key", http_client=http)
+
+
+def test_sorties_retourne_des_lignes_typees():
+    """Le client POST le lot et renvoie des `LigneSortie` typées."""
+    client = _client(
+        _handler(
+            [
+                {
+                    "ref_situation_contractuelle": "rA",
+                    "pdl": "PDL-A",
+                    "evenement_declencheur": "RES",
+                    "date_sortie": "2026-03-15",
+                }
+            ]
+        )
+    )
+    resultats = client.sorties(["rA"])
+    assert all(isinstance(r, LigneSortie) for r in resultats)
+    assert resultats[0].ref_situation_contractuelle == "rA"
+    assert resultats[0].evenement_declencheur == "RES"
+    assert resultats[0].date_sortie.isoformat() == "2026-03-15"
+
+
+def test_sorties_envoie_le_lot_dans_le_corps():
+    """Le corps POST porte bien `{rsc: [...]}` (contrat figé)."""
+    capture = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        capture["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"contract_version": 1, "sorties": []}, headers={"X-Contract-Version": "1"})
+
+    client = _client(handler)
+    client.sorties(["rA", "rB"])
+    assert capture["body"] == {"rsc": ["rA", "rB"]}
+
+
+def test_sorties_seules_les_rsc_sorties_reviennent():
+    """Un lot mixte : seules les RSC sorties reviennent (rB, encore présente, absente)."""
+    client = _client(
+        _handler(
+            [
+                {
+                    "ref_situation_contractuelle": "rA",
+                    "pdl": "PDL-A",
+                    "evenement_declencheur": "CFNS",
+                    "date_sortie": "2026-05-02",
+                }
+            ]
+        )
+    )
+    resultats = client.sorties(["rA", "rB"])
+    assert [r.ref_situation_contractuelle for r in resultats] == ["rA"]
+
+
+def test_sorties_lot_vide():
+    """Lot vide → liste vide (le round-trip HTTP a lieu, le court-circuit est côté serveur)."""
+    client = _client(_handler([]))
+    assert client.sorties([]) == []
+
+
+def test_sorties_garde_de_version():
+    """Un serveur **en retard** (contrat servi < attendu) lève `ContractVersionError`."""
+    client = _client(_handler([], version="0"))
+    with pytest.raises(ContractVersionError):
+        client.sorties(["rA"])

--- a/tests/architecture/test_sorties_erp_agnostique.py
+++ b/tests/architecture/test_sorties_erp_agnostique.py
@@ -1,0 +1,62 @@
+"""Garde-fou : les sorties du périmètre sont ERP-agnostiques (#632, ADR-0016/0052).
+
+Le router et le service exposent une projection **electricore-native** du flux C15
+(événements de sortie RES/CFNS) et n'importent **rien** de `electricore.integrations` :
+le RSC de l'appelant est un identifiant opaque, jamais interprété. Analyse statique via
+`ast` (couvre aussi les imports `TYPE_CHECKING`). Miroir de `test_rsc_erp_agnostique` /
+`test_turpe_variable_erp_agnostique` — même barre pour l'endpoint frère.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+API_ROOT = Path(__file__).resolve().parents[2] / "electricore" / "api"
+
+MODULES = [
+    API_ROOT / "routers" / "sorties.py",
+    API_ROOT / "services" / "sorties_service.py",
+]
+
+
+def _absolute_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.add(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            modules.add(node.module)
+    return modules
+
+
+@pytest.mark.parametrize("module", MODULES, ids=lambda p: p.name)
+def test_sorties_n_importe_pas_integrations(module: Path) -> None:
+    """ADR-0016 : ni le router ni le service n'importent `electricore.integrations`."""
+    forbidden = sorted(
+        m
+        for m in _absolute_imports(module)
+        if m == "electricore.integrations" or m.startswith("electricore.integrations.")
+    )
+    assert not forbidden, (
+        f"{module.name} importe {forbidden} — les sorties du périmètre doivent rester ERP-agnostiques (ADR-0016)."
+    )
+
+
+def test_router_sorties_single_source_les_modeles() -> None:
+    """ADR-0043 : le router importe son modèle de `electricore_client`, plus aucune
+    définition inline (`class SortiesRequest` dans le router)."""
+    router = API_ROOT / "routers" / "sorties.py"
+    imports = _absolute_imports(router)
+    assert any(m == "electricore_client.models" or m.startswith("electricore_client") for m in imports), (
+        "Le router sorties doit importer ses modèles depuis electricore_client (single-source)."
+    )
+
+    tree = ast.parse(router.read_text(encoding="utf-8"))
+    classes = {node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef)}
+    inline = classes & {"SortiesRequest", "LigneSortie"}
+    assert not inline, (
+        f"Modèles encore définis inline dans le router : {sorted(inline)} (déménager vers electricore_client)."
+    )

--- a/tests/integration/test_sorties_endpoint.py
+++ b/tests/integration/test_sorties_endpoint.py
@@ -1,0 +1,90 @@
+"""Tests d'intégration de `POST /perimetre/sorties` (fin de souscription, #632, ADR-0052).
+
+Sans état : Odoo POST un lot de RSC, electricore renvoie uniquement celles qui sont
+**sorties** du périmètre (code C15 RES/CFNS) — une RSC encore présente ou inconnue
+n'apparaît simplement pas (pas d'erreur, cas nominal). Le seam de chargement DuckDB
+(`_charger_c15_sorties`) est monkeypatché : on vérifie le câblage transport + enveloppe,
+pas le loader. Le seam d'auth est surchargé comme pour la résolution RSC / turpe-variable.
+"""
+
+from datetime import datetime
+
+import polars as pl
+import pytest
+from fastapi.testclient import TestClient
+
+from electricore.api.main import app
+from electricore.api.security import get_current_api_key
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[get_current_api_key] = lambda: "test-key"
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _brancher(monkeypatch, c15_sorties: pl.DataFrame):
+    """Court-circuite le seam DuckDB du router avec une frame synthétique déjà filtrée
+    aux codes de sortie (comme le fait réellement `c15().filter(...).sorties()`)."""
+    monkeypatch.setattr("electricore.api.routers.sorties._charger_c15_sorties", lambda rsc: c15_sorties)
+
+
+def _c15_sorties() -> pl.DataFrame:
+    return pl.DataFrame(
+        [
+            ("rA", "PDL-A", datetime(2026, 3, 15), "RES"),
+            ("rC", "PDL-C", datetime(2026, 5, 2), "CFNS"),
+        ],
+        schema={
+            "ref_situation_contractuelle": pl.Utf8,
+            "pdl": pl.Utf8,
+            "date_evenement": pl.Datetime,
+            "evenement_declencheur": pl.Utf8,
+        },
+        orient="row",
+    )
+
+
+def test_lot_mixte_ne_rend_que_les_sorties_avec_code_et_date_exacts(client, monkeypatch):
+    """rA et rC sont sorties, rB (encore présente) n'est pas renvoyée par le seam (déjà
+    filtrée côté loader), rZ est inconnue — les deux dernières sont simplement absentes."""
+    _brancher(monkeypatch, _c15_sorties())
+
+    response = client.post("/perimetre/sorties", json={"rsc": ["rA", "rB", "rC", "rZ"]})
+    assert response.status_code == 200
+    assert response.headers["X-Contract-Version"] == "1"
+
+    body = response.json()
+    assert body["contract_version"] == 1
+    par_rsc = {s["ref_situation_contractuelle"]: s for s in body["sorties"]}
+    assert set(par_rsc) == {"rA", "rC"}  # rB et rZ absentes, pas d'erreur
+    assert par_rsc["rA"] == {
+        "ref_situation_contractuelle": "rA",
+        "pdl": "PDL-A",
+        "evenement_declencheur": "RES",
+        "date_sortie": "2026-03-15",
+    }
+    assert par_rsc["rC"]["evenement_declencheur"] == "CFNS"
+    assert par_rsc["rC"]["date_sortie"] == "2026-05-02"
+
+
+def test_lot_vide_court_circuite_sans_toucher_duckdb(client, monkeypatch):
+    """Lot vide → `sorties: []` sans appeler le seam (un `IN ()` casserait le SQL)."""
+
+    def _interdit(rsc):
+        raise AssertionError("le loader ne doit pas être appelé pour un lot vide")
+
+    monkeypatch.setattr("electricore.api.routers.sorties._charger_c15_sorties", _interdit)
+
+    response = client.post("/perimetre/sorties", json={"rsc": []})
+    assert response.status_code == 200
+    assert response.json() == {"contract_version": 1, "sorties": []}
+
+
+def test_refuse_sans_api_key():
+    """Endpoint sécurisé : 401 sans clé (pas d'override d'auth ici)."""
+    response = TestClient(app).post("/perimetre/sorties", json={"rsc": []})
+    assert response.status_code == 401

--- a/tests/unit/test_sorties_service.py
+++ b/tests/unit/test_sorties_service.py
@@ -1,0 +1,80 @@
+"""Tests du service des sorties du périmètre (#632, ADR-0052).
+
+`lister_sorties` reçoit des événements `flux_c15` **déjà filtrés** aux codes de sortie
+(RES/CFNS) et aux RSC demandées (le filtre RSC + le filtre code sont poussés côté
+loader, comme `_charger_c15` pour la résolution RSC) : une simple projection/dédup, pas
+de logique métier de filtrage.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import polars as pl
+
+from electricore.api.services.sorties_service import lister_sorties
+
+
+def _c15_sorties(rows: list[tuple[str, str, datetime, str]]) -> pl.DataFrame:
+    """Événements C15 de sortie minimaux : (rsc, pdl, date_evenement, evenement_declencheur)."""
+    return pl.DataFrame(
+        rows,
+        schema={
+            "ref_situation_contractuelle": pl.Utf8,
+            "pdl": pl.Utf8,
+            "date_evenement": pl.Datetime,
+            "evenement_declencheur": pl.Utf8,
+        },
+        orient="row",
+    )
+
+
+def test_une_ligne_par_rsc_sortie_avec_code_et_date_exacts():
+    """Tracer : une sortie RES → sa ligne, code et date jour civil exacts."""
+    resultats = lister_sorties(_c15_sorties([("rA", "PDL-A", datetime(2026, 3, 15, 10, 30), "RES")]))
+    assert resultats == [
+        {
+            "ref_situation_contractuelle": "rA",
+            "pdl": "PDL-A",
+            "evenement_declencheur": "RES",
+            "date_sortie": date(2026, 3, 15),
+        }
+    ]
+
+
+def test_code_cfns_egalement_reconnu():
+    resultats = lister_sorties(_c15_sorties([("rB", "PDL-B", datetime(2026, 4, 1), "CFNS")]))
+    assert resultats[0]["evenement_declencheur"] == "CFNS"
+
+
+def test_plusieurs_rsc_triees():
+    """Lot de plusieurs RSC sorties → une ligne chacune, triées par RSC."""
+    resultats = lister_sorties(
+        _c15_sorties(
+            [
+                ("rZ", "PDL-Z", datetime(2026, 1, 1), "RES"),
+                ("rA", "PDL-A", datetime(2026, 2, 1), "CFNS"),
+            ]
+        )
+    )
+    assert [r["ref_situation_contractuelle"] for r in resultats] == ["rA", "rZ"]
+
+
+def test_lot_vide_renvoie_liste_vide():
+    """Frame vide (aucune RSC demandée n'est sortie) → liste vide, sans erreur."""
+    assert lister_sorties(_c15_sorties([])) == []
+
+
+def test_evenement_duplique_sur_la_meme_rsc_reste_dedupe():
+    """Défense : si le même événement de sortie apparaît deux fois pour une RSC (ré-ingestion),
+    une seule ligne en sort — pas de doublon."""
+    resultats = lister_sorties(
+        _c15_sorties(
+            [
+                ("rA", "PDL-A", datetime(2026, 3, 15), "RES"),
+                ("rA", "PDL-A", datetime(2026, 3, 15), "RES"),
+            ]
+        )
+    )
+    assert len(resultats) == 1
+    assert resultats[0]["ref_situation_contractuelle"] == "rA"


### PR DESCRIPTION
Closes #632

Ajoute POST /perimetre/sorties (+ méthode client `sorties(rsc=...)`) : Odoo
soumet un lot de RSC, electricore renvoie uniquement celles sorties du
périmètre (code C15 RES/CFNS, date jour civil demi-ouverte, ADR-0042/0052). Miroir exact du
motif POST /facturation/rsc (enveloppe versionnée, court-circuit lot vide,
ERP-agnostique). Modèles single-sourcés dans electricore-client (ADR-0043), bump 0.4.0 →
0.5.0 + changelogs.

Suite complète verte : 1194 passed, 4 skipped (skips préexistants/environnementaux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)