### PR TITLE
chore: bump electricore 3.7.0rc2 → 3.7.0rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,24 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.7.0rc3] - 2026-07-14
+
+Release candidate : **fin de souscription Odoo** — l'endpoint sorties C15 arrive
+côté moteur, consommable par `electricore-client` 0.5.0 (en ligne sur PyPI).
+
 ### ✨ Ajouté
 
 - **`POST /perimetre/sorties`** (#632) : sorties du périmètre par lot de RSC
   (événement C15 `RES`/`CFNS`), filtre à la requête (l'autorité du « à
   nous » est la souscription Odoo). Consommé par le client
   `electricore-client` 0.5.0 (`sorties(rsc=...)`).
+
+### ♻️ Modifié
+
+- **`GET /provision/estimation`** (#630) : le 503 « `flux_r67` non matérialisé »
+  est tagué `X-Error-Kind: precondition` (code HTTP inchangé) → le client typé
+  le mappe en `PreconditionNonRemplie` au lieu d'un `HTTPStatusError`
+  inattrapable. Nouvelle méthode client `provision_estimation(pdl)` (0.5.0).
 
 ## [3.7.0rc2] - 2026-07-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.7.0rc2"
+version = "3.7.0rc3"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.7.0rc2"
+version = "3.7.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Bump avant tag (process release) : **rc2 (11/07) précède les merges de #630 et #634** — l'endpoint `POST /perimetre/sorties` et le 503 `precondition` de `/provision/estimation` ne sont dans aucune release moteur, alors que le client 0.5.0 qui les consomme est déjà sur PyPI.

- `pyproject.toml` : 3.7.0rc2 → 3.7.0rc3
- `CHANGELOG.md` : section 3.7.0rc3 (sorties #632 en Ajouté, provision #630 en Modifié — #630 n'avait pas écrit d'entrée), `[Unreleased]` vidé
- `uv.lock` : relock (version self uniquement)

Après merge : tag `v3.7.0rc3` → workflow release (PyPI + image ghcr), puis `reconfigure`/pin côté déploiement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)