### PR TITLE
feat(ingestion): audit de séquences — macro dbt commune + mart + test warn (#645)

### DIFF
--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -192,17 +192,21 @@ absente (landing partiel, smoke `max_files`).
   jamais atterri — mais une re-livraison sous un nom de zip *différent* pour le même
   contenu (dédoublonnée par le merge dlt sur `file_name`) peut ponctuellement produire un
   faux positif. Vérifier sur le SFTP / auprès d'Enedis avant d'escalader.
-- **`queue_inverifiable` n'est jamais un feu vert.** Le dernier numéro observé d'une clé
-  n'est jamais requalifié en « sain » — un trou n'est constatable qu'*entre* deux numéros ;
-  le suivant n'est simplement pas encore arrivé.
+- **`queue_inverifiable` n'est jamais un feu vert — mais n'est pas une anomalie.** Le
+  dernier numéro observé d'une clé n'est jamais requalifié en « sain » — un trou n'est
+  constatable qu'*entre* deux numéros. La queue est l'état permanent de toute séquence
+  ouverte : elle reste dans la vue (consultation « jusqu'où ai-je vérifié ? ») mais est
+  exclue du data test `warn` — un fichier perdu en queue se déclarera de lui-même comme
+  trou encadré à l'arrivée du numéro suivant.
 - **R17 pas encore couvert.** Aucune table `raw_r17` n'existe côté ingestion — pas de zip
   réel à caler contre la macro pour l'instant. Le jour où `sources.yml` la déclarera,
   ajouter sa règle (clé = contrat seul, guide SGE, même forme que C12) au dict `regles`
   de la macro et l'unioner dans `source_union` du mart.
-- **Data test `warn`, jamais bloquant.** `aucune_anomalie` (0 ligne attendue) tourne en
-  `severity: warn` à chaque `dbt build` — il trace les trous dans la sortie du job sans
-  jamais le faire échouer (l'ingestion reste verte sur une base réelle qui a ses trous
-  historiques connus).
+- **Data test `warn`, jamais bloquant, discriminant.** `aucune_anomalie` (0 anomalie
+  *actionnable* attendue : `trou`, `nom_non_reconnu`, `intra_zip_incomplet` — queues
+  exclues) tourne en `severity: warn` à chaque `dbt build` — silencieux sur base saine,
+  il trace les vraies anomalies dans la sortie du job sans jamais le faire échouer
+  (l'ingestion reste verte sur une base réelle qui a ses trous historiques connus).
 
 ### Les trois pièges DuckDB (appris sur données réelles, encodés dans les modèles)
 

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -148,6 +148,62 @@ occupant) il est coupé à l'entrée → sans valeur (mur occupant RGPD). La voi
 recevable **aussi** pour les non-communicants, mais le contenu y est grossier (BASE,
 bimestriel, estimé).
 
+### Audit de séquences (complétude des flux)
+
+Le mart `audit_sequences` ([#645](https://github.com/Energie-De-Nantes/electricore/issues/645),
+PRD [#644](https://github.com/Energie-De-Nantes/electricore/issues/644)) répond à une seule
+question : *a-t-on manqué une archive Enedis ?* Le *numéro de séquence* porté par le nom de
+chaque zip est le seul témoin qu'Enedis fournit — glossaire complet (numéro/clé de séquence,
+trou, compteur intra-zip) dans
+[`electricore/ingestion/CONTEXT.md`](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/ingestion/CONTEXT.md)
+§ Complétude des flux.
+
+**Consultation** — une ligne par anomalie, jamais 0 ligne sur un historique non-vide (la
+queue est toujours signalée) :
+
+```sql
+select * from flux_enedis.audit_sequences order by flux, type_anomalie;
+```
+
+Colonnes : `flux`, `cle_sequence` (nullable), `type_anomalie` (`trou` /
+`queue_inverifiable` / `nom_non_reconnu` / `intra_zip_incomplet`), `seq_ou_plage` (numéro,
+plage `"00003-00005"`, nom de zip, ou décompte `"<zip> (2/3)"`).
+
+**Où vivent les règles.** Toute la nomenclature (regexp par flux, clé de séquence,
+découpage en segments, trous, queue) vit dans **une seule macro**,
+`macros/audit_sequences.sql` — brique commune destinée à être réutilisée telle quelle par
+le relais de flux ([#646](https://github.com/Energie-De-Nantes/electricore/issues/646), import
+dbt package local). Le mart ingestion l'appelle sur l'union des tables brutes du landing, et
+y ajoute son propre volet : le **contrôle intra-zip rétrospectif** (chaque zip atterri a-t-il
+un XML en base pour chaque rang 1..Y de son compteur `_XXXXX_YYYYY` ?) — spécifique à
+l'ingestion (le relais ne dézippe rien en base), donc hors macro.
+
+**Sélection runner.** Comme les marts périodiques (`releves`/`chronologie_releves`),
+`construire_dbt()` n'ajoute `+audit_sequences` que si **toutes** ses tables brutes sources
+(C15, R15, F12, F15, R151, C12, X12/X13) sont présentes — sinon dbt échoue sur une source
+absente (landing partiel, smoke `max_files`).
+
+**Limites à connaître avant d'agir sur une ligne :**
+
+- **R64/R67 hors champ.** Publications ponctuelles (à la demande M023) — leur séquence est
+  toujours figée à `00001`, elles ne portent aucune notion de continuité. Ne pas les
+  chercher dans la vue, ne pas s'étonner de leur absence.
+- **`trou` = « à vérifier », pas certain.** Un trou signale qu'Enedis a annoncé un numéro
+  jamais atterri — mais une re-livraison sous un nom de zip *différent* pour le même
+  contenu (dédoublonnée par le merge dlt sur `file_name`) peut ponctuellement produire un
+  faux positif. Vérifier sur le SFTP / auprès d'Enedis avant d'escalader.
+- **`queue_inverifiable` n'est jamais un feu vert.** Le dernier numéro observé d'une clé
+  n'est jamais requalifié en « sain » — un trou n'est constatable qu'*entre* deux numéros ;
+  le suivant n'est simplement pas encore arrivé.
+- **R17 pas encore couvert.** Aucune table `raw_r17` n'existe côté ingestion — pas de zip
+  réel à caler contre la macro pour l'instant. Le jour où `sources.yml` la déclarera,
+  ajouter sa règle (clé = contrat seul, guide SGE, même forme que C12) au dict `regles`
+  de la macro et l'unioner dans `source_union` du mart.
+- **Data test `warn`, jamais bloquant.** `aucune_anomalie` (0 ligne attendue) tourne en
+  `severity: warn` à chaque `dbt build` — il trace les trous dans la sortie du job sans
+  jamais le faire échouer (l'ingestion reste verte sur une base réelle qui a ses trous
+  historiques connus).
+
 ### Les trois pièges DuckDB (appris sur données réelles, encodés dans les modèles)
 
 1. **Pushdown sous unnest** : un `WHERE` sur un chemin JSON d'un élément unnesté peut être poussé

--- a/electricore/ingestion/CONTEXT.md
+++ b/electricore/ingestion/CONTEXT.md
@@ -76,6 +76,23 @@ _Éviter_ : recopier la liste ailleurs (toute copie manuelle dérive en silence 
 
 ---
 
+## Complétude des flux
+
+**Numéro de séquence** :
+Compteur sur 5 chiffres (00001 → 99999) porté par le **nom** de chaque archive Enedis, incrémenté de 1 à chaque flux produit — lisible sans déchiffrer. C'est le seul témoin qu'Enedis fournit pour prouver qu'aucune archive n'a été manquée.
+_Éviter_ : confondre avec `Num_Sequence` du contenu C15/C12 (numéro de la situation contractuelle d'un PRM, sans rapport).
+
+**Clé de séquence** :
+Périmètre au sein duquel un *numéro de séquence* est continu — **propre à chaque type de flux** : (contrat, DIR) pour C15/R15, sextuplet contrat×DIR×type_facture×fréquence×type_client pour F15, triplet contrat×DIR pour F12, contrat seul pour C12/R17, destinataire×flux pour X12/X13, abonnement pour R151, demande pour R64. Un contrôle qui ignore la clé produit de faux trous en pagaille (une séquence *par DIR* pour C15/R15).
+
+**Trou de séquence** :
+Numéro absent entre deux numéros observés d'une même *clé de séquence* : l'archive a été émise par Enedis mais n'a jamais atterri (jamais reçue, ou reçue et jamais déchiffrée/traitée — les deux sont des anomalies). Un trou n'est constatable qu'*entre* deux numéros observés : la queue de séquence est invérifiable jusqu'à l'arrivée du numéro suivant. Une séquence peut légitimement **redémarrer** à 00001 (F15 à la bascule Ginko v2) — un redémarrage n'est pas un trou.
+
+**Compteur intra-zip** :
+Paire `XXXXX_YYYYY` dans le nom de chaque XML d'une archive (C15, R15, C12, R17, X12, F12) : « fichier X sur Y » — un dézippage est complet ssi chaque rang de 1 à Y est présent une fois. **R151 fait exception** : son compteur est *inter-zips* (un XML par zip, Y = nombre de zips de la même séquence).
+
+---
+
 ## Déchiffrement
 
 **Trousseau de clés AES** :

--- a/electricore/ingestion/dbt/macros/audit_sequences.sql
+++ b/electricore/ingestion/dbt/macros/audit_sequences.sql
@@ -164,9 +164,12 @@ select * from non_reconnus
 {% endmacro %}
 
 
--- Data test générique (severity: warn côté schema.yml) : 0 anomalie attendue. Le mart
--- audit_sequences PRODUIT une ligne par anomalie — appliquer ce test au modèle entier
--- revient donc à vérifier qu'il est vide, sans dupliquer une requête `select * from`.
+-- Data test générique (severity: warn côté schema.yml) : 0 anomalie ACTIONNABLE attendue.
+-- `queue_inverifiable` est exclue : la queue est l'état permanent de toute séquence ouverte
+-- (il y a toujours un dernier numéro reçu), pas une anomalie — la compter ferait tirer le
+-- warn à chaque build et noierait les vrais trous. Un fichier perdu en queue se déclarera
+-- de lui-même comme trou encadré à l'arrivée du numéro suivant ; la queue reste visible
+-- dans la vue pour la consultation (« jusqu'où ai-je vérifié ? »).
 {% test aucune_anomalie(model) %}
-select * from {{ model }}
+select * from {{ model }} where type_anomalie != 'queue_inverifiable'
 {% endtest %}

--- a/electricore/ingestion/dbt/macros/audit_sequences.sql
+++ b/electricore/ingestion/dbt/macros/audit_sequences.sql
@@ -1,0 +1,172 @@
+-- Brique commune d'audit de séquences Enedis (#645, PRD #644 ; réutilisée telle quelle
+-- par le relais de flux #646 via import dbt package local).
+--
+-- SEUL lieu où vivent les règles de nomenclature Enedis : extraction du *numéro de
+-- séquence* et de la *clé de séquence* depuis le nom du zip (glossaire, `CONTEXT.md`
+-- « Complétude des flux »), propres à chaque type de flux (guides SGE) :
+--   C15/R15 = (contrat, DIR) ; F15 = destinataire×contrat×DIR×type_facture×fréquence×
+--   type_client ; F12 = destinataire×contrat×DIR ; C12 = contrat ; X12/X13 =
+--   destinataire×code_flux ; R151 = abonnement (compteur INTER-zips, hors macro — la
+--   caller ingestion le traite dans sa propre CTE, cf. `models/marts/audit_sequences.sql`).
+--
+-- Paramètres :
+--   relation    : relation déjà UNIONÉE (une ligne par document), portant une colonne
+--                 `flux` (code flux Enedis : 'C15'/'R15'/'F15'/'F12'/'R151'/'C12'/
+--                 'X12'/'X13') — convention fixe, pas un paramètre (le caller construit
+--                 l'union avec ce nom de colonne).
+--   colonne_zip : nom de la colonne portant le nom de l'archive (`_source_zip` côté
+--                 ingestion — même colonne côté relais #646).
+--
+-- Publications ponctuelles (R64, R67) HORS CHAMP : séquence toujours figée à 00001 —
+-- ne pas les unioner dans `relation` (pas de règle ici, un flux inconnu du dict `regles`
+-- retombe sur `nom_reconnu = false`, ce qui produirait de faux `nom_non_reconnu` sur des
+-- publications ponctuelles jamais nommées selon ces règles).
+--
+-- Sortie : une ligne par anomalie — (flux, cle_sequence, type_anomalie, seq_ou_plage) :
+--   - 'trou' : numéro absent ENTRE deux numéros observés d'une même clé de séquence.
+--     Découpage en SEGMENTS d'abord (un segment casse quand le numéro repart en
+--     arrière — redémarrage légitime, type F15/bascule Ginko v2) : un trou n'est
+--     détecté qu'AU SEIN d'un segment, jamais à la jointure de deux segments.
+--   - 'queue_inverifiable' : le numéro le plus RÉCENT (chronologiquement, via
+--     l'horodate du nom de zip) d'une clé — jamais déclaré sain, un trou n'est
+--     constatable qu'entre deux numéros observés (le suivant n'est pas encore arrivé).
+--   - 'nom_non_reconnu' : nom de zip qui ne correspond à aucune règle connue pour son
+--     flux — jamais ignoré en silence.
+{% macro audit_sequences(relation, colonne_zip) %}
+
+{%- set regles = {
+    'C15':  {'pattern': '^[^_]+_C15_[^_]+_([^_]+)_([^_]+)_([0-9]{5})_[0-9]+$',
+             'cle': '\\1|\\2', 'seq': '\\3'},
+    'R15':  {'pattern': '^[^_]+_R15_[^_]+_([^_]+)_([^_]+)_([0-9]{5})_[0-9]+$',
+             'cle': '\\1|\\2', 'seq': '\\3'},
+    'F15':  {'pattern': '^[^_]+_F15_([^_]+)_([^_]+)_([^_]+)_([^_]+)_([^_]+)_([^_]+)_[^_]+_([0-9]{5})_[0-9]+$',
+             'cle': '\\1|\\2|\\3|\\4|\\5|\\6', 'seq': '\\7'},
+    'F12':  {'pattern': '^[^_]+_F12_([^_]+)_([^_]+)_([^_]+)_([0-9]{5})_[^_]+_[^_]+_[0-9]+$',
+             'cle': '\\1|\\2|\\3', 'seq': '\\4'},
+    'R151': {'pattern': '^[^_]+_R151_[^_]+_[^_]+_([^_]+)_([0-9]{5})_[^_]+_[0-9]{5}_[0-9]{5}_[0-9]+$',
+             'cle': '\\1', 'seq': '\\2'},
+    'C12':  {'pattern': '^[^_]+_C12_[^_]+_([^_]+)_([0-9]{5})_[0-9]+$',
+             'cle': '\\1', 'seq': '\\2'},
+    'X12':  {'pattern': '^[^_]+_X12_([^_]+)_([0-9]{5})_[0-9]+$',
+             'cle': '\\1', 'seq': '\\2'},
+    'X13':  {'pattern': '^[^_]+_X13_([^_]+)_([0-9]{5})_[0-9]+$',
+             'cle': '\\1', 'seq': '\\2'},
+} -%}
+
+with brut as (
+    select
+        flux,
+        {{ colonne_zip }}                               as nom_zip,
+        regexp_replace({{ colonne_zip }}, '\.zip$', '')  as base
+    from {{ relation }}
+),
+
+-- Extraction par flux — reconnaissance, clé de séquence (préfixée du flux : distingue
+-- nativement X12/X13, même clé destinataire) et numéro de séquence.
+extraits as (
+    select
+        flux,
+        nom_zip,
+        case flux
+        {%- for f, r in regles.items() %}
+            when '{{ f }}' then regexp_matches(base, '{{ r.pattern }}')
+        {%- endfor %}
+            else false
+        end as nom_reconnu,
+        case flux
+        {%- for f, r in regles.items() %}
+            when '{{ f }}' then case when regexp_matches(base, '{{ r.pattern }}')
+                then flux || '|' || regexp_replace(base, '{{ r.pattern }}', '{{ r.cle }}') end
+        {%- endfor %}
+        end as cle_sequence,
+        case flux
+        {%- for f, r in regles.items() %}
+            when '{{ f }}' then case when regexp_matches(base, '{{ r.pattern }}')
+                then try_cast(regexp_replace(base, '{{ r.pattern }}', '{{ r.seq }}') as integer) end
+        {%- endfor %}
+        end as numero_sequence,
+        -- Horodate générique (dernier champ `_YYYYMMDDHHMMSS` avant `.zip`, convention
+        -- Enedis stable tous flux confondus) : ordre CHRONOLOGIQUE d'arrivée, seul repère
+        -- fiable pour distinguer un redémarrage (numéro qui repart en arrière dans le
+        -- temps) d'un simple tri numérique (qui confondrait redémarrage et trou).
+        regexp_extract(base, '_([0-9]{14})$', 1)         as horodate
+    from brut
+),
+
+-- Occurrences reconnues, dédoublonnées par (flux, clé, numéro) : une re-livraison sous
+-- un nom de zip différent pour le même numéro ne doit pas se compter deux fois.
+reconnus as (
+    select distinct flux, cle_sequence, numero_sequence, horodate
+    from extraits
+    where nom_reconnu and cle_sequence is not null and numero_sequence is not null
+),
+
+ordonnes as (
+    select
+        *,
+        lag(numero_sequence) over (partition by flux, cle_sequence order by horodate, numero_sequence) as seq_precedent
+    from reconnus
+),
+
+-- Segments : un nouveau segment démarre dès que le numéro repart en arrière par rapport
+-- au précédent (chronologiquement) — redémarrage légitime (F15/Ginko v2), pas un trou.
+segments as (
+    select
+        *,
+        sum(case when seq_precedent is not null and numero_sequence < seq_precedent then 1 else 0 end)
+            over (partition by flux, cle_sequence order by horodate, numero_sequence rows unbounded preceding) as segment_id
+    from ordonnes
+),
+
+trous as (
+    select
+        flux,
+        cle_sequence,
+        'trou' as type_anomalie,
+        lpad(cast(precedent + 1 as varchar), 5, '0')
+            || case when numero_sequence - precedent > 2
+                    then '-' || lpad(cast(numero_sequence - 1 as varchar), 5, '0')
+                    else '' end                                                       as seq_ou_plage
+    from (
+        select
+            flux, cle_sequence, numero_sequence,
+            lag(numero_sequence) over (partition by flux, cle_sequence, segment_id order by numero_sequence) as precedent
+        from segments
+    )
+    where precedent is not null and numero_sequence - precedent > 1
+),
+
+-- Queue : le numéro le plus RÉCENT (horodate desc) de chaque clé — jamais numériquement
+-- le plus grand (un redémarrage a un numéro plus petit mais plus récent : c'est LUI la
+-- vraie queue invérifiable, pas le dernier numéro de l'ancien segment).
+queues as (
+    select flux, cle_sequence, 'queue_inverifiable' as type_anomalie, lpad(cast(numero_sequence as varchar), 5, '0') as seq_ou_plage
+    from (
+        select flux, cle_sequence, numero_sequence,
+               row_number() over (partition by flux, cle_sequence order by horodate desc, numero_sequence desc) as rn
+        from reconnus
+    )
+    where rn = 1
+),
+
+non_reconnus as (
+    select flux, cast(null as varchar) as cle_sequence, 'nom_non_reconnu' as type_anomalie, nom_zip as seq_ou_plage
+    from extraits
+    where not nom_reconnu
+)
+
+select * from trous
+union all
+select * from queues
+union all
+select * from non_reconnus
+
+{% endmacro %}
+
+
+-- Data test générique (severity: warn côté schema.yml) : 0 anomalie attendue. Le mart
+-- audit_sequences PRODUIT une ligne par anomalie — appliquer ce test au modèle entier
+-- revient donc à vérifier qu'il est vide, sans dupliquer une requête `select * from`.
+{% test aucune_anomalie(model) %}
+select * from {{ model }}
+{% endtest %}

--- a/electricore/ingestion/dbt/models/marts/audit_sequences.sql
+++ b/electricore/ingestion/dbt/models/marts/audit_sequences.sql
@@ -1,0 +1,123 @@
+{{ config(materialized='view') }}
+
+-- Audit de séquences Enedis (#645, PRD #644) : une ligne par anomalie détectée sur les
+-- tables brutes du landing. Deux volets :
+-- 1. Nomenclature (macro `audit_sequences`, brique commune #645/#646, SEUL lieu où
+--    vivent les regexp de nom de zip) : trou de séquence, queue invérifiable, nom non
+--    reconnu — sur l'union des tables brutes portant le numéro de séquence.
+-- 2. Contrôle intra-zip rétrospectif (spécifique ingestion, PAS dans la macro) : chaque
+--    zip atterri a-t-il un XML en base pour chaque rang 1..Y de son compteur
+--    `_XXXXX_YYYYY` ? Attrape un échec de linéarisation isolé que l'escalade d'échec de
+--    chaîne (ADR-0037 étendu) tolère (documents > 0 au flux, mais un fichier manque).
+--
+-- Publications ponctuelles R64/R67 EXCLUES (séquence toujours figée à 00001, hors champ
+-- — cf. macro). C15/R15/C12/X12/X13/F12(détail) portent un compteur intra-zip (au sein
+-- de CHAQUE zip) ; R151 fait exception : son compteur est INTER-zips (un XML par zip,
+-- Y = nombre de zips de la même séquence) — CTE dédiée `r151_*` ci-dessous. X12/X13
+-- partagent `raw_affaires` : l'origine se dérive du nom de zip (même convention que
+-- `stg_affaires`, qui la dérive du file_name).
+
+with source_union as (
+    select 'C15' as flux, _source_zip as nom_zip, file_name from {{ source('flux_raw', 'raw_c15') }}
+    union all
+    select 'R15', _source_zip, file_name from {{ source('flux_raw', 'raw_r15') }}
+    union all
+    select 'F15', _source_zip, file_name from {{ source('flux_raw', 'raw_f15') }}
+    union all
+    select 'F12', _source_zip, file_name from {{ source('flux_raw', 'raw_f12') }}
+    union all
+    select 'R151', _source_zip, file_name from {{ source('flux_raw', 'raw_r151') }}
+    union all
+    select 'C12', _source_zip, file_name from {{ source('flux_raw', 'raw_c12') }}
+    union all
+    select
+        case when _source_zip like '%X12%' then 'X12' else 'X13' end,
+        _source_zip,
+        file_name
+    from {{ source('flux_raw', 'raw_affaires') }}
+),
+
+anomalies_sequences as (
+    {{ audit_sequences('source_union', 'nom_zip') }}
+),
+
+-- Intra-zip (C15/R15/C12/X12/X13/F12) : rang/total = les deux derniers groupes à 5
+-- chiffres du `file_name` (convention `..._XXXXX_YYYYY.xml`, F12 détail `..._FL_XXXXX_YYYYY`).
+intra_zip_brut as (
+    select
+        flux,
+        nom_zip,
+        try_cast(regexp_extract(file_name, '_([0-9]{5})_([0-9]{5})[^0-9]*$', 1) as integer) as rang,
+        try_cast(regexp_extract(file_name, '_([0-9]{5})_([0-9]{5})[^0-9]*$', 2) as integer) as total
+    from source_union
+    where flux in ('C15', 'R15', 'C12', 'X12', 'X13', 'F12')
+),
+
+intra_zip_grp as (
+    select
+        flux,
+        nom_zip,
+        max(total)              as total,
+        count(distinct rang)    as rangs_distincts,
+        min(rang)                as rang_min,
+        max(rang)                as rang_max
+    from intra_zip_brut
+    where rang is not null and total is not null
+    group by flux, nom_zip
+),
+
+intra_zip_anomalies as (
+    select
+        flux,
+        cast(null as varchar)                                              as cle_sequence,
+        'intra_zip_incomplet'                                              as type_anomalie,
+        nom_zip || ' (' || rangs_distincts || '/' || total || ')'          as seq_ou_plage
+    from intra_zip_grp
+    where rangs_distincts <> total or rang_min <> 1 or rang_max <> total
+),
+
+-- R151 : compteur INTER-zips. rang/total viennent du nom du ZIP lui-même (un seul XML
+-- par zip), l'enveloppe est (abonnement, seq) — même clé de séquence que la macro.
+r151_brut as (
+    select
+        regexp_extract(regexp_replace(nom_zip, '\.zip$', ''),
+            '^[^_]+_R151_[^_]+_[^_]+_([^_]+)_([0-9]{5})_[^_]+_[0-9]{5}_[0-9]{5}_[0-9]+$', 1)
+            || '|' ||
+        regexp_extract(regexp_replace(nom_zip, '\.zip$', ''),
+            '^[^_]+_R151_[^_]+_[^_]+_([^_]+)_([0-9]{5})_[^_]+_[0-9]{5}_[0-9]{5}_[0-9]+$', 2)
+                                                                                            as enveloppe,
+        try_cast(regexp_extract(regexp_replace(nom_zip, '\.zip$', ''),
+            '^[^_]+_R151_[^_]+_[^_]+_[^_]+_[0-9]{5}_[^_]+_([0-9]{5})_([0-9]{5})_[0-9]+$', 1) as integer) as rang,
+        try_cast(regexp_extract(regexp_replace(nom_zip, '\.zip$', ''),
+            '^[^_]+_R151_[^_]+_[^_]+_[^_]+_[0-9]{5}_[^_]+_([0-9]{5})_([0-9]{5})_[0-9]+$', 2) as integer) as total
+    from source_union
+    where flux = 'R151'
+),
+
+r151_grp as (
+    select
+        enveloppe,
+        max(total)              as total,
+        count(distinct rang)    as rangs_distincts,
+        min(rang)                as rang_min,
+        max(rang)                as rang_max
+    from r151_brut
+    where enveloppe is not null and rang is not null and total is not null
+    group by enveloppe
+),
+
+r151_anomalies as (
+    select
+        'R151'                                                    as flux,
+        cast(null as varchar)                                     as cle_sequence,
+        'intra_zip_incomplet'                                     as type_anomalie,
+        enveloppe || ' (' || rangs_distincts || '/' || total || ')' as seq_ou_plage
+    from r151_grp
+    where rangs_distincts <> total or rang_min <> 1 or rang_max <> total
+)
+
+select * from anomalies_sequences
+union all
+select * from intra_zip_anomalies
+union all
+select * from r151_anomalies

--- a/electricore/ingestion/dbt/models/marts/schema.yml
+++ b/electricore/ingestion/dbt/models/marts/schema.yml
@@ -105,3 +105,36 @@ models:
           Référence (clé métier ADR-0028) vers `releves` — la relation par laquelle le payload
           d'index est ré-attaché. NULLABLE : une borne sans relevé apparié (releve_manquant)
           ne référence rien (payload nul).
+
+  - name: audit_sequences
+    description: >
+      Audit de séquences Enedis (#645, PRD #644) — VUE, une ligne par anomalie détectée :
+      trou de séquence, queue invérifiable, nom de zip non reconnu (macro `audit_sequences`,
+      brique commune réutilisée par le relais de flux #646) + intra-zip incomplet (contrôle
+      spécifique ingestion, R151 en inter-zips). Publications ponctuelles R64/R67 hors champ
+      (séquence toujours figée à 00001). Voir docs/ingestion.md pour la requête de
+      consultation et les limites (trous « à vérifier », queue jamais saine).
+    data_tests:
+      - aucune_anomalie:
+          config:
+            severity: warn
+    columns:
+      - name: flux
+        description: Code flux Enedis de l'anomalie (C15, R15, F15, F12, R151, C12, X12, X13).
+        data_tests: [not_null]
+      - name: cle_sequence
+        description: >
+          Clé de séquence (préfixée du flux) — NULLABLE : absente pour `nom_non_reconnu`
+          (le nom n'a pas pu être décomposé) et `intra_zip_incomplet` (anomalie par zip, pas
+          par clé de séquence).
+      - name: type_anomalie
+        description: Classification — trou / queue_inverifiable / nom_non_reconnu / intra_zip_incomplet.
+        data_tests:
+          - not_null
+          - accepted_values:
+              values: ["trou", "queue_inverifiable", "nom_non_reconnu", "intra_zip_incomplet"]
+      - name: seq_ou_plage
+        description: >
+          Numéro(s) ou zip concerné(s) — un numéro seul ("00003"), une plage ("00003-00005"),
+          un nom de zip non reconnu, ou un décompte intra-zip ("<zip> (2/3)").
+        data_tests: [not_null]

--- a/electricore/ingestion/dbt/models/marts/schema.yml
+++ b/electricore/ingestion/dbt/models/marts/schema.yml
@@ -115,6 +115,8 @@ models:
       (séquence toujours figée à 00001). Voir docs/ingestion.md pour la requête de
       consultation et les limites (trous « à vérifier », queue jamais saine).
     data_tests:
+      # Warn discriminant : ne compte que les anomalies actionnables (trou, nom_non_reconnu,
+      # intra_zip_incomplet) — les queues, permanentes par nature, en sont exclues (macro).
       - aucune_anomalie:
           config:
             severity: warn

--- a/electricore/ingestion/runner.py
+++ b/electricore/ingestion/runner.py
@@ -232,6 +232,21 @@ def construire_dbt(db_path: Path) -> bool:
     # (C15 + R151/R64) ; `+chronologie_releves` tire ses ancêtres (spine, releves, flux_*).
     if periodiques_ok:
         selection.append("+chronologie_releves")
+    # L'audit de séquences (mart, #645/PRD #644) union TOUTES les tables brutes portant
+    # un numéro de séquence nommé (R64/R67 ponctuels exclus, hors champ des règles) : même
+    # motif que les marts périodiques — on ne le construit que si toutes ses sources sont
+    # matérialisables, sinon dbt échoue sur une source absente (smoke/dev partiel).
+    audit_sequences_ok = {
+        "raw_c15",
+        "raw_r15",
+        "raw_f12",
+        "raw_f15",
+        "raw_r151",
+        "raw_c12",
+        "raw_affaires",
+    } <= presentes
+    if audit_sequences_ok:
+        selection.append("+audit_sequences")
     if not selection:
         _out("  aucune table brute landée — rien à construire")
         return False

--- a/tests/ingestion/test_dbt_audit_sequences.py
+++ b/tests/ingestion/test_dbt_audit_sequences.py
@@ -1,0 +1,314 @@
+"""Audit de séquences Enedis (#645, PRD #644) : macro `audit_sequences` (brique commune,
+regexp de nomenclature + segments + trous + queue + noms non reconnus) et mart
+`audit_sequences` (union des tables brutes + contrôle intra-zip rétrospectif).
+
+Harnais in-process (mécanique, fixtures contrôlées) : lande des documents synthétiques
+dans les tables `raw_*`, `_source_zip` porté par des noms d'archive couvrant chaque
+classe d'anomalie (glossaire, `electricore/ingestion/CONTEXT.md` « Complétude des flux »),
+lance `dbt build --select +audit_sequences`, vérifie les lignes de la vue.
+
+Skip si dbt absent (`uv sync --extra dbt`).
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("dbt.cli.main", reason="dbt absent — uv sync --extra dbt")
+pytest.importorskip("dbt.adapters.duckdb", reason="dbt-duckdb absent — uv sync --extra dbt")
+
+import duckdb  # noqa: E402
+from dbt.cli.main import dbtRunner  # noqa: E402
+
+from electricore.ingestion.parsing.xml import xml_vers_dict  # noqa: E402
+
+RACINE = Path(__file__).parents[2]
+PROJET_DBT = RACINE / "electricore" / "ingestion" / "dbt"
+FIXTURES = RACINE / "tests" / "fixtures" / "flux"
+
+
+def _invoke(commande: list[str], db_path: Path, tmp_path: Path):
+    import os
+
+    ancien = os.environ.get("DBT_DUCKDB_PATH")
+    os.environ["DBT_DUCKDB_PATH"] = str(db_path)
+    try:
+        return dbtRunner().invoke(
+            [
+                *commande,
+                "--project-dir",
+                str(PROJET_DBT),
+                "--profiles-dir",
+                str(PROJET_DBT),
+                "--target-path",
+                str(tmp_path / "target"),
+            ]
+        )
+    finally:
+        if ancien is None:
+            os.environ.pop("DBT_DUCKDB_PATH", None)
+        else:
+            os.environ["DBT_DUCKDB_PATH"] = ancien
+
+
+# Contenu XML réutilisé pour toutes les lignes saines par défaut : seul `_source_zip`
+# (et `file_name`, pour la distinction de clé primaire dlt) varie d'un scénario à l'autre —
+# le CONTENU du document n'a aucune incidence sur l'audit de séquences (qui ne lit que le
+# nom de zip). Un seul document par flux est pré-parsé, réutilisé partout.
+_CONTENUS = {
+    "raw_c15": xml_vers_dict((FIXTURES / "c15_avec_releves.xml").read_bytes()),
+    "raw_r15": xml_vers_dict((FIXTURES / "r15.xml").read_bytes()),
+    "raw_f12": xml_vers_dict((FIXTURES / "f12.xml").read_bytes()),
+    "raw_f15": xml_vers_dict((FIXTURES / "f15.xml").read_bytes()),
+    "raw_r151": xml_vers_dict((FIXTURES / "r151.xml").read_bytes()),
+    "raw_c12": xml_vers_dict((FIXTURES / "c12_xsd.xml").read_bytes()),
+    "raw_affaires": xml_vers_dict((FIXTURES / "affaires_X12.xml").read_bytes()),
+}
+
+# Une ligne saine par flux requis (audit_sequences union les 7 tables) — sert de socle,
+# overridée scénario par scénario par `_construire_audit`.
+_ZIPS_SAINS = {
+    "raw_c15": "17X100A100A0001A_C15_17X000001117366M_GRD-F139_0327_00001_20240530050823.zip",
+    "raw_r15": "17X100A100A0001A_R15_17X000001117366M_GRD-F139_0321_00001_20140923034411.zip",
+    "raw_f12": "ENEDIS_F12_17X000001117366M_GRD-F139_0322_00001_D_30_20240601183412.zip",
+    "raw_f15": "17X100A100A0001A_F15_17X000001117366M_GRD-F139_0321_C_M_1_P_00001_20140923034411.zip",
+    "raw_r151": "ERDF_R151_17X000001117366M_GRD-F139_108529521_00001_Q_00001_00001_20260608030716.zip",
+    "raw_c12": "ENEDIS_C12_17X000001117366M_GRD-F139_00001_20240401091056.zip",
+    "raw_affaires": "ENEDIS_X12_17X000001117366M_00001_20240401091056.zip",
+}
+
+
+def _construire_audit(tmp_path, overrides: dict[str, list[dict]]) -> list[dict]:
+    """Lande une ligne saine par flux requis (overridée par `overrides`), bâtit
+    `+audit_sequences`, retourne les lignes de la vue (liste de dicts)."""
+    import dlt
+
+    from electricore.ingestion.raw_landing import lander_documents_bruts
+
+    db_path = tmp_path / "flux.duckdb"
+    pipeline = dlt.pipeline(
+        pipeline_name="test_audit_sequences",
+        destination=dlt.destinations.duckdb(str(db_path)),
+        dataset_name="flux_raw",
+    )
+    for raw, zip_sain in _ZIPS_SAINS.items():
+        documents = overrides.get(
+            raw,
+            [
+                {
+                    "file_name": f"{raw}_defaut.xml",
+                    "modification_date": "2026-01-01T00:00:00",
+                    "content": _CONTENUS[raw],
+                    "_source_zip": zip_sain,
+                }
+            ],
+        )
+        lander_documents_bruts(pipeline, raw, documents)
+
+    res = _invoke(["build", "--select", "+audit_sequences"], db_path, tmp_path)
+    assert res.success, f"dbt build +audit_sequences a échoué : {res.exception}"
+
+    con = duckdb.connect(str(db_path))
+    cur = con.execute("select * from flux_enedis.audit_sequences")
+    cols = [d[0] for d in cur.description]
+    lignes = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+    con.close()
+    return lignes
+
+
+def _doc(raw: str, file_name: str, zip_name: str) -> dict:
+    return {
+        "file_name": file_name,
+        "modification_date": "2026-01-01T00:00:00",
+        "content": _CONTENUS[raw],
+        "_source_zip": zip_name,
+    }
+
+
+def test_socle_sans_anomalie(tmp_path):
+    """Un landing entièrement sain (une archive par clé, aucun trou) ne produit AUCUNE
+    ligne de type 'trou' — seule la queue invérifiable de chaque clé est présente
+    (jamais 0 ligne du tout : le dernier numéro observé est toujours signalé)."""
+    lignes = _construire_audit(tmp_path, {})
+    types = {ligne["type_anomalie"] for ligne in lignes}
+    assert "trou" not in types
+    assert "nom_non_reconnu" not in types
+    assert "intra_zip_incomplet" not in types
+    assert "queue_inverifiable" in types  # jamais 0 ligne : la queue est toujours signalée
+
+
+def test_trou_franc_detecte(tmp_path):
+    """Un numéro absent ENTRE deux numéros observés d'une même clé C15 → 'trou'."""
+    prefix = "17X100A100A0001A_C15_17X000001117366M_GRD-F139_0327_{seq}_2024010{j}000000.zip"
+    docs = [
+        _doc("raw_c15", "c15_1.xml", prefix.format(seq="00001", j=1)),
+        _doc("raw_c15", "c15_2.xml", prefix.format(seq="00002", j=2)),
+        # 00003 manque
+        _doc("raw_c15", "c15_4.xml", prefix.format(seq="00004", j=4)),
+    ]
+    lignes = _construire_audit(tmp_path, {"raw_c15": docs})
+    trous = [ligne for ligne in lignes if ligne["flux"] == "C15" and ligne["type_anomalie"] == "trou"]
+    assert len(trous) == 1
+    assert trous[0]["seq_ou_plage"] == "00003"
+    assert trous[0]["cle_sequence"] == "C15|GRD-F139|0327"
+
+
+def test_redemarrage_f15_ginko_v2_pas_un_trou(tmp_path):
+    """Un redémarrage à 00001 (F15/Ginko v2) — numéro qui repart en arrière
+    CHRONOLOGIQUEMENT — n'est PAS un trou."""
+    docs = [
+        _doc(
+            "raw_f15",
+            "f15_1.xml",
+            "17X100A100A0001A_F15_17X000001117366M_GRD-F139_0321_C_M_1_P_99998_20240101000000.zip",
+        ),
+        _doc(
+            "raw_f15",
+            "f15_2.xml",
+            "17X100A100A0001A_F15_17X000001117366M_GRD-F139_0321_C_M_1_P_99999_20240102000000.zip",
+        ),
+        _doc(
+            "raw_f15",
+            "f15_3.xml",
+            "17X100A100A0001A_F15_17X000001117366M_GRD-F139_0321_C_M_1_P_00001_20240201000000.zip",
+        ),
+    ]
+    lignes = _construire_audit(tmp_path, {"raw_f15": docs})
+    trous_f15 = [ligne for ligne in lignes if ligne["flux"] == "F15" and ligne["type_anomalie"] == "trou"]
+    assert trous_f15 == []
+    # La queue invérifiable suit le redémarrage (le numéro le plus RÉCENT, pas le plus grand).
+    queue_f15 = [ligne for ligne in lignes if ligne["flux"] == "F15" and ligne["type_anomalie"] == "queue_inverifiable"]
+    assert len(queue_f15) == 1
+    assert queue_f15[0]["seq_ou_plage"] == "00001"
+
+
+def test_queue_toujours_signalee_jamais_saine(tmp_path):
+    """Le dernier numéro observé d'une clé est TOUJOURS en 'queue_inverifiable' —
+    même sur un landing par ailleurs sans aucun trou (jamais déclaré sain)."""
+    docs = [
+        _doc(
+            "raw_c15",
+            "c15_1.xml",
+            "17X100A100A0001A_C15_17X000001117366M_GRD-F139_0327_00001_20240101000000.zip",
+        ),
+        _doc(
+            "raw_c15",
+            "c15_2.xml",
+            "17X100A100A0001A_C15_17X000001117366M_GRD-F139_0327_00002_20240102000000.zip",
+        ),
+    ]
+    lignes = _construire_audit(tmp_path, {"raw_c15": docs})
+    queues = [ligne for ligne in lignes if ligne["flux"] == "C15" and ligne["type_anomalie"] == "queue_inverifiable"]
+    assert len(queues) == 1
+    assert queues[0]["seq_ou_plage"] == "00002"
+
+
+def test_nom_de_zip_non_reconnu_jamais_ignore(tmp_path):
+    """Un nom de zip hors nomenclature apparaît dans la vue avec le type dédié — jamais
+    silencieusement ignoré."""
+    docs = [
+        _doc("raw_c15", "c15_ok.xml", _ZIPS_SAINS["raw_c15"]),
+        _doc("raw_c15", "c15_bizarre.xml", "un_nom_de_zip_totalement_hors_nomenclature.zip"),
+    ]
+    lignes = _construire_audit(tmp_path, {"raw_c15": docs})
+    non_reconnus = [ligne for ligne in lignes if ligne["type_anomalie"] == "nom_non_reconnu"]
+    assert len(non_reconnus) == 1
+    assert non_reconnus[0]["seq_ou_plage"] == "un_nom_de_zip_totalement_hors_nomenclature.zip"
+    assert non_reconnus[0]["cle_sequence"] is None
+
+
+def test_intra_zip_rang_manquant_detecte(tmp_path):
+    """Un zip C15 dont le compteur intra-zip `_XXXXX_YYYYY` annonce 3 fichiers mais dont
+    seuls 2 ont atterri en base → 'intra_zip_incomplet' (échec de linéarisation isolé
+    que l'escalade d'échec de chaîne tolère)."""
+    zip_name = "17X100A100A0001A_C15_17X000001117366M_GRD-F139_0327_00001_20240101000000.zip"
+    docs = [
+        _doc("raw_c15", "17X100A100A0001A_C15_17X000001117366M_GRD-F139_00017_00001_00003.xml", zip_name),
+        _doc("raw_c15", "17X100A100A0001A_C15_17X000001117366M_GRD-F139_00017_00002_00003.xml", zip_name),
+        # rang 00003 manque (annoncé par YYYYY=00003)
+    ]
+    lignes = _construire_audit(tmp_path, {"raw_c15": docs})
+    incomplets = [
+        ligne for ligne in lignes if ligne["flux"] == "C15" and ligne["type_anomalie"] == "intra_zip_incomplet"
+    ]
+    assert len(incomplets) == 1
+    assert zip_name in incomplets[0]["seq_ou_plage"]
+    assert "2/3" in incomplets[0]["seq_ou_plage"]
+
+
+def test_intra_zip_complet_pas_d_anomalie(tmp_path):
+    """Les 3 rangs 1..3 annoncés sont tous landés → pas d'anomalie intra-zip."""
+    zip_name = "17X100A100A0001A_C15_17X000001117366M_GRD-F139_0327_00001_20240101000000.zip"
+    docs = [
+        _doc("raw_c15", "17X100A100A0001A_C15_17X000001117366M_GRD-F139_00017_00001_00003.xml", zip_name),
+        _doc("raw_c15", "17X100A100A0001A_C15_17X000001117366M_GRD-F139_00017_00002_00003.xml", zip_name),
+        _doc("raw_c15", "17X100A100A0001A_C15_17X000001117366M_GRD-F139_00017_00003_00003.xml", zip_name),
+    ]
+    lignes = _construire_audit(tmp_path, {"raw_c15": docs})
+    incomplets = [ligne for ligne in lignes if ligne["type_anomalie"] == "intra_zip_incomplet"]
+    assert incomplets == []
+
+
+def test_r151_inter_zips_rang_manquant_detecte(tmp_path):
+    """R151 : le compteur est INTER-zips (un XML par zip). 2 zips annoncés (YYYYY=00002)
+    pour la même séquence, un seul atterri → 'intra_zip_incomplet'."""
+    docs = [
+        _doc(
+            "raw_r151",
+            "r151_1.xml",
+            "ERDF_R151_17X000001117366M_GRD-F139_108529521_00794_Q_00001_00002_20260608030716.zip",
+        ),
+        # zip XXXXX=00002/00002 jamais atterri
+    ]
+    lignes = _construire_audit(tmp_path, {"raw_r151": docs})
+    incomplets = [
+        ligne for ligne in lignes if ligne["flux"] == "R151" and ligne["type_anomalie"] == "intra_zip_incomplet"
+    ]
+    assert len(incomplets) == 1
+    assert "1/2" in incomplets[0]["seq_ou_plage"]
+
+
+def test_r151_inter_zips_complet_pas_d_anomalie(tmp_path):
+    docs = [
+        _doc(
+            "raw_r151",
+            "r151_1.xml",
+            "ERDF_R151_17X000001117366M_GRD-F139_108529521_00794_Q_00001_00002_20260608030716.zip",
+        ),
+        _doc(
+            "raw_r151",
+            "r151_2.xml",
+            "ERDF_R151_17X000001117366M_GRD-F139_108529521_00794_Q_00002_00002_20260608030823.zip",
+        ),
+    ]
+    lignes = _construire_audit(tmp_path, {"raw_r151": docs})
+    incomplets = [
+        ligne for ligne in lignes if ligne["flux"] == "R151" and ligne["type_anomalie"] == "intra_zip_incomplet"
+    ]
+    assert incomplets == []
+
+
+def test_x13_derive_du_nom_de_zip(tmp_path):
+    """`raw_affaires` sert X12 ET X13, distingués par le nom de zip (même convention que
+    `stg_affaires` sur file_name) : une clé de séquence X13 apparaît sous flux='X13'."""
+    docs = [
+        _doc("raw_affaires", "x13.xml", "ENEDIS_X13_17X000001117366M_00001_20240401091056.zip"),
+    ]
+    lignes = _construire_audit(tmp_path, {"raw_affaires": docs})
+    cles_x13 = {ligne["cle_sequence"] for ligne in lignes if ligne["flux"] == "X13"}
+    assert any(cle is not None and cle.startswith("X13|") for cle in cles_x13)
+
+
+def test_data_test_severity_warn_zero_anomalie_sur_landing_partiel(tmp_path):
+    """Le data test `aucune_anomalie` tourne en `warn` : sur un landing avec un trou franc,
+    `dbt build` reste GLOBALEMENT réussi (warning, pas d'échec) — c'est l'invariant du
+    critère d'acceptation (le job ne casse jamais dessus)."""
+    prefix = "17X100A100A0001A_C15_17X000001117366M_GRD-F139_0327_{seq}_2024010{j}000000.zip"
+    docs = [
+        _doc("raw_c15", "c15_1.xml", prefix.format(seq="00001", j=1)),
+        _doc("raw_c15", "c15_3.xml", prefix.format(seq="00003", j=3)),
+    ]
+    # `_construire_audit` asserte déjà `res.success` — un data test `warn` qui ferait
+    # échouer le build romprait ce test avant même d'atteindre les assertions ci-dessous.
+    lignes = _construire_audit(tmp_path, {"raw_c15": docs})
+    assert any(ligne["type_anomalie"] == "trou" for ligne in lignes)

--- a/tests/ingestion/test_dbt_audit_sequences.py
+++ b/tests/ingestion/test_dbt_audit_sequences.py
@@ -312,3 +312,12 @@ def test_data_test_severity_warn_zero_anomalie_sur_landing_partiel(tmp_path):
     # échouer le build romprait ce test avant même d'atteindre les assertions ci-dessous.
     lignes = _construire_audit(tmp_path, {"raw_c15": docs})
     assert any(ligne["type_anomalie"] == "trou" for ligne in lignes)
+
+
+def test_base_saine_aucune_anomalie_actionnable(tmp_path):
+    """Pas de trou dans le vérifiable = valide : sur un landing sain, la vue ne contient
+    QUE des queues (état permanent de toute séquence ouverte, exclues du data test warn) —
+    le warn est discriminant : silencieux ici, il ne tire que sur une anomalie actionnable."""
+    lignes = _construire_audit(tmp_path, {})
+    assert lignes, "une queue par clé de séquence est attendue même sur base saine"
+    assert {ligne["type_anomalie"] for ligne in lignes} == {"queue_inverifiable"}

--- a/tests/ingestion/test_dbt_releves_golden.py
+++ b/tests/ingestion/test_dbt_releves_golden.py
@@ -51,6 +51,7 @@ def base_periodiques(tmp_path, monkeypatch):
                 "file_name": "r151.xml",
                 "modification_date": "2026-01-01T00:00:00",
                 "content": xml_vers_dict((FIXTURES / "r151.xml").read_bytes()),
+                "_source_zip": ("ERDF_R151_17X000001117366M_GRD-F139_108529521_00001_Q_00001_00001_20260608030716.zip"),
             }
         ],
     )
@@ -73,9 +74,53 @@ def base_periodiques(tmp_path, monkeypatch):
                 "file_name": "c15_avec_releves.xml",
                 "modification_date": "2026-01-01T00:00:00",
                 "content": xml_vers_dict((FIXTURES / "c15_avec_releves.xml").read_bytes()),
+                "_source_zip": "17X100A100A0001A_C15_17X000001117366M_GRD-F139_0327_00011_20240530050823.zip",
             }
         ],
     )
+    # Le reste des flux (R15/F12/F15/C12/X12) n'apporte rien à `releves`/`spine_contrat` —
+    # landé uniquement pour que `audit_sequences` (#645) ait toutes ses sources et entre
+    # dans le périmètre de la garde anti-dérive `test_construire_dbt_materialise_tous_les_marts`
+    # ci-dessous (sinon ce mart, comme tout mart aux sources partielles, resterait absent).
+    for raw, fixture, zip_name in [
+        (
+            "raw_r15",
+            "r15.xml",
+            "17X100A100A0001A_R15_17X000001117366M_GRD-F139_0321_00001_20140923034411.zip",
+        ),
+        (
+            "raw_f12",
+            "f12.xml",
+            "ENEDIS_F12_17X000001117366M_GRD-F139_0322_00001_D_30_20240601183412.zip",
+        ),
+        (
+            "raw_f15",
+            "f15.xml",
+            "17X100A100A0001A_F15_17X000001117366M_GRD-F139_0321_C_M_1_P_00001_20140923034411.zip",
+        ),
+        (
+            "raw_c12",
+            "c12_xsd.xml",
+            "ENEDIS_C12_17X000001117366M_GRD-F139_00001_20240401091056.zip",
+        ),
+        (
+            "raw_affaires",
+            "affaires_X12.xml",
+            "ENEDIS_X12_17X000001117366M_00001_20240401091056.zip",
+        ),
+    ]:
+        lander_documents_bruts(
+            pipeline,
+            raw,
+            [
+                {
+                    "file_name": fixture,
+                    "modification_date": "2026-01-01T00:00:00",
+                    "content": xml_vers_dict((FIXTURES / fixture).read_bytes()),
+                    "_source_zip": zip_name,
+                }
+            ],
+        )
     monkeypatch.setenv("DBT_DUCKDB_PATH", str(db_path))
     return db_path
 


### PR DESCRIPTION
Closes #645

Ajoute l'audit de séquences (PRD #644) : une macro dbt unique (`macros/audit_sequences.sql`)
portant toutes les règles de nomenclature Enedis — regexp par flux, clé de séquence,
découpage en segments, trous, queue invérifiable, noms non reconnus — brique commune
réutilisable telle quelle par le relais de flux (#646). Le mart `audit_sequences` (view)
l'appelle sur l'union des tables brutes du landing et ajoute le contrôle intra-zip
rétrospectif (C15/R15/C12/X12/X13/F12 en intra-zip, R151 en inter-zips). Data test
`aucune_anomalie` en `severity: warn` : trace les trous sans jamais casser le build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)