### PR TITLE
feat(notebooks): turpe_cta_complet (local) + bump 3.7.0

### DIFF
--- a/notebooks/turpe_cta_complet.py
+++ b/notebooks/turpe_cta_complet.py
@@ -1,0 +1,93 @@
+"""TURPE + CTA parc complet — sans jointure Odoo (analyse rapide, non embarqué dans le wheel).
+
+Lit directement le DuckDB local via `contexte_du_mois()` : tout le parc du flux
+Enedis, tous les mois, `turpe_fixe_eur` / `turpe_variable_eur` + `cta_eur`
+(assiette = TURPE fixe). Lancer : `uv run marimo edit notebooks/turpe_cta_complet.py`
+"""
+
+import marimo
+
+__generated_with = "0.21.1"
+app = marimo.App(width="medium")
+
+with app.setup:
+    import marimo as mo
+    import polars as pl
+
+    from electricore.core.builds.contexte_mensuel import contexte_du_mois
+    from electricore.core.pipelines.cta import ajouter_cta
+    from electricore.core.pipelines.facturation import expr_calculer_trimestre
+
+
+@app.cell
+def _():
+    ctx = contexte_du_mois()  # parc entier, tous les mois disponibles
+    detail = (
+        ajouter_cta(ctx.facturation_mensuelle.lazy())
+        .with_columns(expr_calculer_trimestre().alias("trimestre"))
+        .select(
+            "ref_situation_contractuelle",
+            "pdl",
+            "mois_annee",
+            "trimestre",
+            "turpe_fixe_eur",
+            "turpe_variable_eur",
+            "taux_cta_pct",
+            "cta_eur",
+        )
+        .sort("pdl", "mois_annee")
+        .collect()
+    )
+    mo.md(f"**{detail['pdl'].n_unique()} PDL** × {detail['mois_annee'].n_unique()} mois — {detail.height} lignes")
+    return (detail,)
+
+
+@app.cell
+def _(detail):
+    par_mois = (
+        detail.group_by("mois_annee")
+        .agg(
+            pl.len().alias("nb_lignes"),
+            pl.col("turpe_fixe_eur").sum().round(2),
+            pl.col("turpe_variable_eur").sum().round(2),
+            pl.col("cta_eur").sum().round(2),
+        )
+        .sort("mois_annee")
+    )
+    par_mois
+    return (par_mois,)
+
+
+@app.cell
+def _(detail):
+    par_trimestre = (
+        detail.group_by("trimestre")
+        .agg(
+            pl.col("turpe_fixe_eur").sum().round(2),
+            pl.col("turpe_variable_eur").sum().round(2),
+            pl.col("cta_eur").sum().round(2),
+        )
+        .sort("trimestre")
+    )
+    par_trimestre
+    return (par_trimestre,)
+
+
+@app.cell
+def _(detail):
+    detail
+    return
+
+
+@app.cell
+def _(detail):
+    mo.download(
+        detail.write_csv().encode(),
+        filename="turpe_cta_complet.csv",
+        label="⬇️ Télécharger le détail (CSV)",
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.7.0rc3"
+version = "3.7.0"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.7.0rc3"
+version = "3.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Quoi

Notebook marimo **local** d'analyse `turpe_cta_complet` : TURPE fixe/variable + CTA sur le **parc entier** du flux Enedis, sans la jointure Odoo du `pipeline_cta` legacy (qui restreint les rapports `/taxes/cta/*` au sous-périmètre des commandes Odoo).

- Lit le DuckDB local via `contexte_du_mois()`, CTA via `ajouter_cta()` (la brique ERP-agnostique, pas le pipeline legacy)
- Détail RSC × mois : `turpe_fixe_eur`, `turpe_variable_eur`, `taux_cta_pct`, `cta_eur`, trimestre ; agrégats mois + trimestre ; export CSV
- Vérifié sur base locale : 1372 PDL, 16 833 lignes
- **Hors wheel** (pas de force-include) : outil d'analyse local, pas un notebook opérateur — il exige un DuckDB local

La version **distante** (servie par `electricore-notebooks`, données via l'API) est déférée : elle demande un endpoint parc entier cohérent avec la famille `facturation` ERP-tire, pas avec le legacy — voir l'issue de cadrage liée.

## Release

Bump `3.7.0rc3 → 3.7.0`. ⚠️ Depuis la rc3, `main` a gagné le relais Haulogy (#643) et l'audit de séquences (#645) : le tag `v3.7.0` posé sur main post-merge les embarquera — ce n'est plus une promotion byte-identique de la rc3 testée. Si tu préfères passer par une `3.7.0rc4` d'abord, dis-le en commentaire et j'amende le bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)