### PR TITLE
fix(ci): épingle ruff 0.15.15 sur le job lint — aligne sur pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # Version épinglée sur .pre-commit-config.yaml : non épinglée, l'action tire
+      # le dernier ruff (0.16.0 s'est mis à formater les .md → main rouge le 27/07).
       - uses: astral-sh/ruff-action@v3
         with:
+          version: "0.15.15"
           args: "check"
       - uses: astral-sh/ruff-action@v3
         with:
+          version: "0.15.15"
           args: "format --check"
 
   typecheck:


### PR DESCRIPTION
## Contexte

La CI de main est passée au rouge sur `34d8bad` (merge de #652) **sans lien avec le code mergé** : le job `lint (ruff)` n'épingle pas de version, et `ruff-action` tire le dernier ruff. La 0.16.0 (sortie cette semaine, dernier run vert = 0.15.22 le 21/07) vérifie désormais le formatage des blocs de code **Markdown** → 13 `.md` préexistants en échec (CLAUDE.md, docs/, READMEs), zéro fichier Python.

## Fix

Épingle `version: "0.15.15"` sur les deux invocations de `ruff-action`, alignée sur le `rev: v0.15.15` de `.pre-commit-config.yaml` — une seule vérité locale/CI. Monter ruff redevient un geste délibéré : bump pre-commit + CI ensemble, avec le reformat des .md qui va avec.

## Note release

C'est le dernier verrou avant le tag `v3.7.0` : le bump est déjà sur main, la CI de `34d8bad` est verte partout sauf ce job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)