### PR TITLE
feat(deploy): relais — hook mail OnFailure, alerte shell+msmtp via token SMTP Proton (#659)

### DIFF
--- a/deploy/relais/README.md
+++ b/deploy/relais/README.md
@@ -23,20 +23,31 @@ RELAIS__PARTNER_URL=sftp://relais@partenaire.example/in
 RELAIS__DESTINATION_DB=/opt/electricore-relais/relais.duckdb
 RELAIS__FLUX=C15,R151,R15,F12,F15   # phase 1 : liste explicite, vide = tous
 AES__TROUSSEAU__aes256_2026__KEY=...
+RELAIS_ALERTE_MAILS=alertes-ops@example.fr   # CSV, alerte OnFailure= (#659, voir plus bas)
 ENV
 sudo chmod 600 /etc/electricore-relais/relais.env
 
-# 3. Auth SFTP partenaire : clé SSH ed25519 DÉDIÉE (jamais de mot de passe en dur),
+# 3. Alerte mail (#659) : installer msmtp, écrire /etc/electricore-relais/msmtprc
+#    (token SMTP Proton — contenu complet dans la section « Alerte mail
+#    (OnFailure=, #659) » plus bas de ce README), puis chmod 600 + poser le script.
+sudo apt install -y msmtp
+sudo $EDITOR /etc/electricore-relais/msmtprc   # coller le contenu de la section plus bas
+sudo chmod 600 /etc/electricore-relais/msmtprc
+sudo cp electricore-relais-alerte.sh /usr/local/bin/
+sudo chmod +x /usr/local/bin/electricore-relais-alerte.sh
+
+# 4. Auth SFTP partenaire : clé SSH ed25519 DÉDIÉE (jamais de mot de passe en dur),
 #    générée pour ce seul usage — pas de réutilisation d'une clé d'ingestion existante.
 
-# 4. Amorçage (#643) : marque l'historique existant comme livré SANS le pousser au
+# 5. Amorçage (#643) : marque l'historique existant comme livré SANS le pousser au
 #    partenaire — acte UNIQUE, à faire une fois avant d'activer le timer (sinon le
 #    premier run pousserait tout l'historique). Refuse s'il y a déjà des livraisons.
 sudo -u electricore-relais env $(cat /etc/electricore-relais/relais.env | xargs) \
   python -m electricore.ingestion.relais seed --avant 2026-06-01
 
-# 5. Units
-sudo cp electricore-relais.service electricore-relais.timer /etc/systemd/system/
+# 6. Units (le service d'alerte n'est PAS activé : déclenché uniquement par
+#    OnFailure=, jamais par le timer ni par enable --now)
+sudo cp electricore-relais.service electricore-relais-alerte.service electricore-relais.timer /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now electricore-relais.timer
 ```
@@ -71,6 +82,91 @@ con = duckdb.connect('/opt/electricore-relais/relais.duckdb')
 print(con.execute('select * from journal.relais_audit_sequences').fetchall())
 "
 ```
+
+## Alerte mail (`OnFailure=`, #659)
+
+Quand `electricore-relais.service` échoue (run aveugle, #643 — voir
+`electricore/ingestion/relais/pipeline.py`), `OnFailure=` déclenche
+`electricore-relais-alerte.service` : un mail part vers `RELAIS_ALERTE_MAILS`
+sans que personne n'ait à regarder `systemctl status`. Le hook est un simple
+script shell + [msmtp](https://marlam.de/msmtp/), délibérément sans Python — le
+scénario où l'alerte est la plus nécessaire est celui où le venv du relais est
+cassé.
+
+### Installer msmtp
+
+```bash
+sudo apt install -y msmtp   # paquet système, aucune dépendance Python
+```
+
+### Configurer `/etc/electricore-relais/msmtprc`
+
+Le SMTP submission de Proton (`smtp.protonmail.ch:587`, STARTTLS) authentifie par
+**token SMTP**, pas par le mot de passe du compte — **exclusif aux adresses du
+domaine custom `electricore.fr`** (les adresses @proton.me / @pm.me n'ont pas
+cette fonctionnalité) :
+
+1. Proton → Settings → SMTP submission (sous le domaine custom `electricore.fr`)
+2. Générer un token pour l'adresse d'envoi (ex. `alertes@electricore.fr`)
+3. Coller ce token comme `password` ci-dessous — **jamais** le mot de passe du compte
+
+```
+defaults
+tls on
+tls_starttls on
+
+account electricore-relais
+host smtp.protonmail.ch
+port 587
+auth on
+from alertes@electricore.fr
+user alertes@electricore.fr
+password <token SMTP Proton>
+
+account default : electricore-relais
+```
+
+```bash
+sudo chmod 600 /etc/electricore-relais/msmtprc
+```
+
+Aucun secret dans le repo : le token ne vit que dans ce fichier local en 600.
+
+### Destinataires
+
+Une seule variable, dans le **même** fichier d'env que le relais
+(`/etc/electricore-relais/relais.env`) — le domaine runtime pydantic du relais
+est en `extra="ignore"` (voir `electricore/config/runtime.py`), donc
+`RELAIS_ALERTE_MAILS` cohabite avec `RELAIS__*` sans aucune modification de
+code Python :
+
+```bash
+RELAIS_ALERTE_MAILS=alice@example.fr,bob@example.fr
+```
+
+Modifier la liste = éditer cette seule ligne, sans toucher aux unités ni au script.
+
+### Tester la chaîne
+
+```bash
+sudo cp electricore-relais-alerte.sh /usr/local/bin/
+sudo chmod +x /usr/local/bin/electricore-relais-alerte.sh
+sudo cp electricore-relais-alerte.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl start electricore-relais-alerte.service   # → le mail doit arriver
+```
+
+## Générale : l'état ne survit pas (PRD #658)
+
+> **L'état d'une générale ne survit jamais à la générale.**
+
+Pendant une répétition (générale, PRD #658) sur le VPS partenaire, on pointe
+`RELAIS__DESTINATION_DB` dans un répertoire dédié **jetable** — ça isole aussi
+l'état dlt, `pipelines_dir` étant épinglé sur son parent (voir
+`electricore/ingestion/relais/pipeline.py`). En fin de générale, ce répertoire
+est **détruit**. Sans cette destruction, tout zip marqué « livré » au faux
+partenaire de la répétition le resterait **à vie** dans un état qui n'aurait
+jamais dû exister — et le vrai partenaire ne le recevrait alors jamais.
 
 ## Pourquoi systemd et pas docker compose / crontab.example
 

--- a/deploy/relais/README.md
+++ b/deploy/relais/README.md
@@ -23,7 +23,9 @@ RELAIS__PARTNER_URL=sftp://relais@partenaire.example/in
 RELAIS__DESTINATION_DB=/opt/electricore-relais/relais.duckdb
 RELAIS__FLUX=C15,R151,R15,F12,F15   # phase 1 : liste explicite, vide = tous
 AES__TROUSSEAU__aes256_2026__KEY=...
-RELAIS_ALERTE_MAILS=alertes-ops@example.fr   # CSV, alerte OnFailure= (#659, voir plus bas)
+# CSV, destinataires de l'alerte OnFailure= (#659, voir plus bas). Commentaire sur sa
+# PROPRE ligne : systemd n'ignore un « # » qu'en début de ligne — en fin de ligne il entre dans la valeur.
+RELAIS_ALERTE_MAILS=alertes-ops@example.fr
 ENV
 sudo chmod 600 /etc/electricore-relais/relais.env
 

--- a/deploy/relais/README.md
+++ b/deploy/relais/README.md
@@ -30,7 +30,7 @@ ENV
 sudo chmod 600 /etc/electricore-relais/relais.env
 
 # 3. Alerte mail (#659) : installer msmtp, écrire /etc/electricore-relais/msmtprc
-#    (mot de passe de la boîte OVH — contenu complet dans la section « Alerte mail
+#    (token SMTP Proton — contenu complet dans la section « Alerte mail
 #    (OnFailure=, #659) » plus bas de ce README), puis chmod 600 + poser le script.
 sudo apt install -y msmtp
 sudo $EDITOR /etc/electricore-relais/msmtprc   # coller le contenu de la section plus bas
@@ -103,13 +103,19 @@ sudo apt install -y msmtp   # paquet système, aucune dépendance Python
 
 ### Configurer `/etc/electricore-relais/msmtprc`
 
-L'envoi sort par une **boîte OVH du domaine** (`ssl0.ovh.net:587`, STARTTLS) :
-`electricore.fr` a déjà ses MX chez OVH et son SPF (`include:mx.ovh.com`) couvre
-cet envoi — **aucun changement DNS**, la délivrabilité est celle d'OVH.
+Le SMTP submission de Proton (`smtp.protonmail.ch:587`, STARTTLS) authentifie par
+**token SMTP**, pas par le mot de passe du compte — **exclusif aux adresses du
+domaine custom `electricore.fr`** (les adresses @proton.me / @pm.me n'ont pas
+cette fonctionnalité).
 
-1. Manager OVH → Web Cloud → E-mails (`electricore.fr`) : créer la boîte d'envoi
-   (ex. `alertes@electricore.fr`) avec un mot de passe dédié à cet usage
-2. Coller ce mot de passe comme `password` ci-dessous
+Prérequis one-shot déjà fait (27/07/2026, à refaire seulement si le domaine change
+de main) : `electricore.fr` rattaché à Proton Mail — TXT de vérification, MX Proton
+(les MX OVH retirés, l'offre « redirect » n'avait aucun compte), SPF
+`v=spf1 include:_spf.protonmail.ch -all`, 3 CNAME DKIM. Ensuite :
+
+1. Proton → Settings → SMTP submission (sous le domaine custom `electricore.fr`)
+2. Générer un token pour l'adresse d'envoi (ex. `alertes@electricore.fr`)
+3. Coller ce token comme `password` ci-dessous — **jamais** le mot de passe du compte
 
 ```
 defaults
@@ -117,12 +123,12 @@ tls on
 tls_starttls on
 
 account electricore-relais
-host ssl0.ovh.net
+host smtp.protonmail.ch
 port 587
 auth on
 from alertes@electricore.fr
 user alertes@electricore.fr
-password <mot de passe de la boîte OVH>
+password <token SMTP Proton>
 
 account default : electricore-relais
 ```
@@ -131,7 +137,7 @@ account default : electricore-relais
 sudo chmod 600 /etc/electricore-relais/msmtprc
 ```
 
-Aucun secret dans le repo : le mot de passe ne vit que dans ce fichier local en 600.
+Aucun secret dans le repo : le token ne vit que dans ce fichier local en 600.
 
 ### Destinataires
 

--- a/deploy/relais/README.md
+++ b/deploy/relais/README.md
@@ -30,7 +30,7 @@ ENV
 sudo chmod 600 /etc/electricore-relais/relais.env
 
 # 3. Alerte mail (#659) : installer msmtp, écrire /etc/electricore-relais/msmtprc
-#    (token SMTP Proton — contenu complet dans la section « Alerte mail
+#    (mot de passe de la boîte OVH — contenu complet dans la section « Alerte mail
 #    (OnFailure=, #659) » plus bas de ce README), puis chmod 600 + poser le script.
 sudo apt install -y msmtp
 sudo $EDITOR /etc/electricore-relais/msmtprc   # coller le contenu de la section plus bas
@@ -103,14 +103,13 @@ sudo apt install -y msmtp   # paquet système, aucune dépendance Python
 
 ### Configurer `/etc/electricore-relais/msmtprc`
 
-Le SMTP submission de Proton (`smtp.protonmail.ch:587`, STARTTLS) authentifie par
-**token SMTP**, pas par le mot de passe du compte — **exclusif aux adresses du
-domaine custom `electricore.fr`** (les adresses @proton.me / @pm.me n'ont pas
-cette fonctionnalité) :
+L'envoi sort par une **boîte OVH du domaine** (`ssl0.ovh.net:587`, STARTTLS) :
+`electricore.fr` a déjà ses MX chez OVH et son SPF (`include:mx.ovh.com`) couvre
+cet envoi — **aucun changement DNS**, la délivrabilité est celle d'OVH.
 
-1. Proton → Settings → SMTP submission (sous le domaine custom `electricore.fr`)
-2. Générer un token pour l'adresse d'envoi (ex. `alertes@electricore.fr`)
-3. Coller ce token comme `password` ci-dessous — **jamais** le mot de passe du compte
+1. Manager OVH → Web Cloud → E-mails (`electricore.fr`) : créer la boîte d'envoi
+   (ex. `alertes@electricore.fr`) avec un mot de passe dédié à cet usage
+2. Coller ce mot de passe comme `password` ci-dessous
 
 ```
 defaults
@@ -118,12 +117,12 @@ tls on
 tls_starttls on
 
 account electricore-relais
-host smtp.protonmail.ch
+host ssl0.ovh.net
 port 587
 auth on
 from alertes@electricore.fr
 user alertes@electricore.fr
-password <token SMTP Proton>
+password <mot de passe de la boîte OVH>
 
 account default : electricore-relais
 ```
@@ -132,7 +131,7 @@ account default : electricore-relais
 sudo chmod 600 /etc/electricore-relais/msmtprc
 ```
 
-Aucun secret dans le repo : le token ne vit que dans ce fichier local en 600.
+Aucun secret dans le repo : le mot de passe ne vit que dans ce fichier local en 600.
 
 ### Destinataires
 

--- a/deploy/relais/electricore-relais-alerte.service
+++ b/deploy/relais/electricore-relais-alerte.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Alerte mail sur échec du relais (OnFailure=, #659, PRD #658)
+# Déclenchée exclusivement par OnFailure=electricore-relais-alerte.service posé
+# sur electricore-relais.service — jamais lancée directement par le timer.
+
+[Service]
+Type=oneshot
+# Pas de User= : root par défaut, nécessaire pour lire le journal de l'unité du
+# relais (journalctl -u electricore-relais.service) et le fichier env en 600.
+# Même fichier d'env que le relais (décision #659) : modifier les destinataires
+# se fait en éditant ce seul fichier, sans toucher aux unités ni au script.
+EnvironmentFile=/etc/electricore-relais/relais.env
+ExecStart=/usr/local/bin/electricore-relais-alerte.sh

--- a/deploy/relais/electricore-relais-alerte.sh
+++ b/deploy/relais/electricore-relais-alerte.sh
@@ -13,11 +13,14 @@ if [[ -z "${RELAIS_ALERTE_MAILS:-}" ]]; then
     exit 0
 fi
 
-sujet="[electricore] échec de ${UNIT} sur $(hostname)"
+# ${HOSTNAME} (posé par bash lui-même) et pas $(hostname) : sous set -e, un binaire
+# hostname absent ou en échec tuerait le script AVANT le moindre envoi.
+sujet="[electricore] échec de ${UNIT} sur ${HOSTNAME:-inconnu}"
 corps="$(journalctl -u "$UNIT" --no-pager -n 50 2>/dev/null)" || corps="(journalctl indisponible pour ${UNIT})"
 
-# CSV → tableau bash : msmtp attend les destinataires en arguments séparés.
-IFS=',' read -ra destinataires <<< "$RELAIS_ALERTE_MAILS"
+# CSV → tableau bash : msmtp attend les destinataires en arguments séparés. L'espace
+# dans IFS absorbe le « a@x.fr, b@y.fr » écrit à la main (sinon msmtp reçoit " b@y.fr").
+IFS=', ' read -ra destinataires <<< "$RELAIS_ALERTE_MAILS"
 
 {
     printf 'To: %s\n' "$RELAIS_ALERTE_MAILS"

--- a/deploy/relais/electricore-relais-alerte.sh
+++ b/deploy/relais/electricore-relais-alerte.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Hook d'alerte OnFailure= du relais (#659, PRD #658) : mail vers les destinataires
+# de RELAIS_ALERTE_MAILS quand electricore-relais.service échoue (run aveugle, #643 —
+# voir electricore/ingestion/relais/pipeline.py). Volontairement SANS Python : le
+# scénario où l'alerte est la plus nécessaire est précisément celui où le venv du
+# relais est cassé.
+set -euo pipefail
+
+UNIT="electricore-relais.service"
+
+if [[ -z "${RELAIS_ALERTE_MAILS:-}" ]]; then
+    echo "electricore-relais-alerte: RELAIS_ALERTE_MAILS absent/vide — aucun mail envoyé" >&2
+    exit 0
+fi
+
+sujet="[electricore] échec de ${UNIT} sur $(hostname)"
+corps="$(journalctl -u "$UNIT" --no-pager -n 50 2>/dev/null)" || corps="(journalctl indisponible pour ${UNIT})"
+
+# CSV → tableau bash : msmtp attend les destinataires en arguments séparés.
+IFS=',' read -ra destinataires <<< "$RELAIS_ALERTE_MAILS"
+
+{
+    printf 'To: %s\n' "$RELAIS_ALERTE_MAILS"
+    printf 'Subject: %s\n' "$sujet"
+    printf '\n%s\n' "$corps"
+} | msmtp --file=/etc/electricore-relais/msmtprc -- "${destinataires[@]}"

--- a/deploy/relais/electricore-relais.service
+++ b/deploy/relais/electricore-relais.service
@@ -5,6 +5,8 @@ Description=Relais de flux Enedis déchiffrés vers SFTP partenaire (#637)
 # par electricore-relais.timer. Ni inotify, ni le service d'ingestion existant.
 After=network-online.target
 Wants=network-online.target
+# Alerte mail si le run échoue (#659, PRD #658) — voir electricore-relais-alerte.service.
+OnFailure=electricore-relais-alerte.service
 
 [Service]
 Type=oneshot

--- a/deploy/tests/relais_alerte.sh
+++ b/deploy/tests/relais_alerte.sh
@@ -56,6 +56,21 @@ rc=$?
 [[ "$rc" -eq 0 ]] && ok "RELAIS_ALERTE_MAILS vide → exit 0" || ko "RELAIS_ALERTE_MAILS vide → exit non-zéro (got $rc)"
 [[ ! -f "$args_file" ]] && ok "RELAIS_ALERTE_MAILS vide → msmtp jamais appelé" || ko "msmtp a été appelé malgré RELAIS_ALERTE_MAILS vide"
 
+# Cas 3 : CSV édité à la main, avec espaces autour des virgules → adresses propres
+# (un " b@y.fr" avec espace de tête est un destinataire invalide côté msmtp).
+( PATH="${stub_dir}:$PATH" RELAIS_ALERTE_MAILS="a@x.fr , b@y.fr" bash "$ALERTE_SH" )
+grep -qx 'a@x.fr' "$args_file" && grep -qx 'b@y.fr' "$args_file" \
+    && ok "CSV avec espaces → destinataires sans espace parasite" \
+    || ko "CSV avec espaces → adresses polluées dans les args msmtp"
+
+# Cas 4 : hostname en échec → le mail part quand même (sous set -e, fabriquer le
+# sujet ne doit jamais pouvoir tuer le script avant l'envoi).
+printf '#!/usr/bin/env bash\nexit 1\n' > "${stub_dir}/hostname"; chmod +x "${stub_dir}/hostname"
+rm -f "$args_file"
+( PATH="${stub_dir}:$PATH" RELAIS_ALERTE_MAILS="a@x.fr" bash "$ALERTE_SH" )
+rc=$?
+[[ "$rc" -eq 0 && -f "$args_file" ]] && ok "hostname en échec → mail envoyé quand même" || ko "hostname en échec → pas de mail (rc=$rc)"
+
 rm -rf "$stub_dir" "$args_file" "$stdin_file" 2>/dev/null
 
 echo

--- a/deploy/tests/relais_alerte.sh
+++ b/deploy/tests/relais_alerte.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Test unitaire autonome du hook d'alerte OnFailure= du relais (#659).
+# Bash only, stubs msmtp/journalctl sur le PATH — même style que unit.sh (PASS/FAIL,
+# ok/ko), mais fichier séparé : ce script exerce un exécutable standalone en
+# subprocess, pas des fonctions de deploy/lib/ à sourcer.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ALERTE_SH="${SCRIPT_DIR}/../relais/electricore-relais-alerte.sh"
+
+PASS=0; FAIL=0
+ok() { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+ko() { printf '  \033[31m✗\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+echo "→ electricore-relais-alerte.sh"
+
+bash -n "$ALERTE_SH" && ok "bash -n : syntaxe valide" || ko "bash -n a échoué"
+[[ -x "$ALERTE_SH" ]] && ok "exécutable (chmod +x commité)" || ko "pas exécutable"
+
+stub_dir=$(mktemp -d)
+args_file=$(mktemp)
+stdin_file=$(mktemp)
+
+cat > "${stub_dir}/msmtp" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "${args_file}"
+cat > "${stdin_file}"
+STUB
+chmod +x "${stub_dir}/msmtp"
+
+cat > "${stub_dir}/journalctl" <<'STUB'
+#!/usr/bin/env bash
+echo "STUB_JOURNAL_LINE_1 relais: échec push vers partenaire"
+echo "STUB_JOURNAL_LINE_2 relais: run aveugle (#643)"
+STUB
+chmod +x "${stub_dir}/journalctl"
+
+# Cas 1 : destinataires renseignés → msmtp appelé avec les 2 destinataires en
+# arguments séparés, corps = Subject + lignes du journal stub.
+( PATH="${stub_dir}:$PATH" RELAIS_ALERTE_MAILS="a@x.fr,b@y.fr" bash "$ALERTE_SH" )
+rc=$?
+[[ "$rc" -eq 0 ]] && ok "exit 0 (mail envoyé)" || ko "exit non-zéro (got $rc)"
+grep -qx 'a@x.fr' "$args_file" && grep -qx 'b@y.fr' "$args_file" \
+    && ok "msmtp reçoit les 2 destinataires en arguments séparés" \
+    || ko "destinataires absents ou non séparés dans les args msmtp"
+grep -q '^Subject:' "$stdin_file" && ok "le mail contient un Subject:" || ko "Subject: absent du mail"
+grep -q 'STUB_JOURNAL_LINE_1' "$stdin_file" && grep -q 'STUB_JOURNAL_LINE_2' "$stdin_file" \
+    && ok "le corps contient les lignes du journal stub" \
+    || ko "lignes du journal absentes du corps du mail"
+
+# Cas 2 : RELAIS_ALERTE_MAILS vide → exit 0 sans appeler msmtp (le chemin
+# d'échec ne doit jamais échouer lui-même pour cause de config absente).
+rm -f "$args_file"
+( PATH="${stub_dir}:$PATH" RELAIS_ALERTE_MAILS="" bash "$ALERTE_SH" ) 2>/dev/null
+rc=$?
+[[ "$rc" -eq 0 ]] && ok "RELAIS_ALERTE_MAILS vide → exit 0" || ko "RELAIS_ALERTE_MAILS vide → exit non-zéro (got $rc)"
+[[ ! -f "$args_file" ]] && ok "RELAIS_ALERTE_MAILS vide → msmtp jamais appelé" || ko "msmtp a été appelé malgré RELAIS_ALERTE_MAILS vide"
+
+rm -rf "$stub_dir" "$args_file" "$stdin_file" 2>/dev/null
+
+echo
+if [[ "$FAIL" -eq 0 ]]; then
+    printf "\033[32m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
+    exit 0
+else
+    printf "\033[31m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
+    exit 1
+fi


### PR DESCRIPTION
## Résumé

Ajoute le hook d'alerte mail sur échec du relais (#659, PRD #658) : une unité systemd `OnFailure=` déclenche un script shell (délibérément sans Python — l'alerte doit survivre à un venv cassé) qui envoie via msmtp les dernières lignes de `journalctl` vers les destinataires configurés (`RELAIS_ALERTE_MAILS`, CSV dans le fichier d'env du relais). Une seule ligne ajoutée à `electricore-relais.service`, rien d'autre touché (`ExecStart` reste hors périmètre, chantier #657). README mis à jour avec le setup msmtp/token SMTP Proton et l'invariant décidé au PRD : *l'état d'une générale ne survit jamais à la générale*.

Vérifications : test bash autonome 8/8 (stubs msmtp/journalctl), `systemd-analyze verify` propre sur les 3 unités, `bash -n` OK, suite `tests/ingestion` 161 passed (aucun `.py` modifié), aucun secret committé.

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)
