### PR TITLE
docs(deps): documente le pin paramiko <5 — dlt sftp passe gss_auth (dlt-hub/dlt#3931)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 ingestion = [
     "dlt[filesystem]>=1.16.0,<2.0.0",
     "pycryptodome>=3.23.0,<4.0.0",
-    "paramiko>=4.0.0,<5.0.0",
+    "paramiko>=4.0.0,<5.0.0",  # <5 : dlt sftp passe gss_auth à SSHClient.connect(), retiré en paramiko 5 (dlt-hub/dlt#3931, leur « fix » = même pin) ; testé en réel 07/2026, crash à l'extract
     "lxml>=6.1.0,<7.0.0",  # XXE fix (CVE-2026-41066)
     "psutil>=5.9.0,<8.0.0",  # stats mémoire dlt sur VPS contraint (sinon UserWarning au run)
     "pyyaml>=6.0.0,<7.0.0",  # flux.yaml : déjà transitif via dlt, déclaré explicitement (#535)


### PR DESCRIPTION
Le pin `paramiko>=4.0.0,<5.0.0` était muet sur sa raison d'être — et c'est le **seul** garde-fou réel : le pin `paramiko<5` de dlt vit dans son extra `sftp`, or on dépend de `dlt[filesystem]`, donc dependabot a pu résoudre paramiko 5.0.0 (PR #653, CI verte car aucun test ne touche un vrai serveur SSH).

Testé en réel (`ingestion test` + overlay paramiko 5.0.0) : crash à l'extract, `SSHClient.connect() got an unexpected keyword argument 'gss_auth'` — dlt passe inconditionnellement ses kwargs GSS ([sftp_credentials.py](https://github.com/dlt-hub/dlt/blob/master/dlt/common/configuration/specs/sftp_credentials.py)), et paramiko 5 a retiré GSSAPI. Le « fix » upstream de dlt-hub/dlt#3931 (jusqu'en 1.29.1) = le même pin `<5`.

Une ligne de commentaire pour que le prochain bump ne reparte pas de zéro. #653 fermée via `@dependabot ignore paramiko major version` ; à dé-ignorer quand dlt supprimera ses kwargs GSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)