### PR TITLE
fix(deploy): e2e — multipass exec re-parse les arguments, scripts VM via stdin (#656)

### DIFF
--- a/deploy/tests/e2e/multipass.sh
+++ b/deploy/tests/e2e/multipass.sh
@@ -127,6 +127,15 @@ cmd_seed_password_account() {
 set -euo pipefail
 id -u '${user}' >/dev/null 2>&1 || useradd --create-home --shell /usr/sbin/nologin '${user}'
 echo '${user}:electricore-test-656' | chpasswd
+# Le compte doit être JOIGNABLE par mot de passe (tout le cas Enargia) : les images
+# cloud posent PasswordAuthentication no en drop-in (60-cloudimg-settings.conf sur
+# 24.04, 50-cloud-init.conf ailleurs) — une box legacy n'a pas ces fichiers.
+# Ciblage par NOM d'image cloud uniquement, jamais par contenu : le drop-in posé
+# par harden.sh doit survivre (finding 3 : re-seed sur box déjà durcie, où ce
+# seed ne doit RIEN rouvrir — d'où, aussi, aucune assertion « yes » ici).
+rm -f /etc/ssh/sshd_config.d/*cloudimg*.conf /etc/ssh/sshd_config.d/*cloud-init*.conf
+systemctl daemon-reload
+systemctl reload ssh
 EOF
     echo "✓ Compte ${user} semencé : mot de passe usable, shell nologin, AUCUNE clé (cas Enargia #656)."
 }

--- a/deploy/tests/e2e/multipass.sh
+++ b/deploy/tests/e2e/multipass.sh
@@ -69,6 +69,16 @@ require_multipass() {
     }
 }
 
+# multipass exec re-joint ses arguments en une chaîne que le shell de la VM
+# RE-PARSE : quotes et pipes d'un `bash -c "…"` s'y évaporent (constaté à la
+# première exécution réelle : `bash -c echo` nu, pipe exécuté hors du -c,
+# prompts ssh-keygen au up). Tout script multi-commandes passe donc par STDIN —
+# transmis verbatim, jamais re-parsé. Les exec à arguments simples (chemins,
+# flags, sans métacaractère shell) restent en ligne : le re-parse y est sans effet.
+vm_root() {
+    multipass exec "$VM_NAME" -- sudo bash -s
+}
+
 cmd_up() {
     if multipass info "$VM_NAME" >/dev/null 2>&1; then
         echo "VM ${VM_NAME} existe déjà. Utiliser '$0 down' avant de recréer." >&2
@@ -77,9 +87,11 @@ cmd_up() {
     multipass launch "$UBUNTU_VERSION" --name "$VM_NAME" --memory 4G --cpus 2 --disk 20G
     multipass mount "$REPO_ROOT" "${VM_NAME}:/repo"
     multipass exec "$VM_NAME" -- sudo mkdir -p /root/.ssh
-    multipass exec "$VM_NAME" -- sudo bash -c \
-        "ssh-keygen -t ed25519 -N '' -f /root/.ssh/id_ed25519 && \
-         cat /root/.ssh/id_ed25519.pub > /root/.ssh/authorized_keys"
+    vm_root <<'EOF'
+set -euo pipefail
+ssh-keygen -t ed25519 -N '' -f /root/.ssh/id_ed25519 -q
+cat /root/.ssh/id_ed25519.pub > /root/.ssh/authorized_keys
+EOF
     echo "✓ VM ${VM_NAME} prête. Repo monté sur /repo."
 }
 
@@ -111,9 +123,11 @@ cmd_status()  { multipass info "$VM_NAME" 2>/dev/null || echo "VM ${VM_NAME} n'e
 # ForceCommand internal-sftp ; le préflight ne doit PAS se fier au shell, #656 AC4).
 cmd_seed_password_account() {
     local user="${1:?user requis}"
-    multipass exec "$VM_NAME" -- sudo bash -c \
-        "id -u '${user}' >/dev/null 2>&1 || useradd --create-home --shell /usr/sbin/nologin '${user}'"
-    multipass exec "$VM_NAME" -- sudo bash -c "echo '${user}:electricore-test-656' | chpasswd"
+    vm_root <<EOF
+set -euo pipefail
+id -u '${user}' >/dev/null 2>&1 || useradd --create-home --shell /usr/sbin/nologin '${user}'
+echo '${user}:electricore-test-656' | chpasswd
+EOF
     echo "✓ Compte ${user} semencé : mot de passe usable, shell nologin, AUCUNE clé (cas Enargia #656)."
 }
 
@@ -122,14 +136,15 @@ cmd_seed_password_account() {
 # comme authorized_keys de <user>. Alternative à une exception Match User.
 cmd_remediate_key() {
     local user="${1:?user requis}"
-    multipass exec "$VM_NAME" -- sudo bash -c "
-        install -d -m 700 -o '${user}' -g '${user}' /home/${user}/.ssh
-        ssh-keygen -t ed25519 -N '' -f /tmp/${user}_key -q
-        cat /tmp/${user}_key.pub > /home/${user}/.ssh/authorized_keys
-        chown '${user}:${user}' /home/${user}/.ssh/authorized_keys
-        chmod 600 /home/${user}/.ssh/authorized_keys
-        rm -f /tmp/${user}_key /tmp/${user}_key.pub
-    "
+    vm_root <<EOF
+set -euo pipefail
+install -d -m 700 -o '${user}' -g '${user}' /home/${user}/.ssh
+ssh-keygen -t ed25519 -N '' -f /tmp/${user}_key -q
+cat /tmp/${user}_key.pub > /home/${user}/.ssh/authorized_keys
+chown '${user}:${user}' /home/${user}/.ssh/authorized_keys
+chmod 600 /home/${user}/.ssh/authorized_keys
+rm -f /tmp/${user}_key /tmp/${user}_key.pub
+EOF
     echo "✓ Clé SSH posée pour ${user} (remédiation #656 : migration en clé)."
 }
 

--- a/deploy/tests/e2e/multipass.sh
+++ b/deploy/tests/e2e/multipass.sh
@@ -111,8 +111,20 @@ cmd_unharden()       { multipass exec "$VM_NAME" -- sudo bash /repo/deploy/unhar
 cmd_verify()         { multipass exec "$VM_NAME" -- sudo bash /repo/deploy/tests/e2e/assert_harden.sh "$@"; }
 cmd_verify_reverse() { multipass exec "$VM_NAME" -- sudo bash /repo/deploy/tests/e2e/assert_unharden.sh "$@"; }
 cmd_shell()   { multipass shell "$VM_NAME"; }
-cmd_snap()    { multipass snapshot "$VM_NAME" --name "${1:?nom de snapshot requis}"; }
-cmd_restore() { multipass restore "${VM_NAME}.${1:?nom de snapshot requis}"; }
+# multipass ne snapshote/restaure qu'une VM ARRÊTÉE, et restore sans --destructive
+# attend une confirmation interactive (pendaison en usage script) — stop/start encadrent.
+cmd_snap() {
+    local name="${1:?nom de snapshot requis}"
+    multipass stop "$VM_NAME"
+    multipass snapshot "$VM_NAME" --name "$name"
+    multipass start "$VM_NAME"
+}
+cmd_restore() {
+    local name="${1:?nom de snapshot requis}"
+    multipass stop "$VM_NAME"
+    multipass restore --destructive "${VM_NAME}.${name}"
+    multipass start "$VM_NAME"
+}
 cmd_status()  { multipass info "$VM_NAME" 2>/dev/null || echo "VM ${VM_NAME} n'existe pas."; }
 
 # ── Scénario « box non-vierge » (#656, cas Enargia) ─────────────────────────


### PR DESCRIPTION
## Résumé

Première exécution réelle du harnais e2e multipass (mergé via #662 sans avoir jamais tourné) : `multipass exec` re-joint ses arguments en une chaîne que le shell de la VM **re-parse**. Dans les `bash -c "…"`, quotes et pipes s'évaporent : `chpasswd` recevait une ligne vide (« missing new password »), le `useradd` était court-circuité (`bash -c id` nu réussit → `||` saute), et le `up` affichait les prompts interactifs de ssh-keygen (`-N -f` mangés). Constaté empiriquement : `bash -c "echo 'a:b' | cat -A"` → ligne vide.

Correctif : les scripts multi-commandes de la VM passent par **stdin** (`vm_root`, heredoc) — transmis verbatim par multipass, jamais re-parsé. Les exec à arguments simples (chemins, flags) restent en ligne. Vérifié sur VM vivante : `echo \"echo 'a:b' | cat -A\" | multipass exec … -- sudo bash -s` → `a:b$` intact.

⚠️ Note pour la branche #657 (pas encore poussée) : son `seed-relais-key` hérite du même idiome cassé — à convertir au motif `vm_root` lors de son rebase sur ce fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)