### PR TITLE
fix(deploy): install — ensure_secrets_tools jamais appelé, die sur variable morte (étape 7 --relais)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -238,11 +238,16 @@ main() {
     # On ne valide PLUS le contenu de secrets.env par un preflight bash : le vrai conteneur le
     # fait verbatim via `sops exec-env` aux étapes 11-12 (cf. ADR-0049, classe de bug rc12).
     log_step "Identité de la box (age + SSH deploy key)"
+    # Les outils hôte (sops + age + age-keygen) d'abord : `generate_box_identities` et
+    # `box_can_decrypt` en dépendent. L'appel manquait — défini dans secrets.sh mais plus
+    # invoqué nulle part (constaté sur la 1re box fraîche : « échec age-keygen », puis le
+    # die crashait lui-même sur ${SECRETS_IMAGE}, résidu de l'approche par image sous set -u).
+    ensure_secrets_tools || die "Installation des outils secrets (sops + age) échouée."
     if pubs=$(generate_box_identities "$OPT_SLUG"); then
         age_pub=$(printf '%s\n' "$pubs" | sed -n 's/^AGE_PUBLIC_KEY=//p')
         ssh_pub=$(printf '%s\n' "$pubs" | sed -n 's/^SSH_DEPLOY_PUBKEY=//p')
     else
-        die "Génération des identités de la box échouée (image ${SECRETS_IMAGE} indisponible ?)."
+        die "Génération des identités de la box échouée (age-keygen indisponible ?)."
     fi
 
     log_step "Pull du dépôt de déploiement privé"


### PR DESCRIPTION
## Résumé

Premier run réel de `install.sh --relais` sur le VPS Enargia, étape 7 « Identité de la box » :

1. **`ensure_secrets_tools` n'est appelé nulle part** — défini dans `lib/secrets.sh`, plus aucun call site dans `install.sh` (perdu dans un refactor ; les `fake_bin` des tests unitaires fournissent `age-keygen`/`sops`, donc l'absence d'appel y est invisible, et l'e2e n'a jamais déroulé l'étape 7 sur VM vierge). Sur une box fraîche : `échec age-keygen (outil hôte absent ?)`.
2. **Le `die` crashait lui-même** : `SECRETS_IMAGE: unbound variable` sous `set -u` — résidu de l'approche par image docker abandonnée au profit des outils hôte.

Fix minimal : appel `ensure_secrets_tools || die` juste avant `generate_box_identities` (étape commune stack/relais — couvre les deux chemins), et message d'erreur purgé de la variable morte.

Vérifié : `bash -n` propre. Validation réelle = la relance sur le VPS Enargia (install.sh re-servi depuis main après merge : re-curl nécessaire, le bootstrap ne rafraîchit que les libs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)