### PR TITLE
fix(deploy): secrets — age.key vide (résidu de run interrompu) régénéré, écriture atomique

### DIFF
--- a/deploy/lib/secrets.sh
+++ b/deploy/lib/secrets.sh
@@ -66,14 +66,30 @@ ensure_secrets_tools() {
 generate_age_identity() {
     local home="$1"
     local keyfile="${home}/age.key"
+    # Un age.key VIDE n'est pas une identité : c'est le résidu d'un run interrompu
+    # (l'ancienne redirection créait le fichier AVANT l'échec d'age-keygen — constaté
+    # sur le VPS Enargia, où la garde « conservée » ré-empoisonnait ensuite chaque run).
+    # On ne supprime QUE le cas vide, sans ambiguïté ; un fichier non-vide mais invalide
+    # échoue plus loin (age_public_key) : à un opérateur d'arbitrer, jamais au script —
+    # régénérer en silence l'identité d'une box enrôlée masquerait une corruption.
+    if [[ -e "$keyfile" && ! -s "$keyfile" ]]; then
+        rm -f "$keyfile"
+        log_warn "age.key vide (résidu d'un run interrompu) — supprimé, régénération." >&2
+    fi
     if [[ -f "$keyfile" ]]; then
         log_skip "clé age déjà présente (${keyfile}) — conservée" >&2
     else
         # age-keygen écrit la clé privée sur stdout (+ la pub en commentaire) et la pub
         # sur stderr. On capture la privée dans le keyfile, sans jamais l'exposer.
-        age-keygen 2>/dev/null > "$keyfile" \
-            || { log_err "échec age-keygen (outil hôte absent ? cf. ensure_secrets_tools)" >&2; return 1; }
-        chmod 600 "$keyfile"
+        # tmp + mv : jamais de keyfile partiel si age-keygen échoue à mi-course.
+        local tmp="${keyfile}.tmp.$$"
+        if ! age-keygen 2>/dev/null > "$tmp"; then
+            rm -f "$tmp"
+            log_err "échec age-keygen (outil hôte absent ? cf. ensure_secrets_tools)" >&2
+            return 1
+        fi
+        chmod 600 "$tmp"
+        mv "$tmp" "$keyfile"
         log_ok "paire age générée (${keyfile}, 600)" >&2
     fi
     age_public_key "$keyfile"

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -685,6 +685,14 @@ key_before=$(cat "${secrets_root}/edn/age.key")
 PATH="${FAKE_BIN}:$PATH" generate_box_identities edn >/dev/null 2>&1
 key_after=$(cat "${secrets_root}/edn/age.key")
 assert_eq "$key_after" "$key_before" "generate_box_identities: idempotent (clé privée conservée au 2e run)"
+# Résidu d'un run interrompu : un age.key VIDE (l'ancienne redirection le créait avant
+# l'échec d'age-keygen — VPS Enargia) doit être remplacé, pas « conservé ».
+install -d "${secrets_root}/residu"
+: > "${secrets_root}/residu/age.key"
+out=$(PATH="${FAKE_BIN}:$PATH" generate_box_identities residu 2>/dev/null)
+[[ -s "${secrets_root}/residu/age.key" ]] && grep -q "^AGE_PUBLIC_KEY=age1" <<<"$out" \
+    && ok "generate_age_identity: age.key vide (résidu) → régénéré, pub imprimée" \
+    || ko "generate_age_identity: age.key vide conservé — runs empoisonnés à vie"
 
 # pull_deploy_repo : clone le dépôt privé simulé, relie providers/, tire config.env.
 git_src=$(mktemp -d)


### PR DESCRIPTION
## Résumé

Suite du premier run réel sur le VPS Enargia (après #670) : le run planté d'avant avait laissé un **`age.key` de 0 octet** — la redirection `age-keygen > age.key` crée le fichier AVANT que la commande échoue. La garde d'idempotence « clé age déjà présente — conservée » (conçue pour ne jamais régénérer l'identité d'une box enrôlée, ce qui reste juste) préservait fidèlement le fichier vide → `age-keygen -y` en échec à chaque run, pour toujours.

Correctif à deux étages :
- **Le cas VIDE — sans ambiguïté un résidu, jamais une identité — est supprimé et régénéré** (log warn explicite). Un fichier non-vide mais invalide continue d'échouer explicitement : régénérer en silence l'identité d'une box enrôlée masquerait une corruption — c'est à l'opérateur d'arbitrer.
- **Écriture atomique tmp+mv** : plus aucun chemin ne peut laisser un keyfile partiel.

Unit : cas « résidu vide → régénéré » ajouté dans la section secrets.sh — `deploy/tests/unit.sh` : **237 passed, 0 failed**.

Sur la box Enargia, le déblocage immédiat a été manuel (`rm /srv/enargia/age.key` — sûr : box jamais enrôlée, fichier vide) ; ce fix évite le piège à toute prochaine box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)