### PR TITLE
fix(deploy): secrets — age.key appartient à CONTAINER_UID (lisible du conteneur, entrypoint SOPS)

### DIFF
--- a/deploy/lib/secrets.sh
+++ b/deploy/lib/secrets.sh
@@ -131,7 +131,14 @@ generate_box_identities() {
     local age_pub ssh_pub
     age_pub=$(generate_age_identity "$home") || return 1
     ssh_pub=$(generate_ssh_deploy_identity "$home") || return 1
-    chown "$slug:$slug" "${home}/age.key" "${home}/ssh_deploy_key" "${home}/ssh_deploy_key.pub" 2>/dev/null || true
+    # age.key est monté ro DANS le conteneur (SOPS_AGE_KEY_FILE, stack comme relais) : en
+    # 600 il doit appartenir à l'uid de l'IMAGE (CONTAINER_UID), pas au slug — sinon
+    # « permission denied » à l'entrypoint dès que l'uid du slug ≠ uid image (constaté sur
+    # la première box non-vierge, VPS Enargia ; EDN ne le voyait pas : edn=1000 par
+    # coïncidence — même classe que #459, et même traitement que relais_ssh_key).
+    # La deploy key SSH reste au slug : elle ne sert qu'à l'HÔTE (git pull), jamais montée.
+    chown "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}" "${home}/age.key" 2>/dev/null || true
+    chown "$slug:$slug" "${home}/ssh_deploy_key" "${home}/ssh_deploy_key.pub" 2>/dev/null || true
     printf 'AGE_PUBLIC_KEY=%s\n' "$age_pub"
     printf 'SSH_DEPLOY_PUBKEY=%s\n' "$ssh_pub"
 }


### PR DESCRIPTION
## Résumé

Premier passage réel du timer relais sur le VPS Enargia : l'entrypoint SOPS meurt sur `/run/secrets/age.key: permission denied`. Cause : `generate_box_identities` chownait `age.key` (600) au **slug**, alors que le fichier est monté ro **dans le conteneur** (uid image 1000, `SOPS_AGE_KEY_FILE`) — stack comme relais. EDN n'a jamais vu le bug (edn=uid 1000 par coïncidence) ; sur toute box non-vierge où le slug arrive après d'autres users (uid décalé), l'entrypoint fail-fast bloque tout. Même classe que #459 (backups), même traitement que `relais_ssh_key` (déjà chowné `CONTAINER_UID` par l'installeur, avec gestion d'ordre vs `chown -R`).

- `age.key` → `CONTAINER_UID:CONTAINER_GID` (600 conservé)
- la deploy key SSH **reste au slug** : usage hôte uniquement (git pull), jamais montée

Le fail-fast a fait exactement son travail au passage : zéro donnée sortie tant que le déchiffrement échouait. Unit : 237/0 (aucun test d'ownership à ajuster — les fakes tournent sans root). Validation réelle = reconfigure sur le VPS Enargia.

Sur la box, déblocage manuel appliqué en attendant : `chown 1000:1000 /srv/enargia/age.key` — ce fix le rend permanent (le prochain reconfigure ne le re-cassera plus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)