### PR TITLE
feat(deploy): relais — token SMTP dans secrets.env, msmtprc rendu par l'installeur (passwordeval sops)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -411,7 +411,9 @@ EOF
   plus aucune étape manuelle : le token vit dans providers/${OPT_SLUG}/secrets.env
   (ALERTE__SMTP__PASSWORD, chiffré), extrait à l'envoi par passwordeval (sops hôte).
   Params de routage (ALERTE__SMTP__{HOST,PORT,FROM,USER}) et destinataires
-  (RELAIS_ALERTE_MAILS) vivent dans ${HOME_DIR}/config.env (voir deploy/relais/README.md).
+  (RELAIS_ALERTE_MAILS) s'éditent dans providers/${OPT_SLUG}/config.env du DÉPÔT
+  (la copie ${HOME_DIR}/config.env est écrasée à chaque reconfigure) — voir
+  deploy/relais/README.md.
   Rotation du token : sops providers/${OPT_SLUG}/secrets.env, push, reconfigure.
 
   Amorçage (#643) — marque l'historique existant comme livré SANS le pousser au

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -388,7 +388,8 @@ EOF
         # Hook d'alerte mail (#659, câblé sur ce layout conteneurisé par #668) : posé et
         # référencé par OnFailure= (render_relais_service ci-dessus), mais PAS activé
         # (pas d'enable --now — se déclenche uniquement via OnFailure=). Installe msmtp
-        # (dépendance du composant) ; seul le msmtprc (600) reste manuel, cf. récap.
+        # (dépendance du composant) + rend msmtprc (600, passwordeval → sops sur
+        # secrets.env) — plus AUCUNE étape manuelle (#674).
         install_relais_alerte_units "$OPT_SLUG"
 
         # ─── Étape 13 (relais) : récap ────────────────────────────────────────
@@ -405,11 +406,13 @@ EOF
   Logs             journalctl -u electricore-relais.service -f
   Run manuel       sudo -u ${OPT_SLUG} docker compose --env-file ${HOME_DIR}/config.env -f ${relais_dir}/compose-relais.yml run --rm relais
 
-  Alerte mail (#659/#668) — electricore-relais-alerte.service posée + branchée en
-  OnFailure=, PAS activée (se déclenche uniquement sur échec). Reste à poser à la main :
-    sudo \$EDITOR /etc/electricore-relais/msmtprc   # token SMTP — JAMAIS dans git
-    sudo chmod 600 /etc/electricore-relais/msmtprc
-  RELAIS_ALERTE_MAILS vit déjà dans ${HOME_DIR}/config.env (voir deploy/relais/README.md).
+  Alerte mail (#659/#668/#674) — electricore-relais-alerte.service posée + branchée en
+  OnFailure=, PAS activée (se déclenche uniquement sur échec). msmtprc RENDU (600) —
+  plus aucune étape manuelle : le token vit dans providers/${OPT_SLUG}/secrets.env
+  (ALERTE__SMTP__PASSWORD, chiffré), extrait à l'envoi par passwordeval (sops hôte).
+  Params de routage (ALERTE__SMTP__{HOST,PORT,FROM,USER}) et destinataires
+  (RELAIS_ALERTE_MAILS) vivent dans ${HOME_DIR}/config.env (voir deploy/relais/README.md).
+  Rotation du token : sops providers/${OPT_SLUG}/secrets.env, push, reconfigure.
 
   Amorçage (#643) — marque l'historique existant comme livré SANS le pousser au
   partenaire. Acte UNIQUE, geste conscient d'opérateur — JAMAIS exécuté par cet

--- a/deploy/lib/env_validate.sh
+++ b/deploy/lib/env_validate.sh
@@ -74,6 +74,20 @@ validate_config_env() {
             [[ -n "$deposit_dir" && "file://${deposit_dir}" == "$source_url" ]] || \
                 errors+=("RELAIS__SOURCE_URL en file:// exige FLUX_DEPOSIT_DIR=${source_url#file://} (montage du dépôt dans le conteneur, #657)")
         fi
+        # Alerte mail (#674) : RELAIS_ALERTE_MAILS posé = alerte voulue ⇒ le msmtprc
+        # rendu doit être complet. msmtp refuse un fichier à directive vide (host/from/
+        # user sans valeur) : sans ce fail-fast, le premier reconfigure écraserait un
+        # msmtprc qui marche par un fichier invalide — alerte morte EN SILENCE. On
+        # avorte ici, AVANT toute pose (le msmtprc existant reste intact tant que
+        # providers/<slug>/config.env n'est pas complété). PORT a un défaut (587).
+        local alerte_mails champ
+        alerte_mails=$(read_env_var "$file" RELAIS_ALERTE_MAILS)
+        if [[ -n "$alerte_mails" ]]; then
+            for champ in HOST FROM USER; do
+                [[ -n "$(read_env_var "$file" "ALERTE__SMTP__${champ}")" ]] || \
+                    errors+=("RELAIS_ALERTE_MAILS posé mais ALERTE__SMTP__${champ} manquant — le msmtprc rendu serait invalide, l'alerte morte en silence (#674)")
+            done
+        fi
     else
         local version backups
         version=$(read_env_var "$file" ELECTRICORE_VERSION)

--- a/deploy/lib/env_validate.sh
+++ b/deploy/lib/env_validate.sh
@@ -84,7 +84,7 @@ validate_config_env() {
 
     # Garde-fou anti-fuite : un credential n'a RIEN à faire dans config.env (clair).
     local leaked
-    leaked=$(grep -oE '^[[:space:]]*(API__TROUSSEAU__|API_KEY|API_KEYS|SFTP__URL|BOT__(TOKEN|ALLOWED_USERS)|AES__TROUSSEAU__|ODOO__PASSWORD)' "$file" 2>/dev/null | head -1)
+    leaked=$(grep -oE '^[[:space:]]*(API__TROUSSEAU__|API_KEY|API_KEYS|SFTP__URL|BOT__(TOKEN|ALLOWED_USERS)|AES__TROUSSEAU__|ODOO__PASSWORD|ALERTE__SMTP__PASSWORD)' "$file" 2>/dev/null | head -1)
     [[ -z "$leaked" ]] || \
         errors+=("secret en clair détecté dans config.env (« ${leaked} ») — il doit vivre dans secrets.env chiffré")
 

--- a/deploy/lib/relais.sh
+++ b/deploy/lib/relais.sh
@@ -370,13 +370,13 @@ EOF
 }
 
 # install_relais_alerte_units <slug>
-# Pose le hook d'alerte (script + unité) — pendant #668 de install_relais_units.
-# N'active PAS l'unité elle-même (pas d'enable --now : electricore-relais-alerte.service
-# ne se déclenche que via OnFailure=, jamais par un timer). Idempotent : régénère les
-# deux fichiers à chaque appel. Le paquet msmtp est une dépendance DU COMPOSANT (#668) :
-# ensure_packages l'installe ici (no-op s'il est déjà là) ; seul
-# /etc/electricore-relais/msmtprc (600, token SMTP) reste posé à la main — jamais dans
-# git ni dans l'image, voir deploy/relais/README.md.
+# Pose le hook d'alerte (script + unité + msmtprc, #674) — pendant #668 de
+# install_relais_units. N'active PAS l'unité elle-même (pas d'enable --now :
+# electricore-relais-alerte.service ne se déclenche que via OnFailure=, jamais par un
+# timer). Idempotent : régénère les trois fichiers à chaque appel — plus AUCUNE étape
+# manuelle (#674 : c'était le dernier secret hors secrets-as-code de tout le composant
+# relais). Le paquet msmtp est une dépendance DU COMPOSANT (#668) : ensure_packages
+# l'installe ici (no-op s'il est déjà là).
 install_relais_alerte_units() {
     local slug="$1"
     ensure_packages msmtp
@@ -390,6 +390,26 @@ install_relais_alerte_units() {
     install -m 0755 "$tmp" /usr/local/bin/electricore-relais-alerte.sh
     rm -f "$tmp"
     render_relais_alerte_service "$slug" > /etc/systemd/system/electricore-relais-alerte.service
+
+    # msmtprc (#674) : RENDU, params non-secrets lus dans config.env (déjà pullé à la
+    # racine du home par pull_deploy_repo) ; le token (ALERTE__SMTP__PASSWORD) reste
+    # dans secrets.env chiffré, jamais copié ici — voir render_relais_alerte_msmtprc.
+    local home="${SRV_BASE:-/srv}/${slug}"
+    local config_env="${home}/config.env"
+    local smtp_host smtp_port smtp_from smtp_user
+    smtp_host=$(read_env_var "$config_env" ALERTE__SMTP__HOST 2>/dev/null || true)
+    smtp_port=$(read_env_var "$config_env" ALERTE__SMTP__PORT 2>/dev/null || true)
+    smtp_from=$(read_env_var "$config_env" ALERTE__SMTP__FROM 2>/dev/null || true)
+    smtp_user=$(read_env_var "$config_env" ALERTE__SMTP__USER 2>/dev/null || true)
+    [[ -n "$smtp_port" ]] || smtp_port=587
+    if [[ -z "$smtp_host" ]]; then
+        log_warn "ALERTE__SMTP__HOST absent de config.env — msmtprc rendu incomplet, l'alerte échouera bruyamment tant qu'il n'est pas renseigné (providers/${slug}/config.env, voir deploy/relais/README.md « Alerte mail »)."
+    fi
+    tmp="$(mktemp)"
+    render_relais_alerte_msmtprc "$slug" "$smtp_host" "$smtp_port" "$smtp_from" "$smtp_user" > "$tmp"
+    install -m 0600 "$tmp" /etc/electricore-relais/msmtprc
+    rm -f "$tmp"
+
     systemctl daemon-reload
-    log_ok "hook d'alerte mail posé (/usr/local/bin/electricore-relais-alerte.sh, electricore-relais-alerte.service) — /etc/electricore-relais/msmtprc (600, token SMTP) reste à poser à la main (deploy/relais/README.md)"
+    log_ok "hook d'alerte mail posé (/usr/local/bin/electricore-relais-alerte.sh, electricore-relais-alerte.service, /etc/electricore-relais/msmtprc rendu 600) — token SMTP jamais en clair, extrait de secrets.env par passwordeval (#674)"
 }

--- a/deploy/lib/relais.sh
+++ b/deploy/lib/relais.sh
@@ -308,9 +308,12 @@ EOF
 # deploy/lib/ingestion.sh) — SOPS_AGE_KEY_FILE pointe la clé age de LA BOX
 # (/srv/<slug>/age.key, déjà là depuis l'onboarding, ADR-0044), sur le secrets.env déjà
 # pullé (providers/<slug>/secrets.env). `bash -o pipefail -c '...'` : si le sops hôte
-# échoue (clé absente/invalide, champ manquant), le PIPE entier remonte son code de
-# sortie non-zéro (sans pipefail, seul le code de `head -1`, toujours 0, survivrait) —
-# msmtp voit passwordeval échouer, logue bruyamment sur stderr (capté par
+# échoue (clé absente/invalide), le PIPE entier remonte son code de sortie non-zéro
+# (sans pipefail, seul le code du dernier maillon survivrait) ; si sops réussit mais
+# que le CHAMP manque, c'est le `| grep .` final qui échoue (rc=1 sur extraction vide
+# — sinon msmtp partirait authentifier avec un mot de passe vide, erreur d'auth
+# confuse loin de secrets.env ; arbitrage revue #675). Dans les deux cas msmtp voit
+# passwordeval échouer, logue bruyamment sur stderr (capté par
 # `journalctl -u electricore-relais-alerte.service`), pas de crash silencieux : mode
 # dégradé assumé (cf. deploy/relais/README.md « Alerte mail »).
 render_relais_alerte_msmtprc() {
@@ -333,7 +336,7 @@ port ${port}
 auth on
 from ${from}
 user ${user}
-passwordeval bash -o pipefail -c "SOPS_AGE_KEY_FILE=${agekey} sops decrypt --input-type dotenv --output-type dotenv ${secrets} | sed -n s/^ALERTE__SMTP__PASSWORD=//p | head -1"
+passwordeval bash -o pipefail -c "SOPS_AGE_KEY_FILE=${agekey} sops decrypt --input-type dotenv --output-type dotenv ${secrets} | sed -n s/^ALERTE__SMTP__PASSWORD=//p | head -1 | grep ."
 
 account default : electricore-relais
 EOF
@@ -344,10 +347,11 @@ EOF
 # bare-metal (#659) : EnvironmentFile= pointe désormais sur le config.env du layout
 # conteneurisé (#657, ${SRV_BASE:-/srv}/<slug>/config.env — où vit déjà
 # RELAIS_ALERTE_MAILS) au lieu de /etc/electricore-relais/relais.env, qui n'existe pas
-# dans ce layout. Paramétrée par slug comme render_relais_service ; msmtprc (chemin de
-# convention host-level /etc/electricore-relais/, un seul token SMTP par box, pas par
-# instance) est désormais RENDUE elle aussi (#674, render_relais_alerte_msmtprc) — plus
-# aucune édition manuelle.
+# dans ce layout. Paramétrée par slug comme render_relais_service ; msmtprc est
+# désormais RENDU lui aussi (#674, render_relais_alerte_msmtprc), paramétré par slug
+# (chemins /srv/<slug>/…) mais posé au chemin de convention host-level
+# /etc/electricore-relais/ : sur une box multi-slug le dernier install gagnerait —
+# assumé, une box = un relais aujourd'hui (arbitrage revue #675).
 render_relais_alerte_service() {
     local slug="$1"
     local home="${SRV_BASE:-/srv}/${slug}"

--- a/deploy/lib/relais.sh
+++ b/deploy/lib/relais.sh
@@ -294,14 +294,60 @@ IFS=', ' read -ra destinataires <<< "$RELAIS_ALERTE_MAILS"
 EOF
 }
 
+# render_relais_alerte_msmtprc <slug> <host> <port> <from> <user>
+# Émet le msmtprc du hook d'alerte sur stdout — pure comme les autres render_* de ce
+# fichier (aucun accès disque/réseau), mais PARAMÉTRÉE par les valeurs non-secrètes de
+# config.env (ALERTE__SMTP__{HOST,PORT,FROM,USER}, ADR-0046 §7 : routage = config.env,
+# clair) : c'est install_relais_alerte_units qui les lit (read_env_var) et les passe ici
+# — même découpage caller-fait-l'I/O / rendu-reste-pur que render_relais_service.
+#
+# Le token SMTP (ALERTE__SMTP__PASSWORD, secrets.env chiffré) n'apparaît JAMAIS dans ce
+# fichier (#674 — c'était le dernier secret hors secrets-as-code de tout le composant
+# relais, objection Virgile posée en revue Enargia le 28/07) : `passwordeval` l'extrait
+# à l'ENVOI par un `sops decrypt` HÔTE (même motif que _ingestion_read_scheduler_key,
+# deploy/lib/ingestion.sh) — SOPS_AGE_KEY_FILE pointe la clé age de LA BOX
+# (/srv/<slug>/age.key, déjà là depuis l'onboarding, ADR-0044), sur le secrets.env déjà
+# pullé (providers/<slug>/secrets.env). `bash -o pipefail -c '...'` : si le sops hôte
+# échoue (clé absente/invalide, champ manquant), le PIPE entier remonte son code de
+# sortie non-zéro (sans pipefail, seul le code de `head -1`, toujours 0, survivrait) —
+# msmtp voit passwordeval échouer, logue bruyamment sur stderr (capté par
+# `journalctl -u electricore-relais-alerte.service`), pas de crash silencieux : mode
+# dégradé assumé (cf. deploy/relais/README.md « Alerte mail »).
+render_relais_alerte_msmtprc() {
+    local slug="$1" host="$2" port="$3" from="$4" user="$5"
+    local home="${SRV_BASE:-/srv}/${slug}"
+    local secrets="${home}/providers/${slug}/secrets.env"
+    local agekey="${home}/age.key"
+    cat <<EOF
+# ElectriCore — msmtprc du hook d'alerte relais (#659/#668/#674). RENDU par install.sh
+# --relais (deploy/lib/relais.sh::render_relais_alerte_msmtprc) — ne pas éditer à la
+# main, régénéré à chaque reconfigure. Le token SMTP n'est JAMAIS écrit ici en clair :
+# passwordeval l'extrait de secrets.env (chiffré SOPS+age) à l'envoi (#674).
+defaults
+tls on
+tls_starttls on
+
+account electricore-relais
+host ${host}
+port ${port}
+auth on
+from ${from}
+user ${user}
+passwordeval bash -o pipefail -c "SOPS_AGE_KEY_FILE=${agekey} sops decrypt --input-type dotenv --output-type dotenv ${secrets} | sed -n s/^ALERTE__SMTP__PASSWORD=//p | head -1"
+
+account default : electricore-relais
+EOF
+}
+
 # render_relais_alerte_service <slug>
 # Émet l'unité systemd du service d'alerte sur stdout — ADAPTÉE de l'ancienne unité
 # bare-metal (#659) : EnvironmentFile= pointe désormais sur le config.env du layout
 # conteneurisé (#657, ${SRV_BASE:-/srv}/<slug>/config.env — où vit déjà
 # RELAIS_ALERTE_MAILS) au lieu de /etc/electricore-relais/relais.env, qui n'existe pas
-# dans ce layout. Paramétrée par slug comme render_relais_service ; msmtprc (secret,
-# jamais dans git) reste au chemin de convention host-level /etc/electricore-relais/
-# (un seul token SMTP par box, pas par instance).
+# dans ce layout. Paramétrée par slug comme render_relais_service ; msmtprc (chemin de
+# convention host-level /etc/electricore-relais/, un seul token SMTP par box, pas par
+# instance) est désormais RENDUE elle aussi (#674, render_relais_alerte_msmtprc) — plus
+# aucune édition manuelle.
 render_relais_alerte_service() {
     local slug="$1"
     local home="${SRV_BASE:-/srv}/${slug}"

--- a/deploy/providers/example/config.env.example
+++ b/deploy/providers/example/config.env.example
@@ -39,6 +39,14 @@ RELAIS__PARTNER_URL=sftp://relais@partenaire.example/in
 RELAIS__FLUX=C15,R151,R15,F12,F15
 # CSV, alerte OnFailure= (#659/#668) : mail envoyé par electricore-relais-alerte.service
 # quand electricore-relais.service échoue (run aveugle). Optionnel — vide = aucun mail
-# (le script ne casse rien pour autant). msmtp est installé par le composant ; seul son
-# msmtprc reste posé à la main, voir deploy/relais/README.md « Alerte mail ».
+# (le script ne casse rien pour autant).
 RELAIS_ALERTE_MAILS=alertes-ops@example.fr
+# Alerte mail — params SMTP NON-secrets (routage, #674, ADR-0046 §7). Le token
+# (ALERTE__SMTP__PASSWORD) vit dans secrets.env chiffré, JAMAIS ici. msmtp est installé
+# par le composant et son msmtprc est RENDU par install.sh --relais depuis ces valeurs +
+# le token extrait de secrets.env à l'envoi (passwordeval) — plus aucun fichier à poser
+# à la main, voir deploy/relais/README.md « Alerte mail ».
+ALERTE__SMTP__HOST=smtp.example.fr
+ALERTE__SMTP__PORT=587
+ALERTE__SMTP__FROM=alertes@example.fr
+ALERTE__SMTP__USER=alertes@example.fr

--- a/deploy/providers/example/secrets.env.example
+++ b/deploy/providers/example/secrets.env.example
@@ -37,6 +37,15 @@ ODOO__DB=odoo_factice
 ODOO__USERNAME=bot@example
 ODOO__PASSWORD=mot_de_passe_factice
 
+# ── Alerte relais — token SMTP (#659/#668/#674) ─────────────────────────────
+# Un TOKEN SMTP (jamais le mot de passe du compte de messagerie). msmtprc est RENDU par
+# install.sh --relais (deploy/lib/relais.sh::render_relais_alerte_msmtprc) : cette
+# valeur n'est JAMAIS copiée en clair sur la box, un `passwordeval` l'extrait ici par un
+# sops decrypt hôte à chaque envoi. Params de routage (host/port/from/user) dans
+# config.env, ADR-0046 §7. Rotation : éditer ce champ (sops providers/<slug>/secrets.env),
+# push, reconfigure — comme tout secret.
+ALERTE__SMTP__PASSWORD=remplacer_par_le_token_smtp_factice
+
 # ── Trousseau AES Enedis (ADR-0037/ADR-0040) ────────────────────────────────
 # Labels DYNAMIQUES choisis par l'opérateur ; injectés sans énumération par
 # l'entrypoint (sops exec-env). __IV optionnel : absent ⇒ schéma IV-préfixé (AES-256).

--- a/deploy/relais/README.md
+++ b/deploy/relais/README.md
@@ -61,11 +61,19 @@ RELAIS__FLUX=C15,R151,R15,F12,F15                        # phase 1 : liste expli
 # contrairement aux clés ci-dessus : cette valeur est lue par systemd (EnvironmentFile=),
 # qui ne coupe PAS les commentaires de fin de ligne — il les avalerait dans les adresses.
 RELAIS_ALERTE_MAILS=alertes-ops@example.fr
+# Alerte mail : params SMTP NON-secrets (routage, #674) — le token vit dans
+# secrets.env (ALERTE__SMTP__PASSWORD), voir section « msmtprc » plus bas.
+ALERTE__SMTP__HOST=smtp.example.fr
+ALERTE__SMTP__PORT=587
+ALERTE__SMTP__FROM=alertes@example.fr
+ALERTE__SMTP__USER=alertes@example.fr
 ```
 
 **Secrets** (`providers/<slug>/secrets.env`, chiffré SOPS) : le trousseau
 `AES__TROUSSEAU__*` est **mutualisé** avec la stack (même fichier, monté ro
-dans les deux conteneurs) — rien à dupliquer.
+dans les deux conteneurs) — rien à dupliquer. `ALERTE__SMTP__PASSWORD` (token
+SMTP de l'alerte, #674) est **propre au relais**, voir section « msmtprc »
+plus bas.
 
 ### Répertoire de dépôt des flux (mode `file://`)
 
@@ -190,7 +198,7 @@ print(con.execute('select * from journal.relais_audit_sequences').fetchall())
 "
 ```
 
-## Alerte mail (`OnFailure=`, #659, câblée sur ce layout par #668)
+## Alerte mail (`OnFailure=`, #659, câblée sur ce layout par #668, msmtprc rendu #674)
 
 Quand `electricore-relais.service` échoue (run aveugle — 0 push réussi, ≥ 1
 échec, cf. `electricore/ingestion/relais/pipeline.py`), `OnFailure=` déclenche
@@ -217,45 +225,60 @@ reste du composant (`install_relais_alerte_units`, `deploy/lib/relais.sh`) :
 - L'unité d'alerte elle-même n'est **jamais activée** (pas de
   `enable --now` : elle n'a pas de section `[Install]`, elle ne se déclenche
   que via `OnFailure=`).
-- Le paquet `msmtp` et le répertoire `/etc/electricore-relais` (700) sont posés
-  par l'installeur — seul le `msmtprc` qu'il abrite reste manuel.
+- Le paquet `msmtp`, le répertoire `/etc/electricore-relais` (700) **et**
+  `/etc/electricore-relais/msmtprc` (600) sont posés par l'installeur —
+  **zéro étape manuelle** (#674, voir section dédiée ci-dessous).
 - Idempotent, comme le reste du composant : un `install.sh --relais` relancé
-  régénère les deux fichiers sans effet de bord.
+  régénère les trois fichiers sans effet de bord.
 - Le **déclenchement** se prouve sans attendre un vrai échec :
   `./deploy/tests/e2e/multipass.sh verify-relais onfailure <slug>` force un
   échec du service (compose écarté, stub msmtp) et vérifie que l'alerte tire —
   la mécanique seulement ; le mail réel se vérifie à la générale (#661).
 
-Ce que l'installeur **ne pose jamais** — un geste manuel, volontairement hors
-de son périmètre (secret, jamais dans un dépôt ni dans l'image) :
+### `msmtprc` : rendu, token SMTP dans `secrets.env` (#674)
 
-```bash
-sudo $EDITOR /etc/electricore-relais/msmtprc     # token SMTP — voir config ci-dessous
-sudo chmod 600 /etc/electricore-relais/msmtprc
-```
+Jusqu'à #674, `/etc/electricore-relais/msmtprc` (dont le **token SMTP**)
+était le **dernier secret hors secrets-as-code** de tout le composant relais —
+posé à la main sur la box, en contradiction avec [ADR-0044](../../docs/adr/0044-secrets-as-code-sops-age.md).
+Ce n'est plus le cas :
 
-Contenu type de `/etc/electricore-relais/msmtprc` (adapter au fournisseur
-SMTP réel — un **token SMTP**, jamais le mot de passe du compte) :
+- Le token SMTP vit dans `providers/<slug>/secrets.env` (chiffré SOPS+age,
+  champ `ALERTE__SMTP__PASSWORD`) — jamais en clair sur la box, jamais dans
+  un dépôt ni dans l'image.
+- Les paramètres NON secrets (routage) vivent dans `providers/<slug>/config.env`
+  (clair, versionné) : `ALERTE__SMTP__HOST`, `ALERTE__SMTP__PORT`,
+  `ALERTE__SMTP__FROM`, `ALERTE__SMTP__USER` (convention `<DOMAINE>__<CHAMP>`,
+  [ADR-0046](../../docs/adr/0046-convention-noms-env-par-domaine-identite-secrets.md)
+  §7 : secret = capacité, config = routage — même split que `BOT__TOKEN` vs
+  `BOT__NOTIFY_CHAT_ID`).
+- `install.sh --relais` lit ces quatre valeurs dans `config.env` et **rend**
+  `/etc/electricore-relais/msmtprc` (600) avec un `passwordeval` : à chaque
+  envoi, msmtp exécute un `sops decrypt` **hôte** sur
+  `providers/<slug>/secrets.env` (`SOPS_AGE_KEY_FILE=/srv/<slug>/age.key` —
+  sops, age et la clé de la box sont déjà là depuis l'onboarding, l'unité
+  d'alerte tourne root) et en extrait `ALERTE__SMTP__PASSWORD` — le token
+  n'existe **jamais** en clair sur la box, seulement en extraction **éphémère**
+  dans le pipe de `passwordeval` (`render_relais_alerte_msmtprc`,
+  `deploy/lib/relais.sh`).
+- **Mode dégradé assumé** : si ce sops hôte échoue (clé age absente/invalide,
+  champ manquant dans `secrets.env`…), `passwordeval` échoue — msmtp logue
+  bruyamment sur stderr, capté par
+  `journalctl -u electricore-relais-alerte.service`, et **n'envoie pas** de
+  mail. C'est une **perte assumée** par rapport au principe « l'alerte survit
+  à tout » de #659 (le hook lui-même reste délibérément sans Python, hors du
+  conteneur) : un SOPS cassé empêche maintenant l'envoi, alors qu'un
+  `msmtprc` posé à la main survivait à une panne SOPS. L'escalade systemd
+  reste intacte dans tous les cas — `electricore-relais-alerte.service`
+  passe `failed`, visible par `systemctl --failed` / le monitoring, jamais un
+  crash silencieux.
+- **Rotation** du token = comme tout secret : `sops providers/<slug>/secrets.env`
+  (éditer `ALERTE__SMTP__PASSWORD`), commit, push, puis `reconfigure` sur la
+  box (`sudo bash install.sh --slug <slug> --relais --deploy-repo <url>`) —
+  `msmtprc` est régénéré, le nouveau token est actif au prochain envoi.
 
-```
-defaults
-tls on
-tls_starttls on
-
-account electricore-relais
-host smtp.example.fr
-port 587
-auth on
-from alertes@example.fr
-user alertes@example.fr
-password <token SMTP>
-
-account default : electricore-relais
-```
-
-Ce chemin (`/etc/electricore-relais/msmtprc`, mode 600) est **host-level, pas
-par slug** — un seul token SMTP par box, partagé si plusieurs instances y
-tournent. Une fois posé, tester la chaîne :
+Une fois posé, tester la chaîne (le token doit être résolu par `passwordeval`
+et le mail doit arriver — **validation réservée à une box réelle**, ex.
+Enargia, pas exécutable depuis un sandbox sans réseau) :
 
 ```bash
 sudo systemctl start electricore-relais-alerte.service   # → le mail doit arriver

--- a/deploy/relais/README.md
+++ b/deploy/relais/README.md
@@ -260,9 +260,18 @@ Ce n'est plus le cas :
   n'existe **jamais** en clair sur la box, seulement en extraction **éphémère**
   dans le pipe de `passwordeval` (`render_relais_alerte_msmtprc`,
   `deploy/lib/relais.sh`).
-- **Mode dégradé assumé** : si ce sops hôte échoue (clé age absente/invalide,
-  champ manquant dans `secrets.env`…), `passwordeval` échoue — msmtp logue
-  bruyamment sur stderr, capté par
+- **Garde-fou au reconfigure** : si `RELAIS_ALERTE_MAILS` est posé (alerte
+  voulue) mais `ALERTE__SMTP__{HOST,FROM,USER}` incomplets, `validate_config_env`
+  **refuse la config avant toute pose** — un msmtprc existant qui marche n'est
+  jamais écrasé par un rendu invalide (msmtp refuse un fichier à directive
+  vide, l'alerte mourrait en silence ; arbitrage revue #675). Compléter
+  `providers/<slug>/config.env`, pousser, relancer.
+- **Mode dégradé assumé** : si ce sops hôte échoue (clé age absente/invalide),
+  le pipe remonte son code non-zéro ; si sops réussit mais que
+  `ALERTE__SMTP__PASSWORD` manque de `secrets.env`, le `| grep .` final échoue
+  sur l'extraction vide (sinon msmtp tenterait une auth avec mot de passe vide
+  — erreur confuse, loin de la cause). Dans les deux cas `passwordeval`
+  échoue — msmtp logue bruyamment sur stderr, capté par
   `journalctl -u electricore-relais-alerte.service`, et **n'envoie pas** de
   mail. C'est une **perte assumée** par rapport au principe « l'alerte survit
   à tout » de #659 (le hook lui-même reste délibérément sans Python, hors du
@@ -275,6 +284,12 @@ Ce n'est plus le cas :
   (éditer `ALERTE__SMTP__PASSWORD`), commit, push, puis `reconfigure` sur la
   box (`sudo bash install.sh --slug <slug> --relais --deploy-repo <url>`) —
   `msmtprc` est régénéré, le nouveau token est actif au prochain envoi.
+- **Surface actée** (arbitrage revue #675) : comme tout champ de `secrets.env`,
+  le token SMTP entre dans l'env des conteneurs qui font `sops exec-env`
+  (API, bot…) alors que seul msmtp **hôte** en a besoin — cohérent avec
+  l'injection en bloc d'[ADR-0044](../../docs/adr/0044-secrets-as-code-sops-age.md),
+  token peu sensible et facile à roter ; un scoping par consommateur serait un
+  chantier à part, non justifié pour ce seul champ.
 
 Une fois posé, tester la chaîne (le token doit être résolu par `passwordeval`
 et le mail doit arriver — **validation réservée à une box réelle**, ex.

--- a/deploy/tests/e2e/assert_relais.sh
+++ b/deploy/tests/e2e/assert_relais.sh
@@ -76,6 +76,17 @@ case "$MODE" in
               "! systemctl is-active electricore-relais-alerte.service"
         check "unité d'alerte SANS [Install] (pas de enable --now — is-enabled répondrait 'static', pas un signal utile)" \
               "! grep -qx '\[Install\]' /etc/systemd/system/electricore-relais-alerte.service"
+
+        # ─── msmtprc RENDU (#674) : plus aucune étape manuelle ───────────────────────
+        echo "→ Composant relais #674 : msmtprc rendu par l'installeur (token jamais en clair)"
+        check "msmtprc posé par l'installeur (RENDU, plus une édition manuelle)" \
+              "test -f /etc/electricore-relais/msmtprc"
+        check "msmtprc : droits 600 exactement" \
+              "[ \"\$(stat -c '%a' /etc/electricore-relais/msmtprc)\" = 600 ]"
+        check "msmtprc : passwordeval extrait le token de secrets.env (sops hôte, jamais en clair)" \
+              "grep -q '^passwordeval' /etc/electricore-relais/msmtprc && grep -q 'sops decrypt' /etc/electricore-relais/msmtprc"
+        check "msmtprc : aucune directive password= en clair (fuite du token)" \
+              "! grep -qE '^[[:space:]]*password[[:space:]]' /etc/electricore-relais/msmtprc"
         if command -v systemd-analyze >/dev/null 2>&1; then
             check "systemd-analyze verify : electricore-relais.service (OnFailure= compris)" \
                   "systemd-analyze verify /etc/systemd/system/electricore-relais.service"

--- a/deploy/tests/e2e/assert_relais.sh
+++ b/deploy/tests/e2e/assert_relais.sh
@@ -83,6 +83,8 @@ case "$MODE" in
               "test -f /etc/electricore-relais/msmtprc"
         check "msmtprc : droits 600 exactement" \
               "[ \"\$(stat -c '%a' /etc/electricore-relais/msmtprc)\" = 600 ]"
+        check "msmtprc : owned root (AC1 #674 — 600 ET root, l'unité d'alerte tourne root)" \
+              "[ \"\$(stat -c '%U' /etc/electricore-relais/msmtprc)\" = root ]"
         check "msmtprc : passwordeval extrait le token de secrets.env (sops hôte, jamais en clair)" \
               "grep -q '^passwordeval' /etc/electricore-relais/msmtprc && grep -q 'sops decrypt' /etc/electricore-relais/msmtprc"
         check "msmtprc : aucune directive password= en clair (fuite du token)" \

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -663,6 +663,17 @@ tmp_cfg=$(mktemp)
 printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nBOT__NOTIFY_CHAT_ID=-100\n' > "$tmp_cfg"
 assert_ok "validate_config_env autorise BOT__NOTIFY_CHAT_ID (routage)" validate_config_env "$tmp_cfg" "edn"
 rm -f "$tmp_cfg"
+# Token SMTP de l'alerte relais : ALERTE__SMTP__PASSWORD confère une capacité ⇒ secret (#674, ADR-0046 §7)
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nALERTE__SMTP__PASSWORD=token_factice\n' > "$tmp_cfg"
+assert_fail "validate_config_env refuse un secret en clair (ALERTE__SMTP__PASSWORD, #674)" validate_config_env "$tmp_cfg" "edn"
+rm -f "$tmp_cfg"
+# Mais ALERTE__SMTP__{HOST,PORT,FROM,USER} (routage SMTP, pas une capacité) sont AUTORISÉS
+# en config.env (#674, ADR-0046 §7 — même split que BOT__NOTIFY_CHAT_ID ci-dessus)
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nALERTE__SMTP__HOST=smtp.example.fr\nALERTE__SMTP__PORT=587\nALERTE__SMTP__FROM=alertes@example.fr\nALERTE__SMTP__USER=alertes@example.fr\n' > "$tmp_cfg"
+assert_ok "validate_config_env autorise ALERTE__SMTP__{HOST,PORT,FROM,USER} (routage, #674)" validate_config_env "$tmp_cfg" "edn"
+rm -f "$tmp_cfg"
 # Trousseau API : une clé API__TROUSSEAU__ en clair dans config.env est une fuite (ADR-0046 §4)
 tmp_cfg=$(mktemp)
 printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nAPI__TROUSSEAU__librewatt__KEY=secret_factice\n' > "$tmp_cfg"

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -410,6 +410,20 @@ pw_rc=$?
                       || ko "passwordeval : échec sops non propagé (exit ${pw_rc})"
 [[ -s "${pw_stub_dir}/err" ]] && ok "passwordeval : le sops stubbé en échec loggue sur stderr (capté par journalctl)" \
                                || ko "passwordeval : aucun message d'erreur sur stderr"
+
+# Champ absent de secrets.env (sops OK, ALERTE__SMTP__PASSWORD manquant) : sans garde,
+# sed n'émet rien et rc=0 → msmtp partirait authentifier avec un mot de passe VIDE
+# (erreur d'auth confuse, loin de secrets.env). Le `| grep .` final transforme
+# l'extraction vide en échec explicite de passwordeval (arbitrage revue #675).
+cat > "${pw_stub_dir}/sops" <<'STUB'
+#!/usr/bin/env bash
+printf 'AUTRE_CHAMP=valeur\n'
+STUB
+chmod +x "${pw_stub_dir}/sops"
+PATH="${pw_stub_dir}:$PATH" bash -c "$pwdeval_cmd" >/dev/null 2>&1
+pw_rc=$?
+[[ "$pw_rc" -ne 0 ]] && ok "passwordeval : champ absent de secrets.env → échec explicite (extraction vide ≠ mot de passe vide)" \
+                      || ko "passwordeval : extraction vide acceptée en silence (exit ${pw_rc})"
 rm -rf "$pw_stub_dir"
 
 echo
@@ -711,6 +725,30 @@ rm -f "$tmp_cfg"
 
 tmp_cfg=$(mktemp); printf 'INSTANCE_SLUG=edn\n' > "$tmp_cfg"
 assert_fail "validate_config_env (component=relais) exige RELAIS_VERSION" \
+    validate_config_env "$tmp_cfg" "edn" "relais"
+rm -f "$tmp_cfg"
+
+# Alerte mail (#674, arbitrage revue #675) : RELAIS_ALERTE_MAILS posé = alerte voulue
+# ⇒ ALERTE__SMTP__{HOST,FROM,USER} requis (PORT a un défaut, 587). msmtp refuse un
+# fichier à directive vide : sans ce fail-fast AVANT la pose, le premier reconfigure
+# écraserait un msmtprc qui marche par un fichier invalide — alerte morte en silence.
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nRELAIS_VERSION=1.2.0\nRELAIS__SOURCE_URL=sftp://relais@source.example/flux\nRELAIS_ALERTE_MAILS=ops@example.fr\n' > "$tmp_cfg"
+assert_fail "validate_config_env (relais) : RELAIS_ALERTE_MAILS posé sans ALERTE__SMTP__* → refuse (msmtprc serait invalide)" \
+    validate_config_env "$tmp_cfg" "edn" "relais"
+printf 'ALERTE__SMTP__HOST=smtp.example.fr\n' >> "$tmp_cfg"
+assert_fail "validate_config_env (relais) : HOST seul ne suffit pas (FROM/USER requis aussi)" \
+    validate_config_env "$tmp_cfg" "edn" "relais"
+printf 'ALERTE__SMTP__FROM=alertes@example.fr\nALERTE__SMTP__USER=alertes@example.fr\n' >> "$tmp_cfg"
+assert_ok "validate_config_env (relais) : alerte complète (HOST/FROM/USER, PORT en défaut) → OK" \
+    validate_config_env "$tmp_cfg" "edn" "relais"
+rm -f "$tmp_cfg"
+
+# Sans RELAIS_ALERTE_MAILS l'alerte est désarmée (le hook sort en 0 avant msmtp) :
+# aucune exigence SMTP — une box relais sans alerte mail reste une config valide.
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nRELAIS_VERSION=1.2.0\nRELAIS__SOURCE_URL=sftp://relais@source.example/flux\n' > "$tmp_cfg"
+assert_ok "validate_config_env (relais) : sans RELAIS_ALERTE_MAILS, aucune exigence ALERTE__SMTP__*" \
     validate_config_env "$tmp_cfg" "edn" "relais"
 rm -f "$tmp_cfg"
 

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -359,6 +359,60 @@ grep -v '^#' <<<"$alerte_sh_out" | grep -qi 'python' \
 bash -n <(printf '%s\n' "$alerte_sh_out") && ok "render_relais_alerte_script: syntaxe bash valide" || ko "render_relais_alerte_script: bash -n a échoué"
 
 echo
+echo "→ relais.sh / render_relais_alerte_msmtprc (msmtprc RENDU, passwordeval sops, #674)"
+SRV_BASE=/srv msmtprc_out="$(render_relais_alerte_msmtprc edn smtp.example.fr 587 alertes@example.fr alertes@example.fr)"
+grep -qx 'host smtp.example.fr' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: host substitué" || ko "render_relais_alerte_msmtprc: host absent/incorrect"
+grep -qx 'port 587' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: port substitué" || ko "render_relais_alerte_msmtprc: port absent/incorrect"
+grep -qx 'from alertes@example.fr' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: from substitué" || ko "render_relais_alerte_msmtprc: from absent/incorrect"
+grep -qx 'user alertes@example.fr' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: user substitué" || ko "render_relais_alerte_msmtprc: user absent/incorrect"
+grep -q '^passwordeval' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: passwordeval présent (token jamais écrit en clair)" || ko "render_relais_alerte_msmtprc: passwordeval absent"
+grep -q 'sops decrypt' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: extraction via un sops decrypt hôte" || ko "render_relais_alerte_msmtprc: sops decrypt absent"
+grep -q 'SOPS_AGE_KEY_FILE=/srv/edn/age.key' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: SOPS_AGE_KEY_FILE pointe la clé age de la box" || ko "render_relais_alerte_msmtprc: chemin age.key absent/incorrect"
+grep -q '/srv/edn/providers/edn/secrets.env' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: cible providers/<slug>/secrets.env" || ko "render_relais_alerte_msmtprc: chemin secrets.env absent/incorrect"
+grep -q 'ALERTE__SMTP__PASSWORD' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: extrait le champ ALERTE__SMTP__PASSWORD" || ko "render_relais_alerte_msmtprc: nom de champ absent"
+grep -q 'pipefail' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: pipefail — un échec sops se propage (pas de mot de passe vide avalé en silence)" || ko "render_relais_alerte_msmtprc: pipefail absent"
+grep -qE '^[[:space:]]*password[[:space:]]' <<<"$msmtprc_out" && ko "render_relais_alerte_msmtprc: directive password= en clair (fuite du token)" || ok "render_relais_alerte_msmtprc: aucune directive password= en clair"
+msmtprc_out2="$(render_relais_alerte_msmtprc enargia smtp2.example.fr 25 a@b.fr a@b.fr)"
+grep -q '/srv/enargia/age.key' <<<"$msmtprc_out2" && ok "render_relais_alerte_msmtprc: paramétré par slug (2e instance)" || ko "render_relais_alerte_msmtprc: pas paramétré par slug"
+msmtprc_out3="$(render_relais_alerte_msmtprc edn smtp.example.fr 587 alertes@example.fr alertes@example.fr)"
+[[ "$msmtprc_out" == "$msmtprc_out3" ]] && ok "render_relais_alerte_msmtprc: rendu idempotent (mêmes entrées → même sortie, re-run sûr)" || ko "render_relais_alerte_msmtprc: rendu non déterministe"
+
+echo
+echo "→ relais.sh / msmtprc passwordeval — comportement stubé (#674 : token jamais en clair, extraction sops)"
+pwdeval_cmd=$(sed -n 's/^passwordeval //p' <<<"$msmtprc_out")
+[[ -n "$pwdeval_cmd" ]] && ok "passwordeval : commande extraite du msmtprc rendu" || ko "passwordeval : commande introuvable dans le msmtprc rendu"
+
+pw_stub_dir=$(mktemp -d)
+cat > "${pw_stub_dir}/sops" <<'STUB'
+#!/usr/bin/env bash
+# Stub sops : ignore ses arguments, émet le secrets.env déchiffré factice (mêmes noms
+# de champs que providers/example/secrets.env.example, #674).
+printf 'ALERTE__SMTP__PASSWORD=stubbed_token_xyz\n'
+STUB
+chmod +x "${pw_stub_dir}/sops"
+pw_out=$(PATH="${pw_stub_dir}:$PATH" bash -c "$pwdeval_cmd" 2>/dev/null)
+[[ "$pw_out" == "stubbed_token_xyz" ]] \
+    && ok "passwordeval (sops stubbé) : extrait exactement la valeur ALERTE__SMTP__PASSWORD" \
+    || ko "passwordeval (sops stubbé) : sortie inattendue (got '${pw_out}')"
+
+# Échec du sops hôte (#674 : log explicite, pas de crash silencieux) : la commande doit
+# échouer (exit non-zéro) plutôt que produire un mot de passe vide accepté en silence —
+# c'est ce code de sortie que msmtp lit pour détecter l'échec de passwordeval.
+cat > "${pw_stub_dir}/sops" <<'STUB'
+#!/usr/bin/env bash
+echo "sops: erreur de déchiffrement (clé age invalide, stub)" >&2
+exit 1
+STUB
+chmod +x "${pw_stub_dir}/sops"
+PATH="${pw_stub_dir}:$PATH" bash -c "$pwdeval_cmd" >/dev/null 2>"${pw_stub_dir}/err"
+pw_rc=$?
+[[ "$pw_rc" -ne 0 ]] && ok "passwordeval : sops hôte en échec → code de sortie non-zéro (pas de crash silencieux)" \
+                      || ko "passwordeval : échec sops non propagé (exit ${pw_rc})"
+[[ -s "${pw_stub_dir}/err" ]] && ok "passwordeval : le sops stubbé en échec loggue sur stderr (capté par journalctl)" \
+                               || ko "passwordeval : aucun message d'erreur sur stderr"
+rm -rf "$pw_stub_dir"
+
+echo
 echo "→ relais.sh / systemd-analyze verify (rendu réel, #668 AC1)"
 if command -v systemd-analyze >/dev/null 2>&1; then
     sdv_dir=$(mktemp -d)

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -360,7 +360,7 @@ bash -n <(printf '%s\n' "$alerte_sh_out") && ok "render_relais_alerte_script: sy
 
 echo
 echo "→ relais.sh / render_relais_alerte_msmtprc (msmtprc RENDU, passwordeval sops, #674)"
-SRV_BASE=/srv msmtprc_out="$(render_relais_alerte_msmtprc edn smtp.example.fr 587 alertes@example.fr alertes@example.fr)"
+msmtprc_out="$(SRV_BASE=/srv render_relais_alerte_msmtprc edn smtp.example.fr 587 alertes@example.fr alertes@example.fr)"
 grep -qx 'host smtp.example.fr' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: host substitué" || ko "render_relais_alerte_msmtprc: host absent/incorrect"
 grep -qx 'port 587' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: port substitué" || ko "render_relais_alerte_msmtprc: port absent/incorrect"
 grep -qx 'from alertes@example.fr' <<<"$msmtprc_out" && ok "render_relais_alerte_msmtprc: from substitué" || ko "render_relais_alerte_msmtprc: from absent/incorrect"


### PR DESCRIPTION
Closes #674

Le token SMTP de l'alerte relais (dernier secret hors secrets-as-code du composant,
#669/#671) rejoint `secrets.env` chiffré (`ALERTE__SMTP__PASSWORD`) ; les paramètres
de routage (`ALERTE__SMTP__{HOST,PORT,FROM,USER}`) restent en clair dans `config.env`.
`install.sh --relais` rend désormais `/etc/electricore-relais/msmtprc` (600) avec un
`passwordeval` qui extrait le token par un `sops decrypt` hôte à chaque envoi — plus
aucune étape manuelle au récap. Un échec du sops hôte fait échouer bruyamment
`passwordeval` (bash -o pipefail) plutôt que d'avaler l'erreur en silence ; le README
relais documente ce mode dégradé assumé face au « survit à tout » de #659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)