### PR TITLE
fix(deploy): relais — le timer n'est jamais armé sur état vierge (garde #673)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -416,13 +416,20 @@ EOF
   deploy/relais/README.md.
   Rotation du token : sops providers/${OPT_SLUG}/secrets.env, push, reconfigure.
 
-  Amorçage (#643) — marque l'historique existant comme livré SANS le pousser au
-  partenaire. Acte UNIQUE, geste conscient d'opérateur — JAMAIS exécuté par cet
-  installeur. Refuse si le journal contient déjà des livraisons (--force sinon) :
+  Mise en service = DEUX gestes d'opérateur, dans cet ordre (#643, #673) :
+
+  1. Amorçage — marque l'historique existant comme livré SANS le pousser au
+     partenaire. Acte UNIQUE, geste conscient d'opérateur — JAMAIS exécuté par cet
+     installeur. Refuse si le journal contient déjà des livraisons (--force sinon) :
 
     sudo -u ${OPT_SLUG} docker compose --env-file ${HOME_DIR}/config.env \\
         -f ${relais_dir}/compose-relais.yml run --rm relais \\
         python -m electricore.ingestion.relais seed --avant <AAAA-MM-JJ>
+
+  2. Armement — sur état vierge, l'installeur pose le timer SANS l'armer (#673 :
+     armé avant l'amorçage, il pousserait tout l'historique au partenaire) :
+
+    systemctl enable --now electricore-relais.timer
 
   Pour reconfigurer plus tard (bump RELAIS_VERSION, rotation clé AES, etc.) :
     sudo bash $0 --slug ${OPT_SLUG} --relais --deploy-repo <url>

--- a/deploy/lib/relais.sh
+++ b/deploy/lib/relais.sh
@@ -218,12 +218,30 @@ WantedBy=timers.target
 EOF
 }
 
+# relais_etat_vierge
+# Vrai si l'état du relais est vierge : volume docker absent, ou point de montage vide
+# (ni journal ni amorce dlt — les deux vivent dans le volume, pipelines_dir épinglé).
+# C'est LA condition de la garde #673 : sur état vierge, un timer armé pousserait TOUT
+# l'historique du dépôt au premier déclenchement (immédiat après `enable --now`, ou
+# OnBootSec=5min après un reboot). Le nom du volume découle du projet compose
+# (`name: electricore-relais` + volume `relais_data`, cf. render_relais_compose).
+relais_etat_vierge() {
+    local mp
+    mp=$(docker volume inspect -f '{{.Mountpoint}}' electricore-relais_relais_data 2>/dev/null) || return 0
+    [[ -z "$(ls -A "$mp" 2>/dev/null)" ]]
+}
+
 # install_relais_units <slug>
-# Pose le mini-compose + les unités systemd, puis active le timer. Idempotent :
-# régénère les fichiers à chaque appel (reconfigure) ; `enable --now` ne redémarre pas
-# un timer déjà actif. N'exécute JAMAIS de `docker compose run` elle-même — le premier
-# run réel se produit au premier déclenchement du timer (OnBootSec=5min), jamais
-# pendant l'installation (cf. install.sh, pas de test ingestion côté relais).
+# Pose le mini-compose + les unités systemd, puis active le timer — SAUF sur état
+# vierge (#673) : l'amorçage (seed) est un acte d'opérateur que l'installeur ne fait
+# jamais, et un timer armé avant lui pousserait tout l'historique au partenaire ;
+# l'installeur n'arme donc JAMAIS le timer tant que l'état est vierge (ni enable — un
+# reboot le démarrerait — ni start), et désarme au passage un résidu armé d'un install
+# antérieur au fix. Idempotent : régénère les fichiers à chaque appel (reconfigure) ;
+# `enable --now` ne redémarre pas un timer déjà actif. N'exécute JAMAIS de
+# `docker compose run` elle-même — le premier run réel se produit au premier
+# déclenchement du timer, jamais pendant l'installation (cf. install.sh, pas de test
+# ingestion côté relais).
 install_relais_units() {
     local slug="$1"
     local home="${SRV_BASE:-/srv}/${slug}"
@@ -234,8 +252,13 @@ install_relais_units() {
     render_relais_service "$slug" > /etc/systemd/system/electricore-relais.service
     render_relais_timer > /etc/systemd/system/electricore-relais.timer
     systemctl daemon-reload
-    systemctl enable --now electricore-relais.timer
-    log_ok "compose relais + timer systemd posés (${relais_dir}/compose-relais.yml, electricore-relais.timer actif)"
+    if relais_etat_vierge; then
+        systemctl disable --now electricore-relais.timer >/dev/null 2>&1 || true
+        log_ok "compose relais + unités posés (${relais_dir}/compose-relais.yml) — timer PAS armé : état vierge (#673), amorcer (seed) PUIS 'systemctl enable --now electricore-relais.timer'"
+    else
+        systemctl enable --now electricore-relais.timer
+        log_ok "compose relais + timer systemd posés (${relais_dir}/compose-relais.yml, electricore-relais.timer actif)"
+    fi
 }
 
 # ─── Alerte mail OnFailure= (#659, câblée sur ce layout conteneurisé par #668) ──────

--- a/deploy/tests/e2e/assert_relais.sh
+++ b/deploy/tests/e2e/assert_relais.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Assertions e2e du composant relais de l'installeur (`install.sh --relais`, #657).
-# Vérifie l'ÉTAT POSÉ (timer actif, compose présent, refus sans clé SSH) — jamais un
-# push réel vers un partenaire (aucune invocation de `docker compose run` ici : le
-# premier run réel appartient au timer, pas à l'installeur ni à ce script).
+# Vérifie l'ÉTAT POSÉ (unités présentes, timer PAS armé sur état vierge #673, refus
+# sans clé SSH) — jamais un push réel vers un partenaire (aucune invocation de
+# `docker compose run` ici : le premier run réel appartient au timer, pas à
+# l'installeur ni à ce script).
 #
 # Le harnais multipass l'invoque via `multipass exec` (pas SSH) :
 #   ./deploy/tests/e2e/multipass.sh verify-relais refuse    <slug>   # avant `run --relais` (clé SSH absente)
@@ -55,9 +56,12 @@ case "$MODE" in
         check "unité service : ExecStart appelle docker compose run --rm" \
               "grep -q 'docker compose .* run --rm relais' /etc/systemd/system/electricore-relais.service"
         check "unité timer systemd présente"                       "test -f /etc/systemd/system/electricore-relais.timer"
-        check "timer electricore-relais.timer actif"                "systemctl is-active electricore-relais.timer"
-        check "timer electricore-relais.timer enabled (survit à un reboot)" \
-              "systemctl is-enabled electricore-relais.timer"
+        # Garde #673 : la VM e2e n'a jamais été amorcée (seed = geste d'opérateur,
+        # jamais joué par l'installeur ni par ce harnais) → état vierge → le timer
+        # doit être posé mais JAMAIS armé (ni actif ni enabled : un reboot ne doit
+        # pas le démarrer).
+        check "timer PAS armé sur état vierge (#673 : ni actif ni enabled)" \
+              "! systemctl is-active electricore-relais.timer && ! systemctl is-enabled electricore-relais.timer"
         check "clé SSH partenaire présente en 600"                 "test -f ${HOME_DIR}/relais_ssh_key"
         check "clé SSH partenaire : droits 600 exactement"         "[ \"\$(stat -c '%a' ${HOME_DIR}/relais_ssh_key)\" = 600 ]"
 

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -302,6 +302,34 @@ grep -qF -- '- ${FLUX_DEPOSIT_DIR:-/srv/electricore/flux-deposit}:${FLUX_DEPOSIT
     || ko "render_relais_compose: montage flux-deposit absent/incorrect"
 
 echo
+echo "→ relais.sh / relais_etat_vierge (garde #673 : timer jamais armé sans amorce)"
+# Fake docker : `volume inspect` répond le mountpoint contrôlé par le test, ou échoue
+# (volume absent) si le drapeau `absent` existe — la garde ne dépend de docker que
+# pour résoudre ce chemin.
+rv_root=$(mktemp -d)
+rv_bin="${rv_root}/bin"; rv_mp="${rv_root}/volume"
+mkdir -p "$rv_bin" "$rv_mp"
+cat > "${rv_bin}/docker" <<EOF
+#!/usr/bin/env bash
+[[ -f "${rv_root}/absent" ]] && { echo "Error: no such volume" >&2; exit 1; }
+echo "${rv_mp}"
+EOF
+chmod +x "${rv_bin}/docker"
+
+: > "${rv_root}/absent"
+PATH="${rv_bin}:$PATH" relais_etat_vierge \
+    && ok "relais_etat_vierge: volume docker absent → vierge" \
+    || ko "relais_etat_vierge: volume absent aurait dû être vierge"
+rm "${rv_root}/absent"
+PATH="${rv_bin}:$PATH" relais_etat_vierge \
+    && ok "relais_etat_vierge: volume vide (aucun journal) → vierge" \
+    || ko "relais_etat_vierge: volume vide aurait dû être vierge"
+touch "${rv_mp}/relais.duckdb"
+PATH="${rv_bin}:$PATH" relais_etat_vierge \
+    && ko "relais_etat_vierge: journal présent aurait dû casser la virginité" \
+    || ok "relais_etat_vierge: journal présent → pas vierge (timer armable)"
+
+echo
 echo "→ relais.sh / ensure_relais_flux_deposit (dépôt file://, jamais modifié si existant, #657)"
 fd_root=$(mktemp -d); mkdir -p "$fd_root/edn"
 ( CONTAINER_UID="$(id -u)" CONTAINER_GID="$(id -g)" ensure_relais_flux_deposit "$fd_root/edn/flux-deposit" >/dev/null 2>&1 )


### PR DESCRIPTION
## Résumé

Constaté au premier install réel sur le VPS Enargia (28/07) : `install.sh --relais` terminait par `systemctl enable --now` inconditionnel — premier déclenchement **immédiat** (`OnBootSec=5min` largement écoulé), et sur un journal vierge le relais partirait pousser **tout l'historique du dépôt** vers le partenaire réel avant tout amorçage. Seuls des accidents heureux (entrypoint SOPS en panne de permissions #672, IP Haulogy filtrée — désormais **débloquée**) l'ont empêché. Détail et arbitrages : #673.

## Ce que fait la tranche

- `relais_etat_vierge()` : vrai si le volume compose (`electricore-relais_relais_data`) est absent ou vide — ni journal ni amorce (l'état dlt vit au même endroit, `pipelines_dir` épinglé).
- `install_relais_units` : état vierge → timer **posé mais jamais armé** (ni `enable` — un timer enabled démarre au reboot, et les box durcies rebootent chaque nuit — ni `start`), et un résidu armé d'un install antérieur au fix est désarmé au passage. État peuplé → comportement inchangé (`enable --now`, reconfigure de routine sur box vivante).
- Récap : la mise en service devient deux gestes ordonnés — 1. `seed --avant`, 2. `systemctl enable --now`.
- e2e `posed` : le timer doit être présent mais **ni actif ni enabled** (la VM n'est jamais amorcée).
- unit : 3 assertions `relais_etat_vierge` sur fake `docker volume inspect` (absent / vide / peuplé). Suite : 264/0.

## Arbitrages

- **« enable sans --now » (formulation initiale de l'issue) rejeté** : insuffisant face au reboot nocturne.
- **Garde moteur (Python) différée** : elle vit dans l'image ghcr épinglée → release + bump du pin obligatoires ; la variante shell est effective au **prochain reconfigure** (refresh des libs depuis main), ce qui débloque la générale #661 sans cycle de release. Défense en profondeur côté moteur possible dans une release future.

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)