### PR TITLE
fix(deploy): secrets — pull du deploy-repo avec safe.directory (dubious ownership au reconfigure)

### DIFF
--- a/deploy/lib/secrets.sh
+++ b/deploy/lib/secrets.sh
@@ -159,7 +159,13 @@ pull_deploy_repo() {
     # GIT_SSH_COMMAND épingle la clé RO et coupe l'interactivité (StrictHostKeyChecking).
     local git_ssh="ssh -i ${deploy_key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
     if [[ -d "${repo_dir}/.git" ]]; then
-        GIT_SSH_COMMAND="$git_ssh" "$GIT_BIN" -C "$repo_dir" pull --ff-only \
+        # -c safe.directory : le home d'instance (dont deploy-repo) appartient au slug,
+        # mais le pull tourne root → git refuse (« dubious ownership », CVE-2022-24765).
+        # Le clone du 1er temps n'est pas concerné (répertoire neuf) : le piège ne mord
+        # qu'au PREMIER reconfigure — constaté sur la box Enargia (28/07), où l'échec se
+        # déguisait en « onboarding 2 temps » alors que les clés étaient déjà enrôlées.
+        # `-c` ponctuel : aucune écriture dans le gitconfig global de root.
+        GIT_SSH_COMMAND="$git_ssh" "$GIT_BIN" -c safe.directory="$repo_dir" -C "$repo_dir" pull --ff-only \
             || { log_err "git pull du dépôt de déploiement a échoué" >&2; return 1; }
         log_ok "dépôt de déploiement mis à jour (${repo_dir})" >&2
     else

--- a/deploy/tests/fixtures/fake_bin/git
+++ b/deploy/tests/fixtures/fake_bin/git
@@ -5,6 +5,9 @@
 [[ -n "${FAKE_GIT_LOG:-}" ]] && printf '%s\n' "$*" >> "$FAKE_GIT_LOG"
 
 cmd="$1"; shift || true
+# `git -c clé=valeur …` (options ponctuelles, ex. safe.directory) : avaler la paire
+# et re-dispatcher sur la commande réelle.
+while [[ "$cmd" == "-c" ]]; do shift; cmd="$1"; shift || true; done
 case "$cmd" in
     clone)
         # `git clone <url> <dest>` → recopie $FAKE_GIT_SRC dans <dest>.

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -835,6 +835,17 @@ PATH="${FAKE_BIN}:$PATH" FAKE_GIT_SRC="$git_src" GIT_BIN=git \
 [[ -L "${secrets_root}/edn/providers" ]] && ok "pull_deploy_repo: providers/ relié (symlink)" || ko "providers/ non relié"
 [[ -f "${secrets_root}/edn/providers/edn/secrets.env" ]] && ok "pull_deploy_repo: secrets.env accessible via providers/<slug>/" || ko "secrets.env inaccessible"
 [[ -f "${secrets_root}/edn/config.env" ]] && ok "pull_deploy_repo: config.env clair tiré à la racine du home" || ko "config.env non tiré"
+
+# Reconfigure (2e appel = pull, .git présent) : l'invocation DOIT porter
+# -c safe.directory=<repo> — le home d'instance appartient au slug, le pull tourne
+# root → « dubious ownership » au premier reconfigure sinon (box Enargia, 28/07).
+git_log=$(mktemp)
+PATH="${FAKE_BIN}:$PATH" FAKE_GIT_SRC="$git_src" FAKE_GIT_LOG="$git_log" GIT_BIN=git \
+    pull_deploy_repo "git@example.test:org/deploy.git" edn >/dev/null 2>&1
+grep -q -- "-c safe.directory=${secrets_root}/edn/deploy-repo -C" "$git_log" \
+    && ok "pull_deploy_repo: reconfigure = pull avec -c safe.directory (root vs home du slug)" \
+    || ko "pull_deploy_repo: -c safe.directory absent de l'invocation pull"
+rm -f "$git_log"
 rm -rf "$git_src"
 
 # box_can_decrypt : vrai si clé + secrets présents ET sops réussit ; faux si sops échoue.


### PR DESCRIPTION
## Résumé

Constaté au **premier reconfigure réel** (VPS Enargia, 28/07, prépa générale #661) : `pull_deploy_repo` fait le `git pull` en root dans `/srv/<slug>/deploy-repo`, qui appartient au **slug** → git refuse (« dubious ownership », CVE-2022-24765). Le clone du 1er temps n'est pas concerné (répertoire neuf) : le piège ne mord qu'au premier reconfigure — donc sur **toutes** les box. Effet trompeur : l'échec du pull fait retomber l'installeur sur le message « onboarding en deux temps » alors que les clés sont déjà enrôlées (vérifié : la clé age imprimée = celle du `.sops.yaml`, l'identité n'a pas bougé).

## Fix

- `git -c safe.directory=<repo_dir> -C <repo_dir> pull --ff-only` — flag ponctuel, aucune écriture dans le gitconfig global de root.
- fake git des tests : avale les paires `-c clé=valeur` avant dispatch.
- unit : nouvelle assertion — le 2ᵉ appel (chemin pull) doit porter le flag. Suite : **265/0**.

Remédiation box en attendant le merge : `git config --global --add safe.directory /srv/enargia/deploy-repo` (une fois), puis relancer le reconfigure — le fix repo rend ça inutile pour les box suivantes.

Contexte : PRD #658 (générale) — surprise n°1 du protocole, consignée ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)