### PR TITLE
fix(deploy): l'exception age.key survit au chown -R du home (#672 incomplet)

### DIFF
--- a/deploy/lib/user.sh
+++ b/deploy/lib/user.sh
@@ -60,13 +60,21 @@ setup_ssh_authorized_keys() {
 
 # chown_instance_home <slug>
 # S'assure que tout sous /srv/<slug>/ est owned par le user.
-# NB : ce chown -R aveugle écrase aussi backups/ → l'exception uid 1000 doit être
-# (ré)appliquée APRÈS lui via ensure_backups_dir (cf. #459, même classe que le seam
-# safe.directory du deploy-repo).
+# NB : ce chown -R aveugle écrase les exceptions uid conteneur → elles doivent être
+# (ré)appliquées APRÈS lui : backups/ via ensure_backups_dir (#459), relais_ssh_key
+# via check_relais_ssh_key (étape 11 relais), et age.key ICI MÊME — le fix #672
+# (generate_box_identities chowne age.key à CONTAINER_UID) tourne à l'étape 7 du
+# chemin relais, AVANT ce balayage (étape 10) qui l'écrasait à CHAQUE reconfigure
+# (constaté box Enargia, 28/07 : entrypoint SOPS « permission denied » de retour).
+# Auto-correctrice plutôt qu'un ré-assert chez chaque appelant : tout futur chemin
+# qui balaie le home garde un age.key lisible du conteneur.
 chown_instance_home() {
     local slug="$1"
     local home="${SRV_BASE:-/srv}/${slug}"
     chown -R "$slug:$slug" "$home"
+    if [[ -f "${home}/age.key" ]]; then
+        chown "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}" "${home}/age.key" 2>/dev/null || true
+    fi
 }
 
 # Identité du user du conteneur (Dockerfile : `USER electricore`, uid:gid 1000:1000).

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -24,6 +24,8 @@ source "${LIB_DIR}/ingestion.sh"
 source "${LIB_DIR}/secrets.sh"
 # shellcheck source=../lib/harden.sh
 source "${LIB_DIR}/harden.sh"
+# shellcheck source=../lib/user.sh
+source "${LIB_DIR}/user.sh"
 # shellcheck source=../lib/relais.sh
 source "${LIB_DIR}/relais.sh"
 
@@ -794,6 +796,31 @@ rm -f "$tmp_cfg"
 
 # Le CONTENU de secrets.env (format clés AES/API, URL SFTP) n'est plus validé en bash :
 # SSOT pydantic (tests/unit/test_runtime.py), vérifié par le conteneur étapes 11-12 (ADR-0049).
+
+echo
+echo "→ user.sh / chown_instance_home (l'exception age.key survit au chown -R, #672 bis)"
+# Fake chown : journalise les appels — l'assertion porte sur l'ORDRE (le ré-assert
+# age.key doit venir APRÈS le balayage -R, sinon il est écrasé — reconfigure Enargia
+# 28/07). Testable sans root : aucun vrai chown n'est exécuté.
+ch_root=$(mktemp -d)
+ch_bin="${ch_root}/bin"; mkdir -p "$ch_bin" "${ch_root}/edn"
+: > "${ch_root}/edn/age.key"
+cat > "${ch_bin}/chown" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${ch_root}/chown.log"
+EOF
+chmod +x "${ch_bin}/chown"
+PATH="${ch_bin}:$PATH" SRV_BASE="$ch_root" CONTAINER_UID=1000 CONTAINER_GID=1000 chown_instance_home edn
+grep -q -- "-R edn:edn ${ch_root}/edn" "${ch_root}/chown.log" \
+    && ok "chown_instance_home: balayage -R slug:slug du home" || ko "chown_instance_home: balayage -R absent"
+tail -1 "${ch_root}/chown.log" | grep -q "1000:1000 ${ch_root}/edn/age.key" \
+    && ok "chown_instance_home: age.key ré-asserté CONTAINER_UID APRÈS le balayage" \
+    || ko "chown_instance_home: age.key pas ré-asserté après le -R (l'entrypoint SOPS re-cassera au reconfigure)"
+rm -f "${ch_root}/chown.log" "${ch_root}/edn/age.key"
+PATH="${ch_bin}:$PATH" SRV_BASE="$ch_root" chown_instance_home edn
+[[ "$(wc -l < "${ch_root}/chown.log")" == "1" ]] \
+    && ok "chown_instance_home: sans age.key → seul le balayage (pas de chown fantôme)" \
+    || ko "chown_instance_home: appel chown inattendu en l'absence d'age.key"
 
 echo
 echo "→ secrets.sh (fake-binaries age-keygen/ssh-keygen/sops/git)"


### PR DESCRIPTION
## Résumé

Reconfigure réel sur le VPS Enargia (28/07, prépa générale #661) : l'entrypoint SOPS **re-meurt** sur `/run/secrets/age.key: permission denied` — `age.key` est revenu au slug (uid 1005, constaté `ls -ln`). Le fix #672 (PR dad28a1) ne tenait pas sa promesse « le prochain reconfigure ne le re-cassera plus ».

## Cause : un bug d'ordre, spécifique au chemin relais

- Le fix #672 vit dans `generate_box_identities` — **étape 7** du chemin `--relais` — qui chowne `age.key` → `CONTAINER_UID` (1000).
- `chown_instance_home` (**étape 10** du même chemin) fait ensuite un `chown -R slug:slug` du home entier → **l'exception est écrasée à chaque reconfigure**.
- Le chemin **stack** ne voit rien : ordre inverse (balayage étape 7, identités étape 9). EDN doublement aveugle (uid slug = 1000 par coïncidence).
- Même classe déjà documentée dans le code : backups/ (#459, ré-asserté par `ensure_backups_dir` APRÈS le balayage) et `relais_ssh_key` (ré-asserté par `check_relais_ssh_key`, étape 11). `age.key` était la seule exception sans ré-assert post-balayage.

## Fix

`chown_instance_home` ré-asserte lui-même `age.key` → `CONTAINER_UID` **après** son balayage — auto-correctrice : couvre les deux chemins d'install et tout futur appelant, au lieu d'un ré-assert à poser chez chaque caller.

## Tests

Fake `chown` journalisant (aucun vrai chown, pas de root requis) — l'assertion porte sur l'**ordre** des appels, précisément ce qui a manqué à #672 :
- balayage `-R slug:slug` présent ;
- `age.key` ré-asserté `1000:1000` **en dernier** ;
- sans `age.key` : aucun chown fantôme.

Suite : **268/0**. Validation réelle = prochain reconfigure Enargia (le chown manuel posé sur la box tient d'ici là ; aucun reconfigure prévu avant la purge de la générale).

Surprise n°3 de la prépa de la générale (PRD #658). Refs #672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)