### PR TITLE
fix(deploy): relais — filtre le bruit de pull docker du mail d'alerte (#678)

### DIFF
--- a/deploy/lib/relais.sh
+++ b/deploy/lib/relais.sh
@@ -303,7 +303,20 @@ fi
 # ${HOSTNAME} (posé par bash lui-même) et pas $(hostname) : sous set -e, un binaire
 # hostname absent ou en échec tuerait le script AVANT le moindre envoi.
 sujet="[electricore] échec de ${UNIT} sur ${HOSTNAME:-inconnu}"
-corps="$(journalctl -u "$UNIT" --no-pager -n 50 2>/dev/null)" || corps="(journalctl indisponible pour ${UNIT})"
+
+# Le run conteneurisé (#668) émet sur stdout la progression du pull d'image
+# (Extracting/Pull complete/…, des dizaines de lignes répétées) : sans filtrage elle
+# noie l'erreur réelle dans la fenêtre lue (#678, constaté sur le premier mail réel —
+# ~30 lignes de bruit pour 15 lignes utiles). On élargit la fenêtre journalctl (500
+# lignes) puis on retire le bruit AVANT le tail final : sur un pull très verbeux, le
+# signal reste dans le corps même si la queue brute ne contenait que du bruit.
+bruit_docker='Extracting|Downloading|Pull complete|Waiting|Verifying Checksum|Already exists'
+corps="$(journalctl -u "$UNIT" --no-pager -n 500 2>/dev/null | grep -Ev "$bruit_docker")" || true
+if [[ -z "$corps" ]]; then
+    corps="(journalctl indisponible pour ${UNIT})"
+else
+    corps="$(printf '%s\n' "$corps" | tail -n 50)"
+fi
 
 # CSV → tableau bash : msmtp attend les destinataires en arguments séparés. L'espace
 # dans IFS absorbe le « a@x.fr, b@y.fr » écrit à la main (sinon msmtp reçoit " b@y.fr").

--- a/deploy/lib/relais.sh
+++ b/deploy/lib/relais.sh
@@ -313,7 +313,7 @@ sujet="[electricore] échec de ${UNIT} sur ${HOSTNAME:-inconnu}"
 bruit_docker='Extracting|Downloading|Pull complete|Waiting|Verifying Checksum|Already exists'
 corps="$(journalctl -u "$UNIT" --no-pager -n 500 2>/dev/null | grep -Ev "$bruit_docker")" || true
 if [[ -z "$corps" ]]; then
-    corps="(journalctl indisponible pour ${UNIT})"
+    corps="(aucune ligne exploitable pour ${UNIT} : journalctl indisponible, ou journal entièrement filtré — voir 'journalctl -u ${UNIT}')"
 else
     corps="$(printf '%s\n' "$corps" | tail -n 50)"
 fi

--- a/deploy/tests/relais_alerte.sh
+++ b/deploy/tests/relais_alerte.sh
@@ -141,10 +141,10 @@ rm -f "$args_file" "$stdin_file"
 ( PATH="${noisy_stub_dir}:${stub_dir}:$PATH" RELAIS_ALERTE_MAILS="a@x.fr" bash "$ALERTE_SH" )
 rc=$?
 [[ "$rc" -eq 0 ]] && ok "pull bruyant → exit 0" || ko "pull bruyant → exit non-zéro (got $rc)"
-grep -q 'SopsDecryptionError' "$stdin_file" \
+grep -q 'SopsDecryptionError' "$stdin_file" 2>/dev/null \
     && ok "pull bruyant → l'erreur réelle est dans le corps du mail" \
     || ko "pull bruyant → l'erreur réelle est ABSENTE du corps du mail"
-grep -q 'Extracting' "$stdin_file" \
+grep -q 'Extracting' "$stdin_file" 2>/dev/null \
     && ko "pull bruyant → la progression docker a fui dans le corps du mail" \
     || ok "pull bruyant → aucune ligne de progression docker dans le corps du mail"
 

--- a/deploy/tests/relais_alerte.sh
+++ b/deploy/tests/relais_alerte.sh
@@ -116,6 +116,40 @@ grep -q '/etc/electricore-relais/relais.env' "$ALERTE_SH" \
     && ko "résidu bare-metal /etc/electricore-relais/relais.env dans le script" \
     || ok "aucun résidu /etc/electricore-relais/relais.env dans le script"
 
+# Cas 8 : pull d'image docker bruyant (#678) — le journal réel mêle des dizaines de
+# lignes de progression (Extracting/Pull complete/Waiting/Verifying Checksum/Already
+# exists) à l'erreur réelle (constaté sur le premier mail réel, VPS Enargia 28/07 :
+# ~30 lignes de bruit pour 15 lignes utiles). Le corps du mail doit montrer l'erreur,
+# pas la progression — un journalctl dédié (prioritaire dans le PATH) simule ce mélange.
+noisy_stub_dir=$(mktemp -d)
+cat > "${noisy_stub_dir}/journalctl" <<'STUB'
+#!/usr/bin/env bash
+for i in $(seq 1 30); do
+    echo "Extracting [==================================================>]  13B/13B"
+done
+echo "Pull complete"
+echo "Waiting"
+echo "Verifying Checksum"
+echo "Already exists"
+echo "electricore-relais-1  | Traceback (most recent call last):"
+echo "electricore-relais-1  | sops.exceptions.SopsDecryptionError: échec du déchiffrement (clé absente ?)"
+echo "electricore-relais.service: Main process exited, code=exited, status=1/FAILURE"
+STUB
+chmod +x "${noisy_stub_dir}/journalctl"
+
+rm -f "$args_file" "$stdin_file"
+( PATH="${noisy_stub_dir}:${stub_dir}:$PATH" RELAIS_ALERTE_MAILS="a@x.fr" bash "$ALERTE_SH" )
+rc=$?
+[[ "$rc" -eq 0 ]] && ok "pull bruyant → exit 0" || ko "pull bruyant → exit non-zéro (got $rc)"
+grep -q 'SopsDecryptionError' "$stdin_file" \
+    && ok "pull bruyant → l'erreur réelle est dans le corps du mail" \
+    || ko "pull bruyant → l'erreur réelle est ABSENTE du corps du mail"
+grep -q 'Extracting' "$stdin_file" \
+    && ko "pull bruyant → la progression docker a fui dans le corps du mail" \
+    || ok "pull bruyant → aucune ligne de progression docker dans le corps du mail"
+
+rm -rf "$noisy_stub_dir"
+
 rm -rf "$stub_dir" "$work_dir" "$args_file" "$stdin_file" 2>/dev/null
 
 echo


### PR DESCRIPTION
Filtre le bruit de progression docker (`Extracting`/`Pull complete`/`Waiting`/`Verifying Checksum`/`Already exists`) du corps du mail d'alerte relais, avant le `tail` final, et élargit la fenêtre `journalctl` lue de 50 à 500 lignes pour que l'erreur réelle reste visible même sur un pull très verbeux. Constaté sur le premier mail d'alerte réel (28/07, VPS Enargia) : ~30 lignes de bruit pour 15 lignes utiles (erreur SOPS). Reste strictement shell-only (#659).

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)