### PR TITLE
fix(deploy): relais — OnActiveSec=1min, un timer (re)démarré à froid planifie (#682)

### DIFF
--- a/deploy/lib/relais.sh
+++ b/deploy/lib/relais.sh
@@ -210,6 +210,13 @@ Description=Déclenche electricore-relais.service périodiquement (balayage réc
 # passage relit toute la source, cf. incremental=False côté pipeline).
 OnBootSec=5min
 OnUnitActiveSec=15min
+# OnActiveSec : point d'élapse relatif à l'activation DU TIMER lui-même, ré-armé à
+# chaque `systemctl start`/`enable --now`. Sans lui, un timer (re)démarré à froid ne
+# planifie RIEN (#682, constaté à la générale #661) : OnBootSec est consommé une fois
+# par boot, et OnUnitActiveSec pointe dans le passé tant que le service n'a pas tourné
+# timer actif — interblocage silencieux jusqu'au reboot suivant. Premier run 1 min
+# après l'armement, puis la chaîne OnUnitActiveSec prend le relais.
+OnActiveSec=1min
 Persistent=true
 Unit=electricore-relais.service
 

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -489,6 +489,9 @@ echo "→ relais.sh / render_relais_timer (unité systemd, pure, #657)"
 timer_out="$(render_relais_timer)"
 grep -qx "Unit=electricore-relais.service" <<<"$timer_out" && ok "render_relais_timer: cible electricore-relais.service" || ko "render_relais_timer Unit= incorrect"
 grep -qx "Persistent=true" <<<"$timer_out" && ok "render_relais_timer: Persistent=true (rattrape un boot manqué)" || ko "render_relais_timer Persistent manquant"
+grep -qx "OnActiveSec=1min" <<<"$timer_out" \
+    && ok "render_relais_timer: OnActiveSec=1min (un timer démarré à froid planifie, #682)" \
+    || ko "render_relais_timer OnActiveSec manquant — start à froid = interblocage jusqu'au reboot"
 grep -qx "WantedBy=timers.target" <<<"$timer_out" && ok "render_relais_timer: WantedBy=timers.target" || ko "render_relais_timer WantedBy manquant"
 
 echo


### PR DESCRIPTION
## Résumé

Découverte majeure n°2 de la générale (#661, VPS Enargia, 28/07) : `systemctl start electricore-relais.timer` sur box vivante → **NEXT = n/a, aucun déclenchement, jamais**. Les deux clauses sont monotones et écoulées : `OnBootSec` est consommé une fois par boot, `OnUnitActiveSec` pointe dans le passé tant que le service n'a pas tourné pendant que le timer est actif — interblocage silencieux jusqu'au reboot suivant (04h30). Au go-live : `seed` + `enable --now` en journée = rien ne part avant le lendemain 04h35.

## Fix

`OnActiveSec=1min` dans `render_relais_timer` : point d'élapse relatif à l'activation **du timer lui-même**, ré-armé à chaque `start`/`enable --now` — premier run 1 min après l'armement, puis la chaîne `OnUnitActiveSec` prend le relais (réarmement prouvé en générale : kick manuel → NEXT à +15 min). L'armement redevient déterministe, sans kick au runbook.

- Assertion `unit.sh` sur le rendu (suite verte)
- Shell only : effectif au prochain reconfigure (refresh des libs depuis main), sans release

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)