### PR TITLE
feat(relais): dépôt par flux chez le partenaire — <partner_url>/<CODE_FLUX>/ (#686)

### DIFF
--- a/deploy/relais/README.md
+++ b/deploy/relais/README.md
@@ -91,6 +91,12 @@ modifié** — c'est à l'opérateur d'ouvrir la lecture à l'uid 1000 (groupe/A
 sur toute l'arborescence), l'installeur avertit si elle manque. Sur une box à
 source SFTP distante, le montage est inerte (dossier vide).
 
+Côté **destination** (partenaire), le relais reproduit désormais ce même
+rangement par flux (#686, demande Haulogy) : chaque fichier extrait atterrit
+dans `<RELAIS__PARTNER_URL>/<CODE_FLUX>/` (`C15/`, `R151/`, `R15/`, `F12/`,
+`F15/`, …), dossier créé au besoin. Câblé en dur — pas de knob d'arborescence
+ni de template dans l'URL, `RELAIS__PARTNER_URL` reste une racine simple.
+
 ## Clé SSH partenaire
 
 Le conteneur relais monte en lecture seule une clé SSH **PRIVÉE**, dédiée à ce

--- a/electricore/ingestion/relais/pipeline.py
+++ b/electricore/ingestion/relais/pipeline.py
@@ -200,9 +200,11 @@ def _controle_intra_zip(flux: str | None, fichiers: list[tuple[str, bytes]], zip
 def pousser_vers_partenaire(fichiers: list[tuple[str, bytes]], partner_url: str, flux: str | None) -> None:
     """Pousse les fichiers extraits vers `<partner_url>/<CODE_FLUX>/` — rangement par flux
     côté partenaire (#686, demande Haulogy), fsspec-agnostic (file://, sftp://). `flux` vient
-    de `_flux_du_zip` (réutilisé, pas re-dérivé) : `None` (nom de zip à moins de deux segments,
-    jamais observé sur un vrai zip Enedis) **lève AVANT tout dépôt** — jamais de dépôt racine
-    silencieux. Câblé en dur : pas de knob d'arborescence, un seul partenaire réel (#686).
+    de `_flux_du_zip` (réutilisé, pas re-dérivé) : absent (`None`, nom de zip à moins de deux
+    segments) ou vide (2e segment vide, `A__B.zip`) — jamais observé sur un vrai zip Enedis —
+    **lève AVANT tout dépôt** : `""` concaténé donnerait un chemin racine, exactement le dépôt
+    racine silencieux qu'on refuse. Câblé en dur : pas de knob d'arborescence, un seul
+    partenaire réel (#686).
 
     Effet de bord : une cible injoignable (permission, réseau…) **lève** — direction
     d'échec sûre, le zip n'est alors PAS enregistré comme livré (discipline `etape_chaine`
@@ -210,7 +212,7 @@ def pousser_vers_partenaire(fichiers: list[tuple[str, bytes]], partner_url: str,
     AVANT de considérer le fichier posé — un mismatch lève au même titre qu'une cible
     injoignable, retenté au passage suivant.
     """
-    if flux is None:
+    if not flux:
         raise ValueError("Code flux introuvable dans le nom du zip — dépôt refusé (#686)")
     fs, base_path = fsspec.core.url_to_fs(partner_url)
     base = f"{base_path.rstrip('/')}/{flux}"

--- a/electricore/ingestion/relais/pipeline.py
+++ b/electricore/ingestion/relais/pipeline.py
@@ -34,6 +34,9 @@ l'ingestion (`etape_chaine`) : le compteur `StatsRelais` alimente le prédicat
 `relais_aveugle()` (même forme que `StatsChaine.flux_aveugle()`, ADR-0037 ext.
 #445) — un run où TOUS les push échouent doit escalader (sortie non-zéro), pas
 retenter en silence pour toujours (le reproche adressé à inotify dans #637).
+Dépôt rangé par flux chez le partenaire, `<partner_url>/<CODE_FLUX>/<fichier>`
+(#686, demande Haulogy) — symétrique du rangement déjà en place côté source
+Enargia (`FLUX_DEPOSIT_DIR`, `deploy/relais/README.md`).
 
 Amorçage (`seed_avant`, #643) : remplace l'ancien filtre `depuis` (knob
 permanent) par un acte UNIQUE — marquer les zips antérieurs à une date comme
@@ -194,8 +197,12 @@ def _controle_intra_zip(flux: str | None, fichiers: list[tuple[str, bytes]], zip
         raise ValueError(f"{zip_name} : F15 sans fichier de données générales (_FA)")
 
 
-def pousser_vers_partenaire(fichiers: list[tuple[str, bytes]], partner_url: str) -> None:
-    """Pousse les fichiers extraits vers la cible partenaire (fsspec-agnostic : file://, sftp://).
+def pousser_vers_partenaire(fichiers: list[tuple[str, bytes]], partner_url: str, flux: str | None) -> None:
+    """Pousse les fichiers extraits vers `<partner_url>/<CODE_FLUX>/` — rangement par flux
+    côté partenaire (#686, demande Haulogy), fsspec-agnostic (file://, sftp://). `flux` vient
+    de `_flux_du_zip` (réutilisé, pas re-dérivé) : `None` (nom de zip à moins de deux segments,
+    jamais observé sur un vrai zip Enedis) **lève AVANT tout dépôt** — jamais de dépôt racine
+    silencieux. Câblé en dur : pas de knob d'arborescence, un seul partenaire réel (#686).
 
     Effet de bord : une cible injoignable (permission, réseau…) **lève** — direction
     d'échec sûre, le zip n'est alors PAS enregistré comme livré (discipline `etape_chaine`
@@ -203,9 +210,11 @@ def pousser_vers_partenaire(fichiers: list[tuple[str, bytes]], partner_url: str)
     AVANT de considérer le fichier posé — un mismatch lève au même titre qu'une cible
     injoignable, retenté au passage suivant.
     """
+    if flux is None:
+        raise ValueError("Code flux introuvable dans le nom du zip — dépôt refusé (#686)")
     fs, base_path = fsspec.core.url_to_fs(partner_url)
-    fs.makedirs(base_path, exist_ok=True)
-    base = base_path.rstrip("/")
+    base = f"{base_path.rstrip('/')}/{flux}"
+    fs.makedirs(base, exist_ok=True)
     for nom, contenu in fichiers:
         chemin = f"{base}/{nom}"
         with fs.open(chemin, "wb") as f:
@@ -230,8 +239,9 @@ def _pousser(decrypted_file: dict, partner_url: str) -> Iterator[dict]:
     # file_extension="" : `str.endswith("")` est toujours vrai → extrait TOUT le
     # contenu du zip (xml et json compris), pas seulement les .xml.
     fichiers = extract_files_from_zip(decrypted_file["decrypted_content"], file_extension="")
-    _controle_intra_zip(_flux_du_zip(zip_name), fichiers, zip_name)
-    pousser_vers_partenaire(fichiers, partner_url)
+    flux = _flux_du_zip(zip_name)
+    _controle_intra_zip(flux, fichiers, zip_name)
+    pousser_vers_partenaire(fichiers, partner_url, flux)
 
     livres = dlt.current.resource_state(NOM_RESOURCE).setdefault("zips_livrés", [])
     livres.append(zip_name)

--- a/tests/ingestion/test_relais_pipeline.py
+++ b/tests/ingestion/test_relais_pipeline.py
@@ -187,7 +187,7 @@ def test_bout_en_bout_un_zip_dechiffre_decompresse_pousse(tmp_path, monkeypatch)
 
     executer(_pipeline(tmp_path, db))
 
-    assert (cible / "ENEDIS_C15_20260615_001.xml").read_bytes() == b"<data>c15</data>"
+    assert (cible / "C15" / "ENEDIS_C15_20260615_001.xml").read_bytes() == b"<data>c15</data>"
     assert _zips_journalises(db) == ["ENEDIS_C15_20260615_001.zip"]
 
 
@@ -199,11 +199,11 @@ def test_idempotence_second_run_ne_repousse_pas(tmp_path, monkeypatch):
     _configurer_env(monkeypatch, source, cible, db)
 
     executer(_pipeline(tmp_path, db))
-    (cible / "ENEDIS_C15_20260615_001.xml").unlink()  # preuve qu'un 2e run ne le re-dépose pas
+    (cible / "C15" / "ENEDIS_C15_20260615_001.xml").unlink()  # preuve qu'un 2e run ne le re-dépose pas
 
     executer(_pipeline(tmp_path, db))
 
-    assert not (cible / "ENEDIS_C15_20260615_001.xml").exists()
+    assert not (cible / "C15" / "ENEDIS_C15_20260615_001.xml").exists()
     assert _zips_journalises(db) == ["ENEDIS_C15_20260615_001.zip"]  # une seule ligne, pas deux
 
 
@@ -223,7 +223,7 @@ def test_echec_push_ne_marque_pas_livre_et_retente_au_run_suivant(tmp_path, monk
 
     _configurer_env(monkeypatch, source, cible_valide, db)
     executer(_pipeline(tmp_path, db))  # retente : cible désormais valide
-    assert (cible_valide / "ENEDIS_C15_20260615_001.xml").read_bytes() == b"<data>c15</data>"
+    assert (cible_valide / "C15" / "ENEDIS_C15_20260615_001.xml").read_bytes() == b"<data>c15</data>"
     assert _zips_journalises(db) == ["ENEDIS_C15_20260615_001.zip"]
 
 
@@ -239,8 +239,8 @@ def test_incremental_false_reliste_toute_la_source_a_chaque_run(tmp_path, monkey
     _deposer_zip(source, "ENEDIS_C15_20260616_002.zip", b"<data>deux</data>", date=(2026, 6, 16, 12, 0, 0))
     executer(_pipeline(tmp_path, db))
 
-    assert (cible / "ENEDIS_C15_20260615_001.xml").exists()
-    assert (cible / "ENEDIS_C15_20260616_002.xml").exists()
+    assert (cible / "C15" / "ENEDIS_C15_20260615_001.xml").exists()
+    assert (cible / "C15" / "ENEDIS_C15_20260616_002.xml").exists()
     assert set(_zips_journalises(db)) == {"ENEDIS_C15_20260615_001.zip", "ENEDIS_C15_20260616_002.zip"}
 
 
@@ -254,8 +254,8 @@ def test_filtre_flux_configure_exclut_les_flux_non_retenus(tmp_path, monkeypatch
 
     executer(_pipeline(tmp_path, db))
 
-    assert (cible / "ENEDIS_C15_20260615_001.xml").exists()
-    assert not (cible / "ENEDIS_R151_20260615_002.xml").exists()
+    assert (cible / "C15" / "ENEDIS_C15_20260615_001.xml").exists()
+    assert not (cible / "R151" / "ENEDIS_R151_20260615_002.xml").exists()
     assert _zips_journalises(db) == ["ENEDIS_C15_20260615_001.zip"]
 
 
@@ -288,6 +288,29 @@ def test_completude_reste_correcte_avec_un_zip_en_echec(tmp_path, monkeypatch):
 
     manquants = zips_non_relayes(f"file://{source}/", db)
     assert manquants == ["ENEDIS_C15_20260615_001.zip"]
+
+
+# =============================================================================
+# Dépôt par flux chez le partenaire (#686) : <partner_url>/<CODE_FLUX>/<fichier>
+# =============================================================================
+
+
+@pytest.mark.integration
+def test_zip_sans_code_flux_echoue_et_ne_depose_rien(tmp_path, monkeypatch):
+    """Zip dont le nom ne porte pas de code flux (moins de deux segments `_`-délimités,
+    jamais rencontré sur un vrai zip Enedis, inatteignable quand `RELAIS__FLUX` est
+    renseigné — ici filtre désactivé pour atteindre le push) : le push lève AVANT tout
+    dépôt — rien à la racine ni dans un sous-dossier, échec compté, ligne journal `echec`."""
+    source, cible, db = tmp_path / "source", tmp_path / "cible", tmp_path / "relais.duckdb"
+    zip_name = "sansflux.zip"
+    _deposer_zip(source, zip_name, b"<data>orpheline</data>")
+    _configurer_env(monkeypatch, source, cible, db)  # flux="" : filtre désactivé
+
+    info, stats = executer(_pipeline(tmp_path, db))
+
+    assert not cible.exists() or list(cible.iterdir()) == []  # rien déposé, nulle part
+    assert (stats.candidats, stats.pousses, stats.echecs_push) == (1, 0, 1)
+    assert dict(_toutes_lignes_journal(db))[zip_name] == "echec"
 
 
 # =============================================================================
@@ -379,8 +402,8 @@ def test_seed_n_amorce_pas_les_zips_posterieurs_a_avant(tmp_path, monkeypatch):
     seed_avant("2026-06-01", pipeline=_pipeline(tmp_path, db))
     executer(_pipeline(tmp_path, db))
 
-    assert not (cible / "ENEDIS_C15_20260101_001.xml").exists()
-    assert (cible / "ENEDIS_C15_20260615_002.xml").exists()
+    assert not (cible / "C15" / "ENEDIS_C15_20260101_001.xml").exists()
+    assert (cible / "C15" / "ENEDIS_C15_20260615_002.xml").exists()
     assert _statuts_journalises(db) == {
         "ENEDIS_C15_20260101_001.zip": "amorce",
         "ENEDIS_C15_20260615_002.zip": "pousse",
@@ -492,7 +515,7 @@ def test_ecriture_tronquee_ne_marque_pas_livre_et_retente(tmp_path, monkeypatch)
 
     monkeypatch.setitem(executer.__globals__, "_verifier_ecriture", verif_originale)  # vérification désormais saine
     executer(_pipeline(tmp_path, db))  # retente
-    assert (cible / "ENEDIS_C15_20260615_001.xml").read_bytes() == b"<data>c15</data>"
+    assert (cible / "C15" / "ENEDIS_C15_20260615_001.xml").read_bytes() == b"<data>c15</data>"
     assert _zips_journalises(db) == ["ENEDIS_C15_20260615_001.zip"]
 
 
@@ -730,7 +753,7 @@ def test_cli_run_normal_reussi_ne_sort_pas_en_erreur(tmp_path, monkeypatch):
 
     main()  # ne lève pas
 
-    assert (cible / "ENEDIS_C15_20260615_001.xml").exists()
+    assert (cible / "C15" / "ENEDIS_C15_20260615_001.xml").exists()
 
 
 @pytest.mark.integration

--- a/tests/ingestion/test_relais_pipeline.py
+++ b/tests/ingestion/test_relais_pipeline.py
@@ -296,13 +296,14 @@ def test_completude_reste_correcte_avec_un_zip_en_echec(tmp_path, monkeypatch):
 
 
 @pytest.mark.integration
-def test_zip_sans_code_flux_echoue_et_ne_depose_rien(tmp_path, monkeypatch):
-    """Zip dont le nom ne porte pas de code flux (moins de deux segments `_`-délimités,
-    jamais rencontré sur un vrai zip Enedis, inatteignable quand `RELAIS__FLUX` est
-    renseigné — ici filtre désactivé pour atteindre le push) : le push lève AVANT tout
-    dépôt — rien à la racine ni dans un sous-dossier, échec compté, ligne journal `echec`."""
+@pytest.mark.parametrize("zip_name", ["sansflux.zip", "ENEDIS__20260615_001.zip"])
+def test_zip_sans_code_flux_echoue_et_ne_depose_rien(tmp_path, monkeypatch, zip_name):
+    """Zip dont le nom ne porte pas de code flux — moins de deux segments `_`-délimités, ou
+    2e segment VIDE (`ENEDIS__…`, qui concaténé donnerait un chemin racine). Jamais rencontré
+    sur un vrai zip Enedis, inatteignable quand `RELAIS__FLUX` est renseigné (ici filtre
+    désactivé pour atteindre le push) : le push lève AVANT tout dépôt — rien à la racine ni
+    dans un sous-dossier, échec compté, ligne journal `echec`."""
     source, cible, db = tmp_path / "source", tmp_path / "cible", tmp_path / "relais.duckdb"
-    zip_name = "sansflux.zip"
     _deposer_zip(source, zip_name, b"<data>orpheline</data>")
     _configurer_env(monkeypatch, source, cible, db)  # flux="" : filtre désactivé
 


### PR DESCRIPTION
Closes #686

Le relais dépose désormais chaque fichier extrait dans `<RELAIS__PARTNER_URL>/<CODE_FLUX>/`
(`C15/`, `R151/`, `R15/`, `F12/`, `F15/`, …) au lieu de tout poser à plat — demande Haulogy,
rangement symétrique de la source Enargia déjà organisée par flux.

Le code flux est réutilisé depuis `_flux_du_zip` (déjà utilisé pour le contrôle intra-zip),
pas re-dérivé. Un zip sans code flux (nom à moins de deux segments `_`-délimités — jamais
observé sur un vrai zip Enedis) fait lever le push avant tout dépôt : la discipline
`etape_chaine` compte l'échec et journalise `statut='echec'`, jamais de dépôt racine
silencieux. Comportement câblé en dur, sans knob de config — `runtime.py` inchangé.

Tests bout-en-bout mis à jour sur les nouveaux chemins + nouveau test du cas « flux
introuvable ». README du relais complété côté destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)