### PR TITLE
fix(relais): outillage opérateur — zips_non_relayes str+filtre, compte d'amorçage du seed (#683, #684)

### DIFF
--- a/deploy/relais/README.md
+++ b/deploy/relais/README.md
@@ -186,6 +186,11 @@ print(zips_non_relayes('sftp://user:pass@source.example/flux', '/data/relais.duc
 "
 ```
 
+Ajouter `flux_filtres=runtime.relais().flux_filtres()` (avec `from
+electricore.config import runtime`) pour ne lister que ce qui est **dû au
+partenaire** — sans lui, l'écart inclut les flux jamais relayés (X13, LTE01,
+R63…), et ce bruit peut masquer un vrai trou (#683).
+
 ## Vue d'audit (#646)
 
 `journal.relais_audit_sequences` (matérialisée en fin de chaque passage du

--- a/electricore/ingestion/relais/__main__.py
+++ b/electricore/ingestion/relais/__main__.py
@@ -43,14 +43,16 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
 def _run_seed(args: argparse.Namespace) -> None:
     try:
-        info = seed_avant(args.avant, force=args.force)
+        info, n_amorces = seed_avant(args.avant, force=args.force)
     except RuntimeError as e:  # garde-fou métier (#643) : message déjà explicite
         print(f"❌ {e}", flush=True)
         sys.exit(1)
     except Exception as e:  # noqa: BLE001 — échec pipeline (pas par-zip) : sortie en erreur
         print(f"❌ Relais seed : échec : {e}", flush=True)
         sys.exit(1)
-    print(f"✅ Amorçage : {info}", flush=True)
+    # Le chiffre qui compte d'abord (#684) — l'info dlt verbeuse (load packages, chemins
+    # duckdb) reste disponible en fin de ligne, cf. `_run_relais` ci-dessous.
+    print(f"✅ Amorçage : {n_amorces} zip(s) marqués livrés (antérieurs à {args.avant}) — {info}", flush=True)
 
 
 def _run_relais() -> None:

--- a/electricore/ingestion/relais/pipeline.py
+++ b/electricore/ingestion/relais/pipeline.py
@@ -573,8 +573,8 @@ def zips_non_relayes(source_url: str, db_path: "Path | str", *, flux_filtres: se
     sinon `zips_non_relayes` perdrait sa sémantique « jamais relayé » (un push qui échoue en
     boucle disparaîtrait à tort de cette liste dès sa première tentative).
 
-    `db_path` : `Path(db_path)` en tête (#683) — outil opérateur invoqué en `python -c`, la
-    commande naturelle passe une string.
+    `db_path` : accepte un `str` (coercé en `Path` par `_zips_dans_journal`, #683) — outil
+    opérateur invoqué en `python -c`, la commande naturelle passe une string.
 
     `flux_filtres` (#683) : restreint l'écart aux flux relayés (même sémantique que
     `_match_flux`, défaut = tout). Sans ce filtre, le résultat mélange les vrais manquants

--- a/electricore/ingestion/relais/pipeline.py
+++ b/electricore/ingestion/relais/pipeline.py
@@ -399,7 +399,17 @@ def executer(pipeline: "dlt.Pipeline | None" = None) -> tuple["dlt.common.pipeli
     return info, stats
 
 
-def _amorcer(zip_item: dict, flux_filtres: set[str] | None, avant: str) -> Iterator[dict]:
+@dataclass
+class _CompteurAmorce:
+    """Compteur mutable du nombre de zips marqués livrés par un amorçage (#684) — même
+    mécanique que `StatsRelais` : muté depuis l'intérieur du générateur dlt, lu après
+    `pipeline.run()` (le retour de `pipeline.run()` lui-même n'expose que du verbiage dlt,
+    pas ce chiffre)."""
+
+    amorces: int = 0
+
+
+def _amorcer(zip_item: dict, flux_filtres: set[str] | None, avant: str, compteur: _CompteurAmorce) -> Iterator[dict]:
     """Étage amorçage (#643) : marque le zip comme livré SANS le pousser — utilisé
     uniquement par `seed_avant`, jamais par le run normal. Même comparaison de chaînes
     ISO-8601 que l'ancien filtre `depuis` (`modification_date` déjà normalisée en ISO
@@ -412,6 +422,7 @@ def _amorcer(zip_item: dict, flux_filtres: set[str] | None, avant: str) -> Itera
 
     livres = dlt.current.resource_state(NOM_RESOURCE).setdefault("zips_livrés", [])
     livres.append(nom)
+    compteur.amorces += 1
     yield {
         "zip": nom,
         "fichiers": [],
@@ -420,21 +431,21 @@ def _amorcer(zip_item: dict, flux_filtres: set[str] | None, avant: str) -> Itera
     }
 
 
-def _create_amorce_transformer(flux_filtres: set[str] | None, avant: str):
+def _create_amorce_transformer(flux_filtres: set[str] | None, avant: str, compteur: _CompteurAmorce):
     @dlt.transformer
     def amorcer(zip_item: dict) -> Iterator[dict]:
-        return _amorcer(zip_item, flux_filtres, avant)
+        return _amorcer(zip_item, flux_filtres, avant, compteur)
 
     return amorcer
 
 
 @dlt.source(name=NOM_PIPELINE)
-def _seed_source(source_url: str, flux_filtres: set[str] | None, avant: str):
+def _seed_source(source_url: str, flux_filtres: set[str] | None, avant: str, compteur: _CompteurAmorce):
     """Source dlt de l'amorçage : même `NOM_PIPELINE`/`NOM_RESOURCE` que `relais_source` —
     partage le même `resource_state` (`zips_livrés`), sinon le run normal repousserait tout
     ce que le seed vient de marquer livré."""
     sftp_resource = create_sftp_resource("RELAIS", "relais", "**/*.zip", source_url, incremental=False)
-    amorce = _create_amorce_transformer(flux_filtres, avant)
+    amorce = _create_amorce_transformer(flux_filtres, avant, compteur)
 
     pipeline_seed = (sftp_resource | amorce).with_name(NOM_RESOURCE)
     pipeline_seed.apply_hints(write_disposition="append")
@@ -454,7 +465,9 @@ def _journal_deja_peuple(db_path: Path) -> bool:
     return bool(_zips_dans_journal(db_path, statuts=_STATUTS_LIVRES))
 
 
-def seed_avant(avant: str, *, force: bool = False, pipeline: "dlt.Pipeline | None" = None):
+def seed_avant(
+    avant: str, *, force: bool = False, pipeline: "dlt.Pipeline | None" = None
+) -> tuple["dlt.common.pipeline.LoadInfo", int]:
     """Amorçage explicite (#643) : marque tous les zips de la source antérieurs à `avant`
     (date ISO `YYYY-MM-DD`, comparée au mtime SFTP) comme livrés SANS les pousser — évite de
     noyer le partenaire dans l'historique au tout premier run. Remplace l'ancien filtre
@@ -465,6 +478,10 @@ def seed_avant(avant: str, *, force: bool = False, pipeline: "dlt.Pipeline | Non
     l'opérateur qui sait ce qu'il fait) : lancé par erreur après la mise en service d'un
     relais déjà en route, l'amorçage enterrerait silencieusement tout ce qui restait à
     relayer — c'est la seule opération du relais capable de fabriquer un « oubli définitif ».
+
+    Retourne `(info, n_amorces)` (#684) — `n_amorces` : le nombre de zips effectivement
+    marqués livrés, le chiffre que l'opérateur cherche dans la sortie CLI (`__main__.py`),
+    pas seulement l'`info` dlt verbeuse (load packages, chemins duckdb).
     """
     cfg = runtime.relais()
     if not force and _journal_deja_peuple(cfg.destination_db):
@@ -475,7 +492,9 @@ def seed_avant(avant: str, *, force: bool = False, pipeline: "dlt.Pipeline | Non
         )
     if pipeline is None:
         pipeline = _pipeline_par_defaut(cfg)
-    return pipeline.run(_seed_source(cfg.source_url, cfg.flux_filtres(), avant))
+    compteur = _CompteurAmorce()
+    info = pipeline.run(_seed_source(cfg.source_url, cfg.flux_filtres(), avant, compteur))
+    return info, compteur.amorces
 
 
 _STATUTS_LIVRES = ("pousse", "amorce")  # les deux seuls statuts qui valent « relayé » (#646)

--- a/electricore/ingestion/relais/pipeline.py
+++ b/electricore/ingestion/relais/pipeline.py
@@ -481,10 +481,13 @@ def seed_avant(avant: str, *, force: bool = False, pipeline: "dlt.Pipeline | Non
 _STATUTS_LIVRES = ("pousse", "amorce")  # les deux seuls statuts qui valent « relayé » (#646)
 
 
-def _zips_dans_journal(db_path: Path, *, statuts: tuple[str, ...] | None = None) -> set[str]:
+def _zips_dans_journal(db_path: "Path | str", *, statuts: tuple[str, ...] | None = None) -> set[str]:
     """Noms de zip présents dans le journal — `statuts=None` : toute ligne, quel que soit son
     statut (vu/pousse/amorce/echec) ; `statuts=(...)` : restreint à ces statuts. Base absente
     ou table pas encore créée (aucune ligne écrite) → ensemble vide, jamais une exception.
+
+    `db_path` : `Path(db_path)` en tête (#683) — outil opérateur invoqué en `python -c`, la
+    commande naturelle passe une string, pas un `Path`.
 
     Connexion `read_only` d'abord, repli lecture-écriture (#646, revue) : les chemins
     opérateur (`zips_non_relayes`, garde-fou du seed) sont des lectures pures — plusieurs
@@ -496,6 +499,7 @@ def _zips_dans_journal(db_path: Path, *, statuts: tuple[str, ...] | None = None)
     opérateur pendant la passe du timer échoue proprement sur le verrou — relancer après."""
     import duckdb
 
+    db_path = Path(db_path)
     if not db_path.exists():
         return set()
     try:
@@ -540,7 +544,7 @@ def _journaliser_vus(pipeline: "dlt.Pipeline", cfg: "runtime.Relais") -> None:
     pipeline.run(lignes, table_name=NOM_RESOURCE, write_disposition="append")
 
 
-def zips_non_relayes(source_url: str, db_path: Path) -> list[str]:
+def zips_non_relayes(source_url: str, db_path: "Path | str", *, flux_filtres: set[str] | None = None) -> list[str]:
     """Vérification de complétude (#637) : zips de la source absents du journal de destination.
 
     Écart entre le listing source (fsspec, tous les `*.zip` récursivement) et les zips
@@ -548,8 +552,18 @@ def zips_non_relayes(source_url: str, db_path: Path) -> list[str]:
     `resource_state` (qui gouverne seulement le skip du run suivant). Journal enrichi (#646) :
     un zip seulement `'vu'` ou en `'echec'` N'EST PAS relayé — il doit rester manquant ici,
     sinon `zips_non_relayes` perdrait sa sémantique « jamais relayé » (un push qui échoue en
-    boucle disparaîtrait à tort de cette liste dès sa première tentative)."""
+    boucle disparaîtrait à tort de cette liste dès sa première tentative).
+
+    `db_path` : `Path(db_path)` en tête (#683) — outil opérateur invoqué en `python -c`, la
+    commande naturelle passe une string.
+
+    `flux_filtres` (#683) : restreint l'écart aux flux relayés (même sémantique que
+    `_match_flux`, défaut = tout). Sans ce filtre, le résultat mélange les vrais manquants
+    avec les zips de flux jamais dus au partenaire (X13, LTE01, R63…) — du bruit qui a failli
+    masquer un vrai trou (#681)."""
     fs, base_path = fsspec.core.url_to_fs(source_url)
-    zips_source = {Path(p).name for p in fs.glob(f"{base_path.rstrip('/')}/**/*.zip")}
+    zips_source = {
+        Path(p).name for p in fs.glob(f"{base_path.rstrip('/')}/**/*.zip") if _match_flux(Path(p).name, flux_filtres)
+    }
     livres = _zips_dans_journal(db_path, statuts=_STATUTS_LIVRES)
     return sorted(zips_source - livres)

--- a/tests/ingestion/test_relais_pipeline.py
+++ b/tests/ingestion/test_relais_pipeline.py
@@ -315,6 +315,43 @@ def test_zip_sans_code_flux_echoue_et_ne_depose_rien(tmp_path, monkeypatch, zip_
 
 
 # =============================================================================
+# #683 : zips_non_relayes — db_path str, bruit des flux hors liste
+# =============================================================================
+
+
+@pytest.mark.integration
+def test_completude_accepte_un_db_path_str(tmp_path, monkeypatch):
+    """`zips_non_relayes` est un outil opérateur invoqué en `python -c` : la commande
+    naturelle passe une string, pas un `Path` — coercion en tête de fonction (#683)."""
+    source, cible, db = tmp_path / "source", tmp_path / "cible", tmp_path / "relais.duckdb"
+    _deposer_zip(source, "ENEDIS_C15_20260615_001.zip", b"<data>c15</data>")
+    _configurer_env(monkeypatch, source, cible, db, flux="R151")  # exclut le C15 déposé → jamais relayé
+
+    executer(_pipeline(tmp_path, db))
+
+    manquants = zips_non_relayes(f"file://{source}/", str(db))  # str, pas Path
+    assert manquants == ["ENEDIS_C15_20260615_001.zip"]
+
+
+@pytest.mark.integration
+def test_completude_flux_filtres_exclut_les_zips_hors_liste(tmp_path, monkeypatch):
+    """Avec `flux_filtres`, les zips hors liste (jamais dus au partenaire, ex. X13/LTE01)
+    n'apparaissent plus dans l'écart — même sémantique que `_match_flux` (#683) : le
+    R151 filtré côté relais (`RELAIS__FLUX=C15`) reste « vu » mais jamais relayé, or ce
+    n'est pas ce bruit que l'opérateur cherche quand il demande « qu'est-ce qui manque à
+    Haulogy ? »."""
+    source, cible, db = tmp_path / "source", tmp_path / "cible", tmp_path / "relais.duckdb"
+    _deposer_zip(source, "ENEDIS_C15_20260615_001.zip", b"<data>c15</data>")
+    _deposer_zip(source, "ENEDIS_R151_20260615_002.zip", b"<data>r151</data>")
+    _configurer_env(monkeypatch, source, cible, db, flux="C15")  # seul C15 est relayé
+
+    executer(_pipeline(tmp_path, db))  # C15 poussé ; R151 journalisé 'vu', jamais relayé
+
+    assert zips_non_relayes(f"file://{source}/", db) == ["ENEDIS_R151_20260615_002.zip"]
+    assert zips_non_relayes(f"file://{source}/", db, flux_filtres={"C15"}) == []
+
+
+# =============================================================================
 # Critère 7 (#643) : push via etape_chaine — StatsRelais, statut journalisé, escalade
 # =============================================================================
 

--- a/tests/ingestion/test_relais_pipeline.py
+++ b/tests/ingestion/test_relais_pipeline.py
@@ -449,6 +449,22 @@ def test_seed_n_amorce_pas_les_zips_posterieurs_a_avant(tmp_path, monkeypatch):
 
 
 @pytest.mark.integration
+def test_seed_avant_retourne_le_compte_de_zips_amorces(tmp_path, monkeypatch):
+    """#684 : `seed_avant` retourne `(info, n_amorces)` — le chiffre qui compte (combien de
+    zips ont été marqués livrés), pas seulement l'`info` dlt verbeuse. Un zip postérieur à
+    `--avant` n'est pas amorcé, ne compte donc pas."""
+    source, cible, db = tmp_path / "source", tmp_path / "cible", tmp_path / "relais.duckdb"
+    _deposer_zip(source, "ENEDIS_C15_20260101_001.zip", b"<data>vieux</data>", date=(2026, 1, 1, 12, 0, 0))
+    _deposer_zip(source, "ENEDIS_C15_20260102_002.zip", b"<data>vieux aussi</data>", date=(2026, 1, 2, 12, 0, 0))
+    _deposer_zip(source, "ENEDIS_C15_20260615_003.zip", b"<data>neuf</data>")
+    _configurer_env(monkeypatch, source, cible, db)
+
+    info, n_amorces = seed_avant("2026-06-01", pipeline=_pipeline(tmp_path, db))
+
+    assert n_amorces == 2
+
+
+@pytest.mark.integration
 def test_seed_refuse_si_journal_deja_peuple(tmp_path, monkeypatch):
     """Garde-fou (#643) : le seed refuse si le journal contient déjà des livraisons —
     lancé par erreur après la mise en service, il enterrerait silencieusement tout ce
@@ -813,3 +829,21 @@ def test_cli_seed_marque_livre_et_refuse_sans_force_si_deja_peuple(tmp_path, mon
     with pytest.raises(SystemExit) as exc:
         main()  # relancé sans --force : journal déjà peuplé → refuse
     assert exc.value.code != 0
+
+
+@pytest.mark.integration
+def test_cli_seed_imprime_le_compte_de_zips_amorces(tmp_path, monkeypatch, capsys):
+    """#684 : la sortie CLI du seed affiche le chiffre qui compte — combien de zips ont été
+    marqués livrés — pas seulement le verbiage dlt (load packages, chemins duckdb)."""
+    from electricore.ingestion.relais.__main__ import main
+
+    source, cible, db = tmp_path / "source", tmp_path / "cible", tmp_path / "relais.duckdb"
+    _deposer_zip(source, "ENEDIS_C15_20260101_001.zip", b"<data>un</data>", date=(2026, 1, 1, 12, 0, 0))
+    _deposer_zip(source, "ENEDIS_C15_20260102_002.zip", b"<data>deux</data>", date=(2026, 1, 2, 12, 0, 0))
+    _configurer_env(monkeypatch, source, cible, db)
+    monkeypatch.setattr(sys, "argv", ["relais", "seed", "--avant", "2026-06-01"])
+
+    main()  # ne lève pas
+
+    sortie = capsys.readouterr().out
+    assert "2 zip(s) marqués livrés (antérieurs à 2026-06-01)" in sortie


### PR DESCRIPTION
Deux surprises mineures de la générale du 28/07 (PRD #658, issue #661) sur l'outillage
opérateur du relais.

- #683 : `zips_non_relayes` acceptait uniquement un `Path` alors que c'est un outil
  invoqué en `python -c` (donc naturellement en string) — coercion ajoutée. Un paramètre
  `flux_filtres` (même sémantique que `_match_flux`) permet de restreindre l'écart aux
  flux effectivement relayés, pour ne plus noyer les vrais manquants sous le bruit des
  zips « vu » de flux hors liste (X13, LTE01, R63…).
- #684 : le mode `seed` n'affichait que le verbiage dlt, jamais le chiffre qui compte
  (combien de zips ont été marqués livrés). La sortie CLI affiche maintenant
  « ✅ Amorçage : N zip(s) marqués livrés (antérieurs à <date>) ».

Closes #683
Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)