### PR TITLE
feat(relais): sous-commande completude — l'écart dû au partenaire sans python -c (#690)

### DIFF
--- a/deploy/relais/README.md
+++ b/deploy/relais/README.md
@@ -175,21 +175,30 @@ sudo -u <slug> docker compose --env-file /srv/<slug>/config.env \
 
 ## Complétude
 
-Requête ad hoc (zips reçus jamais relayés), depuis le conteneur :
+Sous-commande dédiée (`relais completude`, #690 — remplace l'ancien `python -c`
+à rallonge), depuis le conteneur. **Défaut** : l'écart restreint aux flux
+**dus** au partenaire (`RELAIS__FLUX`, arbitrage revue #688 — la vraie
+question opérateur) ; sortie : un zip par ligne (lisible à l'œil, consommable
+en pipe) puis une ligne de compte, exit **0** dans tous les cas — consultation
+passive, même philosophie que la vue d'audit ci-dessous, l'escalade du relais
+reste `relais_aveugle()` :
 
 ```bash
 sudo -u <slug> docker compose --env-file /srv/<slug>/config.env \
     -f /srv/<slug>/deploy/relais/compose-relais.yml run --rm relais \
-    python -c "
-from electricore.ingestion.relais.pipeline import zips_non_relayes
-print(zips_non_relayes('sftp://user:pass@source.example/flux', '/data/relais.duckdb'))
-"
+    python -m electricore.ingestion.relais completude
 ```
 
-Ajouter `flux_filtres=runtime.relais().flux_filtres()` (avec `from
-electricore.config import runtime`) pour ne lister que ce qui est **dû au
-partenaire** — sans lui, l'écart inclut les flux jamais relayés (X13, LTE01,
-R63…), et ce bruit peut masquer un vrai trou (#683).
+`--tous` : l'écart brut, tous flux confondus (comportement historique de
+`zips_non_relayes`) — sans le filtre par défaut, l'écart inclut les flux
+jamais dus au partenaire (X13, LTE01, R63…), du bruit qui a failli masquer un
+vrai trou de 47 zips à la générale (#683) :
+
+```bash
+sudo -u <slug> docker compose --env-file /srv/<slug>/config.env \
+    -f /srv/<slug>/deploy/relais/compose-relais.yml run --rm relais \
+    python -m electricore.ingestion.relais completude --tous
+```
 
 ## Vue d'audit (#646)
 

--- a/electricore/ingestion/relais/__main__.py
+++ b/electricore/ingestion/relais/__main__.py
@@ -8,6 +8,17 @@ re-listing, pas par la détection d'événements.
 Sous-commande `seed --avant <date> [--force]` : amorçage explicite, un acte
 UNIQUE distinct du run périodique (voir `pipeline.py::seed_avant`).
 
+Sous-commande `completude [--tous]` (#690) : remplace le `python -c` à
+rallonge qui vivait dans le README opérateur (`deploy/relais/README.md`) —
+zips reçus jamais relayés (`pipeline.py::zips_non_relayes`, #637/#683).
+Défaut : écart restreint aux flux **dus** au partenaire
+(`runtime.relais().flux_filtres()`, arbitrage revue #688) — sans ce filtre,
+le bruit hors liste (X13, LTE01, R63…) a failli masquer un vrai trou de 47
+zips à la générale. `--tous` : écart brut, comportement historique de
+`zips_non_relayes`. Consultation **passive** : sortie toujours 0, même s'il
+manque des zips — l'escalade du relais reste `relais_aveugle()` (run normal),
+jamais cette sous-commande.
+
 Pas de `logging.disable` (retiré, #643) : les `logger.warning` d'échec de push
 (`pipeline.py::_pousser`, via `etape_chaine`) doivent rester visibles dans
 `journalctl` — un relais qui avale ses propres warnings retenterait en
@@ -20,7 +31,7 @@ import argparse
 import sys
 
 from electricore.config import runtime
-from electricore.ingestion.relais.pipeline import executer, seed_avant
+from electricore.ingestion.relais.pipeline import executer, seed_avant, zips_non_relayes
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -38,6 +49,17 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help="outrepasse le refus si le journal contient déjà des livraisons",
     )
 
+    completude = sous.add_parser(
+        "completude",
+        help="Complétude (#690) : zips reçus jamais relayés — restreint aux flux dus par défaut.",
+    )
+    completude.add_argument(
+        "--tous",
+        action="store_true",
+        help="écart brut, tous flux confondus (comportement historique) — "
+        "défaut : restreint aux flux dus au partenaire (RELAIS__FLUX)",
+    )
+
     return parser.parse_args(argv)
 
 
@@ -53,6 +75,18 @@ def _run_seed(args: argparse.Namespace) -> None:
     # Pas de `— {info}` dlt ici (#684) : le seed est un geste interactif, le pavé LoadInfo
     # noyait le chiffre — `_run_relais` (timer → journalctl) garde le sien, lui.
     print(f"✅ Amorçage : {n_amorces} zip(s) marqués livrés (antérieurs à {args.avant})", flush=True)
+
+
+def _run_completude(args: argparse.Namespace) -> None:
+    """Consultation passive (#690) : un zip par ligne (lisible à l'œil, consommable en
+    pipe) puis une ligne de compte — jamais de `sys.exit` non-zéro ici, quel que soit le
+    nombre de manquants (l'escalade du relais reste `relais_aveugle()`, pas cet outil)."""
+    cfg = runtime.relais()
+    flux_filtres = None if args.tous else cfg.flux_filtres()
+    manquants = zips_non_relayes(cfg.source_url, cfg.destination_db, flux_filtres=flux_filtres)
+    for zip_name in manquants:
+        print(zip_name, flush=True)
+    print(f"{len(manquants)} zip(s) manquant(s)", flush=True)
 
 
 def _run_relais() -> None:
@@ -77,6 +111,8 @@ def main() -> None:
     runtime.valider(runtime.relais, runtime.aes)
     if args.commande == "seed":
         _run_seed(args)
+    elif args.commande == "completude":
+        _run_completude(args)
     else:
         _run_relais()
 

--- a/electricore/ingestion/relais/pipeline.py
+++ b/electricore/ingestion/relais/pipeline.py
@@ -573,8 +573,9 @@ def zips_non_relayes(source_url: str, db_path: "Path | str", *, flux_filtres: se
     sinon `zips_non_relayes` perdrait sa sémantique « jamais relayé » (un push qui échoue en
     boucle disparaîtrait à tort de cette liste dès sa première tentative).
 
-    `db_path` : accepte un `str` (coercé en `Path` par `_zips_dans_journal`, #683) — outil
-    opérateur invoqué en `python -c`, la commande naturelle passe une string.
+    `db_path` : accepte un `str` (coercé en `Path` par `_zips_dans_journal`, #683) — la
+    sous-commande `relais completude` (#690) passe un `Path`, un appel ad hoc (notebook,
+    `python -c`) passe naturellement une string.
 
     `flux_filtres` (#683) : restreint l'écart aux flux relayés (même sémantique que
     `_match_flux`, défaut = tout). Sans ce filtre, le résultat mélange les vrais manquants

--- a/tests/ingestion/test_relais_pipeline.py
+++ b/tests/ingestion/test_relais_pipeline.py
@@ -847,3 +847,83 @@ def test_cli_seed_imprime_le_compte_de_zips_amorces(tmp_path, monkeypatch, capsy
 
     sortie = capsys.readouterr().out
     assert "2 zip(s) marqués livrés (antérieurs à 2026-06-01)" in sortie
+
+
+# =============================================================================
+# CLI (__main__.py, #690) : sous-commande completude — remplace le python -c du README
+# =============================================================================
+
+
+@pytest.mark.integration
+def test_cli_completude_par_defaut_restreint_aux_flux_dus(tmp_path, monkeypatch, capsys):
+    """Défaut : l'écart est restreint aux flux dus au partenaire (`RELAIS__FLUX`, arbitrage
+    revue #688) — le R151 (jamais dû ici) n'apparaît pas, même s'il n'a jamais été relayé."""
+    from electricore.ingestion.relais.__main__ import main
+
+    source, cible, db = tmp_path / "source", tmp_path / "cible", tmp_path / "relais.duckdb"
+    _deposer_zip(source, "ENEDIS_C15_20260615_001.zip", b"<data>c15</data>")
+    _deposer_zip(source, "ENEDIS_R151_20260615_002.zip", b"<data>r151</data>")
+    _configurer_env(monkeypatch, source, cible, db, flux="C15")  # seul C15 est dû au partenaire
+    monkeypatch.setattr(sys, "argv", ["relais", "completude"])
+
+    main()  # ne lève pas (exit 0)
+
+    sortie = capsys.readouterr().out
+    lignes = sortie.splitlines()
+    assert "ENEDIS_C15_20260615_001.zip" in lignes
+    assert "ENEDIS_R151_20260615_002.zip" not in lignes
+    assert "1 zip(s) manquant(s)" in sortie
+
+
+@pytest.mark.integration
+def test_cli_completude_tous_donne_l_ecart_brut(tmp_path, monkeypatch, capsys):
+    """`--tous` : l'écart brut, tous flux confondus (comportement historique de
+    `zips_non_relayes`) — le R151 hors liste apparaît désormais."""
+    from electricore.ingestion.relais.__main__ import main
+
+    source, cible, db = tmp_path / "source", tmp_path / "cible", tmp_path / "relais.duckdb"
+    _deposer_zip(source, "ENEDIS_C15_20260615_001.zip", b"<data>c15</data>")
+    _deposer_zip(source, "ENEDIS_R151_20260615_002.zip", b"<data>r151</data>")
+    _configurer_env(monkeypatch, source, cible, db, flux="C15")
+    monkeypatch.setattr(sys, "argv", ["relais", "completude", "--tous"])
+
+    main()  # ne lève pas (exit 0)
+
+    sortie = capsys.readouterr().out
+    lignes = sortie.splitlines()
+    assert "ENEDIS_C15_20260615_001.zip" in lignes
+    assert "ENEDIS_R151_20260615_002.zip" in lignes
+    assert "2 zip(s) manquant(s)" in sortie
+
+
+@pytest.mark.integration
+def test_cli_completude_exit_0_meme_avec_des_manquants(tmp_path, monkeypatch, capsys):
+    """Consultation passive (#690) : sortie 0 même quand il manque des zips — l'escalade du
+    relais reste `relais_aveugle()` (le run normal), jamais cette sous-commande."""
+    from electricore.ingestion.relais.__main__ import main
+
+    source, cible, db = tmp_path / "source", tmp_path / "cible", tmp_path / "relais.duckdb"
+    _deposer_zip(source, "ENEDIS_C15_20260615_001.zip", b"<data>c15</data>")
+    _configurer_env(monkeypatch, source, cible, db)
+    monkeypatch.setattr(sys, "argv", ["relais", "completude"])
+
+    main()  # ne lève PAS SystemExit malgré le manquant — exit 0 implicite
+
+    assert "1 zip(s) manquant(s)" in capsys.readouterr().out
+
+
+@pytest.mark.integration
+def test_cli_completude_sans_manquant_liste_vide_et_compte_zero(tmp_path, monkeypatch, capsys):
+    """Rien à signaler → aucune ligne de zip, seule la ligne de compte (0)."""
+    from electricore.ingestion.relais.__main__ import main
+
+    source, cible, db = tmp_path / "source", tmp_path / "cible", tmp_path / "relais.duckdb"
+    _deposer_zip(source, "ENEDIS_C15_20260615_001.zip", b"<data>c15</data>")
+    _configurer_env(monkeypatch, source, cible, db)
+    executer(_pipeline(tmp_path, db))  # relaie le seul zip présent
+    capsys.readouterr()  # vide le verbiage dbt du executer() ci-dessus
+
+    monkeypatch.setattr(sys, "argv", ["relais", "completude"])
+    main()
+
+    assert capsys.readouterr().out.strip() == "0 zip(s) manquant(s)"

--- a/tests/ingestion/test_relais_pipeline.py
+++ b/tests/ingestion/test_relais_pipeline.py
@@ -321,7 +321,7 @@ def test_zip_sans_code_flux_echoue_et_ne_depose_rien(tmp_path, monkeypatch, zip_
 
 @pytest.mark.integration
 def test_completude_accepte_un_db_path_str(tmp_path, monkeypatch):
-    """`zips_non_relayes` est un outil opérateur invoqué en `python -c` : la commande
+    """`zips_non_relayes` reste appelable ad hoc (notebook, `python -c`) : la commande
     naturelle passe une string, pas un `Path` — coercion en tête de fonction (#683)."""
     source, cible, db = tmp_path / "source", tmp_path / "cible", tmp_path / "relais.duckdb"
     _deposer_zip(source, "ENEDIS_C15_20260615_001.zip", b"<data>c15</data>")


### PR DESCRIPTION
Closes #690

Ajoute `relais completude [--tous]` au CLI du relais, à côté de `seed` :
remplace le `python -c` à rallonge du README opérateur par une vraie
sous-commande. Défaut = écart restreint aux flux dus au partenaire
(`runtime.relais().flux_filtres()`, arbitrage revue #688) ; `--tous` = écart
brut historique. Sortie : un zip par ligne + une ligne de compte, exit 0 dans
tous les cas (consultation passive, l'escalade reste `relais_aveugle()`).
Réutilise `zips_non_relayes` (#683) tel quel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)