### PR TITLE
chore: bump electricore 3.7.0 → 3.8.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.7.0"
+version = "3.8.0rc1"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.7.0"
+version = "3.8.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Bump de version pour la release candidate du cycle relais.

**Contenu du cycle depuis v3.7.0** (43 commits, 100 % relais + deploy) :
- dépôt par flux chez le partenaire `<partner_url>/<CODE_FLUX>/` (#686)
- sous-commande `completude` (#690)
- escalade du déchiffrement — échecs comptés et journalisés (#692)
- alerte mail OnFailure posée par `install.sh --relais` (msmtprc rendu, passwordeval sops) (#668, #674)
- timer fiabilisé (#673, #682), gardes anti-fuite credentials (#693), durcissements secrets/age.key

**Après merge** : tag `v3.8.0rc1` → image ghcr → générale Enargia (#661) → promotion `v3.8.0` stable si verte.

Minor (capacités nouvelles), rc d'abord : la générale n'est pas jouée. #651 (famille facturation) glisse vers 3.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)