### PR TITLE
feat(deploy): mode B sans édition manuelle — montage collocé de la stack piloté par FLUX_DEPOSIT_DIR

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -57,8 +57,12 @@ services:
       # le secrets.env chiffré (pull du dépôt privé dans providers/<slug>/).
       - ../../age.key:/run/secrets/age.key:ro
       - ../../providers/${INSTANCE_SLUG:-electricore}/secrets.env:/run/secrets/secrets.env:ro
-      # Mode "fichiers collocés" : décommenter et adapter si SFTP__URL=file://... dans secrets.env
-      # - /var/enedis:/var/enedis:ro
+      # Mode "fichiers collocés" (SFTP__URL=file://… dans secrets.env) : dépôt monté ro
+      # au MÊME chemin dedans/dehors — l'URL vaut telle quelle des deux côtés.
+      # FLUX_DEPOSIT_DIR vient du config.env racine (substitution --env-file, cf. en-tête) ;
+      # sans la variable, défaut inerte (dossier vide) — mode SFTP distant intact.
+      # Même mécanisme que le relais (compose-relais.yml), même variable.
+      - ${FLUX_DEPOSIT_DIR:-/srv/electricore/flux-deposit}:${FLUX_DEPOSIT_DIR:-/srv/electricore/flux-deposit}:ro
     expose:
       - "8001"
     healthcheck:

--- a/deploy/providers/example/config.env.example
+++ b/deploy/providers/example/config.env.example
@@ -33,7 +33,9 @@ RELAIS__SOURCE_URL=file:///srv/example/flux-deposit
 # Dossier réel du dépôt en mode file:// — monté ro TEL QUEL dans le conteneur (même
 # chemin dedans/dehors) ; DOIT être le chemin de RELAIS__SOURCE_URL (garde de cohérence
 # à l'install, env_validate). Enargia : /flux/enedis (arborescence par flux OK, listing
-# récursif **/*.zip). Inutile en mode sftp://.
+# récursif **/*.zip). Inutile en mode sftp://. Sert AUSSI au montage collocé de la
+# STACK (service api, SFTP__URL=file://… dans secrets.env — docs/deploiement.md
+# « Mode B ») : une seule variable pour les deux composants.
 FLUX_DEPOSIT_DIR=/srv/example/flux-deposit
 RELAIS__PARTNER_URL=sftp://relais@partenaire.example/in
 RELAIS__FLUX=C15,R151,R15,F12,F15

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -318,6 +318,13 @@ grep -qF -- '- ${FLUX_DEPOSIT_DIR:-/srv/electricore/flux-deposit}:${FLUX_DEPOSIT
     || ko "render_relais_compose: montage flux-deposit absent/incorrect"
 
 echo
+echo "→ docker/docker-compose.yml (stack) — montage collocé paramétré (mode B sans édition manuelle)"
+# NB : LIB_DIR et pas SCRIPT_DIR (écrasé par le sourçage d'install.sh, cf. en-tête).
+grep -qF -- '- ${FLUX_DEPOSIT_DIR:-/srv/electricore/flux-deposit}:${FLUX_DEPOSIT_DIR:-/srv/electricore/flux-deposit}:ro' "${LIB_DIR}/../docker/docker-compose.yml" \
+    && ok "docker-compose.yml: montage collocé du service api piloté par FLUX_DEPOSIT_DIR (défaut inerte, même idiome que le relais)" \
+    || ko "docker-compose.yml: montage collocé FLUX_DEPOSIT_DIR absent — le mode B redevient une édition manuelle perdue au reconfigure"
+
+echo
 echo "→ relais.sh / relais_etat_vierge (garde #673 : timer jamais armé sans amorce)"
 # Fake docker : `volume inspect` répond le mountpoint contrôlé par le test, ou échoue
 # (volume absent) si le drapeau `absent` existe — la garde ne dépend de docker que

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -696,19 +696,20 @@ déclenchement d'ingestion.
 Dans `secrets.env` (chiffré, dépôt de déploiement) :
 
 ```
-SFTP__URL=file:///var/enedis/
+SFTP__URL=file:///var/enedis
 ```
 
-Dans `/srv/<slug>/deploy/docker/docker-compose.yml`, décommenter le bind-mount
-du service **`api`** :
+Dans `config.env` (clair, même dépôt) — le même chemin, sans le schéma :
 
-```yaml
-services:
-  api:
-    volumes:
-      - duckdb_data:/data
-      - /var/enedis:/var/enedis:ro     # ← cette ligne
 ```
+FLUX_DEPOSIT_DIR=/var/enedis
+```
+
+Rien à éditer dans `docker-compose.yml` : le service **`api`** monte
+`${FLUX_DEPOSIT_DIR}` en lecture seule au même chemin dedans/dehors (substitution
+`--env-file`), donc l'URL `file://` vaut telle quelle des deux côtés. Sans la
+variable, le montage retombe sur un dossier vide inerte (mode A intact). C'est la
+même variable et le même mécanisme que côté relais (`compose-relais.yml`).
 
 > **⚠️ Important** : les fichiers Enedis restent chiffrés en AES sur disque
 > (même en mode collocé). Les clés `AES__*` sont toujours obligatoires.


### PR DESCRIPTION
Constat du chantier stack Enargia : le mode « fichiers collocés » demandait de décommenter un bind-mount dans `docker-compose.yml`, édition perdue au reconfigure suivant (le fichier est re-téléchargé tel quel).

- Le montage du service `api` est désormais substitué par `${FLUX_DEPOSIT_DIR}` — même variable et même idiome que le relais (chemin identique dedans/dehors, défaut inerte `/srv/electricore/flux-deposit` en mode SFTP distant : EDN ne voit aucune différence).
- Doc « Mode B » et `config.env.example` alignés (plus de « décommenter »).
- Assertion `unit.sh` (275/275 au vert) + rendu `docker compose config` vérifié avec et sans la variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bq5Y8tnCQWiLMtTeDVikh9