### PR TITLE
Kiosque : squelette (ADR + package) — accès néophytes en apps marimo hébergées

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,40 @@ jobs:
         run: |
           /tmp/client-venv/bin/python -m pytest packages/electricore-client/tests -q
 
+  test-kiosque:
+    name: test-kiosque (isolé, sans le moteur)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      # Environnement ISOLÉ : uniquement electricore-kiosque (marimo + fastapi +
+      # electricore-client) + pytest. JAMAIS le moteur (polars/duckdb), même
+      # invariant que le job test-client (ADR-0057, #704).
+      - name: Créer un venv isolé pour le Kiosque
+        run: uv venv /tmp/kiosque-venv
+
+      - name: Installer electricore-kiosque seul (+ ses deps de test)
+        run: |
+          uv pip install --python /tmp/kiosque-venv ./packages/electricore-kiosque ./packages/electricore-client pytest httpx
+
+      - name: Garde-fou — polars/duckdb ABSENTS de l'environnement
+        run: |
+          uv pip list --python /tmp/kiosque-venv | tee /tmp/pkgs-kiosque.txt
+          if grep -iqE '^(polars|duckdb)[[:space:]]' /tmp/pkgs-kiosque.txt; then
+            echo "::error::Le moteur (polars/duckdb) a fuité dans l'env Kiosque isolé."
+            exit 1
+          fi
+
+      - name: Lancer les tests du Kiosque (couture ASGI, sans navigateur ni vrai serveur)
+        run: |
+          /tmp/kiosque-venv/bin/python -m pytest packages/electricore-kiosque/tests -q
+
   deploy-tests:
     name: deploy shell tests (bash, fake-binaries)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ SFTP Enedis → Ingestion (dlt + dbt) → DuckDB → Query Builders → Core Pip
 - **Date convention**: R151 flux uses +1 day adjustment to harmonize with R64/R15/C15 (see [docs/conventions-dates-enedis.md](docs/conventions-dates-enedis.md))
 - **Column naming**: Follows `grandeur_cadran_unité` format
 - **Domain glossary**: see [CONTEXT-MAP.md](CONTEXT-MAP.md) — multi-context layout, business vocabulary in [`electricore/core/CONTEXT.md`](electricore/core/CONTEXT.md) (PDL, FTA, TURPE, cadrans, événements C15, périmètre, abonnement, Odoo); module-specific terms in `ingestion/api/bot/CONTEXT.md`.
-- **Architecture decisions**: see [docs/adr/](docs/adr/) — load-bearing past decisions (monorepo, Polars-only, R151 date adjustment, French language, DuckDB, DLT, query builders, AES rotation, API-centric architecture, Telegram bot, VPS Docker deployment, core ERP-agnostique, rôles loaders/pipelines/builds/integrations, linéarisation dbt + bascule production, surface bot par domaines, périodisations séparées, trois registres de savoir, facturation calendaire, présence au périmètre par RSC)
+- **Architecture decisions**: see [docs/adr/](docs/adr/) — load-bearing past decisions (monorepo, Polars-only, R151 date adjustment, French language, DuckDB, DLT, query builders, AES rotation, API-centric architecture, Telegram bot, VPS Docker deployment, core ERP-agnostique, rôles loaders/pipelines/builds/integrations, linéarisation dbt + bascule production, surface bot par domaines, périodisations séparées, trois registres de savoir, facturation calendaire, présence au périmètre par RSC, accès Kiosque néophytes en package séparé)
 
 #### Column Naming Conventions
 

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -17,5 +17,6 @@ ElectriCore est organisé en modules avec leur propre vocabulaire. Le glossaire 
 - `ingestion` ingère les flux Enedis dans DuckDB, consommés par `core`.
 - `api` expose `core` (calculs) et `integrations/<erp>` (orchestrations), et orchestre `ingestion` (déclenchements + jobs).
 - `bot` consomme `api` exclusivement (pas d'accès direct à `core` ni à `ingestion` ni à `integrations`).
+- Trois accès externes passent par `api` + `electricore-client` (hors repo) : le **module Odoo** (l'ERP tire les données), les **Notebooks** (`electricore-notebooks`, marimo `edit` local, exploratoire, orienté dev) et le **Kiosque** (`electricore-kiosque`, apps marimo hébergées, lecture seule, process fixes pour néophytes — la clé API est la seule identité, pas de comptes).
 
 Les ADRs structurants sont au niveau racine dans [docs/adr/](docs/adr/) ; aucun ADR par contexte pour l'instant.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -17,6 +17,6 @@ ElectriCore est organisé en modules avec leur propre vocabulaire. Le glossaire 
 - `ingestion` ingère les flux Enedis dans DuckDB, consommés par `core`.
 - `api` expose `core` (calculs) et `integrations/<erp>` (orchestrations), et orchestre `ingestion` (déclenchements + jobs).
 - `bot` consomme `api` exclusivement (pas d'accès direct à `core` ni à `ingestion` ni à `integrations`).
-- Trois accès externes passent par `api` + `electricore-client` (hors repo) : le **module Odoo** (l'ERP tire les données), les **Notebooks** (`electricore-notebooks`, marimo `edit` local, exploratoire, orienté dev) et le **Kiosque** (`electricore-kiosque`, apps marimo hébergées, lecture seule, process fixes pour néophytes — la clé API est la seule identité, pas de comptes).
+- Trois accès externes passent par `api` + `electricore-client` : le **module Odoo** (l'ERP tire les données), les **Notebooks** (`electricore-notebooks`, marimo `run` sur poste, orienté dev) et le **Kiosque** (`electricore-kiosque`, apps marimo hébergées, lecture seule, process fixes pour néophytes — la clé API est la seule identité, pas de comptes).
 
 Les ADRs structurants sont au niveau racine dans [docs/adr/](docs/adr/) ; aucun ADR par contexte pour l'instant.

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -128,7 +128,7 @@ expect: la commande répond (clavier inline sans argument, action directe avec),
 ## notebooks
 
 mode: human
-when: changement des notebooks opérateur (accueil, facturation, injection RSC) — pont transitoire #414
+when: changement des notebooks opérateur (accueil, facturation, injection RSC) — accès dev assumé #414
 do: uv run --extra notebooks electricore-notebooks  # exige dans .env ELECTRICORE_API_URL (dev : http://localhost:8001, voir `api-up`) et ELECTRICORE_API_KEY (une clé du trousseau, reste dans .env)
 look: l'URL affichée par le lanceur marimo
 expect: le notebook charge et parle à l'API (pas de connexion refusée)

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -133,6 +133,14 @@ do: uv run --extra notebooks electricore-notebooks  # exige dans .env ELECTRICOR
 look: l'URL affichée par le lanceur marimo
 expect: le notebook charge et parle à l'API (pas de connexion refusée)
 
+## kiosque-eyeball
+
+mode: human
+when: changement sous packages/electricore-kiosque (assemblage, accueil, notebook du catalogue)
+do: env KIOSQUE__APPS={apps} KIOSQUE__TITRE="{titre}" uv run --package electricore-kiosque electricore-kiosque  # {apps} = noms du catalogue séparés par virgules (vide = accueil seul) ; `env` marche sous fish comme bash
+look: http://127.0.0.1:8765 dans un navigateur
+expect: l'accueil affiche {titre} et exactement les apps de {apps} (une app du catalogue non listée n'a ni lien ni route) ; un nom hors catalogue doit faire échouer le démarrage avec un message explicite
+
 ## trousseau-add-key
 
 mode: human

--- a/docs/adr/0057-kiosque-acces-neophytes-package-separe.md
+++ b/docs/adr/0057-kiosque-acces-neophytes-package-separe.md
@@ -1,0 +1,99 @@
+# Kiosque : accès néophytes en apps marimo hébergées, package séparé
+
+## Contexte
+
+Les deux accès existants à ElectriCore supposent tous deux un humain technique : le
+**module Odoo** (l'ERP tire les données, ADR-0027) suppose un déploiement Odoo, et les
+**Notebooks** (`electricore-notebooks`, marimo `edit`/`run` local, ADR-0009) supposent un
+poste de travail, une installation `uv`, un `.env`. Un troisième public existe — des
+néophytes qui veulent consulter leurs propres données (exports, relevés, facturation) sans
+rien installer, juste un navigateur. Ni Odoo ni les notebooks locaux ne répondent à ce
+besoin.
+
+Contraintes du public visé :
+- **Navigateur seul** — pas de checkout, pas de `.env`, pas de ligne de commande.
+- **Pas de comptes** — un service self-hosted par petite structure (« entité »), pas
+  d'inscription/mot de passe à gérer côté ElectriCore.
+- **Lecture seule** — le Kiosque ne doit jamais écrire (dans Enedis, dans un ERP, nulle
+  part) ; c'est un tableau de bord, pas un outil d'exploitation.
+- **Zéro secret côté service** — le service qui sert les pages web ne doit détenir aucune
+  clé applicative pour le compte de l'utilisateur·ice.
+
+## Décision
+
+### 1. Un paquet workspace de plus, même patron qu'`electricore-client`
+
+`packages/electricore-kiosque/` (src-layout), membre du workspace uv racine
+(`[tool.uv.workspace] members = ["packages/*"]`, glob déjà en place — ADR-0043), pyproject
+et version propres. Dépendances : `marimo`, `fastapi`, `uvicorn`, `electricore-client`
+(workspace) — **jamais** le moteur `electricore` (pas de `polars`/`duckdb`, cf. ADR-0043).
+Le Kiosque est un *consommateur* de l'API au même titre qu'un intégrateur externe, pas un
+sous-module du moteur.
+
+### 2. Apps marimo `run` hébergées, une image / N configs
+
+Chaque app métier (exports, facturation lisible…) est un notebook marimo servi en mode
+**`run`** (lecture seule, pas d'édition possible depuis le navigateur — même garde que les
+notebooks opérateur). Une **seule image Docker** sert **toutes** les entités clientes ; ce
+qui varie par déploiement est la **configuration** (catalogue actif, titre), jamais le code.
+Assemblage ASGI par chaînage `marimo.create_asgi_app().with_app(path=..., root=...)` :
+l'accueil est lui-même un notebook monté à la racine (`path=""`), chaque app active du
+catalogue est montée sous `/{nom}`.
+
+### 3. La clé API est la seule identité — zéro secret côté serveur
+
+Pas de comptes, pas de base utilisateurs. L'utilisateur·ice colle sa clé API dans le
+notebook (saisie navigateur, tranche #705) ; le service Kiosque ne la stocke jamais côté
+serveur, ne la voit qu'en transit vers l'API `electricore` via `electricore-client`. La clé
+**est** l'identité et le périmètre de données — même modèle que le bot Telegram et les
+notebooks opérateur, poussé jusqu'au bout : aucun état d'authentification propre au Kiosque.
+
+### 4. Config par entité, sous-domaine dédié
+
+Deux variables d'environnement pilotent une instance : `KIOSQUE__APPS` (liste de noms
+séparés par virgules, sélection dans le catalogue) et `KIOSQUE__TITRE` (nom affiché par
+l'accueil). **Fail-fast** au démarrage si `KIOSQUE__APPS` contient un nom hors catalogue —
+une faute de frappe se détecte au déploiement, pas en production face à l'utilisateur·ice.
+Déploiement visé : sous-domaine `kiosque.<slug>.electricore.fr` par entité (même patron de
+nommage que le reste de l'infra multi-provider, ADR-0044).
+
+### Alternatives écartées
+
+- **Export WASM/Pyodide (notebooks marimo exportés statiques)** : marimo peut exporter en
+  HTML/WASM exécuté côté navigateur. Écarté : empreinte mémoire ~2 Go par onglet (Pyodide +
+  runtime Python complet chargé client-side) intenable sur le matériel modeste visé par des
+  néophytes, et empaquetage des dépendances (polars/httpx) dans le bundle WASM non maîtrisé.
+- **Repo séparé** : fragmenterait le code alors que l'infra workspace uv + release découplée
+  existe déjà pour exactement ce cas (`electricore-client`, ADR-0043) — un repo de plus
+  n'apporte rien qu'un membre `packages/*` de plus n'apporte pas, avec la CI et le versioning
+  à reconstruire à côté.
+- **Clé API "baked" côté serveur** (une image par config avec la clé en dur ou en secret
+  d'infra) : réinvente des comptes par la bande — il faudrait alors gérer qui a accès à
+  quelle image/config, exactement le problème que « la clé est l'identité » évite.
+- **Une image Docker par client** : chaque nouvelle entité imposerait un build + une image à
+  maintenir en plus de la config — enfer de maintenance à l'échelle de N entités, alors
+  qu'une image partagée + config par variables d'environnement scale sans y toucher.
+
+## Conséquences
+
+- Troisième accès externe acté dans [CONTEXT-MAP.md](../../CONTEXT-MAP.md) aux côtés du
+  module Odoo et des Notebooks, tous via `api` + `electricore-client`.
+- Le catalogue d'apps réelles (exports…) et la saisie de clé côté navigateur arrivent en
+  tranche suivante (#705) ; ce document couvre le squelette d'assemblage (#704).
+- `electricore-notebooks` cesse d'être qualifié de « pont transitoire » : son cycle de vie
+  devient explicite — notebook exploratoire (dev, marimo `edit`) → app opérateur locale
+  (`electricore-notebooks`, marimo `run` sur poste) → app Kiosque hébergée (marimo `run`
+  multi-tenant) — trois étapes assumées du même objet, pas un pont à démolir.
+- Un intégrateur Kiosque n'installe jamais `polars`/`duckdb`/`fastapi` du moteur — mêmes
+  garanties de légèreté qu'`electricore-client` (dont il dépend).
+
+## Statut
+
+Accepté — implémenté par #703 (cet ADR + carte des trois accès) et #704 (squelette
+`packages/electricore-kiosque` : assemblage ASGI, accueil, config par entité, fail-fast).
+Tranches suivantes : #705 (catalogue d'apps réelles + saisie de clé API navigateur),
+#706-#708 (PRD #702).
+
+S'appuie sur ADR-0043 (`electricore-client`, paquet workspace séparé), ADR-0009
+(architecture API-centrique, notebooks comme état transitoire du dev local), ADR-0027
+(« Odoo tire »), ADR-0044 (secrets-as-code, nommage par slug d'entité).

--- a/docs/adr/0057-kiosque-acces-neophytes-package-separe.md
+++ b/docs/adr/0057-kiosque-acces-neophytes-package-separe.md
@@ -1,4 +1,7 @@
-# Kiosque : accès néophytes en apps marimo hébergées, package séparé
+# 0057 — Kiosque : accès néophytes en apps marimo hébergées, package séparé
+
+- Status: accepted
+- Date: 2026-08-11
 
 ## Contexte
 
@@ -89,7 +92,7 @@ nommage que le reste de l'infra multi-provider, ADR-0044).
 
 ## Statut
 
-Accepté — implémenté par #703 (cet ADR + carte des trois accès) et #704 (squelette
+Implémenté par #703 (cet ADR + carte des trois accès) et #704 (squelette
 `packages/electricore-kiosque` : assemblage ASGI, accueil, config par entité, fail-fast).
 Tranches suivantes : #705 (catalogue d'apps réelles + saisie de clé API navigateur),
 #706-#708 (PRD #702).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,18 @@ Domaine `odoo` du registre (`runtime.odoo()`) — bloc unique read-only
 façade déléguant au registre. Plus de sélecteur test/prod (#190 clos) : une variable absente
 lève `ConfigurationManquante` au boot (no-ERP servi tant que le bloc est entièrement absent).
 
+### Kiosque (`packages/electricore-kiosque`)
+
+| variable | rôle |
+|---|---|
+| `KIOSQUE__APPS` | sélection d'apps à monter (noms du catalogue, séparés par virgules ; vide = accueil seul) |
+| `KIOSQUE__TITRE` | nom de l'entité, affiché par l'accueil |
+
+**Exception assumée au registre runtime** (ADR-0025/0049) : le Kiosque ne peut pas dépendre
+du moteur (ADR-0057), donc pas de pydantic-settings — lecture directe de l'env dans
+`electricore_kiosque/config.py`. Le nommage `DOMAINE__CHAMP` (ADR-0046) reste respecté.
+Aucun secret : la clé API est saisie par l'utilisateur·ice dans l'app, jamais côté serveur.
+
 ## 2. Fichiers de configuration versionnés
 
 | fichier | rôle | quand y toucher |

--- a/docs/contribuer/developper.md
+++ b/docs/contribuer/developper.md
@@ -1,5 +1,5 @@
 ---
-fraicheur: 2026-07-04
+fraicheur: 2026-08-11
 ---
 
 # Développer

--- a/docs/contribuer/developper.md
+++ b/docs/contribuer/developper.md
@@ -56,6 +56,7 @@ Deux principes structurants :
 | 🤖 **`bot/`** | Bot Telegram : UI opérationnelle, client de l'API (zéro logique métier) | [README](https://github.com/Energie-De-Nantes/electricore/blob/main/electricore/bot/README.md) |
 | ⚙️ **`config/`** | Registre runtime pydantic-settings + règles tarifaires CSV (TURPE, accise, CTA) | [ADR-0024](../adr/0024-trois-registres-de-savoir.md)/[0025](../adr/0025-registre-runtime-pydantic-settings.md) |
 | 📦 **`packages/electricore-client/`** | **Client léger distribué séparément** (PyPI) : httpx + pydantic, flux JSONL typé | [README](https://github.com/Energie-De-Nantes/electricore/blob/main/packages/electricore-client/README.md) · [ADR-0043](../adr/0043-electricore-client-paquet-separe.md) |
+| 🏪 **`packages/electricore-kiosque/`** | **Apps marimo hébergées en lecture seule** pour néophytes : catalogue → assemblage ASGI, clé API = seule identité | [README](https://github.com/Energie-De-Nantes/electricore/blob/main/packages/electricore-kiosque/README.md) · [ADR-0057](../adr/0057-kiosque-acces-neophytes-package-separe.md) |
 
 > `electricore/operator_launcher.py` (commande `electricore-notebooks`) est **l'accès dev
 > assumé** vers les notebooks opérateur (voir plus bas) — cycle de vie : notebook

--- a/docs/contribuer/developper.md
+++ b/docs/contribuer/developper.md
@@ -57,9 +57,11 @@ Deux principes structurants :
 | ⚙️ **`config/`** | Registre runtime pydantic-settings + règles tarifaires CSV (TURPE, accise, CTA) | [ADR-0024](../adr/0024-trois-registres-de-savoir.md)/[0025](../adr/0025-registre-runtime-pydantic-settings.md) |
 | 📦 **`packages/electricore-client/`** | **Client léger distribué séparément** (PyPI) : httpx + pydantic, flux JSONL typé | [README](https://github.com/Energie-De-Nantes/electricore/blob/main/packages/electricore-client/README.md) · [ADR-0043](../adr/0043-electricore-client-paquet-separe.md) |
 
-> `electricore/operator_launcher.py` (commande `electricore-notebooks`) est un **pont
-> transitoire** vers les notebooks opérateur (voir plus bas). Le dossier `electricore/client/`
-> est un résidu vide : le vrai client est `packages/electricore-client/`.
+> `electricore/operator_launcher.py` (commande `electricore-notebooks`) est **l'accès dev
+> assumé** vers les notebooks opérateur (voir plus bas) — cycle de vie : notebook
+> exploratoire → app opérateur locale → app Kiosque hébergée ([ADR-0057](../adr/0057-kiosque-acces-neophytes-package-separe.md)).
+> Le dossier `electricore/client/` est un résidu vide : le vrai client est
+> `packages/electricore-client/`.
 
 ## Installer pour développer
 
@@ -287,8 +289,9 @@ Ce qui précède décrit la **réalité livrée** sur `main`. Les directions en 
   ([ADR-0044](../adr/0044-secrets-as-code-sops-age.md), déjà mergée pour le mécanisme) : chiffrement
   disque (LUKS + Tang/NBDE), isolation `raw.db`/`serve.db`, durcissement DuckDB de l'API, et OpenBao
   quand la flotte le justifiera.
-- **`souscriptions_odoo`** — addon qui consommera l'API via `electricore-client` et **remplacera**
-  le lanceur de notebooks opérateur transitoire.
+- **`souscriptions_odoo`** — addon qui consommera l'API via `electricore-client` et
+  **remplacera** l'écriture Odoo human-in-the-loop portée aujourd'hui par les notebooks
+  opérateur (`electricore-notebooks` reste l'accès dev assumé, ADR-0057).
 - **Régularisation des contrats lissés** — recalcul a posteriori des contrats facturés au lissé
   ([#191](https://github.com/Energie-De-Nantes/electricore/issues/191)).
 - **Estimation des périodes non-communicantes via R15**

--- a/docs/operateur-notebook.md
+++ b/docs/operateur-notebook.md
@@ -2,13 +2,18 @@
 fraicheur: 2026-07-04
 ---
 
-# Onboarding d'un opérateur notebook (pont transitoire #414)
+# Onboarding d'un opérateur notebook (#414)
 
-> **Pont transitoire.** Les notebooks opérateur (`facturation`, `injection_rsc`)
-> sont la voie **actuelle** par laquelle un humain valide puis **écrit dans Odoo**
-> (human-in-the-loop, [ADR-0012](adr/0012-api-read-only-odoo.md)).
-> Ils disparaîtront à l'arrivée de `souscriptions_odoo` (« Odoo tire »). Ce guide
-> décrit le strict nécessaire pour qu'un **opérateur non-dev** s'en serve aujourd'hui.
+> **Accès dev assumé.** `electricore-notebooks` sert les notebooks opérateur
+> (`facturation`, `injection_rsc`) comme apps marimo en lecture seule sur le poste de
+> l'opérateur·ice — la voie **actuelle** par laquelle un humain valide puis **écrit
+> dans Odoo** (human-in-the-loop, [ADR-0012](adr/0012-api-read-only-odoo.md)). Cycle
+> de vie du notebook : exploratoire en dev (marimo `edit`) → app opérateur locale
+> (ici, marimo `run` sur poste) → app Kiosque hébergée pour les usages en lecture
+> seule ([ADR-0057](adr/0057-kiosque-acces-neophytes-package-separe.md)). L'écriture
+> Odoo human-in-the-loop, elle, migrera vers `souscriptions_odoo` (« Odoo tire »)
+> quand ce chantier arrivera. Ce guide décrit le strict nécessaire pour qu'un
+> **opérateur non-dev** s'en serve aujourd'hui.
 
 ## Ce que fait l'opérateur
 

--- a/docs/operateur-notebook.md
+++ b/docs/operateur-notebook.md
@@ -1,5 +1,5 @@
 ---
-fraicheur: 2026-07-04
+fraicheur: 2026-08-11
 ---
 
 # Onboarding d'un opérateur notebook (#414)

--- a/electricore/operator_launcher.py
+++ b/electricore/operator_launcher.py
@@ -1,6 +1,9 @@
-"""Lanceur opérateur `electricore-notebooks` — pont transitoire (#414).
+"""Lanceur opérateur `electricore-notebooks` — accès dev assumé (#414).
 
-PONT TRANSITOIRE — retirer à l'arrivée de `souscriptions_odoo`.
+Cycle de vie d'un notebook opérateur : exploratoire en dev (marimo `edit`) → app
+opérateur locale servie par CE lanceur (marimo `run` sur poste) → app Kiosque hébergée
+pour les usages en lecture seule (ADR-0057). `souscriptions_odoo` remplacera à terme
+l'écriture Odoo human-in-the-loop portée par ces notebooks, pas ce lanceur.
 
 Une seule commande pour qu'un opérateur non-dev fasse tourner les deux notebooks
 Odoo opérationnels (`facturation`, `injection_rsc`) comme apps marimo en mode

--- a/packages/electricore-kiosque/README.md
+++ b/packages/electricore-kiosque/README.md
@@ -1,0 +1,24 @@
+# electricore-kiosque
+
+Service qui assemble des notebooks [marimo](https://marimo.io) `run` (lecture seule) en une
+seule app web, pour des néophytes qui consultent leurs données via un navigateur seul — voir
+[ADR-0057](../../docs/adr/0057-kiosque-acces-neophytes-package-separe.md).
+
+Aucun secret côté serveur : la clé API `electricore` est saisie par l'utilisateur·ice dans le
+notebook et sert de seule identité (tranche #705).
+
+## Configuration (par entité)
+
+- `KIOSQUE__APPS` — noms séparés par des virgules, sélection dans le catalogue à monter.
+- `KIOSQUE__TITRE` — nom de l'entité, affiché par l'accueil.
+
+Un nom absent du catalogue dans `KIOSQUE__APPS` fait échouer le démarrage (message explicite).
+
+## Lancement local
+
+```bash
+KIOSQUE__APPS= KIOSQUE__TITRE="Ma structure" uv run --package electricore-kiosque electricore-kiosque
+```
+
+Le catalogue réel (exports…) arrive en tranche suivante (#705) ; ce squelette part d'un
+catalogue vide.

--- a/packages/electricore-kiosque/README.md
+++ b/packages/electricore-kiosque/README.md
@@ -17,7 +17,7 @@ Un nom absent du catalogue dans `KIOSQUE__APPS` fait échouer le démarrage (mes
 ## Lancement local
 
 ```bash
-KIOSQUE__APPS= KIOSQUE__TITRE="Ma structure" uv run --package electricore-kiosque electricore-kiosque
+env KIOSQUE__APPS= KIOSQUE__TITRE="Ma structure" uv run --package electricore-kiosque electricore-kiosque
 ```
 
 Le catalogue réel (exports…) arrive en tranche suivante (#705) ; ce squelette part d'un

--- a/packages/electricore-kiosque/pyproject.toml
+++ b/packages/electricore-kiosque/pyproject.toml
@@ -1,0 +1,59 @@
+[project]
+name = "electricore-kiosque"
+version = "0.1.0"
+description = "Kiosque : apps marimo hébergées en lecture seule pour néophytes — voir ADR-0057"
+authors = [
+    {name = "Virgile"}
+]
+license = {text = "AGPL-3.0"}
+readme = "README.md"
+requires-python = ">=3.12"
+keywords = [
+    "electricore",
+    "energy",
+    "enedis",
+    "marimo",
+    "kiosque",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU Affero General Public License v3",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
+]
+# JAMAIS le moteur `electricore` (pas de polars/duckdb) — même invariant de légèreté
+# qu'electricore-client (ADR-0043), dont le Kiosque dépend comme tout intégrateur.
+dependencies = [
+    "marimo>=0.23.0",  # pre-auth RCE fix (CVE-2026-39987) — même pin que le moteur
+    "fastapi>=0.116.1",
+    "uvicorn>=0.35.0,<0.36.0",
+    "electricore-client",
+]
+
+[project.scripts]
+electricore-kiosque = "electricore_kiosque.__main__:main"
+
+[project.urls]
+Homepage = "https://github.com/Energie-De-Nantes/electricore"
+Repository = "https://github.com/Energie-De-Nantes/electricore"
+Issues = "https://github.com/Energie-De-Nantes/electricore/issues"
+
+[tool.uv.sources]
+electricore-client = { workspace = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/electricore_kiosque"]
+
+[dependency-groups]
+test = [
+    "pytest>=8.2.0",
+    "httpx>=0.27.0",  # requis par starlette.testclient.TestClient
+]

--- a/packages/electricore-kiosque/pyproject.toml
+++ b/packages/electricore-kiosque/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
 # qu'electricore-client (ADR-0043), dont le Kiosque dépend comme tout intégrateur.
 dependencies = [
     "marimo>=0.23.0",  # pre-auth RCE fix (CVE-2026-39987) — même pin que le moteur
-    "fastapi>=0.116.1",
     "uvicorn>=0.35.0,<0.36.0",
     "electricore-client",
 ]

--- a/packages/electricore-kiosque/src/electricore_kiosque/__init__.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/__init__.py
@@ -1,0 +1,5 @@
+"""Kiosque — apps marimo hébergées en lecture seule pour néophytes (ADR-0057)."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/packages/electricore-kiosque/src/electricore_kiosque/__main__.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/__main__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import sys
 from importlib import resources
 
-from fastapi import FastAPI
+from starlette.types import ASGIApp
 
 from electricore_kiosque.app import NomAppInconnu, assembler
 from electricore_kiosque.catalogue import CATALOGUE
@@ -23,7 +23,7 @@ def _accueil() -> str:
     return str(resources.files("electricore_kiosque").joinpath("accueil.py"))
 
 
-def construire_app_ou_sortir(*, catalogue: dict[str, str], actifs: list[str], accueil: str) -> FastAPI:
+def construire_app_ou_sortir(*, catalogue: dict[str, str], actifs: list[str], accueil: str) -> ASGIApp:
     """Assemble l'app, ou sort en erreur (message explicite) si `actifs` est mal renseigné.
 
     Fail-fast voulu (ADR-0057) : une faute de frappe dans `KIOSQUE__APPS` doit planter le

--- a/packages/electricore-kiosque/src/electricore_kiosque/__main__.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/__main__.py
@@ -20,8 +20,7 @@ _PORT = 8765
 
 
 def _accueil() -> str:
-    with resources.as_file(resources.files("electricore_kiosque").joinpath("accueil.py")) as chemin:
-        return str(chemin)
+    return str(resources.files("electricore_kiosque").joinpath("accueil.py"))
 
 
 def construire_app_ou_sortir(*, catalogue: dict[str, str], actifs: list[str], accueil: str) -> FastAPI:

--- a/packages/electricore-kiosque/src/electricore_kiosque/__main__.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/__main__.py
@@ -1,0 +1,49 @@
+"""Lancement local du Kiosque : `python -m electricore_kiosque` / `electricore-kiosque`.
+
+Config par variables d'environnement (`KIOSQUE__APPS`, `KIOSQUE__TITRE`, voir `config.py`) —
+une instance par entité, même image (ADR-0057).
+"""
+
+from __future__ import annotations
+
+import sys
+from importlib import resources
+
+from fastapi import FastAPI
+
+from electricore_kiosque.app import NomAppInconnu, assembler
+from electricore_kiosque.catalogue import CATALOGUE
+from electricore_kiosque.config import apps_actives
+
+_HOTE = "127.0.0.1"
+_PORT = 8765
+
+
+def _accueil() -> str:
+    with resources.as_file(resources.files("electricore_kiosque").joinpath("accueil.py")) as chemin:
+        return str(chemin)
+
+
+def construire_app_ou_sortir(*, catalogue: dict[str, str], actifs: list[str], accueil: str) -> FastAPI:
+    """Assemble l'app, ou sort en erreur (message explicite) si `actifs` est mal renseigné.
+
+    Fail-fast voulu (ADR-0057) : une faute de frappe dans `KIOSQUE__APPS` doit planter le
+    démarrage du service, pas silencieusement servir un Kiosque incomplet en production.
+    """
+    try:
+        return assembler(catalogue, actifs, accueil=accueil)
+    except NomAppInconnu as exc:
+        print(f"Kiosque : configuration invalide — {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> None:
+    app = construire_app_ou_sortir(catalogue=CATALOGUE, actifs=apps_actives(), accueil=_accueil())
+
+    import uvicorn
+
+    uvicorn.run(app, host=_HOTE, port=_PORT)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/electricore-kiosque/src/electricore_kiosque/accueil.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/accueil.py
@@ -4,17 +4,16 @@ __generated_with = "0.23.9"
 app = marimo.App(width="medium")
 
 with app.setup:
-    import os
-
     import marimo as mo
+
+    from electricore_kiosque import config
 
 
 @app.cell(hide_code=True)
 def _():
-    titre = os.environ.get("KIOSQUE__TITRE", "ElectriCore")
-    noms = sorted(n.strip() for n in os.environ.get("KIOSQUE__APPS", "").split(",") if n.strip())
+    noms = sorted(config.apps_actives())
     liens = "\n".join(f"- [{nom}](/{nom})" for nom in noms) if noms else "_Aucune app active._"
-    mo.md(f"## Kiosque {titre}\n\n{liens}\n")
+    mo.md(f"## Kiosque {config.titre()}\n\n{liens}\n")
     return
 
 

--- a/packages/electricore-kiosque/src/electricore_kiosque/accueil.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/accueil.py
@@ -1,0 +1,22 @@
+import marimo
+
+__generated_with = "0.23.9"
+app = marimo.App(width="medium")
+
+with app.setup:
+    import os
+
+    import marimo as mo
+
+
+@app.cell(hide_code=True)
+def _():
+    titre = os.environ.get("KIOSQUE__TITRE", "ElectriCore")
+    noms = sorted(n.strip() for n in os.environ.get("KIOSQUE__APPS", "").split(",") if n.strip())
+    liens = "\n".join(f"- [{nom}](/{nom})" for nom in noms) if noms else "_Aucune app active._"
+    mo.md(f"## Kiosque {titre}\n\n{liens}\n")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/packages/electricore-kiosque/src/electricore_kiosque/app.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/app.py
@@ -1,4 +1,4 @@
-"""Assemblage ASGI du Kiosque : catalogue de notebooks marimo → app FastAPI unique.
+"""Assemblage ASGI du Kiosque : catalogue de notebooks marimo → app ASGI unique.
 
 Le Kiosque sert plusieurs notebooks marimo en mode `run` (lecture seule, ADR-0057) sous un
 seul process : un accueil monté à la racine (`path=""`), chaque app active du catalogue
@@ -9,7 +9,7 @@ en paramètres — c'est la couture testable, sans lecture d'env (voir `config.p
 from __future__ import annotations
 
 import marimo
-from fastapi import FastAPI
+from starlette.types import ASGIApp
 
 
 class NomAppInconnu(ValueError):
@@ -20,8 +20,8 @@ class NomAppInconnu(ValueError):
     """
 
 
-def assembler(catalogue: dict[str, str], actifs: list[str], *, accueil: str) -> FastAPI:
-    """Construit l'app FastAPI du Kiosque à partir d'un catalogue et d'une sélection active.
+def assembler(catalogue: dict[str, str], actifs: list[str], *, accueil: str) -> ASGIApp:
+    """Construit l'app ASGI du Kiosque à partir d'un catalogue et d'une sélection active.
 
     `catalogue` : nom → chemin de notebook marimo disponible.
     `actifs` : sélection à monter (valeur de `KIOSQUE__APPS`) — chaque nom DOIT exister
@@ -41,6 +41,4 @@ def assembler(catalogue: dict[str, str], actifs: list[str], *, accueil: str) -> 
         server = server.with_app(path=f"/{nom}", root=catalogue[nom])
     server = server.with_app(path="", root=accueil)
 
-    app = FastAPI()
-    app.mount("/", server.build())
-    return app
+    return server.build()

--- a/packages/electricore-kiosque/src/electricore_kiosque/app.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/app.py
@@ -1,0 +1,46 @@
+"""Assemblage ASGI du Kiosque : catalogue de notebooks marimo → app FastAPI unique.
+
+Le Kiosque sert plusieurs notebooks marimo en mode `run` (lecture seule, ADR-0057) sous un
+seul process : un accueil monté à la racine (`path=""`), chaque app active du catalogue
+montée sous son propre chemin (`path=f"/{nom}"`). `assembler()` prend catalogue + sélection
+en paramètres — c'est la couture testable, sans lecture d'env (voir `config.py` pour ça).
+"""
+
+from __future__ import annotations
+
+import marimo
+from fastapi import FastAPI
+
+
+class NomAppInconnu(ValueError):
+    """Un nom de la sélection active (`KIOSQUE__APPS`) n'existe pas dans le catalogue.
+
+    Fail-fast voulu (ADR-0057) : une faute de frappe se détecte au démarrage du service,
+    pas en production face à l'utilisateur·ice.
+    """
+
+
+def assembler(catalogue: dict[str, str], actifs: list[str], *, accueil: str) -> FastAPI:
+    """Construit l'app FastAPI du Kiosque à partir d'un catalogue et d'une sélection active.
+
+    `catalogue` : nom → chemin de notebook marimo disponible.
+    `actifs` : sélection à monter (valeur de `KIOSQUE__APPS`) — chaque nom DOIT exister
+    dans `catalogue`, sinon `NomAppInconnu`.
+    `accueil` : chemin du notebook marimo monté à la racine (`/`).
+    """
+    inconnus = [nom for nom in actifs if nom not in catalogue]
+    if inconnus:
+        disponibles = ", ".join(sorted(catalogue)) or "aucune"
+        raise NomAppInconnu(
+            f"KIOSQUE__APPS référence des apps inconnues du catalogue : "
+            f"{', '.join(inconnus)} (disponibles : {disponibles})"
+        )
+
+    server = marimo.create_asgi_app()
+    for nom in actifs:
+        server = server.with_app(path=f"/{nom}", root=catalogue[nom])
+    server = server.with_app(path="", root=accueil)
+
+    app = FastAPI()
+    app.mount("/", server.build())
+    return app

--- a/packages/electricore-kiosque/src/electricore_kiosque/catalogue.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/catalogue.py
@@ -1,0 +1,10 @@
+"""Catalogue des notebooks marimo disponibles au Kiosque.
+
+Squelette (#704) : catalogue vide. Les apps réelles (exports, facturation lisible…)
+arrivent en tranche suivante (#705) — il suffira de peupler ce dict, `assembler()`
+(voir `app.py`) est déjà la couture qui les monte selon `KIOSQUE__APPS`.
+"""
+
+from __future__ import annotations
+
+CATALOGUE: dict[str, str] = {}

--- a/packages/electricore-kiosque/src/electricore_kiosque/config.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/config.py
@@ -1,0 +1,18 @@
+"""Config Kiosque par variables d'environnement — une instance par entité (ADR-0057)."""
+
+from __future__ import annotations
+
+import os
+
+_TITRE_DEFAUT = "ElectriCore"
+
+
+def apps_actives() -> list[str]:
+    """`KIOSQUE__APPS` : noms séparés par virgule, sélection à monter dans le catalogue."""
+    brut = os.environ.get("KIOSQUE__APPS", "")
+    return [nom.strip() for nom in brut.split(",") if nom.strip()]
+
+
+def titre() -> str:
+    """`KIOSQUE__TITRE` : nom de l'entité, affiché par l'accueil."""
+    return os.environ.get("KIOSQUE__TITRE", _TITRE_DEFAUT)

--- a/packages/electricore-kiosque/tests/test_accueil.py
+++ b/packages/electricore-kiosque/tests/test_accueil.py
@@ -1,0 +1,33 @@
+"""L'accueil reflète `KIOSQUE__TITRE` et exactement la sélection `KIOSQUE__APPS` (#704).
+
+`app.run()` exécute le notebook marimo en process et rend ses sorties — pas de
+navigateur, pas de serveur : juste le markdown produit par la cellule d'accueil.
+"""
+
+from __future__ import annotations
+
+import pytest
+from electricore_kiosque import accueil
+
+
+def _rendu() -> str:
+    sorties, _ = accueil.app.run()
+    return sorties[0].text
+
+
+def test_accueil_affiche_le_titre_et_les_seules_apps_actives(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KIOSQUE__TITRE", "Ma structure")
+    monkeypatch.setenv("KIOSQUE__APPS", "exports")
+
+    rendu = _rendu()
+
+    assert "Ma structure" in rendu
+    assert 'href="/exports"' in rendu
+    assert "facturation" not in rendu  # app du catalogue non listée : aucun lien
+
+
+def test_accueil_sans_app_active_le_dit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KIOSQUE__APPS", raising=False)
+    monkeypatch.setenv("KIOSQUE__TITRE", "Ma structure")
+
+    assert "Aucune app active" in _rendu()

--- a/packages/electricore-kiosque/tests/test_app.py
+++ b/packages/electricore-kiosque/tests/test_app.py
@@ -1,0 +1,86 @@
+"""Tests de la couture ASGI du Kiosque.
+
+`assembler()` prend catalogue + sélection en paramètres (couture testable, pas de lecture
+d'env ici) : les notebooks sont des fixtures factices, il n'y a ni navigateur ni vrai
+serveur — juste l'app FastAPI assemblée, exercée par `TestClient`.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from electricore_kiosque.app import NomAppInconnu, assembler
+from starlette.testclient import TestClient
+
+_NOTEBOOK_FACTICE = textwrap.dedent(
+    """
+    import marimo
+
+    __generated_with = "0.23.0"
+    app = marimo.App()
+
+    with app.setup:
+        import marimo as mo
+
+    @app.cell
+    def _():
+        mo.md("bonjour")
+        return
+
+    if __name__ == "__main__":
+        app.run()
+    """
+)
+
+
+def _ecrire_notebook(chemin: Path) -> str:
+    chemin.write_text(_NOTEBOOK_FACTICE)
+    return str(chemin)
+
+
+@pytest.fixture
+def catalogue(tmp_path: Path) -> dict[str, str]:
+    return {
+        "exports": _ecrire_notebook(tmp_path / "exports.py"),
+        "facturation": _ecrire_notebook(tmp_path / "facturation.py"),
+    }
+
+
+@pytest.fixture
+def accueil(tmp_path: Path) -> str:
+    return _ecrire_notebook(tmp_path / "accueil.py")
+
+
+def test_route_active_presente(catalogue: dict[str, str], accueil: str) -> None:
+    app = assembler(catalogue, ["exports"], accueil=accueil)
+    with TestClient(app) as client:
+        reponse = client.get("/exports")
+    assert reponse.status_code == 200
+
+
+def test_route_non_listee_absente(catalogue: dict[str, str], accueil: str) -> None:
+    """Un notebook du catalogue non listé dans la sélection n'est pas monté."""
+    app = assembler(catalogue, ["exports"], accueil=accueil)
+    with TestClient(app) as client:
+        reponse = client.get("/facturation")
+    assert reponse.status_code == 404
+
+
+def test_accueil_monte_a_la_racine(catalogue: dict[str, str], accueil: str) -> None:
+    app = assembler(catalogue, [], accueil=accueil)
+    with TestClient(app) as client:
+        reponse = client.get("/")
+    assert reponse.status_code == 200
+
+
+def test_fail_fast_nom_hors_catalogue(catalogue: dict[str, str], accueil: str) -> None:
+    """Une faute de frappe dans KIOSQUE__APPS est détectée au démarrage, pas en prod."""
+    with pytest.raises(NomAppInconnu, match="typo_exports"):
+        assembler(catalogue, ["typo_exports"], accueil=accueil)
+
+
+def test_fail_fast_message_liste_le_catalogue_disponible(catalogue: dict[str, str], accueil: str) -> None:
+    with pytest.raises(NomAppInconnu, match="exports"):
+        assembler(catalogue, ["inconnu"], accueil=accueil)

--- a/packages/electricore-kiosque/tests/test_app.py
+++ b/packages/electricore-kiosque/tests/test_app.py
@@ -2,7 +2,7 @@
 
 `assembler()` prend catalogue + sélection en paramètres (couture testable, pas de lecture
 d'env ici) : les notebooks sont des fixtures factices, il n'y a ni navigateur ni vrai
-serveur — juste l'app FastAPI assemblée, exercée par `TestClient`.
+serveur — juste l'app ASGI assemblée, exercée par `TestClient`.
 """
 
 from __future__ import annotations

--- a/packages/electricore-kiosque/tests/test_config.py
+++ b/packages/electricore-kiosque/tests/test_config.py
@@ -1,0 +1,26 @@
+"""Tests de la lecture de config par variables d'environnement (par entité, ADR-0057)."""
+
+from __future__ import annotations
+
+import pytest
+from electricore_kiosque.config import apps_actives, titre
+
+
+def test_apps_actives_liste_les_noms_separes_par_virgule(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KIOSQUE__APPS", "exports, facturation ,rsc")
+    assert apps_actives() == ["exports", "facturation", "rsc"]
+
+
+def test_apps_actives_vide_par_defaut(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KIOSQUE__APPS", raising=False)
+    assert apps_actives() == []
+
+
+def test_titre_lit_kiosque_titre(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KIOSQUE__TITRE", "Ma structure")
+    assert titre() == "Ma structure"
+
+
+def test_titre_a_un_defaut(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KIOSQUE__TITRE", raising=False)
+    assert titre() == "ElectriCore"

--- a/packages/electricore-kiosque/tests/test_main.py
+++ b/packages/electricore-kiosque/tests/test_main.py
@@ -1,0 +1,18 @@
+"""Fail-fast au démarrage : nom hors catalogue → message explicite + sortie non-nulle."""
+
+from __future__ import annotations
+
+import pytest
+from electricore_kiosque.__main__ import construire_app_ou_sortir
+
+
+def test_construire_app_ou_sortir_leve_sysexit_sur_nom_inconnu(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        construire_app_ou_sortir(catalogue={"exports": "quelque_part.py"}, actifs=["typo"], accueil="accueil.py")
+
+    assert exc_info.value.code == 1
+    erreur = capsys.readouterr().err
+    assert "typo" in erreur
+    assert "exports" in erreur

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,8 @@ viz = [
     "marimo>=0.23.0",  # pre-auth RCE fix (CVE-2026-39987)
     "plotly[express]>=6.2.0",
 ]
-# Lanceur opérateur `electricore-notebooks` (pont transitoire, #414) : mêmes libs
-# que `viz` (uvicorn est déjà une dépendance de base). À retirer à l'arrivée de
-# souscriptions_odoo.
+# Lanceur opérateur `electricore-notebooks` (accès dev assumé, #414) : mêmes libs
+# que `viz` (uvicorn est déjà une dépendance de base).
 notebooks = [
     "marimo>=0.23.0",  # pre-auth RCE fix (CVE-2026-39987)
     "altair>=5.5.0,<6.0.0",
@@ -81,7 +80,7 @@ dbt = [
     "dbt-duckdb>=1.9.0,<2.0.0",
 ]
 
-# Lanceur opérateur (pont transitoire #414, à retirer avec souscriptions_odoo).
+# Lanceur opérateur — accès dev assumé (#414).
 [project.scripts]
 electricore-notebooks = "electricore.operator_launcher:main"
 
@@ -103,10 +102,10 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["electricore"]
 
-# Pont transitoire (#414) : les sources des notebooks opérateur restent dans
+# Accès dev assumé (#414) : les sources des notebooks opérateur restent dans
 # notebooks/ (aucun déplacement), mais sont force-incluses dans le wheel à un
 # emplacement résolvable par importlib.resources (electricore/_operator_notebooks/).
-# Le lanceur electricore-notebooks les sert en mode run. À retirer avec souscriptions_odoo.
+# Le lanceur electricore-notebooks les sert en mode run.
 [tool.hatch.build.targets.wheel.force-include]
 "notebooks/accueil.py" = "electricore/_operator_notebooks/accueil.py"
 "notebooks/facturation.py" = "electricore/_operator_notebooks/facturation.py"

--- a/tests/integration/test_operator_notebooks_bundle.py
+++ b/tests/integration/test_operator_notebooks_bundle.py
@@ -1,4 +1,4 @@
-"""Vérifie que le wheel force-inclut les notebooks opérateur (pont transitoire, #414).
+"""Vérifie que le wheel force-inclut les notebooks opérateur (accès dev assumé, #414).
 
 `uv build` doit produire un wheel `electricore` qui CONTIENT `accueil.py`,
 `facturation.py` et `injection_rsc.py` sous `electricore/_operator_notebooks/`,

--- a/tests/unit/test_operator_launcher.py
+++ b/tests/unit/test_operator_launcher.py
@@ -1,4 +1,4 @@
-"""Tests du lanceur opérateur `electricore-notebooks` (pont transitoire, #414).
+"""Tests du lanceur opérateur `electricore-notebooks` (accès dev assumé, #414).
 
 Couvre deux seams :
 - validation de l'environnement (creds Odoo + ELECTRICORE_API_URL/KEY) ;

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,7 @@ requires-python = ">=3.12, <3.14"
 members = [
     "electricore",
     "electricore-client",
+    "electricore-kiosque",
 ]
 
 [[package]]
@@ -888,6 +889,37 @@ provides-extras = ["arrow"]
 
 [package.metadata.requires-dev]
 test = [{ name = "pytest", specifier = ">=8.2.0" }]
+
+[[package]]
+name = "electricore-kiosque"
+version = "0.1.0"
+source = { editable = "packages/electricore-kiosque" }
+dependencies = [
+    { name = "electricore-client" },
+    { name = "fastapi" },
+    { name = "marimo" },
+    { name = "uvicorn" },
+]
+
+[package.dev-dependencies]
+test = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "electricore-client", editable = "packages/electricore-client" },
+    { name = "fastapi", specifier = ">=0.116.1" },
+    { name = "marimo", specifier = ">=0.23.0" },
+    { name = "uvicorn", specifier = ">=0.35.0,<0.36.0" },
+]
+
+[package.metadata.requires-dev]
+test = [
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "pytest", specifier = ">=8.2.0" },
+]
 
 [[package]]
 name = "execnet"

--- a/uv.lock
+++ b/uv.lock
@@ -896,7 +896,6 @@ version = "0.1.0"
 source = { editable = "packages/electricore-kiosque" }
 dependencies = [
     { name = "electricore-client" },
-    { name = "fastapi" },
     { name = "marimo" },
     { name = "uvicorn" },
 ]
@@ -910,7 +909,6 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "electricore-client", editable = "packages/electricore-client" },
-    { name = "fastapi", specifier = ">=0.116.1" },
     { name = "marimo", specifier = ">=0.23.0" },
     { name = "uvicorn", specifier = ">=0.35.0,<0.36.0" },
 ]


### PR DESCRIPTION
Closes #703
Closes #704

Acte la décision d'architecture du Kiosque (ADR-0057) et livre le squelette du package `packages/electricore-kiosque` : assemblage ASGI multi-notebooks (catalogue → sélection `KIOSQUE__APPS`, accueil `KIOSQUE__TITRE` monté à la racine), fail-fast sur nom hors catalogue, zéro secret côté serveur. `electricore-notebooks` cesse d'être qualifié de « pont transitoire » : c'est l'accès dev assumé, premier maillon du cycle exploratoire → app kiosque. Tests sur la couture ASGI (TestClient, notebooks factices) + job CI isolé `test-kiosque` (même patron que `test-client`, jamais le moteur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VGKygHXtY5bvxZgHWkkkU