### PR TITLE
feat(audit): règle R17 dans l'audit de séquences — l'angle mort du relais est levé

### DIFF
--- a/electricore/ingestion/dbt/macros/audit_sequences.sql
+++ b/electricore/ingestion/dbt/macros/audit_sequences.sql
@@ -4,14 +4,17 @@
 -- SEUL lieu où vivent les règles de nomenclature Enedis : extraction du *numéro de
 -- séquence* et de la *clé de séquence* depuis le nom du zip (glossaire, `CONTEXT.md`
 -- « Complétude des flux »), propres à chaque type de flux (guides SGE) :
---   C15/R15 = (contrat, DIR) ; F15 = destinataire×contrat×DIR×type_facture×fréquence×
---   type_client ; F12 = destinataire×contrat×DIR ; C12 = contrat ; X12/X13 =
---   destinataire×code_flux ; R151 = abonnement (compteur INTER-zips, hors macro — la
+--   C15/R15 = (contrat, DIR) ; R17 = destinataire×contrat (pas de segment DIR —
+--   nomenclature constatée sur les dépôts Enargia 2023→2026 :
+--   `ENEDIS_R17_<EIC destinataire>_<contrat>_NNNNN_<horodate>`) ; F15 = destinataire×
+--   contrat×DIR×type_facture×fréquence×type_client ; F12 = destinataire×contrat×DIR ;
+--   C12 = contrat ; X12/X13 = destinataire×code_flux ; R151 = abonnement (compteur
+--   INTER-zips, hors macro — la
 --   caller ingestion le traite dans sa propre CTE, cf. `models/marts/audit_sequences.sql`).
 --
 -- Paramètres :
 --   relation    : relation déjà UNIONÉE (une ligne par document), portant une colonne
---                 `flux` (code flux Enedis : 'C15'/'R15'/'F15'/'F12'/'R151'/'C12'/
+--                 `flux` (code flux Enedis : 'C15'/'R15'/'R17'/'F15'/'F12'/'R151'/'C12'/
 --                 'X12'/'X13') — convention fixe, pas un paramètre (le caller construit
 --                 l'union avec ce nom de colonne).
 --   colonne_zip : nom de la colonne portant le nom de l'archive (`_source_zip` côté
@@ -38,6 +41,8 @@
     'C15':  {'pattern': '^[^_]+_C15_[^_]+_([^_]+)_([^_]+)_([0-9]{5})_[0-9]+$',
              'cle': '\\1|\\2', 'seq': '\\3'},
     'R15':  {'pattern': '^[^_]+_R15_[^_]+_([^_]+)_([^_]+)_([0-9]{5})_[0-9]+$',
+             'cle': '\\1|\\2', 'seq': '\\3'},
+    'R17':  {'pattern': '^[^_]+_R17_([^_]+)_([^_]+)_([0-9]{5})_[0-9]+$',
              'cle': '\\1|\\2', 'seq': '\\3'},
     'F15':  {'pattern': '^[^_]+_F15_([^_]+)_([^_]+)_([^_]+)_([^_]+)_([^_]+)_([^_]+)_[^_]+_([0-9]{5})_[0-9]+$',
              'cle': '\\1|\\2|\\3|\\4|\\5|\\6', 'seq': '\\7'},

--- a/tests/ingestion/test_dbt_relais_audit_sequences.py
+++ b/tests/ingestion/test_dbt_relais_audit_sequences.py
@@ -143,6 +143,28 @@ def test_flux_derive_du_nom_de_zip(tmp_path):
     assert any(ligne["flux"] == "R151" for ligne in lignes)
 
 
+def test_r17_reconnu_et_trou_detecte(tmp_path):
+    """Le R17 (flux relayé mais non ingéré, nomenclature sans segment DIR :
+    `ENEDIS_R17_<EIC>_<contrat>_NNNNN_<horodate>`) est reconnu par la macro — plus de
+    `nom_non_reconnu` systématique, et un trou de séquence est détecté comme pour les
+    autres flux (l'audit n'est plus aveugle sur le R17)."""
+    prefix = "ENEDIS_R17_17X000000501934R_GRD-F091_{seq}_2026081{j}120000.zip"
+    lignes = _construire_audit(
+        tmp_path,
+        [
+            _ligne(prefix.format(seq="00786", j=1)),
+            _ligne(prefix.format(seq="00787", j=2)),
+            # 00788 manque
+            _ligne(prefix.format(seq="00789", j=4)),
+        ],
+    )
+    r17 = [ligne for ligne in lignes if ligne["flux"] == "R17"]
+    assert not any(ligne["type_anomalie"] == "nom_non_reconnu" for ligne in r17)
+    trous = [ligne for ligne in r17 if ligne["type_anomalie"] == "trou"]
+    assert len(trous) == 1
+    assert trous[0]["seq_ou_plage"] == "00788"
+
+
 def test_vue_passive_aucun_data_test_aucune_anomalie(tmp_path):
     """Vue passive (#646) : `dbt build` reste vert même sur un journal avec un trou franc —
     aucun data test `aucune_anomalie` n'est câblé côté relais (contrairement à l'ingestion),


### PR DESCRIPTION
## Quoi

Ajoute la règle `R17` au dict `regles` de la macro `audit_sequences` (seul lieu des nomenclatures Enedis) + un test côté relais.

## Pourquoi

`journal.relais_audit_sequences` classait tous les R17 en `nom_non_reconnu` : la continuité 00786→00849 a dû être vérifiée à la main (2026-08-22) et un futur trou passerait inaperçu.

## Nomenclature

`ENEDIS_R17_<EIC destinataire>_<contrat>_NNNNN_<horodate>` — pas de segment DIR (contrairement à R15/C15), clé de séquence destinataire×contrat. Constatée sur les 185 zips historiques 2023→2026 **et vérifiée le 2026-08-24 sur les dépôts récents de la box** (00845→00849, conformes).

## Tests

`test_r17_reconnu_et_trou_detecte` (relais) : R17 reconnu, trou de séquence détecté. 18/18 verts sur les deux harnais d'audit ; suite complète passée au pre-push.

Acteur: enargia

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2ZKtXVzSCJqz7Fdz2NDX2