### PR TITLE
chore: bump 3.8.1 → 3.8.2 — release des prix Enedis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+## [3.8.2] - 2026-08-24
+
+Patch de mise à jour des registres de taux régulés (#713, PR #716) — à déployer
+avant la facturation d'août (03/09).
+
+### 🐛 Corrigé
+
+- **Grille TURPE 7 au 1ᵉʳ août 2026** : +3,04 % (délibération CRE n° 2026-105
+  du 21 mai 2026) — fenêtres 2025-08-01 fermées, 11 nouvelles lignes (BTINF,
+  BTINF ACC, BTSUP), valeurs recoupées délibération + brochure tarifaire Enedis.
+- **Accise au 1ᵉʳ février 2026** : 30,85 €/MWh (tarif ménages 25,19 + majoration
+  ZNI 5,66 ; pas d'indexation au 1ᵉʳ janvier faute de LF 2026). Le constat de
+  sous-facturation février–juillet est suivi en #714.
+- Le check de péremption (#186) redevient muet une fois la version déployée.
+
+## [3.8.1] - 2026-08-24
+
+Patch sécurité dépendances (#711) : re-lock `uv.lock` seul, aucun pin pyproject.
+
+### 🔒 Sécurité
+
+- 19 alertes Dependabot résorbées : gitpython 3.1.59, aiohttp 3.14.3,
+  cryptography 50.0.0, sqlparse 0.6.0 (via dbt-core 1.12.3 + dbt-duckdb 1.11.0),
+  pymdown-extensions 11.0.2 (via marimo 0.24.0).
+
 ## [3.8.0] - 2026-08-03
 
 Minor centrée sur le **relais de flux Haulogy** : le cycle post-générale du 28/07

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "electricore"
-version = "3.8.1"
+version = "3.8.2"
 description = "Moteur de traitement données énergétiques françaises - Architecture Polars/DuckDB pour flux Enedis"
 authors = [
     {name = "Virgile"}

--- a/uv.lock
+++ b/uv.lock
@@ -740,7 +740,7 @@ wheels = [
 
 [[package]]
 name = "electricore"
-version = "3.8.1"
+version = "3.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Quoi

- `pyproject.toml` + `uv.lock` : 3.8.1 → 3.8.2 (bump via PR **avant** tag, process release habituel).
- CHANGELOG : entrée **3.8.2** (prix Enedis, PR #716) + entrée **3.8.1** manquante rattrapée (patch sécurité #711).

## Après merge

1. Je tague `v3.8.2` sur main → le workflow construit l'image ghcr.io.
2. Bump du pin dans electricore-secrets, puis reconfigure box (Virgile) — **avant le 03/09**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)