### PR TITLE
Kiosque : notebook « exports » + helpers clé API → electricore-client

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -137,9 +137,9 @@ expect: le notebook charge et parle à l'API (pas de connexion refusée)
 
 mode: human
 when: changement sous packages/electricore-kiosque (assemblage, accueil, notebook du catalogue)
-do: env KIOSQUE__APPS={apps} KIOSQUE__TITRE="{titre}" uv run --package electricore-kiosque electricore-kiosque  # {apps} = noms du catalogue séparés par virgules (vide = accueil seul) ; `env` marche sous fish comme bash
+do: env KIOSQUE__APPS={apps} KIOSQUE__TITRE="{titre}" KIOSQUE__API_URL={api_url} uv run --package electricore-kiosque electricore-kiosque  # {apps} = noms du catalogue séparés par virgules (vide = accueil seul) ; {api_url} = URL d'une API electricore réelle (requise dès qu'une app comme exports est active) ; `env` marche sous fish comme bash
 look: http://127.0.0.1:8765 dans un navigateur
-expect: l'accueil affiche {titre} et exactement les apps de {apps} (une app du catalogue non listée n'a ni lien ni route) ; un nom hors catalogue doit faire échouer le démarrage avec un message explicite
+expect: l'accueil affiche {titre} et exactement les apps de {apps} (une app du catalogue non listée n'a ni lien ni route) ; un nom hors catalogue doit faire échouer le démarrage avec un message explicite ; sur `exports`, coller une clé API réelle affiche un tableau filtrable téléchargeable en CSV, une clé invalide affiche un message clair (pas de stacktrace)
 
 ## trousseau-add-key
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,7 @@ lève `ConfigurationManquante` au boot (no-ERP servi tant que le bloc est entiè
 |---|---|
 | `KIOSQUE__APPS` | sélection d'apps à monter (noms du catalogue, séparés par virgules ; vide = accueil seul) |
 | `KIOSQUE__TITRE` | nom de l'entité, affiché par l'accueil |
+| `KIOSQUE__API_URL` | URL de l'API `electricore` interrogée par les notebooks (ex. `exports`) ; **requise**, aucun défaut codé en dur — fournie par le `config.env` du provider (`electricore-secrets`, ADR-0044), fail-fast sinon |
 
 **Exception assumée au registre runtime** (ADR-0025/0049) : le Kiosque ne peut pas dépendre
 du moteur (ADR-0057), donc pas de pydantic-settings — lecture directe de l'env dans

--- a/packages/electricore-kiosque/README.md
+++ b/packages/electricore-kiosque/README.md
@@ -11,14 +11,23 @@ notebook et sert de seule identité (tranche #705).
 
 - `KIOSQUE__APPS` — noms séparés par des virgules, sélection dans le catalogue à monter.
 - `KIOSQUE__TITRE` — nom de l'entité, affiché par l'accueil.
+- `KIOSQUE__API_URL` — URL de l'API `electricore` interrogée par les notebooks (ex.
+  `exports`). **Requise**, sans défaut codé en dur : c'est de la config de déploiement,
+  fournie par le `config.env` du provider (`electricore-secrets`, ADR-0044). Absente →
+  message explicite au moment où un notebook en a besoin (pas au démarrage du service).
 
 Un nom absent du catalogue dans `KIOSQUE__APPS` fait échouer le démarrage (message explicite).
+
+## Catalogue
+
+- **`exports`** — clé API (saisie navigateur, jamais stockée côté serveur) → tableau
+  filtrable de la facturation mensuelle via `electricore-client` → téléchargement CSV de
+  la vue filtrée (bouton natif de `mo.ui.table`). Clé invalide ou révoquée : message clair,
+  pas de stacktrace.
 
 ## Lancement local
 
 ```bash
-env KIOSQUE__APPS= KIOSQUE__TITRE="Ma structure" uv run --package electricore-kiosque electricore-kiosque
+env KIOSQUE__APPS=exports KIOSQUE__TITRE="Ma structure" KIOSQUE__API_URL=https://mon-api.exemple.fr \
+    uv run --package electricore-kiosque electricore-kiosque
 ```
-
-Le catalogue réel (exports…) arrive en tranche suivante (#705) ; ce squelette part d'un
-catalogue vide.

--- a/packages/electricore-kiosque/README.md
+++ b/packages/electricore-kiosque/README.md
@@ -5,7 +5,7 @@ seule app web, pour des néophytes qui consultent leurs données via un navigate
 [ADR-0057](../../docs/adr/0057-kiosque-acces-neophytes-package-separe.md).
 
 Aucun secret côté serveur : la clé API `electricore` est saisie par l'utilisateur·ice dans le
-notebook et sert de seule identité (tranche #705).
+notebook et sert de seule identité.
 
 ## Configuration (par entité)
 

--- a/packages/electricore-kiosque/src/electricore_kiosque/catalogue.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/catalogue.py
@@ -1,10 +1,20 @@
 """Catalogue des notebooks marimo disponibles au Kiosque.
 
-Squelette (#704) : catalogue vide. Les apps réelles (exports, facturation lisible…)
-arrivent en tranche suivante (#705) — il suffira de peupler ce dict, `assembler()`
-(voir `app.py`) est déjà la couture qui les monte selon `KIOSQUE__APPS`.
+Premier peuplement (#705) : `exports` — consultation + téléchargement CSV de la
+facturation mensuelle via `electricore-client` (voir `helpers.py`). `assembler()`
+(`app.py`) est la couture qui monte la sélection active (`KIOSQUE__APPS`) parmi
+ces entrées ; ajouter une app future = ajouter une entrée ici.
 """
 
 from __future__ import annotations
 
-CATALOGUE: dict[str, str] = {}
+from importlib import resources
+
+
+def _chemin(nom_fichier: str) -> str:
+    return str(resources.files("electricore_kiosque").joinpath(nom_fichier))
+
+
+CATALOGUE: dict[str, str] = {
+    "exports": _chemin("exports.py"),
+}

--- a/packages/electricore-kiosque/src/electricore_kiosque/config.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/config.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import os
 
 _TITRE_DEFAUT = "ElectriCore"
-_API_URL_DEFAUT = "https://edn.electricore.fr"
+
+
+class ApiUrlManquante(ValueError):
+    """`KIOSQUE__API_URL` absente — fail-fast, message actionnable.
+
+    L'URL d'une box réelle est de la config de déploiement (config.env du
+    provider, `electricore-secrets`, ADR-0044) — jamais un défaut codé en dur ici.
+    """
 
 
 def apps_actives() -> list[str]:
@@ -22,7 +29,11 @@ def titre() -> str:
 def api_url() -> str:
     """`KIOSQUE__API_URL` : API `electricore` interrogée par les notebooks (#705).
 
-    Défaut : l'API publique de la box de référence (même URL que l'onboarding
-    notebook opérateur, `docs/operateur-notebook.md`).
+    Requise, sans défaut — l'URL d'une box réelle vit dans le config.env du
+    provider (`electricore-secrets`, ADR-0044), pas dans ce code versionné.
+    Lue paresseusement (à l'usage, pas à l'import) ; fail-fast si absente.
     """
-    return os.environ.get("KIOSQUE__API_URL", _API_URL_DEFAUT)
+    valeur = os.environ.get("KIOSQUE__API_URL")
+    if not valeur:
+        raise ApiUrlManquante("KIOSQUE__API_URL manquante — configure-la dans le config.env du provider.")
+    return valeur

--- a/packages/electricore-kiosque/src/electricore_kiosque/config.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 
 _TITRE_DEFAUT = "ElectriCore"
+_API_URL_DEFAUT = "https://edn.electricore.fr"
 
 
 def apps_actives() -> list[str]:
@@ -16,3 +17,12 @@ def apps_actives() -> list[str]:
 def titre() -> str:
     """`KIOSQUE__TITRE` : nom de l'entité, affiché par l'accueil."""
     return os.environ.get("KIOSQUE__TITRE", _TITRE_DEFAUT)
+
+
+def api_url() -> str:
+    """`KIOSQUE__API_URL` : API `electricore` interrogée par les notebooks (#705).
+
+    Défaut : l'API publique de la box de référence (même URL que l'onboarding
+    notebook opérateur, `docs/operateur-notebook.md`).
+    """
+    return os.environ.get("KIOSQUE__API_URL", _API_URL_DEFAUT)

--- a/packages/electricore-kiosque/src/electricore_kiosque/exports.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/exports.py
@@ -6,7 +6,7 @@ app = marimo.App(width="medium")
 with app.setup:
     import marimo as mo
 
-    from electricore_kiosque import helpers
+    from electricore_kiosque import config, helpers
 
 
 @app.cell(hide_code=True)
@@ -34,7 +34,7 @@ def _(cle):
     try:
         client = helpers.construire_client(cle.value)
         lignes = helpers.recuperer_meta_periodes(client)
-    except helpers.CleApiRefusee as exc:
+    except (helpers.CleApiRefusee, config.ApiUrlManquante) as exc:
         mo.stop(True, mo.md(f"⚠️ **{exc}**"))
     return (lignes,)
 

--- a/packages/electricore-kiosque/src/electricore_kiosque/exports.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/exports.py
@@ -32,8 +32,7 @@ def _(cle):
         mo.stop(True, mo.md("_En attente d'une clé API…_"))
 
     try:
-        client = helpers.construire_client(cle.value)
-        lignes = helpers.recuperer_meta_periodes(client)
+        lignes = helpers.recuperer_meta_periodes(cle.value)
     except (helpers.CleApiRefusee, config.ApiUrlManquante) as exc:
         mo.stop(True, mo.md(f"⚠️ **{exc}**"))
     return (lignes,)

--- a/packages/electricore-kiosque/src/electricore_kiosque/exports.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/exports.py
@@ -1,0 +1,49 @@
+import marimo
+
+__generated_with = "0.23.9"
+app = marimo.App(width="medium")
+
+with app.setup:
+    import marimo as mo
+
+    from electricore_kiosque import helpers
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(
+        "## Exports\n\n"
+        "Colle ta clé API pour consulter ta facturation mensuelle : tableau "
+        "filtrable, téléchargeable en CSV (bouton en haut du tableau)."
+    )
+    return
+
+
+@app.cell
+def _():
+    cle = mo.ui.text(label="Clé API", kind="password")
+    mo.output.replace(cle)
+    return (cle,)
+
+
+@app.cell
+def _(cle):
+    if not cle.value:
+        mo.stop(True, mo.md("_En attente d'une clé API…_"))
+
+    try:
+        client = helpers.construire_client(cle.value)
+        lignes = helpers.recuperer_meta_periodes(client)
+    except helpers.CleApiRefusee as exc:
+        mo.stop(True, mo.md(f"⚠️ **{exc}**"))
+    return (lignes,)
+
+
+@app.cell
+def _(lignes):
+    mo.output.replace(mo.ui.table(lignes, label="Facturation mensuelle"))
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
@@ -1,10 +1,11 @@
 """Helpers partagés par les notebooks Kiosque : clé API → client `electricore-client`.
 
 Zéro secret côté serveur (ADR-0057) : la clé vit dans la session navigateur du
-notebook, jamais stockée ici. Un notebook construit son client via
-`construire_client(cle)`, récupère ses données via une fonction `recuperer_*` —
-toute la logique de fetch/erreur vit ici pour que le notebook reste de la
-présentation pure au-dessus des helpers (voir `exports.py`).
+notebook, jamais stockée ici. Un notebook appelle directement une fonction
+`recuperer_*(cle)` — elle ouvre et referme son propre client (`construire_client`,
+toujours public pour les cas qui ont besoin du client nu) — toute la logique de
+fetch/erreur/cycle de vie vit ici pour que le notebook reste de la présentation
+pure au-dessus des helpers (voir `exports.py`).
 """
 
 from __future__ import annotations
@@ -29,20 +30,26 @@ def construire_client(cle: str, *, http_client: httpx.Client | None = None) -> E
     return ElectricoreClient(url=api_url(), api_key=cle, http_client=http_client)
 
 
-def recuperer_meta_periodes(client: ElectricoreClient) -> list[dict]:
+def recuperer_meta_periodes(cle: str, *, http_client: httpx.Client | None = None) -> list[dict]:
     """Méta-périodes mensuelles (facturation), aplaties en lignes tabulaires pour l'UI.
 
     `releves_utilises` (trace d'index imbriquée) est exclu : la table Kiosque
     reste plate — les néophytes consultent des montants/consos, pas la trace
     légale détaillée.
 
+    Ouvre et referme son propre client (context manager `ElectricoreClient`) :
+    le kiosque est un process long-vécu multi-visiteurs, chaque appel referme
+    sa connexion plutôt que de laisser trainer un pool par entrée de clé.
+
     Raises:
         CleApiRefusee: clé API invalide ou révoquée (401/403 côté API).
+        config.ApiUrlManquante: `KIOSQUE__API_URL` absente (via `construire_client`).
     """
-    try:
-        with client.meta_periodes() as stream:
-            return [ligne.model_dump(exclude={"releves_utilises"}) for ligne in stream]
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code in _STATUTS_CLE_REFUSEE:
-            raise CleApiRefusee() from exc
-        raise
+    with construire_client(cle, http_client=http_client) as client:
+        try:
+            with client.meta_periodes() as stream:
+                return [ligne.model_dump(exclude={"releves_utilises"}) for ligne in stream]
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in _STATUTS_CLE_REFUSEE:
+                raise CleApiRefusee() from exc
+            raise

--- a/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
@@ -1,0 +1,48 @@
+"""Helpers partagés par les notebooks Kiosque : clé API → client `electricore-client`.
+
+Zéro secret côté serveur (ADR-0057) : la clé vit dans la session navigateur du
+notebook, jamais stockée ici. Un notebook construit son client via
+`construire_client(cle)`, récupère ses données via une fonction `recuperer_*` —
+toute la logique de fetch/erreur vit ici pour que le notebook reste de la
+présentation pure au-dessus des helpers (voir `exports.py`).
+"""
+
+from __future__ import annotations
+
+import httpx
+from electricore_client import ElectricoreClient
+
+from electricore_kiosque.config import api_url
+
+_STATUTS_CLE_REFUSEE = {401, 403}
+
+
+class CleApiRefusee(Exception):
+    """La clé API saisie est invalide ou révoquée — message actionnable, pas de stacktrace."""
+
+    def __init__(self) -> None:
+        super().__init__("Clé API refusée : contacte ton admin.")
+
+
+def construire_client(cle: str, *, http_client: httpx.Client | None = None) -> ElectricoreClient:
+    """Client `electricore-client` configuré depuis une clé saisie + `KIOSQUE__API_URL`."""
+    return ElectricoreClient(url=api_url(), api_key=cle, http_client=http_client)
+
+
+def recuperer_meta_periodes(client: ElectricoreClient) -> list[dict]:
+    """Méta-périodes mensuelles (facturation), aplaties en lignes tabulaires pour l'UI.
+
+    `releves_utilises` (trace d'index imbriquée) est exclu : la table Kiosque
+    reste plate — les néophytes consultent des montants/consos, pas la trace
+    légale détaillée.
+
+    Raises:
+        CleApiRefusee: clé API invalide ou révoquée (401/403 côté API).
+    """
+    try:
+        with client.meta_periodes() as stream:
+            return [ligne.model_dump(exclude={"releves_utilises"}) for ligne in stream]
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in _STATUTS_CLE_REFUSEE:
+            raise CleApiRefusee() from exc
+        raise

--- a/packages/electricore-kiosque/tests/test_catalogue.py
+++ b/packages/electricore-kiosque/tests/test_catalogue.py
@@ -1,0 +1,39 @@
+"""Le catalogue réel entre en jeu (#705) : `exports` existe et se monte.
+
+Complète `test_app.py` (couture ASGI générique, catalogue factice) : ici on
+exerce le VRAI catalogue du paquet, pour prouver que `KIOSQUE__APPS=exports`
+donne effectivement un Kiosque avec une app montée — et rien de plus si
+`exports` n'est pas listé.
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+
+from electricore_kiosque.app import assembler
+from electricore_kiosque.catalogue import CATALOGUE
+from starlette.testclient import TestClient
+
+
+def _accueil() -> str:
+    return str(resources.files("electricore_kiosque").joinpath("accueil.py"))
+
+
+def test_exports_est_au_catalogue() -> None:
+    assert "exports" in CATALOGUE
+    assert Path(CATALOGUE["exports"]).is_file()
+
+
+def test_exports_se_monte_quand_liste() -> None:
+    app = assembler(CATALOGUE, ["exports"], accueil=_accueil())
+    with TestClient(app) as client:
+        reponse = client.get("/exports")
+    assert reponse.status_code == 200
+
+
+def test_exports_absent_quand_non_liste() -> None:
+    app = assembler(CATALOGUE, [], accueil=_accueil())
+    with TestClient(app) as client:
+        reponse = client.get("/exports")
+    assert reponse.status_code == 404

--- a/packages/electricore-kiosque/tests/test_config.py
+++ b/packages/electricore-kiosque/tests/test_config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from electricore_kiosque.config import api_url, apps_actives, titre
+from electricore_kiosque.config import ApiUrlManquante, api_url, apps_actives, titre
 
 
 def test_apps_actives_liste_les_noms_separes_par_virgule(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -31,6 +31,8 @@ def test_api_url_lit_kiosque_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
     assert api_url() == "https://kiosque.exemple.fr"
 
 
-def test_api_url_a_un_defaut(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_api_url_manquante_leve_une_erreur_actionnable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pas de défaut codé en dur : une box réelle vient du config.env du provider."""
     monkeypatch.delenv("KIOSQUE__API_URL", raising=False)
-    assert api_url() == "https://edn.electricore.fr"
+    with pytest.raises(ApiUrlManquante, match="KIOSQUE__API_URL"):
+        api_url()

--- a/packages/electricore-kiosque/tests/test_config.py
+++ b/packages/electricore-kiosque/tests/test_config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from electricore_kiosque.config import apps_actives, titre
+from electricore_kiosque.config import api_url, apps_actives, titre
 
 
 def test_apps_actives_liste_les_noms_separes_par_virgule(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -24,3 +24,13 @@ def test_titre_lit_kiosque_titre(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_titre_a_un_defaut(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("KIOSQUE__TITRE", raising=False)
     assert titre() == "ElectriCore"
+
+
+def test_api_url_lit_kiosque_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KIOSQUE__API_URL", "https://kiosque.exemple.fr")
+    assert api_url() == "https://kiosque.exemple.fr"
+
+
+def test_api_url_a_un_defaut(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KIOSQUE__API_URL", raising=False)
+    assert api_url() == "https://edn.electricore.fr"

--- a/packages/electricore-kiosque/tests/test_exports.py
+++ b/packages/electricore-kiosque/tests/test_exports.py
@@ -1,0 +1,42 @@
+"""Tests du notebook exports : erreurs de config/clé affichées, pas de traceback (#719 revue).
+
+`app.run(defs=...)` exécute le notebook marimo en process et permet d'injecter
+une valeur pour la clé sans passer par une vraie interaction UI — même patron
+que `test_accueil.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from electricore_kiosque import exports, helpers
+
+
+class _FakeCle:
+    """Stand-in pour `mo.ui.text` : seule sa `.value` compte pour le notebook."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+def _rendu(cle: str) -> str:
+    sorties, _ = exports.app.run(defs={"cle": _FakeCle(cle)})
+    return sorties[-1].text
+
+
+def test_exports_api_url_manquante_affiche_un_message_actionnable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`config.ApiUrlManquante` (KIOSQUE__API_URL absente) est rattrapée, pas un traceback brut."""
+    monkeypatch.delenv("KIOSQUE__API_URL", raising=False)
+
+    assert "KIOSQUE__API_URL manquante" in _rendu("une-cle")
+
+
+def test_exports_cle_refusee_affiche_toujours_un_message_actionnable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-régression : `CleApiRefusee` reste rattrapée après l'élargissement du except."""
+    monkeypatch.setenv("KIOSQUE__API_URL", "https://kiosque.test.invalide")
+
+    def _lever(cle: str, **kwargs: object) -> list[dict]:
+        raise helpers.CleApiRefusee()
+
+    monkeypatch.setattr(helpers, "recuperer_meta_periodes", _lever)
+
+    assert "Clé API refusée" in _rendu("une-cle")

--- a/packages/electricore-kiosque/tests/test_helpers.py
+++ b/packages/electricore-kiosque/tests/test_helpers.py
@@ -12,6 +12,14 @@ import httpx
 import pytest
 from electricore_kiosque.helpers import CleApiRefusee, construire_client, recuperer_meta_periodes
 
+
+@pytest.fixture(autouse=True)
+def _api_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`KIOSQUE__API_URL` requise (fail-fast, pas de défaut) — posée pour les tests
+    qui ne portent pas spécifiquement sur cette configuration."""
+    monkeypatch.setenv("KIOSQUE__API_URL", "https://kiosque.test.invalide")
+
+
 _LIGNE = {
     "ref_situation_contractuelle": "RSC123",
     "pdl": "PDL456",

--- a/packages/electricore-kiosque/tests/test_helpers.py
+++ b/packages/electricore-kiosque/tests/test_helpers.py
@@ -32,9 +32,8 @@ _LIGNE = {
 }
 
 
-def _client(handler, *, cle: str = "une-cle") -> object:
-    http = httpx.Client(transport=httpx.MockTransport(handler))
-    return construire_client(cle, http_client=http)
+def _http(handler) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
 
 
 def test_construire_client_positionne_url_et_cle(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -44,7 +43,7 @@ def test_construire_client_positionne_url_et_cle(monkeypatch: pytest.MonkeyPatch
     assert client.api_key == "ma-cle"
 
 
-def test_recuperer_meta_periodes_retourne_les_lignes() -> None:
+def test_recuperer_meta_periodes_retourne_les_lignes_et_ferme_le_client() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             200,
@@ -52,30 +51,33 @@ def test_recuperer_meta_periodes_retourne_les_lignes() -> None:
             content=(json.dumps(_LIGNE) + "\n").encode(),
         )
 
-    client = _client(handler)
-    lignes = recuperer_meta_periodes(client)
+    http = _http(handler)
+    lignes = recuperer_meta_periodes("une-cle", http_client=http)
 
     assert len(lignes) == 1
     assert lignes[0]["ref_situation_contractuelle"] == "RSC123"
     assert lignes[0]["turpe_fixe_eur"] == 12.3
     assert "releves_utilises" not in lignes[0]
+    assert http.is_closed  # chaque appel referme sa connexion (kiosque multi-visiteurs)
 
 
-def test_recuperer_meta_periodes_cle_refusee() -> None:
+def test_recuperer_meta_periodes_cle_refusee_ferme_quand_meme_le_client() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(401)
 
-    client = _client(handler)
+    http = _http(handler)
     with pytest.raises(CleApiRefusee, match="admin"):
-        recuperer_meta_periodes(client)
+        recuperer_meta_periodes("une-cle", http_client=http)
+    assert http.is_closed
 
 
-def test_recuperer_meta_periodes_propage_les_autres_erreurs() -> None:
+def test_recuperer_meta_periodes_propage_les_autres_erreurs_et_ferme_le_client() -> None:
     """Une erreur qui n'est pas une clé refusée reste une erreur HTTP normale."""
 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500)
 
-    client = _client(handler)
+    http = _http(handler)
     with pytest.raises(httpx.HTTPStatusError):
-        recuperer_meta_periodes(client)
+        recuperer_meta_periodes("une-cle", http_client=http)
+    assert http.is_closed

--- a/packages/electricore-kiosque/tests/test_helpers.py
+++ b/packages/electricore-kiosque/tests/test_helpers.py
@@ -1,0 +1,73 @@
+"""Tests des helpers clé API → client `electricore-client` (#705).
+
+Transport HTTP mocké (`httpx.MockTransport`) : aucun réseau, même patron que
+`electricore_client/tests/test_transport.py`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from electricore_kiosque.helpers import CleApiRefusee, construire_client, recuperer_meta_periodes
+
+_LIGNE = {
+    "ref_situation_contractuelle": "RSC123",
+    "pdl": "PDL456",
+    "mois_annee": "2026-05",
+    "debut": "2026-05-01",
+    "fin": "2026-06-01",
+    "nb_jours": 31,
+    "turpe_fixe_eur": 12.3,
+    "source_hash": "abc123",
+}
+
+
+def _client(handler, *, cle: str = "une-cle") -> object:
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    return construire_client(cle, http_client=http)
+
+
+def test_construire_client_positionne_url_et_cle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KIOSQUE__API_URL", "https://kiosque.exemple.fr")
+    client = construire_client("ma-cle")
+    assert client.url == "https://kiosque.exemple.fr"
+    assert client.api_key == "ma-cle"
+
+
+def test_recuperer_meta_periodes_retourne_les_lignes() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"X-Contract-Version": "3"},
+            content=(json.dumps(_LIGNE) + "\n").encode(),
+        )
+
+    client = _client(handler)
+    lignes = recuperer_meta_periodes(client)
+
+    assert len(lignes) == 1
+    assert lignes[0]["ref_situation_contractuelle"] == "RSC123"
+    assert lignes[0]["turpe_fixe_eur"] == 12.3
+    assert "releves_utilises" not in lignes[0]
+
+
+def test_recuperer_meta_periodes_cle_refusee() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401)
+
+    client = _client(handler)
+    with pytest.raises(CleApiRefusee, match="admin"):
+        recuperer_meta_periodes(client)
+
+
+def test_recuperer_meta_periodes_propage_les_autres_erreurs() -> None:
+    """Une erreur qui n'est pas une clé refusée reste une erreur HTTP normale."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    client = _client(handler)
+    with pytest.raises(httpx.HTTPStatusError):
+        recuperer_meta_periodes(client)


### PR DESCRIPTION
## Résumé

Premier notebook réel du catalogue Kiosque : « exports » — clé API saisie côté navigateur (jamais stockée), helpers partagés `construire_client`/`recuperer_meta_periodes` vers `electricore-client`, tableau filtrable de la facturation mensuelle avec téléchargement CSV natif (`mo.ui.table`). Clé invalide/révoquée → message clair, pas de stacktrace. `KIOSQUE__API_URL` est requise (fail-fast explicite), sans défaut codé en dur.

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)