### PR TITLE
Kiosque : exports multi-jeux — onglets Relevés + Flux bruts (client Arrow)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,20 +142,21 @@ jobs:
           python-version: "3.12"
 
       # Environnement ISOLÉ : uniquement electricore-kiosque (marimo + fastapi +
-      # electricore-client) + pytest. JAMAIS le moteur (polars/duckdb), même
-      # invariant que le job test-client (ADR-0057, #704).
+      # electricore-client[arrow]) + pytest. JAMAIS le moteur `electricore` ni
+      # DuckDB — polars est désormais toléré (amendement 2026-08-24 à l'ADR-0057,
+      # #720) : c'est l'extra public du client, pas un accès direct au moteur.
       - name: Créer un venv isolé pour le Kiosque
         run: uv venv /tmp/kiosque-venv
 
       - name: Installer electricore-kiosque seul (+ ses deps de test)
         run: |
-          uv pip install --python /tmp/kiosque-venv ./packages/electricore-kiosque ./packages/electricore-client pytest httpx
+          uv pip install --python /tmp/kiosque-venv ./packages/electricore-kiosque "./packages/electricore-client[arrow]" pytest httpx
 
-      - name: Garde-fou — polars/duckdb ABSENTS de l'environnement
+      - name: Garde-fou — moteur `electricore`/DuckDB ABSENTS de l'environnement
         run: |
           uv pip list --python /tmp/kiosque-venv | tee /tmp/pkgs-kiosque.txt
-          if grep -iqE '^(polars|duckdb)[[:space:]]' /tmp/pkgs-kiosque.txt; then
-            echo "::error::Le moteur (polars/duckdb) a fuité dans l'env Kiosque isolé."
+          if grep -iqE '^(duckdb|electricore)[[:space:]]' /tmp/pkgs-kiosque.txt; then
+            echo "::error::Le moteur electricore (ou DuckDB) a fuité dans l'env Kiosque isolé."
             exit 1
           fi
 

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -139,7 +139,7 @@ mode: human
 when: changement sous packages/electricore-kiosque (assemblage, accueil, notebook du catalogue)
 do: env KIOSQUE__APPS={apps} KIOSQUE__TITRE="{titre}" KIOSQUE__API_URL={api_url} uv run --package electricore-kiosque electricore-kiosque  # {apps} = noms du catalogue séparés par virgules (vide = accueil seul) ; {api_url} = URL d'une API electricore réelle (requise dès qu'une app comme exports est active) ; `env` marche sous fish comme bash
 look: http://127.0.0.1:8765 dans un navigateur
-expect: l'accueil affiche {titre} et exactement les apps de {apps} (une app du catalogue non listée n'a ni lien ni route) ; un nom hors catalogue doit faire échouer le démarrage avec un message explicite ; sur `exports`, coller une clé API réelle affiche un tableau filtrable téléchargeable en CSV, une clé invalide affiche un message clair (pas de stacktrace)
+expect: l'accueil affiche {titre} et exactement les apps de {apps} (une app du catalogue non listée n'a ni lien ni route) ; un nom hors catalogue doit faire échouer le démarrage avec un message explicite ; sur `exports`, coller une clé API réelle affiche trois onglets (Facturation / Relevés / Flux bruts, chargement paresseux) — Facturation : tableau filtrable téléchargeable en CSV (comportement inchangé) ; Relevés : tableau du dernier mois par défaut, resserrer par pdl/dates, bandeau « vue tronquée » si la limite dure est atteinte, CSV ; Flux bruts : choisir une table (ex. c15) dans le dropdown, avertissement conventions Enedis affiché, tableau + CSV, demander une table absente de la box → message propre (pas de stacktrace) ; une clé invalide affiche un message clair dans chaque onglet
 
 ## trousseau-add-key
 

--- a/docs/adr/0057-kiosque-acces-neophytes-package-separe.md
+++ b/docs/adr/0057-kiosque-acces-neophytes-package-separe.md
@@ -1,6 +1,6 @@
 # 0057 — Kiosque : accès néophytes en apps marimo hébergées, package séparé
 
-- Status: accepted
+- Status: accepted (amendé le 2026-08-24 — voir « Amendements »)
 - Date: 2026-08-11
 
 ## Contexte
@@ -100,3 +100,19 @@ Tranches suivantes : #705 (catalogue d'apps réelles + saisie de clé API naviga
 S'appuie sur ADR-0043 (`electricore-client`, paquet workspace séparé), ADR-0009
 (architecture API-centrique, notebooks comme état transitoire du dev local), ADR-0027
 (« Odoo tire »), ADR-0044 (secrets-as-code, nommage par slug d'entité).
+
+## Amendements
+
+### 2026-08-24 — polars admis via `electricore-client[arrow]`, le moteur reste interdit
+
+L'extension du notebook `exports` aux **relevés** (mart canonique, ADR-0029) et aux
+**flux bruts** exige des tableaux volumineux dans le process kiosque. Le seul chemin
+client existant est `ElectricoreArrowClient` (extra `[arrow]`), qui tire `polars` —
+en contradiction avec la lettre de la décision 1 (« pas de `polars`/`duckdb` »).
+
+Amendement : le Kiosque **peut dépendre de `electricore-client[arrow]`** (donc de
+polars) ; c'est l'extra public du client, consommé comme le ferait tout intégrateur.
+L'invariant qui portait la décision est réaffirmé et inchangé : **jamais le moteur
+`electricore`** (ni DuckDB, ni accès direct aux données — tout passe par l'API). La
+« légèreté » cède d'un cran (image plus lourde) ; la frontière d'architecture, elle,
+ne bouge pas.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,11 @@ du moteur (ADR-0057), donc pas de pydantic-settings — lecture directe de l'env
 `electricore_kiosque/config.py`. Le nommage `DOMAINE__CHAMP` (ADR-0046) reste respecté.
 Aucun secret : la clé API est saisie par l'utilisateur·ice dans l'app, jamais côté serveur.
 
+Depuis l'amendement du 2026-08-24 à l'ADR-0057 (#720), le Kiosque dépend d'
+`electricore-client[arrow]` : polars entre dans le package via cet extra public du client
+(onglets Relevés/Flux bruts du notebook `exports`) — l'invariant qui reste : jamais le
+moteur `electricore` ni DuckDB.
+
 ## 2. Fichiers de configuration versionnés
 
 | fichier | rôle | quand y toucher |

--- a/packages/electricore-kiosque/README.md
+++ b/packages/electricore-kiosque/README.md
@@ -20,10 +20,22 @@ Un nom absent du catalogue dans `KIOSQUE__APPS` fait échouer le démarrage (mes
 
 ## Catalogue
 
-- **`exports`** — clé API (saisie navigateur, jamais stockée côté serveur) → tableau
-  filtrable de la facturation mensuelle via `electricore-client` → téléchargement CSV de
-  la vue filtrée (bouton natif de `mo.ui.table`). Clé invalide ou révoquée : message clair,
-  pas de stacktrace.
+- **`exports`** — clé API (saisie navigateur, jamais stockée côté serveur), trois onglets
+  à chargement paresseux (`mo.ui.tabs(..., lazy=True)`), chacun tableau filtrable +
+  téléchargement CSV (bouton natif de `mo.ui.table`) :
+  - **Facturation** — méta-périodes mensuelles.
+  - **Relevés** — mart canonique harmonisé (ADR-0029) ; fenêtre par défaut le dernier
+    mois calendaire, filtres pdl + plage de dates, plafond dur côté kiosque avec bandeau
+    « vue tronquée » quand il est atteint.
+  - **Flux bruts** — tables Enedis fidèles à la source (dropdown en dur : c15, r151, r15,
+    f15_detail, f12_detail, r64), filtre pdl optionnel, avertissement conventions Enedis
+    (`date_releve` R151 nue, sans le +1 d'harmonisation) ; table absente de la box →
+    message propre.
+
+  Les onglets Relevés/Flux bruts passent par `electricore-client[arrow]`
+  (`ElectricoreArrowClient`, amendement 2026-08-24 à l'ADR-0057) — polars entre dans le
+  kiosque via cet extra public du client, jamais via le moteur `electricore`. Clé invalide
+  ou révoquée : message clair, pas de stacktrace.
 
 ## Lancement local
 

--- a/packages/electricore-kiosque/README.md
+++ b/packages/electricore-kiosque/README.md
@@ -29,8 +29,8 @@ Un nom absent du catalogue dans `KIOSQUE__APPS` fait échouer le démarrage (mes
     « vue tronquée » quand il est atteint.
   - **Flux bruts** — tables Enedis fidèles à la source (dropdown en dur : c15, r151, r15,
     f15_detail, f12_detail, r64), filtre pdl optionnel, avertissement conventions Enedis
-    (`date_releve` R151 nue, sans le +1 d'harmonisation) ; table absente de la box →
-    message propre.
+    (colonnes propres à chaque flux, ni dédoublonnage ni harmonisation inter-flux) ;
+    table absente de la box → message propre.
 
   Les onglets Relevés/Flux bruts passent par `electricore-client[arrow]`
   (`ElectricoreArrowClient`, amendement 2026-08-24 à l'ADR-0057) — polars entre dans le

--- a/packages/electricore-kiosque/README.md
+++ b/packages/electricore-kiosque/README.md
@@ -29,8 +29,14 @@ Un nom absent du catalogue dans `KIOSQUE__APPS` fait échouer le démarrage (mes
     « vue tronquée » quand il est atteint.
   - **Flux bruts** — tables Enedis fidèles à la source (dropdown en dur : c15, r151, r15,
     f15_detail, f12_detail, r64), filtre pdl optionnel, avertissement conventions Enedis
-    (colonnes propres à chaque flux, ni dédoublonnage ni harmonisation inter-flux) ;
-    table absente de la box → message propre.
+    (colonnes propres à chaque flux, ni dédoublonnage ni harmonisation inter-flux) ; même
+    plafond dur avec bandeau « vue tronquée » que Relevés ; table absente de la box →
+    message propre.
+
+  Filtres (pdl/dates pour Relevés, dropdown table/pdl pour Flux bruts) déclarés dans leurs
+  propres cellules réactives, hors des fonctions passées à `mo.ui.tabs(..., lazy=True)` —
+  des widgets créés à l'intérieur d'une fonction paresseuse seraient des candidats GC,
+  invisibles aux changements ultérieurs (#721).
 
   Les onglets Relevés/Flux bruts passent par `electricore-client[arrow]`
   (`ElectricoreArrowClient`, amendement 2026-08-24 à l'ADR-0057) — polars entre dans le

--- a/packages/electricore-kiosque/pyproject.toml
+++ b/packages/electricore-kiosque/pyproject.toml
@@ -25,12 +25,14 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
-# JAMAIS le moteur `electricore` (pas de polars/duckdb) — même invariant de légèreté
-# qu'electricore-client (ADR-0043), dont le Kiosque dépend comme tout intégrateur.
+# JAMAIS le moteur `electricore` (ni DuckDB) — polars est désormais toléré via l'extra
+# `[arrow]` public d'electricore-client (amendement 2026-08-24 à l'ADR-0057, #720) :
+# c'est le seul chemin client pour les relevés/flux bruts, consommé comme le ferait
+# tout intégrateur. L'invariant qui reste : jamais d'accès direct à DuckDB/au moteur.
 dependencies = [
     "marimo>=0.23.0",  # pre-auth RCE fix (CVE-2026-39987) — même pin que le moteur
     "uvicorn>=0.35.0,<0.36.0",
-    "electricore-client",
+    "electricore-client[arrow]",
 ]
 
 [project.scripts]

--- a/packages/electricore-kiosque/src/electricore_kiosque/exports.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/exports.py
@@ -34,6 +34,32 @@ def _():
 
 
 @app.cell
+def _():
+    # Widgets de filtre Relevés — cell À PART, hors de toute fonction paresseuse
+    # (#721, bug d'inertie). `mo.lazy` n'appelle `onglet_releves` qu'une fois par
+    # ouverture d'onglet et ne retient pas l'objet résolu ; des widgets créés
+    # DEDANS seraient donc des candidats GC, invisibles aux changements ultérieurs
+    # (`UIElementRegistry` ne les garde qu'en weakref). Déclarés ici, ce sont des
+    # cellules réactives normales : la cellule des onglets (plus bas) en dépend,
+    # donc tout changement de filtre la refait tourner et redéclenche le fetch de
+    # l'onglet ouvert. `_debut_defaut`/`_fin_defaut` préfixés `_` : privés à la
+    # cellule (convention marimo), ils n'ont pas besoin d'exister pour l'onglet.
+    _debut_defaut, _fin_defaut = helpers.fenetre_dernier_mois()
+    pdl_releves = mo.ui.text(label="PDL (optionnel)")
+    debut = mo.ui.date(value=_debut_defaut, label="Depuis")
+    fin = mo.ui.date(value=_fin_defaut, label="Jusqu'à")
+    return pdl_releves, debut, fin
+
+
+@app.cell
+def _():
+    # Widgets de filtre Flux bruts — même raison qu'au-dessus.
+    table_flux = mo.ui.dropdown(TABLES_FLUX, value=TABLES_FLUX[0], label="Table de flux")
+    pdl_flux = mo.ui.text(label="PDL (optionnel)")
+    return table_flux, pdl_flux
+
+
+@app.cell
 def _(cle):
     # Onglet Facturation : comportement inchangé (#705, non-régression) — calculé
     # ici (pas dans un onglet paresseux) pour que clé refusée / KIOSQUE__API_URL
@@ -53,47 +79,47 @@ def _(cle):
 
 
 @app.cell
-def _(cle, onglet_facturation):
+def _(cle, onglet_facturation, pdl_releves, debut, fin, table_flux, pdl_flux):
     # Fonctions (pas des valeurs déjà calculées) : `mo.ui.tabs(..., lazy=True)`
     # ne fetch qu'à l'ouverture de l'onglet — jamais Relevés/Flux bruts au
-    # chargement de la page. Exposées via `return` (pas seulement fermées sur
-    # `cle`) pour rester testables unitairement (voir `test_exports.py`).
+    # chargement de la page. Elles ne FONT que fetch + rendre, en fermant sur les
+    # `.value` des widgets déclarés au-dessus (jamais recréés ici) — c'est ce qui
+    # rend la cellule des onglets dépendante des widgets, donc réactive à leurs
+    # changements (voir cellules précédentes). Exposées via `return` pour rester
+    # testables unitairement (voir `test_exports.py`).
     def onglet_releves():
-        debut_defaut, fin_defaut = helpers.fenetre_dernier_mois()
-        pdl = mo.ui.text(label="PDL (optionnel)")
-        debut = mo.ui.date(value=debut_defaut, label="Depuis")
-        fin = mo.ui.date(value=fin_defaut, label="Jusqu'à")
-
         try:
             lignes, tronque = helpers.recuperer_releves(
                 cle.value,
-                prm=pdl.value or None,
+                prm=pdl_releves.value or None,
                 debut=str(debut.value),
                 fin=str(fin.value),
             )
         except (helpers.CleApiRefusee, config.ApiUrlManquante) as exc:
-            return mo.vstack([pdl, debut, fin, mo.md(f"⚠️ **{exc}**")])
+            return mo.vstack([pdl_releves, debut, fin, mo.md(f"⚠️ **{exc}**")])
 
-        elements = [pdl, debut, fin]
+        elements = [pdl_releves, debut, fin]
         if tronque:
             elements.append(mo.callout("Vue tronquée : resserre tes filtres pour tout voir.", kind="warn"))
         elements.append(mo.ui.table(lignes, label="Relevés"))
         return mo.vstack(elements)
 
     def onglet_flux_bruts():
-        table = mo.ui.dropdown(TABLES_FLUX, value=TABLES_FLUX[0], label="Table de flux")
-        pdl = mo.ui.text(label="PDL (optionnel)")
         avertissement = mo.md(
             "⚠️ Données brutes fidèles à la source, conventions Enedis — pour des "
             "relevés harmonisés, onglet **Relevés**."
         )
 
         try:
-            lignes = helpers.recuperer_flux(cle.value, table.value, prm=pdl.value or None)
+            lignes, tronque = helpers.recuperer_flux(cle.value, table_flux.value, prm=pdl_flux.value or None)
         except (helpers.CleApiRefusee, helpers.TableFluxAbsente, config.ApiUrlManquante) as exc:
-            return mo.vstack([table, pdl, avertissement, mo.md(f"⚠️ **{exc}**")])
+            return mo.vstack([table_flux, pdl_flux, avertissement, mo.md(f"⚠️ **{exc}**")])
 
-        return mo.vstack([table, pdl, avertissement, mo.ui.table(lignes, label=f"Flux {table.value}")])
+        elements = [table_flux, pdl_flux, avertissement]
+        if tronque:
+            elements.append(mo.callout("Vue tronquée : resserre tes filtres pour tout voir.", kind="warn"))
+        elements.append(mo.ui.table(lignes, label=f"Flux {table_flux.value}"))
+        return mo.vstack(elements)
 
     mo.output.replace(
         mo.ui.tabs(

--- a/packages/electricore-kiosque/src/electricore_kiosque/exports.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/exports.py
@@ -8,13 +8,20 @@ with app.setup:
 
     from electricore_kiosque import config, helpers
 
+    # Dropdown en dur (#720) : tables du registre flux DuckDB
+    # (`electricore.core.loaders.duckdb.registry.FLUX_DESCRIPTORS`) — le kiosque
+    # n'a pas accès à la base pour les découvrir dynamiquement. Une table absente
+    # de cette box précise reste un message propre (`TableFluxAbsente`, 404 API).
+    TABLES_FLUX = ["c15", "r151", "r15", "f15_detail", "f12_detail", "r64"]
+
 
 @app.cell(hide_code=True)
 def _():
     mo.md(
         "## Exports\n\n"
-        "Colle ta clé API pour consulter ta facturation mensuelle : tableau "
-        "filtrable, téléchargeable en CSV (bouton en haut du tableau)."
+        "Colle ta clé API : **Facturation** mensuelle, **Relevés** harmonisés et "
+        "**Flux bruts** Enedis, chacun dans son onglet — tableau filtrable, "
+        "téléchargeable en CSV (bouton en haut du tableau)."
     )
     return
 
@@ -30,18 +37,76 @@ def _():
 def _(cle):
     if not cle.value:
         mo.stop(True, mo.md("_En attente d'une clé API…_"))
-
-    try:
-        lignes = helpers.recuperer_meta_periodes(cle.value)
-    except (helpers.CleApiRefusee, config.ApiUrlManquante) as exc:
-        mo.stop(True, mo.md(f"⚠️ **{exc}**"))
-    return (lignes,)
+    return
 
 
 @app.cell
-def _(lignes):
-    mo.output.replace(mo.ui.table(lignes, label="Facturation mensuelle"))
-    return
+def _(cle):
+    # Onglet Facturation : comportement inchangé (#705, non-régression) — calculé
+    # ici (pas dans un onglet paresseux) pour que clé refusée / KIOSQUE__API_URL
+    # manquante restent des erreurs immédiates, avant même d'afficher les onglets.
+    try:
+        lignes_facturation = helpers.recuperer_meta_periodes(cle.value)
+    except (helpers.CleApiRefusee, config.ApiUrlManquante) as exc:
+        mo.stop(True, mo.md(f"⚠️ **{exc}**"))
+    onglet_facturation = mo.ui.table(lignes_facturation, label="Facturation mensuelle")
+    return (onglet_facturation,)
+
+
+@app.cell
+def _(cle, onglet_facturation):
+    # Fonctions (pas des valeurs déjà calculées) : `mo.ui.tabs(..., lazy=True)`
+    # ne fetch qu'à l'ouverture de l'onglet — jamais Relevés/Flux bruts au
+    # chargement de la page. Exposées via `return` (pas seulement fermées sur
+    # `cle`) pour rester testables unitairement (voir `test_exports.py`).
+    def onglet_releves():
+        debut_defaut, fin_defaut = helpers.fenetre_dernier_mois()
+        pdl = mo.ui.text(label="PDL (optionnel)")
+        debut = mo.ui.date(value=debut_defaut, label="Depuis")
+        fin = mo.ui.date(value=fin_defaut, label="Jusqu'à")
+
+        try:
+            lignes, tronque = helpers.recuperer_releves(
+                cle.value,
+                prm=pdl.value or None,
+                debut=str(debut.value),
+                fin=str(fin.value),
+            )
+        except (helpers.CleApiRefusee, config.ApiUrlManquante) as exc:
+            return mo.vstack([pdl, debut, fin, mo.md(f"⚠️ **{exc}**")])
+
+        elements = [pdl, debut, fin]
+        if tronque:
+            elements.append(mo.callout("Vue tronquée : resserre tes filtres pour tout voir.", kind="warn"))
+        elements.append(mo.ui.table(lignes, label="Relevés"))
+        return mo.vstack(elements)
+
+    def onglet_flux_bruts():
+        table = mo.ui.dropdown(TABLES_FLUX, value=TABLES_FLUX[0], label="Table de flux")
+        pdl = mo.ui.text(label="PDL (optionnel)")
+        avertissement = mo.md(
+            "⚠️ Données brutes fidèles à la source, conventions Enedis — pour des "
+            "relevés harmonisés, onglet **Relevés**."
+        )
+
+        try:
+            lignes = helpers.recuperer_flux(cle.value, table.value, prm=pdl.value or None)
+        except (helpers.CleApiRefusee, helpers.TableFluxAbsente, config.ApiUrlManquante) as exc:
+            return mo.vstack([table, pdl, avertissement, mo.md(f"⚠️ **{exc}**")])
+
+        return mo.vstack([table, pdl, avertissement, mo.ui.table(lignes, label=f"Flux {table.value}")])
+
+    mo.output.replace(
+        mo.ui.tabs(
+            {
+                "Facturation": onglet_facturation,
+                "Relevés": onglet_releves,
+                "Flux bruts": onglet_flux_bruts,
+            },
+            lazy=True,
+        )
+    )
+    return onglet_releves, onglet_flux_bruts
 
 
 if __name__ == "__main__":

--- a/packages/electricore-kiosque/src/electricore_kiosque/exports.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/exports.py
@@ -60,6 +60,18 @@ def _():
 
 
 @app.cell
+def _():
+    # Onglet ouvert gardé en `mo.state` (#721) : la cellule des onglets est
+    # reconstruite à chaque changement de filtre, et un `mo.ui.tabs` reconstruit
+    # repart sur son premier onglet — sans ça, toucher un filtre Relevés
+    # renverrait le visiteur sur Facturation. `allow_self_loops=False` (défaut) :
+    # cliquer un onglet ne refait PAS tourner la cellule des onglets, donc pas
+    # de boucle ni de re-fetch au simple changement d'onglet.
+    onglet_ouvert, choisir_onglet = mo.state("Facturation")
+    return onglet_ouvert, choisir_onglet
+
+
+@app.cell
 def _(cle):
     # Onglet Facturation : comportement inchangé (#705, non-régression) — calculé
     # ici (pas dans un onglet paresseux) pour que clé refusée / KIOSQUE__API_URL
@@ -79,7 +91,17 @@ def _(cle):
 
 
 @app.cell
-def _(cle, onglet_facturation, pdl_releves, debut, fin, table_flux, pdl_flux):
+def _(
+    cle,
+    onglet_facturation,
+    pdl_releves,
+    debut,
+    fin,
+    table_flux,
+    pdl_flux,
+    onglet_ouvert,
+    choisir_onglet,
+):
     # Fonctions (pas des valeurs déjà calculées) : `mo.ui.tabs(..., lazy=True)`
     # ne fetch qu'à l'ouverture de l'onglet — jamais Relevés/Flux bruts au
     # chargement de la page. Elles ne FONT que fetch + rendre, en fermant sur les
@@ -128,7 +150,9 @@ def _(cle, onglet_facturation, pdl_releves, debut, fin, table_flux, pdl_flux):
                 "Relevés": onglet_releves,
                 "Flux bruts": onglet_flux_bruts,
             },
+            value=onglet_ouvert(),
             lazy=True,
+            on_change=choisir_onglet,
         )
     )
     return onglet_releves, onglet_flux_bruts

--- a/packages/electricore-kiosque/src/electricore_kiosque/exports.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/exports.py
@@ -35,16 +35,15 @@ def _():
 
 @app.cell
 def _(cle):
-    if not cle.value:
-        mo.stop(True, mo.md("_En attente d'une clé API…_"))
-    return
-
-
-@app.cell
-def _(cle):
     # Onglet Facturation : comportement inchangé (#705, non-régression) — calculé
     # ici (pas dans un onglet paresseux) pour que clé refusée / KIOSQUE__API_URL
     # manquante restent des erreurs immédiates, avant même d'afficher les onglets.
+    # Le garde « pas de clé » vit ICI, dans le même cell que le fetch : `mo.stop`
+    # ne coupe que les *descendants* par flux de données, et un cell qui ne
+    # définit rien n'en a aucun — isolé, il laisserait partir un fetch à vide.
+    if not cle.value:
+        mo.stop(True, mo.md("_En attente d'une clé API…_"))
+
     try:
         lignes_facturation = helpers.recuperer_meta_periodes(cle.value)
     except (helpers.CleApiRefusee, config.ApiUrlManquante) as exc:

--- a/packages/electricore-kiosque/src/electricore_kiosque/exports.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/exports.py
@@ -143,19 +143,27 @@ def _(
         elements.append(mo.ui.table(lignes, label=f"Flux {table_flux.value}"))
         return mo.vstack(elements)
 
-    mo.output.replace(
-        mo.ui.tabs(
-            {
-                "Facturation": onglet_facturation,
-                "Relevés": onglet_releves,
-                "Flux bruts": onglet_flux_bruts,
-            },
-            value=onglet_ouvert(),
-            lazy=True,
-            on_change=choisir_onglet,
-        )
+    # `onglets` est LIÉ à un nom et renvoyé (#721) : `UIElementRegistry` ne garde
+    # les éléments qu'en weakref, et un `mo.ui.tabs(...)` passé directement à
+    # `mo.output.replace()` n'est référencé par rien à la fin de la cellule — il
+    # est collecté, sort du registre, et le kernel jette alors le clic d'onglet
+    # (« A UI element may go out of scope if it was not assigned to a global
+    # variable », `marimo/_runtime/runtime.py`). `on_change` ne partait donc
+    # jamais, `mo.state` restait sur « Facturation », et le prochain re-render
+    # ramenait le visiteur au premier onglet. Lié, l'élément survit et le couple
+    # état/on_change fait son travail.
+    onglets = mo.ui.tabs(
+        {
+            "Facturation": onglet_facturation,
+            "Relevés": onglet_releves,
+            "Flux bruts": onglet_flux_bruts,
+        },
+        value=onglet_ouvert(),
+        lazy=True,
+        on_change=choisir_onglet,
     )
-    return onglet_releves, onglet_flux_bruts
+    mo.output.replace(onglets)
+    return onglet_releves, onglet_flux_bruts, onglets
 
 
 if __name__ == "__main__":

--- a/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
@@ -14,6 +14,8 @@ public du client, jamais via le moteur `electricore`.
 
 from __future__ import annotations
 
+from datetime import date, timedelta
+
 import httpx
 from electricore_client import ElectricoreClient
 from electricore_client.arrow import ElectricoreArrowClient
@@ -41,6 +43,19 @@ class TableFluxAbsente(Exception):
 
     def __init__(self, table: str) -> None:
         super().__init__(f"Table de flux « {table} » absente de cette box.")
+
+
+def fenetre_dernier_mois(aujourdhui: date | None = None) -> tuple[str, str]:
+    """Fenêtre par défaut de l'onglet Relevés : le dernier mois calendaire complet.
+
+    `aujourdhui` injectable pour les tests ; par défaut `date.today()`. Le mois
+    en cours est volontairement exclu (incomplet) — on montre le dernier mois
+    plein, resserrable ensuite via les filtres.
+    """
+    aujourdhui = aujourdhui or date.today()
+    fin = aujourdhui.replace(day=1) - timedelta(days=1)
+    debut = fin.replace(day=1)
+    return debut.isoformat(), fin.isoformat()
 
 
 def construire_client(cle: str, *, http_client: httpx.Client | None = None) -> ElectricoreClient:

--- a/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
@@ -2,20 +2,31 @@
 
 Zéro secret côté serveur (ADR-0057) : la clé vit dans la session navigateur du
 notebook, jamais stockée ici. Un notebook appelle directement une fonction
-`recuperer_*(cle)` — elle ouvre et referme son propre client (`construire_client`,
-toujours public pour les cas qui ont besoin du client nu) — toute la logique de
-fetch/erreur/cycle de vie vit ici pour que le notebook reste de la présentation
-pure au-dessus des helpers (voir `exports.py`).
+`recuperer_*(cle)` — elle ouvre et referme son propre client (`construire_client`/
+`construire_client_arrow`, toujours publics pour les cas qui ont besoin du client
+nu) — toute la logique de fetch/erreur/cycle de vie vit ici pour que le notebook
+reste de la présentation pure au-dessus des helpers (voir `exports.py`).
+
+Les relevés/flux bruts passent par `ElectricoreArrowClient` (extra `[arrow]`,
+amendement 2026-08-24 à l'ADR-0057) : polars entre dans le Kiosque via cet extra
+public du client, jamais via le moteur `electricore`.
 """
 
 from __future__ import annotations
 
 import httpx
 from electricore_client import ElectricoreClient
+from electricore_client.arrow import ElectricoreArrowClient
 
 from electricore_kiosque.config import api_url
 
 _STATUTS_CLE_REFUSEE = {401, 403}
+
+# Bandeau « vue tronquée » de l'onglet Relevés (#720) : plafond dur côté kiosque,
+# jamais de transfert du mart entier. Heuristique de troncature volontairement
+# simple : lignes retournées == la limite ⇒ probablement tronqué (faux positif
+# possible si le mart contient exactement ce compte, sans conséquence pratique).
+LIMITE_RELEVES = 100_000
 
 
 class CleApiRefusee(Exception):
@@ -25,9 +36,24 @@ class CleApiRefusee(Exception):
         super().__init__("Clé API refusée : contacte ton admin.")
 
 
+class TableFluxAbsente(Exception):
+    """La table de flux demandée n'existe pas sur cette box — message propre, pas de 404 brut."""
+
+    def __init__(self, table: str) -> None:
+        super().__init__(f"Table de flux « {table} » absente de cette box.")
+
+
 def construire_client(cle: str, *, http_client: httpx.Client | None = None) -> ElectricoreClient:
     """Client `electricore-client` configuré depuis une clé saisie + `KIOSQUE__API_URL`."""
     return ElectricoreClient(url=api_url(), api_key=cle, http_client=http_client)
+
+
+def construire_client_arrow(cle: str, *, http_client: httpx.Client | None = None) -> ElectricoreArrowClient:
+    """Client Arrow (`electricore-client[arrow]`) configuré depuis une clé saisie + `KIOSQUE__API_URL`.
+
+    Même seam que `construire_client` — injection de `http_client` pour les tests.
+    """
+    return ElectricoreArrowClient(url=api_url(), api_key=cle, http_client=http_client)
 
 
 def recuperer_meta_periodes(cle: str, *, http_client: httpx.Client | None = None) -> list[dict]:
@@ -53,3 +79,62 @@ def recuperer_meta_periodes(cle: str, *, http_client: httpx.Client | None = None
             if exc.response.status_code in _STATUTS_CLE_REFUSEE:
                 raise CleApiRefusee() from exc
             raise
+
+
+def recuperer_releves(
+    cle: str,
+    *,
+    prm: str | None = None,
+    debut: str | None = None,
+    fin: str | None = None,
+    http_client: httpx.Client | None = None,
+) -> tuple[list[dict], bool]:
+    """Mart de relevés canonique harmonisé (ADR-0029), plafonné à `LIMITE_RELEVES`.
+
+    Retourne `(lignes, tronque)` — `tronque=True` quand la limite dure a été
+    atteinte : le notebook affiche alors un bandeau « resserre tes filtres ».
+    Jamais de transfert du mart entier (#720).
+
+    Ouvre et referme son propre client (même patron que `recuperer_meta_periodes`).
+
+    Raises:
+        CleApiRefusee: clé API invalide ou révoquée (401/403 côté API).
+        config.ApiUrlManquante: `KIOSQUE__API_URL` absente (via `construire_client_arrow`).
+    """
+    with construire_client_arrow(cle, http_client=http_client) as client:
+        try:
+            df = client.releves(prm=prm, debut=debut, fin=fin, limit=LIMITE_RELEVES)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in _STATUTS_CLE_REFUSEE:
+                raise CleApiRefusee() from exc
+            raise
+    lignes = df.to_dicts()
+    return lignes, len(lignes) >= LIMITE_RELEVES
+
+
+def recuperer_flux(
+    cle: str,
+    table: str,
+    *,
+    prm: str | None = None,
+    http_client: httpx.Client | None = None,
+) -> list[dict]:
+    """Contenu brut d'une table de flux Enedis, fidèle à la source (pas d'harmonisation).
+
+    Ouvre et referme son propre client (même patron que `recuperer_meta_periodes`).
+
+    Raises:
+        CleApiRefusee: clé API invalide ou révoquée (401/403 côté API).
+        TableFluxAbsente: la table n'existe pas sur cette box (404 côté API).
+        config.ApiUrlManquante: `KIOSQUE__API_URL` absente (via `construire_client_arrow`).
+    """
+    with construire_client_arrow(cle, http_client=http_client) as client:
+        try:
+            df = client.flux(table, prm=prm)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in _STATUTS_CLE_REFUSEE:
+                raise CleApiRefusee() from exc
+            if exc.response.status_code == 404:
+                raise TableFluxAbsente(table) from exc
+            raise
+    return df.to_dicts()

--- a/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
@@ -24,11 +24,13 @@ from electricore_kiosque.config import api_url
 
 _STATUTS_CLE_REFUSEE = {401, 403}
 
-# Bandeau « vue tronquée » de l'onglet Relevés (#720) : plafond dur côté kiosque,
-# jamais de transfert du mart entier. Heuristique de troncature volontairement
-# simple : lignes retournées == la limite ⇒ probablement tronqué (faux positif
-# possible si le mart contient exactement ce compte, sans conséquence pratique).
-LIMITE_RELEVES = 100_000
+# Bandeau « vue tronquée » (relevés + flux bruts, #720/#721) : plafond dur côté
+# kiosque, jamais de transfert du mart/table entier. Heuristique de troncature
+# volontairement simple : lignes retournées >= la limite ⇒ probablement tronqué
+# (faux positif possible si la source contient exactement ce compte, sans
+# conséquence pratique). Partagée entre `recuperer_releves` et `recuperer_flux` :
+# même risque (fuite d'un flux entier), même garde-fou.
+LIMITE_LIGNES = 10_000
 
 
 class CleApiRefusee(Exception):
@@ -104,7 +106,7 @@ def recuperer_releves(
     fin: str | None = None,
     http_client: httpx.Client | None = None,
 ) -> tuple[list[dict], bool]:
-    """Mart de relevés canonique harmonisé (ADR-0029), plafonné à `LIMITE_RELEVES`.
+    """Mart de relevés canonique harmonisé (ADR-0029), plafonné à `LIMITE_LIGNES`.
 
     Retourne `(lignes, tronque)` — `tronque=True` quand la limite dure a été
     atteinte : le notebook affiche alors un bandeau « resserre tes filtres ».
@@ -118,13 +120,13 @@ def recuperer_releves(
     """
     with construire_client_arrow(cle, http_client=http_client) as client:
         try:
-            df = client.releves(prm=prm, debut=debut, fin=fin, limit=LIMITE_RELEVES)
+            df = client.releves(prm=prm, debut=debut, fin=fin, limit=LIMITE_LIGNES)
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code in _STATUTS_CLE_REFUSEE:
                 raise CleApiRefusee() from exc
             raise
     lignes = df.to_dicts()
-    return lignes, len(lignes) >= LIMITE_RELEVES
+    return lignes, len(lignes) >= LIMITE_LIGNES
 
 
 def recuperer_flux(
@@ -133,8 +135,12 @@ def recuperer_flux(
     *,
     prm: str | None = None,
     http_client: httpx.Client | None = None,
-) -> list[dict]:
+) -> tuple[list[dict], bool]:
     """Contenu brut d'une table de flux Enedis, fidèle à la source (pas d'harmonisation).
+
+    Plafonné à `LIMITE_LIGNES`, même garde-fou que `recuperer_releves` — une table
+    de flux brute peut être aussi volumineuse que le mart. Retourne `(lignes,
+    tronque)` — `tronque=True` quand la limite dure a été atteinte.
 
     Ouvre et referme son propre client (même patron que `recuperer_meta_periodes`).
 
@@ -145,11 +151,12 @@ def recuperer_flux(
     """
     with construire_client_arrow(cle, http_client=http_client) as client:
         try:
-            df = client.flux(table, prm=prm)
+            df = client.flux(table, prm=prm, limit=LIMITE_LIGNES)
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code in _STATUTS_CLE_REFUSEE:
                 raise CleApiRefusee() from exc
             if exc.response.status_code == 404:
                 raise TableFluxAbsente(table) from exc
             raise
-    return df.to_dicts()
+    lignes = df.to_dicts()
+    return lignes, len(lignes) >= LIMITE_LIGNES

--- a/packages/electricore-kiosque/tests/test_exports.py
+++ b/packages/electricore-kiosque/tests/test_exports.py
@@ -15,6 +15,8 @@ qui empêche de tester leur rendu via `sorties[-1].text`. Le dernier cell les
 
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 from electricore_kiosque import exports, helpers
 
@@ -23,6 +25,13 @@ class _FakeCle:
     """Stand-in pour `mo.ui.text` : seule sa `.value` compte pour le notebook."""
 
     def __init__(self, value: str) -> None:
+        self.value = value
+
+
+class _FakeWidget:
+    """Stand-in générique pour un widget `mo.ui.*` — seule sa `.value` compte."""
+
+    def __init__(self, value: object) -> None:
         self.value = value
 
 
@@ -126,13 +135,21 @@ def test_onglet_releves_cle_refusee_affiche_un_message_actionnable(monkeypatch: 
 def test_onglet_flux_bruts_affiche_le_tableau_et_l_avertissement_conventions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(helpers, "recuperer_flux", lambda cle, table, **kw: [{"pdl": "PDL456"}])
+    monkeypatch.setattr(helpers, "recuperer_flux", lambda cle, table, **kw: ([{"pdl": "PDL456"}], False))
     defs = _defs(monkeypatch)
 
     rendu = defs["onglet_flux_bruts"]().text
 
     assert "PDL456" in rendu
     assert "conventions Enedis" in rendu
+
+
+def test_onglet_flux_bruts_affiche_le_bandeau_vue_tronquee(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Même plafond `LIMITE_LIGNES` que Relevés — le bandeau doit suivre (#721)."""
+    monkeypatch.setattr(helpers, "recuperer_flux", lambda cle, table, **kw: ([{"pdl": "P1"}], True))
+    defs = _defs(monkeypatch)
+
+    assert "tronqu" in defs["onglet_flux_bruts"]().text.lower()
 
 
 def test_onglet_flux_bruts_table_absente_affiche_un_message_propre(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -143,3 +160,69 @@ def test_onglet_flux_bruts_table_absente_affiche_un_message_propre(monkeypatch: 
     defs = _defs(monkeypatch)
 
     assert "absente de cette box" in defs["onglet_flux_bruts"]().text
+
+
+# -- réactivité des filtres (#721, bug d'inertie) --------------------------------
+#
+# `mo.lazy` n'appelle la fonction d'un onglet qu'UNE fois par ouverture, et ne
+# retient pas l'objet retourné (weakref côté `UIElementRegistry`). Des widgets
+# créés À L'INTÉRIEUR de `onglet_releves`/`onglet_flux_bruts` seraient donc
+# inertes : les tests ci-dessus, qui appellent `defs["onglet_releves"]()`
+# directement, ne l'auraient JAMAIS détecté puisqu'ils recréent des widgets par
+# défaut à chaque appel — exactement le bug. La preuve qui aurait attrapé le
+# bug : les widgets doivent vivre dans leurs PROPRES cellules (`pdl_releves`,
+# `debut`, `fin`, `table_flux`, `pdl_flux`), overridables via `app.run(defs=…)`
+# — si `onglet_releves`/`onglet_flux_bruts` les recréaient en interne, cet
+# override n'aurait aucun effet sur ce que `helpers.recuperer_*` reçoit.
+
+
+def test_onglet_releves_recoit_les_valeurs_des_widgets_de_filtre_injectes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KIOSQUE__API_URL", "https://kiosque.test.invalide")
+    monkeypatch.setattr(helpers, "recuperer_meta_periodes", lambda cle, **kw: [])
+    captures: dict = {}
+
+    def _fake(cle: str, **kwargs: object):
+        captures.update(kwargs)
+        return [], False
+
+    monkeypatch.setattr(helpers, "recuperer_releves", _fake)
+
+    _, defs = exports.app.run(
+        defs={
+            "cle": _FakeCle("une-cle"),
+            "pdl_releves": _FakeWidget("PDL999"),
+            "debut": _FakeWidget(date(2020, 1, 1)),
+            "fin": _FakeWidget(date(2020, 1, 31)),
+        }
+    )
+    defs["onglet_releves"]()
+
+    assert captures["prm"] == "PDL999"
+    assert captures["debut"] == "2020-01-01"
+    assert captures["fin"] == "2020-01-31"
+
+
+def test_onglet_flux_bruts_recoit_la_table_du_dropdown_injecte(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Changer la valeur injectée du dropdown change la table demandée à l'API."""
+    monkeypatch.setenv("KIOSQUE__API_URL", "https://kiosque.test.invalide")
+    monkeypatch.setattr(helpers, "recuperer_meta_periodes", lambda cle, **kw: [])
+    captures: dict = {}
+
+    def _fake(cle: str, table: str, **kwargs: object):
+        captures["table"] = table
+        return [], False
+
+    monkeypatch.setattr(helpers, "recuperer_flux", _fake)
+
+    _, defs = exports.app.run(
+        defs={
+            "cle": _FakeCle("une-cle"),
+            "table_flux": _FakeWidget("r151"),
+            "pdl_flux": _FakeWidget(""),
+        }
+    )
+    defs["onglet_flux_bruts"]()
+
+    assert captures["table"] == "r151"

--- a/packages/electricore-kiosque/tests/test_exports.py
+++ b/packages/electricore-kiosque/tests/test_exports.py
@@ -62,6 +62,26 @@ def test_exports_cle_refusee_affiche_toujours_un_message_actionnable(monkeypatch
     assert "Clé API refusée" in _rendu("une-cle")
 
 
+def test_exports_sans_cle_ne_declenche_aucun_appel_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pas de clé → zéro fetch : le garde `mo.stop` doit vivre dans le cell qui fetch.
+
+    `mo.stop` ne coupe que les *descendants* par flux de données : un garde isolé
+    dans son propre cell (qui ne définit rien) ne couperait rien et laisserait
+    partir une requête avec une clé vide.
+    """
+    monkeypatch.setenv("KIOSQUE__API_URL", "https://kiosque.test.invalide")
+    appels: list[str] = []
+
+    def _fake(cle: str, **kwargs: object) -> list[dict]:
+        appels.append(cle)
+        return []
+
+    monkeypatch.setattr(helpers, "recuperer_meta_periodes", _fake)
+
+    assert "En attente" in _rendu("")
+    assert appels == []
+
+
 # -- onglet Relevés (#720) -----------------------------------------------------
 
 

--- a/packages/electricore-kiosque/tests/test_exports.py
+++ b/packages/electricore-kiosque/tests/test_exports.py
@@ -3,6 +3,14 @@
 `app.run(defs=...)` exécute le notebook marimo en process et permet d'injecter
 une valeur pour la clé sans passer par une vraie interaction UI — même patron
 que `test_accueil.py`.
+
+Les onglets Relevés/Flux bruts sont passés à `mo.ui.tabs(..., lazy=True)` sous
+forme de fonctions (pas de valeurs déjà calculées) : sous `app.run()` (mode
+script, sans kernel), `mo.lazy` ne les invoque jamais — comportement voulu
+(zéro fetch tant que l'onglet n'est pas ouvert dans un vrai navigateur), mais
+qui empêche de tester leur rendu via `sorties[-1].text`. Le dernier cell les
+`return` donc aussi comme définitions (`defs["onglet_releves"]` /
+`defs["onglet_flux_bruts"]`) pour les appeler directement ici.
 """
 
 from __future__ import annotations
@@ -23,6 +31,18 @@ def _rendu(cle: str) -> str:
     return sorties[-1].text
 
 
+def _defs(monkeypatch: pytest.MonkeyPatch, cle: str = "une-cle") -> dict:
+    """Définitions du notebook (dont `onglet_releves`/`onglet_flux_bruts`), clé/config posées.
+
+    `recuperer_meta_periodes` (onglet Facturation, hors sujet ici) est stubbée
+    pour ne pas dépendre de son comportement propre.
+    """
+    monkeypatch.setenv("KIOSQUE__API_URL", "https://kiosque.test.invalide")
+    monkeypatch.setattr(helpers, "recuperer_meta_periodes", lambda cle, **kw: [])
+    _, defs = exports.app.run(defs={"cle": _FakeCle(cle)})
+    return defs
+
+
 def test_exports_api_url_manquante_affiche_un_message_actionnable(monkeypatch: pytest.MonkeyPatch) -> None:
     """`config.ApiUrlManquante` (KIOSQUE__API_URL absente) est rattrapée, pas un traceback brut."""
     monkeypatch.delenv("KIOSQUE__API_URL", raising=False)
@@ -40,3 +60,66 @@ def test_exports_cle_refusee_affiche_toujours_un_message_actionnable(monkeypatch
     monkeypatch.setattr(helpers, "recuperer_meta_periodes", _lever)
 
     assert "Clé API refusée" in _rendu("une-cle")
+
+
+# -- onglet Relevés (#720) -----------------------------------------------------
+
+
+def test_onglet_releves_affiche_le_tableau_avec_la_fenetre_par_defaut(monkeypatch: pytest.MonkeyPatch) -> None:
+    captures: dict = {}
+
+    def _fake(cle: str, **kwargs: object):
+        captures.update(kwargs)
+        return [{"pdl": "PDL456", "date_releve": "2026-07-15"}], False
+
+    monkeypatch.setattr(helpers, "recuperer_releves", _fake)
+    defs = _defs(monkeypatch)
+
+    rendu = defs["onglet_releves"]().text
+
+    assert "PDL456" in rendu
+    debut_defaut, fin_defaut = helpers.fenetre_dernier_mois()
+    assert captures["debut"] == debut_defaut
+    assert captures["fin"] == fin_defaut
+
+
+def test_onglet_releves_affiche_le_bandeau_vue_tronquee(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(helpers, "recuperer_releves", lambda cle, **kw: ([{"pdl": "P1"}], True))
+    defs = _defs(monkeypatch)
+
+    assert "tronqu" in defs["onglet_releves"]().text.lower()
+
+
+def test_onglet_releves_cle_refusee_affiche_un_message_actionnable(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _lever(cle: str, **kwargs: object):
+        raise helpers.CleApiRefusee()
+
+    monkeypatch.setattr(helpers, "recuperer_releves", _lever)
+    defs = _defs(monkeypatch)
+
+    assert "Clé API refusée" in defs["onglet_releves"]().text
+
+
+# -- onglet Flux bruts (#720) ---------------------------------------------------
+
+
+def test_onglet_flux_bruts_affiche_le_tableau_et_l_avertissement_conventions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(helpers, "recuperer_flux", lambda cle, table, **kw: [{"pdl": "PDL456"}])
+    defs = _defs(monkeypatch)
+
+    rendu = defs["onglet_flux_bruts"]().text
+
+    assert "PDL456" in rendu
+    assert "conventions Enedis" in rendu
+
+
+def test_onglet_flux_bruts_table_absente_affiche_un_message_propre(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _lever(cle: str, table: str, **kwargs: object):
+        raise helpers.TableFluxAbsente(table)
+
+    monkeypatch.setattr(helpers, "recuperer_flux", _lever)
+    defs = _defs(monkeypatch)
+
+    assert "absente de cette box" in defs["onglet_flux_bruts"]().text

--- a/packages/electricore-kiosque/tests/test_exports_onglets_kernel.py
+++ b/packages/electricore-kiosque/tests/test_exports_onglets_kernel.py
@@ -1,0 +1,133 @@
+"""Onglet ouvert préservé — preuve dans un VRAI kernel marimo (#721).
+
+`app.run()` (mode script, cf. `test_exports.py`) ne peut pas attraper ce bug :
+sans kernel il n'y a ni `UIElementRegistry`, ni GC d'élément non lié, ni
+`set_ui_element_value`. Or le bug vivait exactement là — `mo.ui.tabs(...)`
+passé directement à `mo.output.replace()` n'était lié à aucun nom, donc
+collecté à la fin de la cellule (le registre ne tient qu'un weakref) ; le
+kernel jetait alors le clic d'onglet (« A UI element may go out of scope if it
+was not assigned to a global variable », `marimo/_runtime/runtime.py`),
+`on_change` ne partait jamais, `mo.state` restait sur « Facturation » et le
+re-render suivant ramenait le visiteur au premier onglet.
+
+Le test monte donc un kernel marimo réel (`marimo._runtime.kernel_lifecycle`)
+et rejoue la séquence du navigateur : saisie de la clé, clic sur « Flux
+bruts », puis changement d'un filtre. API interne de marimo : le module est
+skippé si elle bouge, plutôt que de rougir sur un refactor amont.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import queue
+import sys
+
+import pytest
+from electricore_kiosque import exports, helpers
+
+try:
+    from marimo._ast.cell import CellConfig
+    from marimo._config.config import DEFAULT_CONFIG
+    from marimo._messaging.types import KernelStreams, NoopStream
+    from marimo._runtime.commands import (
+        AppMetadata,
+        CreateNotebookCommand,
+        ExecuteCellCommand,
+        UpdateUIElementCommand,
+    )
+    from marimo._runtime.kernel_lifecycle import KernelArgs, kernel_session
+    from marimo._session.model import SessionMode
+except ImportError as exc:  # pragma: no cover - dépend de la version de marimo
+    pytest.skip(f"API interne marimo indisponible : {exc}", allow_module_level=True)
+
+
+@contextlib.contextmanager
+def _kernel_du_notebook():
+    """Instancie les cellules de `exports.py` dans un kernel marimo vivant."""
+    cellules = exports.app._cell_manager
+    ids = list(cellules.cell_ids())
+    codes = [cellules.get_cell_code(i) for i in ids]
+
+    args = KernelArgs(
+        streams=KernelStreams(stream=NoopStream(), stdout=None, stderr=None, stdin=None),
+        debugger=None,
+        configs={i: CellConfig() for i in ids},
+        app_metadata=AppMetadata(query_params={}, cli_args={}, app_config=exports.app._config),
+        user_config=DEFAULT_CONFIG,
+        mode=SessionMode.RUN,
+        control_queue=queue.Queue(),
+        set_ui_element_queue=queue.Queue(),
+        virtual_file_storage=None,
+    )
+    # `create_kernel` remplace `sys.modules["__main__"]`, `sys.argv` et `sys.path`.
+    principal, argv, chemins = sys.modules["__main__"], sys.argv, list(sys.path)
+    try:
+        with kernel_session(args) as (kernel, ctx):
+            yield kernel, ctx, ids, codes
+    finally:
+        sys.modules["__main__"], sys.argv, sys.path[:] = principal, argv, chemins
+
+
+def _element(registre, genre: str, **args):
+    """Premier élément vivant du registre de classe `genre` (et d'args donnés)."""
+    for oid, ref in registre._objects.items():
+        objet = ref()
+        if objet is None or type(objet).__name__ != genre:
+            continue
+        if all(objet._component_args.get(k) == v for k, v in args.items()):
+            return oid, objet
+    return None, None
+
+
+def test_l_onglet_ouvert_survit_au_changement_de_filtre(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KIOSQUE__API_URL", "https://kiosque.test.invalide")
+    monkeypatch.setattr(helpers, "recuperer_meta_periodes", lambda cle, **kw: [])
+    monkeypatch.setattr(helpers, "recuperer_releves", lambda cle, **kw: ([], False))
+    monkeypatch.setattr(helpers, "recuperer_flux", lambda cle, table, **kw: ([], False))
+
+    async def scenario() -> None:
+        with _kernel_du_notebook() as (kernel, ctx, ids, codes):
+            await kernel.instantiate(
+                CreateNotebookCommand(
+                    execution_requests=tuple(
+                        ExecuteCellCommand(cell_id=i, code=c) for i, c in zip(ids, codes, strict=True)
+                    ),
+                    cell_ids=tuple(ids),
+                    set_ui_element_value_request=UpdateUIElementCommand(object_ids=[], values=[]),
+                    auto_run=True,
+                )
+            )
+            registre = ctx.ui_element_registry
+
+            async def poser(oid, valeur) -> None:
+                await kernel.set_ui_element_value(
+                    UpdateUIElementCommand(object_ids=[oid], values=[valeur]),
+                    notify_frontend=False,
+                )
+
+            # 1. Le visiteur colle sa clé → la cellule des onglets tourne.
+            cle_id, _ = _element(registre, "text", kind="password")
+            await poser(cle_id, "une-cle")
+
+            onglets_id, onglets = _element(registre, "tabs")
+            assert onglets is not None, (
+                "mo.ui.tabs absent du registre : élément non lié à un nom, collecté "
+                "en fin de cellule — tout clic d'onglet sera jeté par le kernel"
+            )
+
+            # 2. Clic sur « Flux bruts » : le frontend envoie l'INDEX de l'onglet
+            #    (chaîne), que `tabs._convert_value` retraduit en nom d'onglet.
+            await poser(onglets_id, str(onglets._tab_keys.index("Flux bruts")))
+            assert kernel.globals["onglet_ouvert"]() == "Flux bruts"
+
+            # 3. Changement d'un filtre : la cellule des onglets est reconstruite.
+            table_id, _ = _element(registre, "dropdown")
+            await poser(table_id, ["r151"])
+
+            assert kernel.globals["onglet_ouvert"]() == "Flux bruts"
+            _, rebati = _element(registre, "tabs")
+            assert rebati is not None
+            assert rebati._initial_value == "Flux bruts", "le mo.ui.tabs reconstruit repart sur son premier onglet"
+
+    asyncio.run(scenario())

--- a/packages/electricore-kiosque/tests/test_helpers.py
+++ b/packages/electricore-kiosque/tests/test_helpers.py
@@ -14,7 +14,7 @@ import httpx
 import polars as pl
 import pytest
 from electricore_kiosque.helpers import (
-    LIMITE_RELEVES,
+    LIMITE_LIGNES,
     CleApiRefusee,
     TableFluxAbsente,
     construire_client,
@@ -133,12 +133,12 @@ def test_recuperer_releves_retourne_les_lignes_transmet_les_bornes_et_ferme_le_c
     assert params.get("prm") == "PDL456"
     assert params.get("debut") == "2026-05-01"
     assert params.get("fin") == "2026-06-01"
-    assert params.get("limit") == str(LIMITE_RELEVES)
+    assert params.get("limit") == str(LIMITE_LIGNES)
 
 
 def test_recuperer_releves_signale_la_troncature_quand_la_limite_est_atteinte() -> None:
-    """La limite dure côté kiosque (`LIMITE_RELEVES`) déclenche le bandeau « vue tronquée »."""
-    df = pl.DataFrame({"pdl": ["PDL456"] * LIMITE_RELEVES})
+    """La limite dure côté kiosque (`LIMITE_LIGNES`) déclenche le bandeau « vue tronquée »."""
+    df = pl.DataFrame({"pdl": ["PDL456"] * LIMITE_LIGNES})
 
     def handler(request: httpx.Request) -> httpx.Response:
         return _reponse_arrow(df)
@@ -146,7 +146,7 @@ def test_recuperer_releves_signale_la_troncature_quand_la_limite_est_atteinte() 
     http = _http(handler)
     lignes, tronque = recuperer_releves("une-cle", http_client=http)
 
-    assert len(lignes) == LIMITE_RELEVES
+    assert len(lignes) == LIMITE_LIGNES
     assert tronque is True
     assert http.is_closed
 
@@ -161,10 +161,22 @@ def test_recuperer_releves_cle_refusee_ferme_quand_meme_le_client() -> None:
     assert http.is_closed
 
 
+def test_recuperer_releves_propage_les_autres_erreurs_et_ferme_le_client() -> None:
+    """Une erreur qui n'est pas une clé refusée reste une erreur HTTP normale."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    http = _http(handler)
+    with pytest.raises(httpx.HTTPStatusError):
+        recuperer_releves("une-cle", http_client=http)
+    assert http.is_closed
+
+
 # -- recuperer_flux ---------------------------------------------------------------
 
 
-def test_recuperer_flux_retourne_les_lignes_et_ferme_le_client() -> None:
+def test_recuperer_flux_retourne_les_lignes_transmet_la_limite_et_ferme_le_client() -> None:
     captures: list[httpx.URL] = []
     df = pl.DataFrame({"pdl": ["PDL456"], "evenement_declencheur": ["MES"]})
 
@@ -173,11 +185,29 @@ def test_recuperer_flux_retourne_les_lignes_et_ferme_le_client() -> None:
         return _reponse_arrow(df)
 
     http = _http(handler)
-    lignes = recuperer_flux("une-cle", "c15", prm="PDL456", http_client=http)
+    lignes, tronque = recuperer_flux("une-cle", "c15", prm="PDL456", http_client=http)
 
     assert lignes == df.to_dicts()
+    assert tronque is False
     assert http.is_closed
     assert captures[0].params.get("prm") == "PDL456"
+    assert captures[0].params.get("limit") == str(LIMITE_LIGNES)
+
+
+def test_recuperer_flux_signale_la_troncature_quand_la_limite_est_atteinte() -> None:
+    """Même plafond dur que `recuperer_releves` (#721) : une table de flux brute
+    peut être aussi volumineuse que le mart de relevés."""
+    df = pl.DataFrame({"pdl": ["PDL456"] * LIMITE_LIGNES})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _reponse_arrow(df)
+
+    http = _http(handler)
+    lignes, tronque = recuperer_flux("une-cle", "c15", http_client=http)
+
+    assert len(lignes) == LIMITE_LIGNES
+    assert tronque is True
+    assert http.is_closed
 
 
 def test_recuperer_flux_table_absente_ferme_quand_meme_le_client() -> None:
@@ -198,6 +228,18 @@ def test_recuperer_flux_cle_refusee_ferme_quand_meme_le_client() -> None:
 
     http = _http(handler)
     with pytest.raises(CleApiRefusee, match="admin"):
+        recuperer_flux("une-cle", "c15", http_client=http)
+    assert http.is_closed
+
+
+def test_recuperer_flux_propage_les_autres_erreurs_et_ferme_le_client() -> None:
+    """Une erreur qui n'est pas une clé refusée ni un 404 reste une erreur HTTP normale."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    http = _http(handler)
+    with pytest.raises(httpx.HTTPStatusError):
         recuperer_flux("une-cle", "c15", http_client=http)
     assert http.is_closed
 

--- a/packages/electricore-kiosque/tests/test_helpers.py
+++ b/packages/electricore-kiosque/tests/test_helpers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import io
 import json
+from datetime import date
 
 import httpx
 import polars as pl
@@ -18,6 +19,7 @@ from electricore_kiosque.helpers import (
     TableFluxAbsente,
     construire_client,
     construire_client_arrow,
+    fenetre_dernier_mois,
     recuperer_flux,
     recuperer_meta_periodes,
     recuperer_releves,
@@ -197,3 +199,16 @@ def test_recuperer_flux_cle_refusee_ferme_quand_meme_le_client() -> None:
     with pytest.raises(CleApiRefusee, match="admin"):
         recuperer_flux("une-cle", "c15", http_client=http)
     assert http.is_closed
+
+
+# -- fenetre_dernier_mois -----------------------------------------------------
+
+
+def test_fenetre_dernier_mois_renvoie_le_mois_calendaire_precedent() -> None:
+    debut, fin = fenetre_dernier_mois(date(2026, 8, 24))
+    assert (debut, fin) == ("2026-07-01", "2026-07-31")
+
+
+def test_fenetre_dernier_mois_traverse_le_changement_d_annee() -> None:
+    debut, fin = fenetre_dernier_mois(date(2026, 1, 15))
+    assert (debut, fin) == ("2025-12-01", "2025-12-31")

--- a/packages/electricore-kiosque/tests/test_helpers.py
+++ b/packages/electricore-kiosque/tests/test_helpers.py
@@ -133,6 +133,7 @@ def test_recuperer_releves_retourne_les_lignes_transmet_les_bornes_et_ferme_le_c
     assert params.get("prm") == "PDL456"
     assert params.get("debut") == "2026-05-01"
     assert params.get("fin") == "2026-06-01"
+    assert params.get("limit") == str(LIMITE_RELEVES)
 
 
 def test_recuperer_releves_signale_la_troncature_quand_la_limite_est_atteinte() -> None:

--- a/packages/electricore-kiosque/tests/test_helpers.py
+++ b/packages/electricore-kiosque/tests/test_helpers.py
@@ -1,16 +1,27 @@
-"""Tests des helpers clé API → client `electricore-client` (#705).
+"""Tests des helpers clé API → client `electricore-client` (#705, #720).
 
 Transport HTTP mocké (`httpx.MockTransport`) : aucun réseau, même patron que
-`electricore_client/tests/test_transport.py`.
+`electricore_client/tests/test_transport.py` et `electricore_client/tests/test_arrow.py`.
 """
 
 from __future__ import annotations
 
+import io
 import json
 
 import httpx
+import polars as pl
 import pytest
-from electricore_kiosque.helpers import CleApiRefusee, construire_client, recuperer_meta_periodes
+from electricore_kiosque.helpers import (
+    LIMITE_RELEVES,
+    CleApiRefusee,
+    TableFluxAbsente,
+    construire_client,
+    construire_client_arrow,
+    recuperer_flux,
+    recuperer_meta_periodes,
+    recuperer_releves,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -34,6 +45,12 @@ _LIGNE = {
 
 def _http(handler) -> httpx.Client:
     return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _reponse_arrow(df: pl.DataFrame, *, status_code: int = 200) -> httpx.Response:
+    buf = io.BytesIO()
+    df.write_ipc_stream(buf)
+    return httpx.Response(status_code, content=buf.getvalue())
 
 
 def test_construire_client_positionne_url_et_cle(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -80,4 +97,103 @@ def test_recuperer_meta_periodes_propage_les_autres_erreurs_et_ferme_le_client()
     http = _http(handler)
     with pytest.raises(httpx.HTTPStatusError):
         recuperer_meta_periodes("une-cle", http_client=http)
+    assert http.is_closed
+
+
+# -- client Arrow (#720) -------------------------------------------------------
+
+
+def test_construire_client_arrow_positionne_url_et_cle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KIOSQUE__API_URL", "https://kiosque.exemple.fr")
+    client = construire_client_arrow("ma-cle")
+    assert client.url == "https://kiosque.exemple.fr"
+    assert client.api_key == "ma-cle"
+
+
+# -- recuperer_releves ----------------------------------------------------------
+
+
+def test_recuperer_releves_retourne_les_lignes_transmet_les_bornes_et_ferme_le_client() -> None:
+    captures: list[httpx.URL] = []
+    df = pl.DataFrame({"pdl": ["PDL456"], "date_releve": ["2026-05-01"]})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captures.append(request.url)
+        return _reponse_arrow(df)
+
+    http = _http(handler)
+    lignes, tronque = recuperer_releves("une-cle", prm="PDL456", debut="2026-05-01", fin="2026-06-01", http_client=http)
+
+    assert lignes == df.to_dicts()
+    assert tronque is False
+    assert http.is_closed
+    params = captures[0].params
+    assert params.get("prm") == "PDL456"
+    assert params.get("debut") == "2026-05-01"
+    assert params.get("fin") == "2026-06-01"
+
+
+def test_recuperer_releves_signale_la_troncature_quand_la_limite_est_atteinte() -> None:
+    """La limite dure côté kiosque (`LIMITE_RELEVES`) déclenche le bandeau « vue tronquée »."""
+    df = pl.DataFrame({"pdl": ["PDL456"] * LIMITE_RELEVES})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _reponse_arrow(df)
+
+    http = _http(handler)
+    lignes, tronque = recuperer_releves("une-cle", http_client=http)
+
+    assert len(lignes) == LIMITE_RELEVES
+    assert tronque is True
+    assert http.is_closed
+
+
+def test_recuperer_releves_cle_refusee_ferme_quand_meme_le_client() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401)
+
+    http = _http(handler)
+    with pytest.raises(CleApiRefusee, match="admin"):
+        recuperer_releves("une-cle", http_client=http)
+    assert http.is_closed
+
+
+# -- recuperer_flux ---------------------------------------------------------------
+
+
+def test_recuperer_flux_retourne_les_lignes_et_ferme_le_client() -> None:
+    captures: list[httpx.URL] = []
+    df = pl.DataFrame({"pdl": ["PDL456"], "evenement_declencheur": ["MES"]})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captures.append(request.url)
+        return _reponse_arrow(df)
+
+    http = _http(handler)
+    lignes = recuperer_flux("une-cle", "c15", prm="PDL456", http_client=http)
+
+    assert lignes == df.to_dicts()
+    assert http.is_closed
+    assert captures[0].params.get("prm") == "PDL456"
+
+
+def test_recuperer_flux_table_absente_ferme_quand_meme_le_client() -> None:
+    """Table hors registre côté box → message propre, pas de stacktrace (404 API)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    http = _http(handler)
+    with pytest.raises(TableFluxAbsente, match="inconnue"):
+        recuperer_flux("une-cle", "inconnue", http_client=http)
+    assert http.is_closed
+
+
+def test_recuperer_flux_cle_refusee_ferme_quand_meme_le_client() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401)
+
+    http = _http(handler)
+    with pytest.raises(CleApiRefusee, match="admin"):
+        recuperer_flux("une-cle", "c15", http_client=http)
     assert http.is_closed

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ name = "electricore-kiosque"
 version = "0.1.0"
 source = { editable = "packages/electricore-kiosque" }
 dependencies = [
-    { name = "electricore-client" },
+    { name = "electricore-client", extra = ["arrow"] },
     { name = "marimo" },
     { name = "uvicorn" },
 ]
@@ -895,7 +895,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "electricore-client", editable = "packages/electricore-client" },
+    { name = "electricore-client", extras = ["arrow"], editable = "packages/electricore-client" },
     { name = "marimo", specifier = ">=0.23.0" },
     { name = "uvicorn", specifier = ">=0.35.0,<0.36.0" },
 ]


### PR DESCRIPTION
Closes #720

Étend le notebook kiosque `exports` à trois onglets à chargement paresseux (`mo.ui.tabs` `lazy=True`) : Facturation (inchangé), Relevés (mart harmonisé, fenêtre dernier mois + filtres pdl/dates, bandeau « vue tronquée ») et Flux bruts (dropdown de tables Enedis, avertissement conventions, message propre si la table est absente de la box). Les deux nouveaux onglets passent par `electricore-client[arrow]` (`ElectricoreArrowClient`), ce qui fait entrer polars dans le kiosque — acté par l'amendement du 2026-08-24 à l'ADR-0057 (déjà sur la branche) : le moteur electricore/DuckDB reste interdit, le garde-fou CI est ajusté en conséquence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)