### PR TITLE
Kiosque : erreurs opérationnelles en messages clairs — 503 ingestion, API injoignable, version de contrat

### DIFF
--- a/packages/electricore-kiosque/README.md
+++ b/packages/electricore-kiosque/README.md
@@ -41,7 +41,9 @@ Un nom absent du catalogue dans `KIOSQUE__APPS` fait échouer le démarrage (mes
   Les onglets Relevés/Flux bruts passent par `electricore-client[arrow]`
   (`ElectricoreArrowClient`, amendement 2026-08-24 à l'ADR-0057) — polars entre dans le
   kiosque via cet extra public du client, jamais via le moteur `electricore`. Clé invalide
-  ou révoquée : message clair, pas de stacktrace.
+  ou révoquée : message clair, pas de stacktrace. Même traitement pour les erreurs
+  opérationnelles côté serveur (ingestion en cours, API injoignable, versions
+  client/serveur désynchronisées, #722).
 
 ## Lancement local
 

--- a/packages/electricore-kiosque/src/electricore_kiosque/exports.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/exports.py
@@ -84,7 +84,7 @@ def _(cle):
 
     try:
         lignes_facturation = helpers.recuperer_meta_periodes(cle.value)
-    except (helpers.CleApiRefusee, config.ApiUrlManquante) as exc:
+    except (helpers.CleApiRefusee, helpers.ServiceIndisponible, config.ApiUrlManquante) as exc:
         mo.stop(True, mo.md(f"⚠️ **{exc}**"))
     onglet_facturation = mo.ui.table(lignes_facturation, label="Facturation mensuelle")
     return (onglet_facturation,)
@@ -117,7 +117,7 @@ def _(
                 debut=str(debut.value),
                 fin=str(fin.value),
             )
-        except (helpers.CleApiRefusee, config.ApiUrlManquante) as exc:
+        except (helpers.CleApiRefusee, helpers.ServiceIndisponible, config.ApiUrlManquante) as exc:
             return mo.vstack([pdl_releves, debut, fin, mo.md(f"⚠️ **{exc}**")])
 
         elements = [pdl_releves, debut, fin]
@@ -134,7 +134,12 @@ def _(
 
         try:
             lignes, tronque = helpers.recuperer_flux(cle.value, table_flux.value, prm=pdl_flux.value or None)
-        except (helpers.CleApiRefusee, helpers.TableFluxAbsente, config.ApiUrlManquante) as exc:
+        except (
+            helpers.CleApiRefusee,
+            helpers.TableFluxAbsente,
+            helpers.ServiceIndisponible,
+            config.ApiUrlManquante,
+        ) as exc:
             return mo.vstack([table_flux, pdl_flux, avertissement, mo.md(f"⚠️ **{exc}**")])
 
         elements = [table_flux, pdl_flux, avertissement]

--- a/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
@@ -17,12 +17,13 @@ from __future__ import annotations
 from datetime import date, timedelta
 
 import httpx
-from electricore_client import ElectricoreClient
+from electricore_client import ContractVersionError, ElectricoreClient, IngestionEnCours
 from electricore_client.arrow import ElectricoreArrowClient
 
 from electricore_kiosque.config import api_url
 
 _STATUTS_CLE_REFUSEE = {401, 403}
+_ERREURS_CONNEXION = (httpx.ConnectError, httpx.ConnectTimeout)
 
 # Bandeau « vue tronquée » (relevés + flux bruts, #720/#721) : plafond dur côté
 # kiosque, jamais de transfert du mart/table entier. Heuristique de troncature
@@ -45,6 +46,30 @@ class TableFluxAbsente(Exception):
 
     def __init__(self, table: str) -> None:
         super().__init__(f"Table de flux « {table} » absente de cette box.")
+
+
+class ServiceIndisponible(Exception):
+    """L'API `electricore` est momentanément inutilisable — message actionnable, pas de stacktrace.
+
+    Une seule classe pour trois causes opérationnelles (#722) : ingestion en cours
+    (`IngestionEnCours`), API injoignable (`httpx.ConnectError`/`ConnectTimeout`),
+    versions client/serveur désynchronisées (`ContractVersionError`). Le notebook
+    les rattrape et les affiche identiquement (`mo.md(f"⚠️ **{exc}**")`) — un seul
+    message par cause suffit, pas besoin d'une hiérarchie.
+
+    `PreconditionNonRemplie` n'est volontairement pas de la partie : les trois
+    endpoints GET utilisés par le kiosque (méta-périodes, relevés, flux bruts)
+    ne l'émettent jamais côté API (seuls `/provision/estimation` et le detail de
+    facturation le font) — rien à convertir tant que ce chemin reste inatteignable.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+_MSG_INGESTION_EN_COURS = "Ingestion en cours côté serveur — réessaie dans quelques minutes."
+_MSG_API_INJOIGNABLE = "L'API est injoignable — vérifie l'URL ou contacte ton admin."
+_MSG_VERSIONS_DESYNCHRONISEES = "Le kiosque et l'API ne parlent plus la même version — préviens ton admin."
 
 
 def fenetre_dernier_mois(aujourdhui: date | None = None) -> tuple[str, str]:
@@ -86,12 +111,20 @@ def recuperer_meta_periodes(cle: str, *, http_client: httpx.Client | None = None
 
     Raises:
         CleApiRefusee: clé API invalide ou révoquée (401/403 côté API).
+        ServiceIndisponible: ingestion en cours, API injoignable, ou versions
+            client/serveur désynchronisées.
         config.ApiUrlManquante: `KIOSQUE__API_URL` absente (via `construire_client`).
     """
     with construire_client(cle, http_client=http_client) as client:
         try:
             with client.meta_periodes() as stream:
                 return [ligne.model_dump(exclude={"releves_utilises"}) for ligne in stream]
+        except _ERREURS_CONNEXION as exc:
+            raise ServiceIndisponible(_MSG_API_INJOIGNABLE) from exc
+        except IngestionEnCours as exc:
+            raise ServiceIndisponible(_MSG_INGESTION_EN_COURS) from exc
+        except ContractVersionError as exc:
+            raise ServiceIndisponible(_MSG_VERSIONS_DESYNCHRONISEES) from exc
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code in _STATUTS_CLE_REFUSEE:
                 raise CleApiRefusee() from exc
@@ -116,11 +149,18 @@ def recuperer_releves(
 
     Raises:
         CleApiRefusee: clé API invalide ou révoquée (401/403 côté API).
+        ServiceIndisponible: ingestion en cours ou API injoignable. (Pas de garde
+            de version de contrat sur cet endpoint Arrow — `ContractVersionError`
+            n'est donc pas de la partie ici, voir `ServiceIndisponible`.)
         config.ApiUrlManquante: `KIOSQUE__API_URL` absente (via `construire_client_arrow`).
     """
     with construire_client_arrow(cle, http_client=http_client) as client:
         try:
             df = client.releves(prm=prm, debut=debut, fin=fin, limit=LIMITE_LIGNES)
+        except _ERREURS_CONNEXION as exc:
+            raise ServiceIndisponible(_MSG_API_INJOIGNABLE) from exc
+        except IngestionEnCours as exc:
+            raise ServiceIndisponible(_MSG_INGESTION_EN_COURS) from exc
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code in _STATUTS_CLE_REFUSEE:
                 raise CleApiRefusee() from exc
@@ -147,11 +187,17 @@ def recuperer_flux(
     Raises:
         CleApiRefusee: clé API invalide ou révoquée (401/403 côté API).
         TableFluxAbsente: la table n'existe pas sur cette box (404 côté API).
+        ServiceIndisponible: ingestion en cours ou API injoignable (même remarque
+            que `recuperer_releves` sur `ContractVersionError`).
         config.ApiUrlManquante: `KIOSQUE__API_URL` absente (via `construire_client_arrow`).
     """
     with construire_client_arrow(cle, http_client=http_client) as client:
         try:
             df = client.flux(table, prm=prm, limit=LIMITE_LIGNES)
+        except _ERREURS_CONNEXION as exc:
+            raise ServiceIndisponible(_MSG_API_INJOIGNABLE) from exc
+        except IngestionEnCours as exc:
+            raise ServiceIndisponible(_MSG_INGESTION_EN_COURS) from exc
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code in _STATUTS_CLE_REFUSEE:
                 raise CleApiRefusee() from exc

--- a/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/helpers.py
@@ -23,6 +23,10 @@ from electricore_client.arrow import ElectricoreArrowClient
 from electricore_kiosque.config import api_url
 
 _STATUTS_CLE_REFUSEE = {401, 403}
+# Portée volontairement étroite : « API injoignable » = on n'a jamais établi la
+# connexion (#722). Une erreur APRÈS connexion (ReadTimeout sur un gros flux,
+# RemoteProtocolError…) n'est pas la même histoire et remonte telle quelle —
+# à élargir le jour où l'une d'elles se voit vraiment en prod.
 _ERREURS_CONNEXION = (httpx.ConnectError, httpx.ConnectTimeout)
 
 # Bandeau « vue tronquée » (relevés + flux bruts, #720/#721) : plafond dur côté
@@ -62,9 +66,6 @@ class ServiceIndisponible(Exception):
     ne l'émettent jamais côté API (seuls `/provision/estimation` et le detail de
     facturation le font) — rien à convertir tant que ce chemin reste inatteignable.
     """
-
-    def __init__(self, message: str) -> None:
-        super().__init__(message)
 
 
 _MSG_INGESTION_EN_COURS = "Ingestion en cours côté serveur — réessaie dans quelques minutes."

--- a/packages/electricore-kiosque/tests/test_exports.py
+++ b/packages/electricore-kiosque/tests/test_exports.py
@@ -71,6 +71,19 @@ def test_exports_cle_refusee_affiche_toujours_un_message_actionnable(monkeypatch
     assert "Clé API refusée" in _rendu("une-cle")
 
 
+def test_exports_service_indisponible_affiche_un_message_actionnable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`ServiceIndisponible` (#722 : ingestion en cours, API injoignable, version) est
+    rattrapée par l'onglet Facturation, pas de traceback marimo brute."""
+    monkeypatch.setenv("KIOSQUE__API_URL", "https://kiosque.test.invalide")
+
+    def _lever(cle: str, **kwargs: object) -> list[dict]:
+        raise helpers.ServiceIndisponible("Ingestion en cours côté serveur — réessaie dans quelques minutes.")
+
+    monkeypatch.setattr(helpers, "recuperer_meta_periodes", _lever)
+
+    assert "Ingestion en cours" in _rendu("une-cle")
+
+
 def test_exports_sans_cle_ne_declenche_aucun_appel_api(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pas de clé → zéro fetch : le garde `mo.stop` doit vivre dans le cell qui fetch.
 
@@ -129,6 +142,20 @@ def test_onglet_releves_cle_refusee_affiche_un_message_actionnable(monkeypatch: 
     assert "Clé API refusée" in defs["onglet_releves"]().text
 
 
+def test_onglet_releves_service_indisponible_affiche_un_message_actionnable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#722 : API injoignable/ingestion en cours rattrapée, pas de traceback."""
+
+    def _lever(cle: str, **kwargs: object):
+        raise helpers.ServiceIndisponible("L'API est injoignable — vérifie l'URL ou contacte ton admin.")
+
+    monkeypatch.setattr(helpers, "recuperer_releves", _lever)
+    defs = _defs(monkeypatch)
+
+    assert "injoignable" in defs["onglet_releves"]().text
+
+
 # -- onglet Flux bruts (#720) ---------------------------------------------------
 
 
@@ -160,6 +187,20 @@ def test_onglet_flux_bruts_table_absente_affiche_un_message_propre(monkeypatch: 
     defs = _defs(monkeypatch)
 
     assert "absente de cette box" in defs["onglet_flux_bruts"]().text
+
+
+def test_onglet_flux_bruts_service_indisponible_affiche_un_message_actionnable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#722 : ingestion en cours/API injoignable rattrapée, pas de traceback."""
+
+    def _lever(cle: str, table: str, **kwargs: object):
+        raise helpers.ServiceIndisponible("Ingestion en cours côté serveur — réessaie dans quelques minutes.")
+
+    monkeypatch.setattr(helpers, "recuperer_flux", _lever)
+    defs = _defs(monkeypatch)
+
+    assert "Ingestion en cours" in defs["onglet_flux_bruts"]().text
 
 
 # -- réactivité des filtres (#721, bug d'inertie) --------------------------------

--- a/packages/electricore-kiosque/tests/test_helpers.py
+++ b/packages/electricore-kiosque/tests/test_helpers.py
@@ -16,6 +16,7 @@ import pytest
 from electricore_kiosque.helpers import (
     LIMITE_LIGNES,
     CleApiRefusee,
+    ServiceIndisponible,
     TableFluxAbsente,
     construire_client,
     construire_client_arrow,
@@ -102,6 +103,43 @@ def test_recuperer_meta_periodes_propage_les_autres_erreurs_et_ferme_le_client()
     assert http.is_closed
 
 
+# -- erreurs opérationnelles (#722) --------------------------------------------
+
+
+def test_recuperer_meta_periodes_ingestion_en_cours_ferme_quand_meme_le_client() -> None:
+    """503 + X-Error-Kind réel (`electricore_client._raise_for_status`) → message clair."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, headers={"X-Error-Kind": "ingestion-lock"})
+
+    http = _http(handler)
+    with pytest.raises(ServiceIndisponible, match="Ingestion en cours"):
+        recuperer_meta_periodes("une-cle", http_client=http)
+    assert http.is_closed
+
+
+def test_recuperer_meta_periodes_api_injoignable_ferme_quand_meme_le_client() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connexion refusée", request=request)
+
+    http = _http(handler)
+    with pytest.raises(ServiceIndisponible, match="injoignable"):
+        recuperer_meta_periodes("une-cle", http_client=http)
+    assert http.is_closed
+
+
+def test_recuperer_meta_periodes_version_desynchronisee_ferme_quand_meme_le_client() -> None:
+    """Serveur en retard (`X-Contract-Version` < attendue) → message « préviens ton admin »."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"X-Contract-Version": "1"}, content=b"")
+
+    http = _http(handler)
+    with pytest.raises(ServiceIndisponible, match="admin"):
+        recuperer_meta_periodes("une-cle", http_client=http)
+    assert http.is_closed
+
+
 # -- client Arrow (#720) -------------------------------------------------------
 
 
@@ -173,6 +211,26 @@ def test_recuperer_releves_propage_les_autres_erreurs_et_ferme_le_client() -> No
     assert http.is_closed
 
 
+def test_recuperer_releves_ingestion_en_cours_ferme_quand_meme_le_client() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, headers={"X-Error-Kind": "ingestion-lock"})
+
+    http = _http(handler)
+    with pytest.raises(ServiceIndisponible, match="Ingestion en cours"):
+        recuperer_releves("une-cle", http_client=http)
+    assert http.is_closed
+
+
+def test_recuperer_releves_api_injoignable_ferme_quand_meme_le_client() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connexion refusée", request=request)
+
+    http = _http(handler)
+    with pytest.raises(ServiceIndisponible, match="injoignable"):
+        recuperer_releves("une-cle", http_client=http)
+    assert http.is_closed
+
+
 # -- recuperer_flux ---------------------------------------------------------------
 
 
@@ -240,6 +298,26 @@ def test_recuperer_flux_propage_les_autres_erreurs_et_ferme_le_client() -> None:
 
     http = _http(handler)
     with pytest.raises(httpx.HTTPStatusError):
+        recuperer_flux("une-cle", "c15", http_client=http)
+    assert http.is_closed
+
+
+def test_recuperer_flux_ingestion_en_cours_ferme_quand_meme_le_client() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, headers={"X-Error-Kind": "ingestion-lock"})
+
+    http = _http(handler)
+    with pytest.raises(ServiceIndisponible, match="Ingestion en cours"):
+        recuperer_flux("une-cle", "c15", http_client=http)
+    assert http.is_closed
+
+
+def test_recuperer_flux_api_injoignable_ferme_quand_meme_le_client() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connexion refusée", request=request)
+
+    http = _http(handler)
+    with pytest.raises(ServiceIndisponible, match="injoignable"):
         recuperer_flux("une-cle", "c15", http_client=http)
     assert http.is_closed
 


### PR DESCRIPTION
## Résumé

Les erreurs opérationnelles connues de l'API (ingestion en cours, API injoignable, versions client/serveur désynchronisées) traversaient les helpers du kiosque sans conversion et faisaient remonter une traceback marimo brute aux néophytes. Une seule classe `ServiceIndisponible` (patron établi de `CleApiRefusee`) convertit ces trois causes en messages français actionnables ; les trois onglets (Facturation/Relevés/Flux bruts) les rattrapent désormais identiquement.

`PreconditionNonRemplie` n'est volontairement pas convertie : aucun des trois endpoints GET du kiosque ne l'émet aujourd'hui côté API — notée dans la docstring plutôt qu'implémentée sans pouvoir la tester.

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)