### PR TITLE
Kiosque : image Docker unique + publication ghcr.io (une image, N configs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,12 @@ jobs:
         run: |
           /tmp/kiosque-venv/bin/python -m pytest packages/electricore-kiosque/tests -q
 
+      # Bash pur, fake-binaires docker/curl, zéro dépendance (même motif que
+      # deploy/tests/unit.sh) — couvre la logique de packages/electricore-kiosque/smoke.sh
+      # (image Docker kiosque, #706) sans jamais lancer de vrai conteneur ici.
+      - name: Auto-test du smoke Docker kiosque (fake docker/curl)
+        run: bash packages/electricore-kiosque/tests/test_smoke.sh
+
   deploy-tests:
     name: deploy shell tests (bash, fake-binaries)
     runs-on: ubuntu-latest
@@ -211,3 +217,12 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/docker-image.yml
+
+  # Idem pour l'image electricore-kiosque (#706) — workflow SIBLING (Dockerfile et
+  # smoke distincts, scope moteur absent). `push` reste à false : seul
+  # release-kiosque.yml (tag kiosque-v*) pousse.
+  docker-image-kiosque:
+    name: docker image kiosque (build + smoke)
+    permissions:
+      contents: read
+    uses: ./.github/workflows/docker-image-kiosque.yml

--- a/.github/workflows/docker-image-kiosque.yml
+++ b/.github/workflows/docker-image-kiosque.yml
@@ -1,0 +1,92 @@
+name: Docker image kiosque (build + smoke)
+
+# Workflow RÉUTILISABLE, SIBLING de docker-image.yml (#435) pour l'image
+# electricore-kiosque (#706) — pas une paramétrisation du workflow moteur : Dockerfile
+# différent (packages/electricore-kiosque/Dockerfile), smoke différent (HTTP + fail-fast
+# KIOSQUE__APPS, pas de fixtures SOPS), et surtout scope moteur totalement absent de
+# cette image (jamais `electricore`, jamais DuckDB — voir le Dockerfile).
+#
+# Appelé par :
+#   - ci.yml              (PR)              → push=false : build + scan + smoke, RIEN n'est poussé.
+#   - release-kiosque.yml (tag kiosque-v*)   → push=true  : idem + push n°2 vers ghcr.io.
+#
+# Même séquence gate que le moteur : rien n'est poussé tant que l'image n'a pas été
+# scannée (TruffleHog) ET fumée (smoke.sh).
+#
+# Pas de bloc `permissions:` ici : le workflow hérite des permissions que LUI DÉLÈGUE
+# l'appelant (ci.yml → contents:read ; release-kiosque.yml → +packages:write pour le push).
+
+on:
+  workflow_call:
+    inputs:
+      push:
+        description: "Pousser l'image vers GHCR après le gate (release uniquement)."
+        type: boolean
+        default: false
+      push_tags:
+        description: "Tags GHCR à pousser (séparés par des virgules) — requis si push=true."
+        type: string
+        default: ""
+
+jobs:
+  build-smoke:
+    name: build + scan + smoke (kiosque)
+    runs-on: ubuntu-latest
+    env:
+      # Tag LOCAL du build n°1 (chargé dans le démon Docker, jamais poussé tel quel).
+      SMOKE_TAG: electricore-kiosque:ci-smoke
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GHCR
+        if: ${{ inputs.push }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      # Build n°1 : le vrai build. Contexte = racine du repo (accès au workspace uv,
+      # même trick que le moteur). Charge l'image en local (load) pour le gate ci-dessous
+      # et alimente le cache GHA (cache-to) que le push n°2 réutilisera.
+      - name: Build image (n°1 — local, sans push, pour le gate scan + smoke)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: packages/electricore-kiosque/Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: ${{ env.SMOKE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image for verified secrets (TruffleHog)
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            trufflesecurity/trufflehog:latest \
+            docker --image "${SMOKE_TAG}" \
+            --only-verified \
+            --fail
+
+      # Fume l'image : le service sert (HTTP 200 sur /) + fail-fast KIOSQUE__APPS
+      # (nom hors catalogue → conteneur en erreur, message explicite).
+      - name: Smoke-test image (sert + fail-fast KIOSQUE__APPS)
+        run: bash packages/electricore-kiosque/smoke.sh "${SMOKE_TAG}"
+
+      # Build n°2 : réhydrate le cache GHA du build n°1 (cache-from) → quasi rien à
+      # reconstruire ; l'essentiel du temps est l'export + le push. Release uniquement.
+      - name: Push image vers GHCR (n°2 — cache du n°1 réhydraté, quasi gratuit)
+        if: ${{ inputs.push }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: packages/electricore-kiosque/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ inputs.push_tags }}
+          cache-from: type=gha

--- a/.github/workflows/release-kiosque.yml
+++ b/.github/workflows/release-kiosque.yml
@@ -1,0 +1,79 @@
+name: Release electricore-kiosque (Docker)
+
+# Publication de l'image Docker electricore-kiosque sur ghcr.io, déclenchée par un tag
+# `kiosque-v*` (distinct des tags `v*` du moteur et `client-v*` du client) — même logique
+# de découplage que release-client.yml (#706, PRD #702) : bump de version via PR AVANT
+# tag, PAS de release moteur ni PyPI impliquée (le Kiosque n'est pas un paquet PyPI).
+on:
+  push:
+    tags:
+      # Stable : kiosque-v0.1.0
+      - 'kiosque-v[0-9]+.[0-9]+.[0-9]+'
+      # Pré-releases PEP 440 : kiosque-v0.1.0a1 / b1 / rc1 / .dev1
+      - 'kiosque-v[0-9]+.[0-9]+.[0-9]+a[0-9]+'
+      - 'kiosque-v[0-9]+.[0-9]+.[0-9]+b[0-9]+'
+      - 'kiosque-v[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
+      - 'kiosque-v[0-9]+.[0-9]+.[0-9]+.dev[0-9]+'
+
+# Pas de bloc concurrency : un release ne doit jamais être annulé en cours de publication.
+
+permissions:
+  contents: read
+  packages: write   # push image Docker sur ghcr.io
+
+jobs:
+  verifier-version:
+    name: Vérifier que le tag correspond à la version du package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Pas de wheel ici (image Docker, pas PyPI) : le garde-fou équivalent au « nom
+      # d'artefact vs tag » de release-client.yml est la version du pyproject.toml.
+      - name: Comparer pyproject.toml et le tag
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF_NAME#kiosque-v}"
+          PKG_VERSION=$(grep -m1 '^version = ' packages/electricore-kiosque/pyproject.toml | sed -E 's/version = "(.*)"/\1/')
+          echo "tag=${TAG_VERSION} pyproject.toml=${PKG_VERSION}"
+          if [[ "${TAG_VERSION}" != "${PKG_VERSION}" ]]; then
+            echo "::error::Tag kiosque-v${TAG_VERSION} ne correspond pas à packages/electricore-kiosque/pyproject.toml (${PKG_VERSION}) — bump de version via PR avant de tagger."
+            exit 1
+          fi
+
+  docker_meta:
+    name: Compute Docker tags
+    needs: verifier-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tags: ${{ steps.compute.outputs.tags }}
+    steps:
+      - name: Compute tags (pré-release ne touche ni :latest ni :MAJOR.MINOR)
+        id: compute
+        run: |
+          set -euo pipefail
+          OWNER="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          V="${GITHUB_REF_NAME#kiosque-v}"
+          MAJOR_MINOR="${V%.*}"
+          if [[ "${GITHUB_REF_NAME}" =~ ^kiosque-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            # Stable : :latest + :MAJOR.MINOR + :version exacte.
+            TAGS="ghcr.io/${OWNER}/electricore-kiosque:${V},ghcr.io/${OWNER}/electricore-kiosque:${MAJOR_MINOR},ghcr.io/${OWNER}/electricore-kiosque:latest"
+          else
+            # Pré-release : seulement :version exacte (ne pas rediriger les déploiements
+            # stables vers la rc/dev).
+            TAGS="ghcr.io/${OWNER}/electricore-kiosque:${V}"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+  image:
+    name: Build, scan, smoke & push image
+    needs: [verifier-version, docker_meta]
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-image-kiosque.yml
+    with:
+      push: true
+      push_tags: ${{ needs.docker_meta.outputs.tags }}

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -109,6 +109,20 @@ gh run list --workflow release-client.yml --limit 1
 look: le run "Release electricore-client" et https://pypi.org/project/electricore-client/
 expect: job vert (build uv → vérif artefacts vs tag → Trusted Publishing OIDC, aucun token PyPI) ; la version apparaît sur PyPI, puis souscriptions_odoo peut bumper son pin
 
+## kiosque-release
+
+mode: human
+when: publier l'image Docker electricore-kiosque sur ghcr.io (après merge dans main du bump de version du pyproject du package)
+do:
+```
+git fetch origin main
+git tag kiosque-v{version} origin/main   # {version} = celle du pyproject mergé (pré-releases PEP 440 : a1/b1/rc1/.devN)
+git push origin kiosque-v{version}       # hors sandbox ; le tag déclenche .github/workflows/release-kiosque.yml
+gh run list --workflow release-kiosque.yml --limit 1
+```
+look: le run "Release electricore-kiosque (Docker)" et https://github.com/Energie-De-Nantes/electricore/pkgs/container/electricore-kiosque
+expect: job vert (tag vs pyproject → build → TruffleHog → smoke → push) ; tag stable → :X.Y.Z + :X.Y + :latest, pré-release → :X.Y.ZrcN seule
+
 ## docs-eyeball
 
 mode: human

--- a/docs/maintenir/release.md
+++ b/docs/maintenir/release.md
@@ -4,11 +4,13 @@ fraicheur: 2026-07-04
 
 # Processus de release
 
-Deux cycles de publication distincts et indépendants : le **moteur** (paquet
-`electricore`, tags `vX.Y.Z…`) et le **client léger** (paquet `electricore-client`, tags
-`client-vX.Y.Z…`, [ADR-0043](../adr/0043-electricore-client-paquet-separe.md)). Ce qui suit
-décrit le moteur ; le client suit le même principe (tag = action publiante) avec un
-paquet PyPI en moins de sortie (pas d'image Docker).
+Trois cycles de publication distincts et indépendants : le **moteur** (paquet
+`electricore`, tags `vX.Y.Z…`), le **client léger** (paquet `electricore-client`, tags
+`client-vX.Y.Z…`, [ADR-0043](../adr/0043-electricore-client-paquet-separe.md)) et le
+**Kiosque** (image Docker seule, tags `kiosque-vX.Y.Z…`,
+[ADR-0057](../adr/0057-kiosque-acces-neophytes-package-separe.md)). Ce qui suit décrit le
+moteur ; les deux autres suivent le même principe (tag = action publiante) avec une
+sortie plus étroite (le client : PyPI sans image ; le Kiosque : image sans PyPI).
 
 ## 1. Avant de taguer : bump en PR, comme tout le reste
 

--- a/packages/electricore-kiosque/Dockerfile
+++ b/packages/electricore-kiosque/Dockerfile
@@ -59,9 +59,11 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends tini \
  && rm -rf /var/lib/apt/lists/*
 
-# Utilisateur non-root
+# Utilisateur non-root, avec un VRAI home writable : marimo cherche sa config sous
+# $HOME/.config au démarrage — un home root-owned (ou /app) spamme les logs de
+# « Permission denied » à chaque requête (vu au premier docker run, PR #724).
 RUN groupadd --system --gid 1000 kiosque \
- && useradd --system --uid 1000 --gid kiosque --home-dir /app --shell /usr/sbin/nologin kiosque
+ && useradd --system --uid 1000 --gid kiosque --create-home --home-dir /home/kiosque --shell /usr/sbin/nologin kiosque
 
 WORKDIR /app
 
@@ -69,7 +71,10 @@ WORKDIR /app
 # aucun `electricore/` : l'image runtime ne peut PAS accidentellement importer le moteur.
 COPY --from=builder --chown=kiosque:kiosque /app/.venv /app/.venv
 
+# HOME explicite : la directive USER ne pose PAS $HOME — sans lui, marimo retombe
+# sur le cwd (/app, root-owned) pour sa config.
 ENV PATH="/app/.venv/bin:${PATH}" \
+    HOME=/home/kiosque \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     TZ=Europe/Paris

--- a/packages/electricore-kiosque/Dockerfile
+++ b/packages/electricore-kiosque/Dockerfile
@@ -1,0 +1,85 @@
+# syntax=docker/dockerfile:1.7
+
+# =============================================================================
+# Image electricore-kiosque (#706, ADR-0057) — UNE image, N configs : tout le
+# catalogue de notebooks embarqué, la personnalisation par entité (KIOSQUE__APPS,
+# KIOSQUE__TITRE, KIOSQUE__API_URL) reste de la config au lancement, pas du build.
+#
+# Contexte de build = RACINE du repo (nécessaire : `packages/electricore-kiosque`
+# dépend de `packages/electricore-client`, tous deux membres du workspace uv résolus
+# par le uv.lock de la racine — même trick que deploy/docker/Dockerfile).
+#
+# JAMAIS le moteur `electricore` : ni installé (scope `--package electricore-kiosque`
+# ci-dessous), ni copié dans le runtime. Aucun secret : la clé API `electricore` est
+# saisie côté navigateur, jamais côté serveur (voir README).
+# =============================================================================
+
+# =============================================================================
+# Stage 1 — builder : résolution du venv avec uv, SCOPE electricore-kiosque seul
+# =============================================================================
+FROM python:3.13-slim AS builder
+
+# uv depuis l'image officielle Astral (binaire statique) — même pin que le moteur.
+COPY --from=ghcr.io/astral-sh/uv:0.5-python3.13-bookworm-slim /usr/local/bin/uv /usr/local/bin/uv
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
+WORKDIR /app
+
+# Manifestes du WORKSPACE (racine, pour le uv.lock partagé) + le dossier `packages/`
+# entier (les deux membres : electricore-client dont le Kiosque dépend, et lui-même).
+# JAMAIS `electricore/` (le moteur, membre racine du workspace) : pas copié ici, donc
+# indisponible pour l'étape suivante — la scope `--package` ci-dessous n'irait de
+# toute façon pas le chercher, mais l'absence physique le garantit à double titre.
+COPY pyproject.toml uv.lock README.md ./
+COPY packages/ ./packages/
+
+# `--package electricore-kiosque` : résout et installe SEULEMENT le sous-arbre de
+# dépendances du Kiosque (marimo, uvicorn, electricore-client[arrow] → polars) —
+# jamais le projet racine du workspace (le moteur `electricore`), jamais DuckDB.
+# `--no-editable` : electricore-client ET electricore-kiosque installés en vrais
+# WHEELS dans le venv (pas de .pth pointant vers /app/packages/…) — le runtime peut
+# donc copier SEULEMENT le venv, sans jamais embarquer `packages/` en source ni
+# `electricore/` (le moteur n'a même pas besoin d'être présent dans ce contexte).
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --package electricore-kiosque --no-dev --no-editable
+
+# =============================================================================
+# Stage 2 — runtime : image légère, sans outils de build ni source `packages/`
+# =============================================================================
+FROM python:3.13-slim AS runtime
+
+# tini uniquement : pas de libxml2/supercronic/duckdb/sops/age — le Kiosque ne fait
+# ni parsing XML Enedis, ni cron, ni DuckDB, ni déchiffrement de secrets (aucun secret
+# côté serveur, ADR-0057).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends tini \
+ && rm -rf /var/lib/apt/lists/*
+
+# Utilisateur non-root
+RUN groupadd --system --gid 1000 kiosque \
+ && useradd --system --uid 1000 --gid kiosque --home-dir /app --shell /usr/sbin/nologin kiosque
+
+WORKDIR /app
+
+# Uniquement le venv déjà résolu (wheels, pas d'éditable) — aucun source `packages/`,
+# aucun `electricore/` : l'image runtime ne peut PAS accidentellement importer le moteur.
+COPY --from=builder --chown=kiosque:kiosque /app/.venv /app/.venv
+
+ENV PATH="/app/.venv/bin:${PATH}" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    TZ=Europe/Paris
+
+USER kiosque
+
+EXPOSE 8765
+
+# tini comme PID 1 (propagation correcte de SIGTERM). Pas d'entrypoint de déchiffrement
+# de secrets (contrairement à l'image moteur) : rien à déchiffrer ici. Configuration
+# entière par variables d'environnement au lancement — voir README (KIOSQUE__APPS,
+# KIOSQUE__TITRE, KIOSQUE__API_URL).
+ENTRYPOINT ["/usr/bin/tini", "--", "electricore-kiosque"]

--- a/packages/electricore-kiosque/README.md
+++ b/packages/electricore-kiosque/README.md
@@ -51,3 +51,37 @@ Un nom absent du catalogue dans `KIOSQUE__APPS` fait échouer le démarrage (mes
 env KIOSQUE__APPS=exports KIOSQUE__TITRE="Ma structure" KIOSQUE__API_URL=https://mon-api.exemple.fr \
     uv run --package electricore-kiosque electricore-kiosque
 ```
+
+## Image Docker
+
+Une seule image publique, publiée sur `ghcr.io/energie-de-nantes/electricore-kiosque` —
+tout le catalogue embarqué, la personnalisation par entité reste de la configuration au
+lancement (voir [ADR-0057](../../docs/adr/0057-kiosque-acces-neophytes-package-separe.md)).
+Aucun secret embarqué, aucun build par client ([`Dockerfile`](Dockerfile)).
+
+```bash
+docker run --rm -p 8765:8765 \
+    -e KIOSQUE__APPS=exports \
+    -e KIOSQUE__TITRE="Ma structure" \
+    -e KIOSQUE__API_URL=https://mon-api.exemple.fr \
+    ghcr.io/energie-de-nantes/electricore-kiosque:latest
+```
+
+Puis ouvrir `http://localhost:8765`. Changer `KIOSQUE__APPS`/`KIOSQUE__TITRE` change les
+apps servies sans rebuild — c'est le même artefact pour toutes les entités.
+
+### Publier une nouvelle version de l'image
+
+Même logique de découplage que `electricore-client` (tag dédié, pas de release moteur) :
+
+1. Bumper `version` dans [`pyproject.toml`](pyproject.toml) via une PR normale, merger.
+2. Tagger `kiosque-vX.Y.Z` (ou une pré-release `kiosque-vX.Y.ZrcN`/`aN`/`bN`/`.devN`) sur
+   `main` et pousser le tag.
+3. Le workflow [`release-kiosque.yml`](../../.github/workflows/release-kiosque.yml) build,
+   scanne (TruffleHog), fume l'image ([`smoke.sh`](smoke.sh)), puis pousse sur ghcr.io.
+   Tag stable → `:X.Y.Z` + `:X.Y` + `:latest` ; pré-release → seulement `:X.Y.ZrcN` (ne
+   touche jamais `:latest`, même convention que l'image moteur).
+
+Chaque PR construit + scanne + fume l'image (sans la pousser) via le même workflow
+réutilisable ([`docker-image-kiosque.yml`](../../.github/workflows/docker-image-kiosque.yml),
+appelé par `ci.yml`) — les régressions Docker sont visibles avant le tag.

--- a/packages/electricore-kiosque/smoke.sh
+++ b/packages/electricore-kiosque/smoke.sh
@@ -41,6 +41,11 @@ smoke_kiosque_sert() {
         tries=$((tries + 1))
     done
 
+    # Logs AVANT le stop : le conteneur tourne en --rm, `docker logs` devient impossible
+    # dès qu'il s'arrête — sans ça le diagnostic d'échec renvoie vers des logs supprimés.
+    if [[ "$rc" -ne 0 ]]; then
+        "$DOCKER_BIN" logs "$cid" >&2 || true
+    fi
     "$DOCKER_BIN" stop "$cid" >/dev/null 2>&1
     return "$rc"
 }
@@ -69,7 +74,7 @@ smoke_kiosque_image() {
     if smoke_kiosque_sert "$tag"; then
         echo "smoke: le service sert (HTTP 200 sur /) OK"
     else
-        echo "smoke: ÉCHEC — le service ne sert pas (voir docker logs)" >&2
+        echo "smoke: ÉCHEC — le service ne sert pas (logs du conteneur ci-dessus)" >&2
         rc=1
     fi
     if smoke_kiosque_fail_fast "$tag"; then

--- a/packages/electricore-kiosque/smoke.sh
+++ b/packages/electricore-kiosque/smoke.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# smoke.sh — fume une image electricore-kiosque DÉJÀ buildée (#706).
+#
+# Deux vérifications, contre l'IMAGE (pas seulement le code Python — déjà couvert par
+# packages/electricore-kiosque/tests/test_main.py) :
+#   1. Le service sert : démarré avec KIOSQUE__APPS/KIOSQUE__TITRE/KIOSQUE__API_URL,
+#      GET / répond 200 (l'accueil). Aucun secret requis — l'API n'est jamais appelée
+#      au démarrage (KIOSQUE__API_URL est lue paresseusement, à l'usage d'un notebook).
+#   2. Fail-fast : KIOSQUE__APPS référence une app hors catalogue → le conteneur
+#      s'arrête en erreur (exit non-zero) avec le message explicite (app.py NomAppInconnu).
+#
+# Usage :   packages/electricore-kiosque/smoke.sh <image-tag>
+#
+# Surcharges de test (motif deploy/docker/smoke.sh, deploy/tests/unit.sh) :
+#   DOCKER_BIN  binaire docker (défaut: docker ; les tests le stubbent)
+#   CURL_BIN    binaire curl (défaut: curl ; les tests le stubbent)
+
+DOCKER_BIN="${DOCKER_BIN:-docker}"
+CURL_BIN="${CURL_BIN:-curl}"
+
+# smoke_kiosque_sert <tag> : le conteneur démarre et sert l'accueil (HTTP 200 sur /).
+smoke_kiosque_sert() {
+    local tag="$1"
+    local port="${SMOKE_KIOSQUE_PORT:-18765}"
+    local cid
+    cid=$("$DOCKER_BIN" run -d --rm \
+        -e KIOSQUE__APPS=exports \
+        -e KIOSQUE__TITRE=Smoke \
+        -e KIOSQUE__API_URL=http://smoke.invalid \
+        -p "${port}:8765" \
+        "$tag") || return 1
+
+    local rc=1 tries=0
+    while [[ $tries -lt 20 ]]; do
+        if "$CURL_BIN" -sf -o /dev/null "http://127.0.0.1:${port}/"; then
+            rc=0
+            break
+        fi
+        sleep 0.5
+        tries=$((tries + 1))
+    done
+
+    "$DOCKER_BIN" stop "$cid" >/dev/null 2>&1
+    return "$rc"
+}
+
+# smoke_kiosque_fail_fast <tag> : nom hors catalogue → conteneur en erreur, message explicite.
+smoke_kiosque_fail_fast() {
+    local tag="$1"
+    local out
+    out=$("$DOCKER_BIN" run --rm \
+        -e KIOSQUE__APPS=typo_inexistante \
+        -e KIOSQUE__TITRE=Smoke \
+        -e KIOSQUE__API_URL=http://smoke.invalid \
+        "$tag" 2>&1)
+    local rc=$?
+    [[ "$rc" -ne 0 && "$out" == *"typo_inexistante"* ]]
+}
+
+# smoke_kiosque_image <tag> : lance les deux fumées, rapporte chaque verdict, échoue si l'une casse.
+smoke_kiosque_image() {
+    local tag="${1:-}"
+    if [[ -z "$tag" ]]; then
+        echo "usage: smoke.sh <image-tag>" >&2
+        return 2
+    fi
+    local rc=0
+    if smoke_kiosque_sert "$tag"; then
+        echo "smoke: le service sert (HTTP 200 sur /) OK"
+    else
+        echo "smoke: ÉCHEC — le service ne sert pas (voir docker logs)" >&2
+        rc=1
+    fi
+    if smoke_kiosque_fail_fast "$tag"; then
+        echo "smoke: fail-fast OK (nom hors catalogue → conteneur en erreur, message explicite)"
+    else
+        echo "smoke: ÉCHEC — le fail-fast n'a pas produit l'erreur/le message attendus" >&2
+        rc=1
+    fi
+    return "$rc"
+}
+
+main_smoke() {
+    set -euo pipefail
+    smoke_kiosque_image "$@"
+}
+
+# Guard : exécute main_smoke seulement si lancé (`bash smoke.sh …`), pas sourcé (tests).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main_smoke "$@"
+fi

--- a/packages/electricore-kiosque/src/electricore_kiosque/__main__.py
+++ b/packages/electricore-kiosque/src/electricore_kiosque/__main__.py
@@ -15,7 +15,10 @@ from electricore_kiosque.app import NomAppInconnu, assembler
 from electricore_kiosque.catalogue import CATALOGUE
 from electricore_kiosque.config import apps_actives
 
-_HOTE = "127.0.0.1"
+# 0.0.0.0 : le Kiosque est un service à joindre depuis l'extérieur du process (navigateur
+# distant, ou port-mapping Docker, #706) — jamais juste une boucle locale, contrairement à
+# un outil CLI de dev. Même convention que l'API du moteur (uvicorn --host 0.0.0.0).
+_HOTE = "0.0.0.0"
 _PORT = 8765
 
 

--- a/packages/electricore-kiosque/tests/fixtures/fake_bin/curl
+++ b/packages/electricore-kiosque/tests/fixtures/fake_bin/curl
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Fake `curl` pour tester packages/electricore-kiosque/smoke.sh (#706).
+# FAKE_CURL_FAIL=1 simule un service qui ne répond pas (HTTP smoke KO).
+[[ "${FAKE_CURL_FAIL:-0}" == "1" ]] && exit 7
+exit 0

--- a/packages/electricore-kiosque/tests/fixtures/fake_bin/docker
+++ b/packages/electricore-kiosque/tests/fixtures/fake_bin/docker
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Fake `docker` pour tester packages/electricore-kiosque/smoke.sh (#706).
+#
+# Modélise le comportement réel de l'image (app.py / __main__.py) : `KIOSQUE__APPS`
+# contenant un nom hors catalogue → le process quitte en erreur avec le message
+# explicite de `NomAppInconnu` sur stderr — SAUF si FAKE_DOCKER_NO_FAILFAST=1 (pour
+# tester que smoke.sh détecte bien l'ABSENCE du fail-fast attendu).
+#
+# `docker run -d …` → imprime un id de conteneur factice.
+# `docker stop …`   → no-op, exit 0.
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+    run)
+        detach=0
+        apps=""
+        args=("$@")
+        i=0
+        while [[ $i -lt ${#args[@]} ]]; do
+            case "${args[$i]}" in
+                -d)
+                    detach=1
+                    i=$((i + 1))
+                    ;;
+                -e)
+                    kv="${args[$((i + 1))]}"
+                    [[ "$kv" == KIOSQUE__APPS=* ]] && apps="${kv#KIOSQUE__APPS=}"
+                    i=$((i + 2))
+                    ;;
+                *)
+                    i=$((i + 1))
+                    ;;
+            esac
+        done
+
+        if [[ "$apps" == *typo* && "${FAKE_DOCKER_NO_FAILFAST:-0}" != "1" ]]; then
+            echo "Kiosque : configuration invalide — KIOSQUE__APPS référence des apps inconnues du catalogue : ${apps} (disponibles : exports)" >&2
+            exit 1
+        fi
+
+        if [[ "$detach" -eq 1 ]]; then
+            echo "fakecid123"
+        fi
+        exit 0
+        ;;
+    stop)
+        exit 0
+        ;;
+    *)
+        echo "fake docker: commande non simulée ($cmd $*)" >&2
+        exit 1
+        ;;
+esac

--- a/packages/electricore-kiosque/tests/fixtures/fake_bin/docker
+++ b/packages/electricore-kiosque/tests/fixtures/fake_bin/docker
@@ -45,6 +45,10 @@ case "$cmd" in
         fi
         exit 0
         ;;
+    logs)
+        echo "fake docker logs: (sortie du conteneur)" >&2
+        exit 0
+        ;;
     stop)
         exit 0
         ;;

--- a/packages/electricore-kiosque/tests/test_smoke.sh
+++ b/packages/electricore-kiosque/tests/test_smoke.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Auto-test de packages/electricore-kiosque/smoke.sh (fake docker/curl, #706).
+# Même motif que deploy/tests/unit.sh (fake binaires, pas de vraie image) — sibling
+# minimal plutôt que le harnais du moteur (fake docker moteur modélise l'entrypoint
+# SOPS, hors-sujet ici : le Kiosque ne déchiffre rien).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FAKE_BIN="${SCRIPT_DIR}/fixtures/fake_bin"
+
+# shellcheck source=../smoke.sh
+source "${SCRIPT_DIR}/../smoke.sh"
+
+PASS=0
+FAIL=0
+ok() {
+    printf '  \033[32m✓\033[0m %s\n' "$1"
+    PASS=$((PASS + 1))
+}
+ko() {
+    printf '  \033[31m✗\033[0m %s\n' "$1"
+    FAIL=$((FAIL + 1))
+}
+
+echo "→ smoke.sh (kiosque, fake docker + curl)"
+
+PATH="${FAKE_BIN}:$PATH" DOCKER_BIN=docker CURL_BIN=curl \
+    smoke_kiosque_image "electricore-kiosque:test" >/dev/null 2>&1 \
+    && ok "smoke_kiosque_image: image saine (sert + fail-fast) → succès" \
+    || ko "smoke_kiosque_image: image saine aurait dû réussir"
+
+out=$(PATH="${FAKE_BIN}:$PATH" DOCKER_BIN=docker CURL_BIN=curl FAKE_CURL_FAIL=1 \
+    smoke_kiosque_image "electricore-kiosque:test" 2>&1)
+rc=$?
+[[ "$rc" -ne 0 ]] && ok "smoke_kiosque_image: service muet (HTTP KO) → exit non-zero" \
+    || ko "smoke_kiosque_image: service muet aurait dû échouer"
+grep -qi "ne sert pas" <<<"$out" && ok "smoke_kiosque_image: message nomme la fumée fautive (sert)" \
+    || ko "smoke_kiosque_image: message de la fumée 'sert' absent"
+
+out=$(PATH="${FAKE_BIN}:$PATH" DOCKER_BIN=docker CURL_BIN=curl FAKE_DOCKER_NO_FAILFAST=1 \
+    smoke_kiosque_image "electricore-kiosque:test" 2>&1)
+rc=$?
+[[ "$rc" -ne 0 ]] && ok "smoke_kiosque_image: fail-fast absent de l'image → détecté, exit non-zero" \
+    || ko "smoke_kiosque_image: absence de fail-fast aurait dû être détectée"
+grep -qi "fail-fast" <<<"$out" && ok "smoke_kiosque_image: message nomme la fumée fautive (fail-fast)" \
+    || ko "smoke_kiosque_image: message de la fumée 'fail-fast' absent"
+
+(smoke_kiosque_image >/dev/null 2>&1)
+rc=$?
+[[ "$rc" -eq 2 ]] && ok "smoke_kiosque_image: sans tag → exit 2 (usage)" \
+    || ko "smoke_kiosque_image: sans tag devait être exit 2 (got $rc)"
+
+echo
+echo "${PASS} ok, ${FAIL} ko"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #706

Image Docker unique du Kiosque (`packages/electricore-kiosque/Dockerfile`), publiée sur `ghcr.io/energie-de-nantes/electricore-kiosque` — tout le catalogue embarqué, la personnalisation par entité reste de la config au lancement (`KIOSQUE__APPS`/`TITRE`/`API_URL`). Le moteur `electricore` et DuckDB sont absents de l'image (scope `uv sync --package electricore-kiosque --no-editable`) ; aucun secret côté serveur, entrypoint sans SOPS.

Workflow `release-kiosque.yml` sur tag `kiosque-v*` (découplé du moteur/client, même logique que les releases `electricore-client`) ; gate PR via `docker-image-kiosque.yml` (build + scan TruffleHog + smoke) intégré à `ci.yml`. Corrige au passage un bind `127.0.0.1` dans `__main__.py` qui aurait rendu le service injoignable via port-mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)