### PR TITLE
Kiosque : intégration deploy provider — profil compose + Caddy kiosque.$DOMAIN + checklist DNS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,9 @@ celerybeat.pid
 .env
 .env.pass
 .env.pass.*
+# config.env local pour tester le compose (docs/deploiement.md « Test local ») —
+# le modèle versionné est deploy/providers/example/config.env.example.
+/config.env
 .venv
 env/
 venv/

--- a/deploy/docker/Caddyfile.example
+++ b/deploy/docker/Caddyfile.example
@@ -35,3 +35,27 @@ electricore.exemple.fr {
         }
     }
 }
+
+# Kiosque (optionnel, #707, ADR-0057) : sous-domaine dédié, dérivé du domaine
+# principal (jamais de montage sous préfixe de chemin — plomberie base-path/
+# WebSockets fragile derrière un proxy). Certificat HTTP-01 automatique, comme
+# ci-dessus. Le conteneur `kiosque` n'existe que si le profil Compose "kiosque"
+# est activé (COMPOSE_PROFILES=kiosque dans config.env) — sans lui, ce bloc
+# répond 502 pour cet hôte, le reste de la stack n'est pas affecté.
+kiosque.electricore.exemple.fr {
+    encode zstd gzip
+
+    log {
+        output stdout
+        format console
+    }
+
+    header {
+        -Server
+        Cache-Control "no-store"
+    }
+
+    # reverse_proxy de Caddy proxie nativement les WebSockets (marimo en dépend) —
+    # aucune configuration supplémentaire requise.
+    reverse_proxy kiosque:8765
+}

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -30,6 +30,13 @@
 # ne sont PAS utilisées pour les substitutions du compose lui-même — c'est une
 # subtilité Compose qui justifie l'invocation explicite.
 #
+# Kiosque (optionnel, #707, ADR-0057) : conteneur derrière un profil Compose
+# ("kiosque"), activé en posant `COMPOSE_PROFILES=kiosque` dans config.env — cette
+# variable spéciale est lue par le CLI Compose lui-même depuis --env-file, pas
+# besoin d'un `--profile kiosque` sur la ligne de commande. Config via les 3
+# `KIOSQUE__*` (aucun secret) + `KIOSQUE_VERSION` (tag GHCR, même logique
+# qu'ELECTRICORE_VERSION) — voir docs/deploiement.md « Kiosque (optionnel) ».
+#
 # Documentation complète : docs/deploiement.md
 
 services:
@@ -108,6 +115,30 @@ services:
     depends_on:
       api:
         condition: service_healthy
+    restart: unless-stopped
+
+  kiosque:
+    image: ghcr.io/energie-de-nantes/electricore-kiosque:${KIOSQUE_VERSION:-latest}
+    container_name: electricore-kiosque
+    # Profil Compose (#707) : conteneur absent tant que COMPOSE_PROFILES (config.env,
+    # lu via --env-file) ne contient pas "kiosque" — activer/désactiver un provider
+    # = une seule ligne dans son config.env, aucune autre plomberie.
+    profiles:
+      - kiosque
+    env_file:
+      - ../../config.env
+    expose:
+      - "8765"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8765/',timeout=5).status==200 else 1)"
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     restart: unless-stopped
 
   caddy:

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -306,6 +306,18 @@ main() {
             wait_for_dns "$OPT_DOMAIN" "$public_ip" || die \
                 "DNS non propagé après 5 minutes." \
                 "Vérifier le A-record de ${OPT_DOMAIN}. Relancer le script quand c'est propre."
+
+            # Kiosque (#707) : sous-domaine optionnel, activé par profil Compose
+            # (COMPOSE_PROFILES=kiosque dans config.env, déjà pullé à l'étape 9). Même
+            # check DNS que le domaine principal, seulement si le profil est posé.
+            kiosque_profiles=$(read_env_var "$config_env" COMPOSE_PROFILES 2>/dev/null || true)
+            if [[ ",${kiosque_profiles}," == *,kiosque,* ]]; then
+                kiosque_domain="kiosque.${OPT_DOMAIN}"
+                log_info "Kiosque activé (COMPOSE_PROFILES=kiosque) — attente que ${kiosque_domain} pointe vers ${public_ip}…"
+                wait_for_dns "$kiosque_domain" "$public_ip" || die \
+                    "DNS non propagé pour ${kiosque_domain} après 5 minutes." \
+                    "Vérifier le A-record de ${kiosque_domain} (même IP que ${OPT_DOMAIN}). Relancer le script quand c'est propre."
+            fi
         fi
 
         # ─── Étape 11 : stack ────────────────────────────────────────────────
@@ -341,12 +353,19 @@ main() {
         # OPT_VERSION pour le chemin legacy .env (pas de config.env).
         effective_version=$(read_env_var "${HOME_DIR}/config.env" ELECTRICORE_VERSION 2>/dev/null || true)
         [[ -n "$effective_version" ]] || effective_version="$OPT_VERSION"
+        # Kiosque (#707) : ligne de récap seulement si activé (COMPOSE_PROFILES=kiosque).
+        kiosque_recap=""
+        kiosque_profiles=$(read_env_var "${HOME_DIR}/config.env" COMPOSE_PROFILES 2>/dev/null || true)
+        if [[ ",${kiosque_profiles}," == *,kiosque,* ]]; then
+            kiosque_recap="  Kiosque          https://kiosque.${OPT_DOMAIN}
+"
+        fi
         cat <<EOF
 
   ${_C_GREEN}${_C_BOLD}✓ Instance ${OPT_SLUG} opérationnelle.${_C_RESET}
 
   URL              https://${OPT_DOMAIN}
-  /health          curl https://${OPT_DOMAIN}/health
+${kiosque_recap}  /health          curl https://${OPT_DOMAIN}/health
   Image            ghcr.io/energie-de-nantes/electricore:${effective_version}
 ${ssh_recap}
   Logs             sudo -u ${OPT_SLUG} docker compose -f ${DOCKER_DIR}/docker-compose.yml logs -f

--- a/deploy/lib/env_validate.sh
+++ b/deploy/lib/env_validate.sh
@@ -97,6 +97,22 @@ validate_config_env() {
         backups=$(read_env_var "$file" BACKUPS_PATH)
         [[ -n "$version" ]] || errors+=("ELECTRICORE_VERSION manquant (substitution compose)")
         [[ -n "$backups" ]] || errors+=("BACKUPS_PATH manquant (substitution compose)")
+
+        # Kiosque (#707, ADR-0057) : service optionnel activé par profil Compose. Le
+        # profil posé sans la config qui va avec ferait planter le conteneur au
+        # démarrage (KIOSQUE__API_URL fail-fast) — on le détecte ici, avant compose up,
+        # même philosophie fail-fast qu'ELECTRICORE_VERSION/BACKUPS_PATH ci-dessus.
+        local profiles
+        profiles=$(read_env_var "$file" COMPOSE_PROFILES)
+        if [[ ",${profiles}," == *,kiosque,* ]]; then
+            local kiosque_version kiosque_api_url kiosque_apps
+            kiosque_version=$(read_env_var "$file" KIOSQUE_VERSION)
+            kiosque_api_url=$(read_env_var "$file" KIOSQUE__API_URL)
+            kiosque_apps=$(read_env_var "$file" KIOSQUE__APPS)
+            [[ -n "$kiosque_version" ]] || errors+=("KIOSQUE_VERSION manquant (COMPOSE_PROFILES contient kiosque, #707)")
+            [[ -n "$kiosque_api_url" ]] || errors+=("KIOSQUE__API_URL manquant (COMPOSE_PROFILES contient kiosque, #707)")
+            [[ -n "$kiosque_apps" ]] || errors+=("KIOSQUE__APPS manquant (COMPOSE_PROFILES contient kiosque, #707)")
+        fi
     fi
 
     # Garde-fou anti-fuite (#693) : RELAIS__SOURCE_URL / RELAIS__PARTNER_URL APPARTIENNENT à

--- a/deploy/providers/example/config.env.example
+++ b/deploy/providers/example/config.env.example
@@ -19,6 +19,19 @@ BOT__NOTIFY_CHAT_ID=-1001234567890
 # Odoo : bloc unique read-only ODOO__* (#439). Les credentials vivent dans secrets.env ;
 # plus de sélecteur test/prod (#190 clos).
 
+# ── Kiosque (optionnel, #707, ADR-0057) — décommenter pour activer sur cette box.
+#    Zéro secret pour ce service (clé API saisie côté navigateur) — tout vit ici.
+# Active le conteneur `kiosque` du docker-compose.yml (profil Compose, lu depuis
+# --env-file par le CLI Compose lui-même — pas de --profile requis sur la commande).
+# COMPOSE_PROFILES=kiosque
+# Tag GHCR à épingler (ghcr.io/energie-de-nantes/electricore-kiosque), à épingler.
+# KIOSQUE_VERSION=latest
+# URL PUBLIQUE de l'API (jamais le réseau Docker interne) — même chemin que n'importe
+# quel client. Vaut https://<DOMAIN> de cette instance.
+# KIOSQUE__API_URL=https://example.electricore.fr
+# KIOSQUE__APPS=exports
+# KIOSQUE__TITRE=Example
+
 # ── Composant relais (optionnel, #637/#657 — seulement si `install.sh --relais`
 #    installe ce composant sur cette box) ───────────────────────────────────
 # Tag GHCR du relais, DÉCOUPLÉ d'ELECTRICORE_VERSION : la stack bouge souvent, le

--- a/deploy/providers/example/config.env.example
+++ b/deploy/providers/example/config.env.example
@@ -24,7 +24,7 @@ BOT__NOTIFY_CHAT_ID=-1001234567890
 # Active le conteneur `kiosque` du docker-compose.yml (profil Compose, lu depuis
 # --env-file par le CLI Compose lui-même — pas de --profile requis sur la commande).
 # COMPOSE_PROFILES=kiosque
-# Tag GHCR à épingler (ghcr.io/energie-de-nantes/electricore-kiosque), à épingler.
+# Tag GHCR du kiosque (ghcr.io/energie-de-nantes/electricore-kiosque), à épingler.
 # KIOSQUE_VERSION=latest
 # URL PUBLIQUE de l'API (jamais le réseau Docker interne) — même chemin que n'importe
 # quel client. Vaut https://<DOMAIN> de cette instance.

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -1176,6 +1176,108 @@ assert_ok   "poll_ingestion_job: running×2 puis completed → 0" \
 rm -f "$_poll_seq" "${_poll_seq}.tmp"
 
 echo
+echo "→ Kiosque (#707, ADR-0057) : intégration deploy provider"
+
+# env_validate.sh : COMPOSE_PROFILES=kiosque exige KIOSQUE_VERSION/KIOSQUE__API_URL/
+# KIOSQUE__APPS, même philosophie fail-fast qu'ELECTRICORE_VERSION/BACKUPS_PATH.
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nCOMPOSE_PROFILES=kiosque\n' > "$tmp_cfg"
+assert_fail_msg "validate_config_env (kiosque activé) : KIOSQUE_VERSION manquant → refuse" \
+    "KIOSQUE_VERSION manquant" \
+    validate_config_env "$tmp_cfg" "edn"
+rm -f "$tmp_cfg"
+
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nCOMPOSE_PROFILES=kiosque\nKIOSQUE_VERSION=1.0.0\n' > "$tmp_cfg"
+assert_fail_msg "validate_config_env (kiosque activé) : KIOSQUE__API_URL manquant → refuse" \
+    "KIOSQUE__API_URL manquant" \
+    validate_config_env "$tmp_cfg" "edn"
+rm -f "$tmp_cfg"
+
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nCOMPOSE_PROFILES=kiosque\nKIOSQUE_VERSION=1.0.0\nKIOSQUE__API_URL=https://edn.electricore.fr\n' > "$tmp_cfg"
+assert_fail_msg "validate_config_env (kiosque activé) : KIOSQUE__APPS manquant → refuse" \
+    "KIOSQUE__APPS manquant" \
+    validate_config_env "$tmp_cfg" "edn"
+rm -f "$tmp_cfg"
+
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nCOMPOSE_PROFILES=kiosque\nKIOSQUE_VERSION=1.0.0\nKIOSQUE__API_URL=https://edn.electricore.fr\nKIOSQUE__APPS=exports\n' > "$tmp_cfg"
+assert_ok "validate_config_env (kiosque activé) : les 3 variables présentes → OK" \
+    validate_config_env "$tmp_cfg" "edn"
+rm -f "$tmp_cfg"
+
+# COMPOSE_PROFILES portant d'autres profils + kiosque (liste virgule) → toujours détecté.
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\nCOMPOSE_PROFILES=autre,kiosque\n' > "$tmp_cfg"
+assert_fail_msg "validate_config_env : kiosque détecté au milieu d'une liste COMPOSE_PROFILES" \
+    "KIOSQUE_VERSION manquant" \
+    validate_config_env "$tmp_cfg" "edn"
+rm -f "$tmp_cfg"
+
+# Sans COMPOSE_PROFILES (ou sans "kiosque" dedans) : aucune exigence KIOSQUE__* — le
+# comportement historique (stack seule) reste intact, config par défaut inchangée.
+tmp_cfg=$(mktemp)
+printf 'INSTANCE_SLUG=edn\nELECTRICORE_VERSION=1.7.0\nBACKUPS_PATH=/srv/edn/backups\n' > "$tmp_cfg"
+assert_ok "validate_config_env : sans COMPOSE_PROFILES, aucune exigence KIOSQUE__*" \
+    validate_config_env "$tmp_cfg" "edn"
+rm -f "$tmp_cfg"
+
+# docker-compose.yml : service kiosque défini derrière un profil Compose, zéro secret
+# (pas de volumes ni de SOPS/age.key montés pour ce service — seulement env_file).
+compose_yml="${LIB_DIR}/../docker/docker-compose.yml"
+grep -q "^  kiosque:" "$compose_yml" \
+    && ok "docker-compose.yml : service kiosque défini" \
+    || ko "docker-compose.yml : service kiosque absent"
+grep -q 'ghcr.io/energie-de-nantes/electricore-kiosque:\${KIOSQUE_VERSION:-latest}' "$compose_yml" \
+    && ok "docker-compose.yml : image kiosque pinnable via KIOSQUE_VERSION" \
+    || ko "docker-compose.yml : image kiosque non pinnable via KIOSQUE_VERSION"
+grep -q '"8765"' "$compose_yml" \
+    && ok "docker-compose.yml : port 8765 exposé" \
+    || ko "docker-compose.yml : port 8765 absent"
+awk '/^  kiosque:/,/^  caddy:/' "$compose_yml" | grep -q "profiles:" \
+    && ok "docker-compose.yml : service kiosque derrière un profil Compose" \
+    || ko "docker-compose.yml : service kiosque sans profil (toujours démarré)"
+awk '/^  kiosque:/,/^  caddy:/' "$compose_yml" | grep -qE '^\s*-\s*(\.\./\.\./age\.key|\.\./\.\./providers)' \
+    && ko "docker-compose.yml : service kiosque monte un secret (age.key/secrets.env) — zéro secret attendu" \
+    || ok "docker-compose.yml : service kiosque ne monte aucun secret"
+
+# Caddyfile.example : bloc kiosque dérivé du même placeholder de domaine — substitute_caddyfile
+# (sed global) le patche gratuitement, sans plomberie dédiée (issue #707).
+caddyfile_example="${LIB_DIR}/../docker/Caddyfile.example"
+grep -q "kiosque.electricore.exemple.fr" "$caddyfile_example" \
+    && ok "Caddyfile.example : bloc kiosque.<domaine> présent" \
+    || ko "Caddyfile.example : bloc kiosque.<domaine> absent"
+grep -q "reverse_proxy kiosque:8765" "$caddyfile_example" \
+    && ok "Caddyfile.example : reverse_proxy vers kiosque:8765" \
+    || ko "Caddyfile.example : reverse_proxy kiosque absent"
+tmp_caddy_kiosque=$(mktemp)
+cp "$caddyfile_example" "$tmp_caddy_kiosque"
+substitute_caddyfile "$tmp_caddy_kiosque" "edn.electricore.fr" "ops@edn.fr"
+grep -q "kiosque.edn.electricore.fr" "$tmp_caddy_kiosque" \
+    && ok "substitute_caddyfile : patche aussi le sous-domaine kiosque (même sed global)" \
+    || ko "substitute_caddyfile : le sous-domaine kiosque n'est pas patché"
+! grep -q "kiosque.electricore.exemple.fr" "$tmp_caddy_kiosque" \
+    && ok "substitute_caddyfile : pas de placeholder kiosque résiduel" \
+    || ko "substitute_caddyfile : placeholder kiosque résiduel"
+rm -f "$tmp_caddy_kiosque"
+
+# install.sh : câblage du check DNS optionnel + du récap kiosque (garde de présence,
+# même motif que la garde anti-régression --version #299 ci-dessus).
+grep -q 'kiosque_profiles' "$install_sh" \
+    && ok "install.sh : lit COMPOSE_PROFILES pour détecter le kiosque" \
+    || ko "install.sh ne lit PAS COMPOSE_PROFILES — DNS/récap kiosque inertes"
+grep -q 'wait_for_dns "\$kiosque_domain"' "$install_sh" \
+    && ok "install.sh : attend la propagation DNS de kiosque.<domain> quand activé" \
+    || ko "install.sh n'attend PAS le DNS du sous-domaine kiosque"
+
+# config.env.example : le modèle documente le bloc kiosque (commenté, prêt à activer).
+provider_example="${LIB_DIR}/../providers/example/config.env.example"
+grep -q "KIOSQUE_VERSION" "$provider_example" && grep -q "KIOSQUE__API_URL" "$provider_example" \
+    && ok "config.env.example : bloc kiosque documenté" \
+    || ko "config.env.example : bloc kiosque absent"
+
+echo
 if [[ "$FAIL" -eq 0 ]]; then
     printf "\033[32m%d passed, %d failed\033[0m\n" "$PASS" "$FAIL"
     exit 0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,6 +79,15 @@ lève `ConfigurationManquante` au boot (no-ERP servi tant que le bloc est entiè
 | `KIOSQUE__TITRE` | nom de l'entité, affiché par l'accueil |
 | `KIOSQUE__API_URL` | URL de l'API `electricore` interrogée par les notebooks (ex. `exports`) ; **requise**, aucun défaut codé en dur — fournie par le `config.env` du provider (`electricore-secrets`, ADR-0044), fail-fast sinon |
 
+Déploiement provider (deploy/docker, #707) — service compose à part, désactivé par défaut :
+
+| variable | rôle |
+|---|---|
+| `COMPOSE_PROFILES` | `kiosque` active le conteneur (profil Compose, `config.env`) ; absent/vide = pas de service kiosque |
+| `KIOSQUE_VERSION` | tag GHCR à épingler (`ghcr.io/energie-de-nantes/electricore-kiosque`), même logique qu'`ELECTRICORE_VERSION` |
+
+Voir [docs/deploiement.md](deploiement.md) « Kiosque (optionnel) » pour l'activation/désactivation côté provider.
+
 **Exception assumée au registre runtime** (ADR-0025/0049) : le Kiosque ne peut pas dépendre
 du moteur (ADR-0057), donc pas de pydantic-settings — lecture directe de l'env dans
 `electricore_kiosque/config.py`. Le nommage `DOMAINE__CHAMP` (ADR-0046) reste respecté.

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -155,6 +155,44 @@ La colonne **Bloc** ci-dessous indique dans quel fichier chaque variable vit.
 |---|---|
 | `ODOO__URL` / `ODOO__DB` / `ODOO__USERNAME` / `ODOO__PASSWORD` | Coordonnées Odoo du fournisseur (bloc unique read-only, #439). |
 
+### Kiosque (optionnel)
+
+Service compose à part ([`packages/electricore-kiosque`](https://github.com/Energie-De-Nantes/electricore/tree/main/packages/electricore-kiosque), [ADR-0057](adr/0057-kiosque-acces-neophytes-package-separe.md)),
+**désactivé par défaut** — un provider qui n'en a pas l'usage ne voit rien de plus.
+Aucun secret : la clé API `electricore` est saisie côté navigateur, jamais stockée
+serveur — tout vit dans `config.env` (clair).
+
+| Variable | Bloc | Notes |
+|---|---|---|
+| `COMPOSE_PROFILES` | `config.env` | `kiosque` pour activer le conteneur (profil Compose, lu par le CLI depuis `--env-file` — pas de `--profile` à ajouter sur la ligne de commande). Absent/vide = pas de conteneur kiosque. |
+| `KIOSQUE_VERSION` | `config.env` | Tag GHCR à épingler (`ghcr.io/energie-de-nantes/electricore-kiosque`), même logique qu'`ELECTRICORE_VERSION`. |
+| `KIOSQUE__API_URL` | `config.env` | URL **publique** de l'API (`https://<domain>` de cette instance) — le kiosque l'appelle comme n'importe quel client, jamais par le réseau Docker interne. |
+| `KIOSQUE__APPS` | `config.env` | Apps du catalogue à monter (ex. `exports`). |
+| `KIOSQUE__TITRE` | `config.env` | Nom de l'entité, affiché à l'accueil. |
+
+**Activer** pour un provider : ajouter les 5 lignes ci-dessus à
+`providers/<slug>/config.env` (dépôt de déploiement — modèle commenté dans
+[`deploy/providers/example/config.env.example`](https://github.com/Energie-De-Nantes/electricore/blob/main/deploy/providers/example/config.env.example)),
+créer le A-record `kiosque.<slug>.electricore.fr` (même IP que le domaine principal,
+cf. [§3](#3-créer-le-a-record-dns)), pousser, relancer `install.sh` en mode
+reconfigure (§5 ci-dessous) — le check DNS et le récap final couvrent
+automatiquement le sous-domaine kiosque dès que le profil est posé.
+
+**Désactiver** : retirer (ou vider) `COMPOSE_PROFILES` dans `config.env`, pousser,
+reconfigure — le conteneur s'arrête, rien d'autre à toucher (le bloc Caddy
+`kiosque.<domain>` répond simplement 502 pour cet hôte tant qu'aucun conteneur
+n'écoute derrière).
+
+**Test local** (avant toute box réelle) : depuis `deploy/docker/`, avec un
+`config.env` local portant `COMPOSE_PROFILES=kiosque` + les 3 `KIOSQUE__*` :
+
+```bash
+docker compose --env-file ../../config.env up -d
+```
+
+Puis `https://kiosque.electricore.localhost` via Caddy (`tls internal`, même
+principe que `https://electricore.localhost` — cf. [TLS local](#tls-local-cert-auto-signé)).
+
 `install.sh` **valide le split** automatiquement (pas d'éditeur) : `validate_config_env`
 sur la moitié claire (slug qui matche, `ELECTRICORE_VERSION`/`BACKUPS_PATH` présents,
 **garde-fou anti-fuite** rejetant tout secret en clair), et un **test de déchiffrement**
@@ -199,6 +237,16 @@ dig +short <slug>.electricore.fr
 
 Pas de wildcard `*.electricore.fr` — chaque VPS gère son propre certificat via
 HTTP-01 (cf. [ADR-0015](adr/0015-deploiement-multi-instance.md)).
+
+**Kiosque activé** (`COMPOSE_PROFILES=kiosque`, cf. [Kiosque (optionnel)](#kiosque-optionnel))
+— ajouter le A-record du sous-domaine, même IP :
+
+```
+kiosque.<slug>.electricore.fr.   A   <IP-VPS>
+```
+
+`install.sh` attend sa propagation en plus de celle du domaine principal
+(sauté avec `--skip-dns`, comme le domaine principal).
 
 ### 4. Configurer l'accès SSH
 

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -179,9 +179,18 @@ reconfigure (§5 ci-dessous) — le check DNS et le récap final couvrent
 automatiquement le sous-domaine kiosque dès que le profil est posé.
 
 **Désactiver** : retirer (ou vider) `COMPOSE_PROFILES` dans `config.env`, pousser,
-reconfigure — le conteneur s'arrête, rien d'autre à toucher (le bloc Caddy
-`kiosque.<domain>` répond simplement 502 pour cet hôte tant qu'aucun conteneur
-n'écoute derrière).
+reconfigure — **puis arrêter le conteneur explicitement**. Le `docker compose up -d`
+du reconfigure ne passe pas `--remove-orphans` : un kiosque déjà lancé survit au
+retrait du profil (Compose le voit comme un orphelin et se contente d'un warning) et
+Caddy continue de le servir. Le retirer par son nom de conteneur (fixe), sans toucher
+au reste de la stack ni à d'éventuels autres conteneurs du même projet Compose :
+
+```bash
+docker rm -f electricore-kiosque
+```
+
+Une fois le conteneur parti, le bloc Caddy `kiosque.<domain>` répond simplement 502
+pour cet hôte, le reste de la stack n'est pas affecté.
 
 **Test local** (avant toute box réelle) : depuis `deploy/docker/`, avec un
 `config.env` local portant `COMPOSE_PROFILES=kiosque` + les 3 `KIOSQUE__*` :
@@ -190,8 +199,18 @@ n'écoute derrière).
 docker compose --env-file ../../config.env up -d
 ```
 
-Puis `https://kiosque.electricore.localhost` via Caddy (`tls internal`, même
-principe que `https://electricore.localhost` — cf. [TLS local](#tls-local-cert-auto-signé)).
+Le `Caddyfile` local (non versionné, copie adaptée de `Caddyfile.example`) n'a pas de
+bloc kiosque : l'ajouter à la main pour ce test, à côté du bloc `electricore.localhost` —
+
+```
+kiosque.electricore.localhost {
+    tls internal
+    reverse_proxy kiosque:8765
+}
+```
+
+puis ouvrir `https://kiosque.electricore.localhost` (`tls internal`, même principe que
+`https://electricore.localhost` — cf. [TLS local](#tls-local-cert-auto-signé)).
 
 `install.sh` **valide le split** automatiquement (pas d'éditeur) : `validate_config_env`
 sur la moitié claire (slug qui matche, `ELECTRICORE_VERSION`/`BACKUPS_PATH` présents,


### PR DESCRIPTION
Closes #707

Branche le Kiosque sur la stack provider existante : un service compose de plus, activé/désactivé par un profil Compose (`COMPOSE_PROFILES=kiosque`), servi sur `kiosque.<domain>` via Caddy (WebSockets natifs, aucune plomberie base-path). Zéro secret pour ce service — tout vit dans `config.env` (`KIOSQUE_VERSION` + les trois `KIOSQUE__*`). `install.sh` attend en plus le DNS de `kiosque.<domain>` quand le profil est posé, et `env_validate.sh` fail-fast si le profil est actif sans la config qui va avec.

## Test plan
- [x] `bash deploy/tests/unit.sh` (18 nouveaux cas kiosque, verts)
- [x] `uv run --group test pytest -q` (suite verte)
- [x] `docker compose --env-file ../../config.env up -d` réel + `https://kiosque.electricore.localhost` (Virgile)
- [ ] Activation sur une box réelle (A-record + config.env provider + reconfigure) — hors périmètre de cette PR

Lignes à ajouter au `config.env` de chaque provider qui veut le kiosque (dépôt privé) :
```
COMPOSE_PROFILES=kiosque
KIOSQUE_VERSION=0.1.0
KIOSQUE__API_URL=https://<domain-du-provider>
KIOSQUE__APPS=exports
KIOSQUE__TITRE=<Nom de l'entité>
```
+ A-record `kiosque.<slug>.electricore.fr` → IP du VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)