### PR TITLE
fix(deploy): recréer caddy plutôt que reload — le Caddyfile est bind-monté par inode (suite #727)

### DIFF
--- a/deploy/lib/stack.sh
+++ b/deploy/lib/stack.sh
@@ -16,11 +16,14 @@ compose_up() {
     # bind-mount). Note : le user <slug> est dans le groupe docker (cf. user.sh).
     sudo -u "$slug" -- bash -c \
         "cd '${home}/deploy/docker' && docker compose --env-file ../../config.env up -d"
-    # Le Caddyfile est un bind-mount : `up -d` ne recrée pas le conteneur quand seul le
-    # CONTENU du fichier change (spec du mount identique) — Caddy garderait l'ancienne
-    # config en mémoire (vécu : bloc kiosque.<domaine> absent après reconfigure, #707).
-    # Reload à chaud, idempotent, zéro coupure.
-    sudo -u "$slug" -- docker exec electricore-caddy caddy reload --config /etc/caddy/Caddyfile
+    # Le Caddyfile est un bind-mount PAR INODE : `up -d` ne recrée pas le conteneur quand
+    # seul le contenu change, et `sed -i` (substitute_caddyfile) écrit un NOUVEL inode —
+    # le conteneur reste attaché à l'ancien, c.-à-d. le template brut écrit par curl.
+    # Un `caddy reload` chargerait donc le template non substitué (vécu sur enargia,
+    # #707 : domaine principal tombé). Seule une recréation re-résout le chemin.
+    # ~1 s de coupure ; les certificats survivent dans le volume caddy_data.
+    sudo -u "$slug" -- bash -c \
+        "cd '${home}/deploy/docker' && docker compose --env-file ../../config.env up -d --force-recreate caddy"
 }
 
 # wait_for_health <slug> [<max_retries>] [<delay_seconds>]

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -1251,11 +1251,14 @@ grep -q "kiosque.electricore.exemple.fr" "$caddyfile_example" \
 grep -q "reverse_proxy kiosque:8765" "$caddyfile_example" \
     && ok "Caddyfile.example : reverse_proxy vers kiosque:8765" \
     || ko "Caddyfile.example : reverse_proxy kiosque absent"
-# compose_up recharge Caddy après `up -d` : un Caddyfile bind-monté modifié ne
-# provoque aucune recréation du conteneur, sans reload l'ancienne config reste en mémoire.
-grep -q "caddy reload --config /etc/caddy/Caddyfile" "${LIB_DIR}/stack.sh" \
-    && ok "stack.sh : compose_up recharge Caddy (Caddyfile bind-monté)" \
-    || ko "stack.sh : compose_up ne recharge pas Caddy"
+# compose_up RECRÉE caddy après `up -d` : le Caddyfile est bind-monté par inode et
+# sed -i en crée un nouveau — ni `up -d` ni `caddy reload` ne voient le fichier substitué.
+grep -q "up -d --force-recreate caddy" "${LIB_DIR}/stack.sh" \
+    && ok "stack.sh : compose_up recrée caddy (Caddyfile bind-monté par inode)" \
+    || ko "stack.sh : compose_up ne recrée pas caddy"
+! grep -q "exec electricore-caddy caddy reload" "${LIB_DIR}/stack.sh" \
+    && ok "stack.sh : pas de caddy reload (chargerait le template brut)" \
+    || ko "stack.sh : caddy reload présent"
 tmp_caddy_kiosque=$(mktemp)
 cp "$caddyfile_example" "$tmp_caddy_kiosque"
 substitute_caddyfile "$tmp_caddy_kiosque" "edn.electricore.fr" "ops@edn.fr"

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -378,8 +378,8 @@ Vérifs manuelles complémentaires :
 ## Reconfigurer une instance existante
 
 Toutes les modifications post-install passent par le **mode reconfigure** : tu
-relances `install.sh` avec les mêmes `--slug`, `--domain` et `--deploy-repo`, le script
-détecte l'instance, **re-pull** `providers/<slug>/{config.env,secrets.env}` depuis le
+relances `install.sh` avec les mêmes `--slug`, `--domain`, `--email` et `--deploy-repo`, le
+script détecte l'instance, **re-pull** `providers/<slug>/{config.env,secrets.env}` depuis le
 dépôt, **valide le split + déchiffre**, restart la stack. Les changements de config/secrets
 se font **dans le dépôt de déploiement** (commit + push), pas sur la box. **Jamais touche à
 la DB ni aux backups.**
@@ -388,8 +388,16 @@ la DB ni aux backups.**
 # VPS durci (ADR-0031) : login admin via ops — le SSH root est désactivé
 ssh ops@<vps>
 sudo bash /srv/<slug>/deploy/install.sh --slug <slug> --domain <slug>.electricore.fr \
+    --email <email-letsencrypt> \
     --deploy-repo git@github.com:Energie-De-Nantes/electricore-secrets.git
 ```
+
+> **`--email` obligatoire en pratique** : le Caddyfile est régénéré à chaque reconfigure
+> depuis le template ; sans `--email`, le placeholder `votre-email@example.com` reste et
+> Let's Encrypt **refuse** ce contact (`invalidContact`) — les certificats déjà en cache
+> continuent de servir, mais aucun nouveau nom (ex. `kiosque.<domaine>`) n'en obtient.
+> L'installeur ne fait qu'un warn. L'email de chaque box est rappelé en commentaire dans
+> son `providers/<slug>/config.env`.
 
 > Sur un VPS pas encore durci (ancienne instance, ou install lancée avec
 > `--no-harden`), c'est encore `ssh root@<vps>`. Le durcissement est idempotent :


### PR DESCRIPTION
## Contexte

#727 a été mergée avec sa **première** version (`caddy reload` après `up -d`). Vécu sur enargia juste après : le reload charge le **template brut** (`electricore.exemple.fr`, `votre-email@example.com`) → Let's Encrypt refuse l'email, le domaine principal disparaît de la config, la box tombe. Le commit correctif (`880e122`) avait été poussé sur la branche après le merge — cette PR le rapporte sur `main`.

**Tant qu'elle n'est pas mergée, un reconfigure fait tomber la box.**

## Cause

Le Caddyfile est bind-monté **par inode**. Le reconfigure fait `curl -o` (template écrit dans l'inode monté) puis `sed -i` (`substitute_caddyfile`) qui écrit un **nouvel** inode — le conteneur reste attaché à l'ancien = le template non substitué. `up -d` ne recrée pas caddy, et `caddy reload` charge le mauvais contenu.

## Correctif

`compose_up` enchaîne `docker compose … up -d --force-recreate caddy` : la recréation re-résout le chemin. ~1 s de coupure ; certificats conservés dans `caddy_data`. Tests de garde : recréation présente, **aucun** `caddy reload`.

Remise en état d'une box déjà touchée : `docker restart electricore-caddy`.

## Vérification

- `bash deploy/tests/unit.sh` : 294 passed ; 1 échec local pré-existant (`sshd -T` exige root, vert en CI).
- Validation réelle = reconfigure enargia après merge (Virgile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)