### PR TITLE
fix(deploy): relais_ssh_key survit au chown -R du reconfigure

### DIFF
--- a/deploy/lib/relais.sh
+++ b/deploy/lib/relais.sh
@@ -39,7 +39,9 @@ relais_ssh_key_mode_ok() {
 # pour que le conteneur puisse la LIRE une fois montée ro — le code du relais ne passe
 # aucun key_filename ; fsspec/paramiko ne cherche que les noms standards dans le HOME
 # du user conteneur (electricore, home /app — cf. deploy/docker/Dockerfile
-# `useradd --home-dir /app`).
+# `useradd --home-dir /app`). Un chown qui échoue REFUSE (die) au lieu d'être avalé :
+# l'avaler (`|| true`, avant l'incident box Enargia du 26/08) loguait « verrouillée »
+# sur une clé que le conteneur ne pouvait pas lire — relais aveugle au premier push.
 check_relais_ssh_key() {
     local slug="$1"
     local path
@@ -55,8 +57,10 @@ check_relais_ssh_key() {
     relais_ssh_key_mode_ok "$path" || \
         die "clé SSH partenaire trop permissive (${path})." \
             "chmod 600 ${path} puis relancer."
-    chown "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}" "$path" 2>/dev/null || true
-    log_ok "clé SSH partenaire présente, verrouillée (${path})"
+    chown "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}" "$path" || \
+        die "chown ${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000} impossible sur la clé SSH partenaire (${path})." \
+            "Sans cet ownership le conteneur (uid ${CONTAINER_UID:-1000}) ne peut pas lire la clé : relais aveugle au premier push. Relancer en root, ou : sudo chown ${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000} ${path}"
+    log_ok "clé SSH partenaire présente, verrouillée, lisible conteneur (${path})"
 }
 
 # ensure_relais_flux_deposit <dir>

--- a/deploy/lib/user.sh
+++ b/deploy/lib/user.sh
@@ -61,20 +61,28 @@ setup_ssh_authorized_keys() {
 # chown_instance_home <slug>
 # S'assure que tout sous /srv/<slug>/ est owned par le user.
 # NB : ce chown -R aveugle écrase les exceptions uid conteneur → elles doivent être
-# (ré)appliquées APRÈS lui : backups/ via ensure_backups_dir (#459), relais_ssh_key
-# via check_relais_ssh_key (étape 11 relais), et age.key ICI MÊME — le fix #672
-# (generate_box_identities chowne age.key à CONTAINER_UID) tourne à l'étape 7 du
-# chemin relais, AVANT ce balayage (étape 10) qui l'écrasait à CHAQUE reconfigure
-# (constaté box Enargia, 28/07 : entrypoint SOPS « permission denied » de retour).
+# (ré)appliquées APRÈS lui : backups/ via ensure_backups_dir (#459), et les clés
+# lues par le conteneur ICI MÊME :
+#   - age.key — fix #672 : generate_box_identities la chowne à CONTAINER_UID à
+#     l'étape 7 du chemin relais, AVANT ce balayage (étape 10) qui l'écrasait à
+#     CHAQUE reconfigure (constaté box Enargia, 28/07 : entrypoint SOPS
+#     « permission denied » de retour) ;
+#   - relais_ssh_key — même bug (constaté box Enargia, 26/08 : relais aveugle,
+#     « permission denied /app/.ssh/id_ed25519 » sur chaque push) :
+#     check_relais_ssh_key (étape 11 relais) la re-chowne, mais un reconfigure
+#     SANS chemin relais balaie le home sans jamais y repasser.
 # Auto-correctrice plutôt qu'un ré-assert chez chaque appelant : tout futur chemin
-# qui balaie le home garde un age.key lisible du conteneur.
+# qui balaie le home garde des clés lisibles du conteneur.
 chown_instance_home() {
     local slug="$1"
     local home="${SRV_BASE:-/srv}/${slug}"
     chown -R "$slug:$slug" "$home"
-    if [[ -f "${home}/age.key" ]]; then
-        chown "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}" "${home}/age.key" 2>/dev/null || true
-    fi
+    local key
+    for key in age.key relais_ssh_key; do
+        if [[ -f "${home}/${key}" ]]; then
+            chown "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}" "${home}/${key}" 2>/dev/null || true
+        fi
+    done
 }
 
 # Identité du user du conteneur (Dockerfile : `USER electricore`, uid:gid 1000:1000).

--- a/deploy/tests/unit.sh
+++ b/deploy/tests/unit.sh
@@ -294,7 +294,19 @@ chmod 600 "${ck_root}/edn/relais_ssh_key"
     && ok "check_relais_ssh_key: présente + 600 → passe" || ko "check_relais_ssh_key aurait dû passer (600)"
 assert_eq "$(stat -c '%u' "${ck_root}/edn/relais_ssh_key")" "$(id -u)" \
     "check_relais_ssh_key: aligne l'ownership sur CONTAINER_UID (lecture conteneur, uid 1000/home /app)"
-rm -rf "$ck_root"
+
+# Échec du chown → refuse (die), plus d'`|| true` silencieux : avant l'incident box
+# Enargia du 26/08, un chown raté loguait quand même « verrouillée » — clé illisible
+# du conteneur, relais aveugle au premier push. Fake chown qui échoue, sur PATH.
+ck_fail_bin=$(mktemp -d)
+printf '#!/usr/bin/env bash\nexit 1\n' > "${ck_fail_bin}/chown"
+chmod +x "${ck_fail_bin}/chown"
+out=$(PATH="${ck_fail_bin}:$PATH" SRV_BASE="$ck_root" check_relais_ssh_key edn 2>&1); rc=$?
+[[ "$rc" -ne 0 ]] && ok "check_relais_ssh_key: échec du chown → refuse (die, plus d'|| true silencieux)" \
+    || ko "check_relais_ssh_key aurait dû refuser (chown échoué = clé illisible conteneur, relais aveugle)"
+grep -q "chown" <<<"$out" && ok "check_relais_ssh_key: message d'échec chown nomme la remédiation" \
+    || ko "check_relais_ssh_key: pas de remédiation dans le message d'échec chown"
+rm -rf "$ck_fail_bin" "$ck_root"
 
 echo
 echo "→ relais.sh / render_relais_compose (mini-compose, pur, #657)"
@@ -858,29 +870,34 @@ rm -f "$tmp_cfg"
 # SSOT pydantic (tests/unit/test_runtime.py), vérifié par le conteneur étapes 11-12 (ADR-0049).
 
 echo
-echo "→ user.sh / chown_instance_home (l'exception age.key survit au chown -R, #672 bis)"
+echo "→ user.sh / chown_instance_home (les exceptions clés conteneur survivent au chown -R, #672 bis)"
 # Fake chown : journalise les appels — l'assertion porte sur l'ORDRE (le ré-assert
-# age.key doit venir APRÈS le balayage -R, sinon il est écrasé — reconfigure Enargia
-# 28/07). Testable sans root : aucun vrai chown n'est exécuté.
+# des clés lues par le conteneur doit venir APRÈS le balayage -R, sinon il est écrasé —
+# age.key : reconfigure Enargia 28/07 ; relais_ssh_key : relais aveugle Enargia 26/08).
+# Testable sans root : aucun vrai chown n'est exécuté.
 ch_root=$(mktemp -d)
 ch_bin="${ch_root}/bin"; mkdir -p "$ch_bin" "${ch_root}/edn"
 : > "${ch_root}/edn/age.key"
+: > "${ch_root}/edn/relais_ssh_key"
 cat > "${ch_bin}/chown" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "${ch_root}/chown.log"
 EOF
 chmod +x "${ch_bin}/chown"
 PATH="${ch_bin}:$PATH" SRV_BASE="$ch_root" CONTAINER_UID=1000 CONTAINER_GID=1000 chown_instance_home edn
-grep -q -- "-R edn:edn ${ch_root}/edn" "${ch_root}/chown.log" \
-    && ok "chown_instance_home: balayage -R slug:slug du home" || ko "chown_instance_home: balayage -R absent"
-tail -1 "${ch_root}/chown.log" | grep -q "1000:1000 ${ch_root}/edn/age.key" \
+head -1 "${ch_root}/chown.log" | grep -q -- "-R edn:edn ${ch_root}/edn" \
+    && ok "chown_instance_home: balayage -R slug:slug du home en PREMIER" || ko "chown_instance_home: balayage -R absent ou pas en premier"
+sed -n '2,$p' "${ch_root}/chown.log" | grep -q "1000:1000 ${ch_root}/edn/age.key" \
     && ok "chown_instance_home: age.key ré-asserté CONTAINER_UID APRÈS le balayage" \
     || ko "chown_instance_home: age.key pas ré-asserté après le -R (l'entrypoint SOPS re-cassera au reconfigure)"
-rm -f "${ch_root}/chown.log" "${ch_root}/edn/age.key"
+sed -n '2,$p' "${ch_root}/chown.log" | grep -q "1000:1000 ${ch_root}/edn/relais_ssh_key" \
+    && ok "chown_instance_home: relais_ssh_key ré-assertée CONTAINER_UID APRÈS le balayage" \
+    || ko "chown_instance_home: relais_ssh_key pas ré-assertée après le -R (relais aveugle au reconfigure sans chemin relais, Enargia 26/08)"
+rm -f "${ch_root}/chown.log" "${ch_root}/edn/age.key" "${ch_root}/edn/relais_ssh_key"
 PATH="${ch_bin}:$PATH" SRV_BASE="$ch_root" chown_instance_home edn
 [[ "$(wc -l < "${ch_root}/chown.log")" == "1" ]] \
-    && ok "chown_instance_home: sans age.key → seul le balayage (pas de chown fantôme)" \
-    || ko "chown_instance_home: appel chown inattendu en l'absence d'age.key"
+    && ok "chown_instance_home: sans clés → seul le balayage (pas de chown fantôme)" \
+    || ko "chown_instance_home: appel chown inattendu en l'absence de clés"
 
 echo
 echo "→ secrets.sh (fake-binaries age-keygen/ssh-keygen/sops/git)"


### PR DESCRIPTION
## Incident

Box Enargia, 26/08 : relais aveugle — `[Errno 13] Permission denied: '/app/.ssh/id_ed25519'` sur chacun des 7 push du jour, service `electricore-relais` en failed, alerte OnFailure déclenchée. La clé partenaire hôte était `enargia:enargia 600`, illisible pour le conteneur (uid 1000).

Latent depuis le passage conteneurisé (3.8.2, lundi) : la clé n'est lue qu'au premier push réel, et R17 était silencieux — aucun candidat avant aujourd'hui.

## Cause

Le `chown -R <slug>:<slug>` de `chown_instance_home` écrase l'ownership de `relais_ssh_key` — exactement le scénario age.key du 28/07 (#672). `check_relais_ssh_key` (étape 11 du chemin relais) est censé la re-chowner, mais un reconfigure **sans** chemin relais balaie le home sans jamais y repasser. En prime, son chown avalait tout échec (`2>/dev/null || true`) en loguant quand même « verrouillée ».

## Fix

- `chown_instance_home` ré-asserte `relais_ssh_key` à `CONTAINER_UID` après le balayage, comme age.key (#672 bis) — auto-correctrice, quel que soit le chemin qui balaie le home.
- `check_relais_ssh_key` : un chown qui échoue `die` désormais avec la remédiation, au lieu d'être avalé.

## Tests

3 nouveaux cas dans `deploy/tests/unit.sh` (ré-assert de relais_ssh_key après le -R, pas de chown fantôme sans clés, die sur chown raté). Harness : 297 passed, 1 failed — l'échec `sshd_preflight_effective_passwordauth` préexiste sur main (environnemental, sshd local).

Remédiation déjà appliquée à la main sur la box (chown + re-run : 7/7 poussés à 14:47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eDQfQykWZWNEnruiKpBff